### PR TITLE
feat(sim): fase-2a scaled enemies + fase-2 goal plan

### DIFF
--- a/docs/planning/2026-06-02-full-loop-fase2-goal.md
+++ b/docs/planning/2026-06-02-full-loop-fase2-goal.md
@@ -1,0 +1,201 @@
+---
+title: 'GOAL fase-2 -- full-loop AI-playtest balance (scaled enemy + band-metriche + N=40)'
+date: 2026-06-02
+type: goal
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-02'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+tags: [goal, full-loop, ai-playtest, balance, band-verify, scaled-enemy, fase-2]
+---
+
+# GOAL fase-2 -- full-loop AI-playtest: balance (band sul meta-loop)
+
+> Goal self-contained ed ESEGUIBILE: una sessione lo riprende via `/goal` e costruisce
+> senza ri-derivare nulla. Continua il full-loop runner dopo **fase-1b COMPLETA**
+> (meta-loop interamente AI-played). Spec di riferimento (band/policy/metodo ancorati a
+> fonti): [`2026-06-02-full-loop-ai-playtest-runner-design.md`](../superpowers/specs/2026-06-02-full-loop-ai-playtest-runner-design.md)
+> (#2559 §4-8). Memory: `~/.claude/projects/C--dev-Game/memory/project_full_loop_ai_playtest_runner.md`.
+
+## TL;DR
+
+Oggi l'AI gioca il meta-loop intero (campagna -> combat reale -> recruit->combat + economia
+Nido + breeding), MA i nemici sono **deboli-fissi** => l'AI vince sempre => **nessuna band
+puo' misurare la salute del gioco**. fase-2 rende il combat **vero** e poi **misura** il
+meta-loop con band-metriche calibrate N=40 e ratificate da master-dd (come le band combat).
+Tre slice in sequenza: **2a scaled enemy** -> **2b band-metriche + aggregatore** -> **2c
+N=40 + mbtiPolicy + GAP-C routing + ratifica**.
+
+## Stato corrente (verify-first, 2026-06-02)
+
+| Slice                       | Cosa                                           | Stato  |
+| --------------------------- | ---------------------------------------------- | ------ |
+| fase-0 #2561 `723b8548`     | combat-policy + combat-adapter (Option B)      | MERGED |
+| fase-1b-1 #2562 `c151ce29`  | campaign + combat join (esiti reali)           | MERGED |
+| fase-1b-2 #2563 `8c41ce84`  | Nido recruit                                   | MERGED |
+| fase-1b-3a #2565 `f7777f28` | recruit -> combat (deriveCombatStats faithful) | MERGED |
+| fase-1b-3b #2566 `66bf849b` | Nido economy (earned recruit) + breeding       | MERGED |
+
+**Moduli `tools/sim/` esistenti**: `combat-policy.js`, `combat-adapter.js`, `campaign-driver.js`,
+`full-loop-invariants.js`, `greedy-policy.js`, `recruit-resolver.js`, `nido-economy.js`,
+`full-loop-runner.js`. Test: `tests/sim/*.test.js` = **24/24**.
+
+## Architettura reale (Option B) -- NON la Option A dello spec
+
+> ATTENZIONE anti-drift: lo spec #2559 §4/§6 descrive Option A (`combatAdapter invoca
+ai-driven-sim` via seam `FULL_LOOP_ROSTER`). Il build l'ha **superata** con **Option B
+> rifinita**: `combat-adapter.js` e' un modulo NUOVO che chiama `/api/session/start`
+> direttamente e riusa `combat-policy.js` (estratto da ai-driven-sim). `ai-driven-sim.js`
+> resta INTOCCATO (coop-coupled, non-testabile). Quindi fase-2 estende i moduli `tools/sim/`,
+> NON wrappa ai-driven-sim.
+
+Harness: `createApp({databasePath:null})` + supertest (no WS/lobby). `http` iniettato.
+
+## Decomposizione fase-2
+
+### fase-2a -- scaled enemy (FONDAZIONE)
+
+**Perche'**: con nemici deboli-fissi l'AI vince sempre => completion_rate = 100% sempre =>
+ogni band-metrica e' priva di senso. Nemici veri = la precondizione per misurare.
+
+**Design (DECISO)**:
+
+- NUOVO `tools/sim/scenario-enemies.js`: porta `buildEnemiesFromYaml` FUORI da
+  `tests/smoke/ai-driven-sim.js` (oggi interno al worker coop-coupled, righe ~181-237) in un
+  modulo puro. Carica `docs/planning/encounters/<encounter_id>.yaml`, prende la wave con
+  `turn_trigger` minimo, espande `units` per `count`, applica la tier-table
+  (`base` hp7/mod1, `elite` hp10/mod2, `apex` hp14/mod4). 10 YAML disponibili (tutorial_01/02,
+  savana_01, caverna_02, ecc.).
+- **MAPPING di shape (load-bearing)**: l'output di `buildEnemiesFromYaml` usa
+  `ap_remaining/ap_max/defense/damage/name` -- va MAPPATO alla shape unit del runner
+  (`id, species, hp, max_hp, ap, mod, dc, attack_range, position, controlled_by:'sistema',
+status`) che `/api/session/start` consuma nel kill-wire path del `combat-adapter`. Verificare
+  i nomi-campo con un probe supertest PRIMA (lezione 3a/3b: i seam vanno verificati).
+- `full-loop-runner.js`: `enemiesForChapter(step)` -> carica lo YAML del capitolo per `enc`
+  (encounter_id da `summary.current_encounter`); **FALLBACK al nemico debole-fisso quando lo
+  YAML manca** (es. boss / id non coperti) cosi' il giro completa comunque.
+
+**Conseguenza**: il combat ora puo' **perdere** => si attivano i path defeat/attrition/
+roster-wipe (gia' presenti negli invarianti) + il recruit-as-replacement diventa
+significativo. Resta **band-safe** (zero engine change; solo `tools/sim/`).
+
+**Test (TDD)**: `scenarioEnemies.test.js` (YAML reale -> nemici scalati, shape corretta,
+YAML mancante -> throw/fallback) + `fullLoopRunner.test.js` e2e (capitolo coperto spawna
+nemici scalati; YAML mancante -> fallback; loop completa).
+
+**DoD 2a**: `node --test tests/sim/*.test.js` verde; prettier+governance verdi; PR band-safe;
+Codex P1/P2 indirizzati+risolti; merge auto-L3.
+
+### fase-2b -- band-metriche + aggregatore batch
+
+**Design (DECISO, definizioni da spec §7)**:
+
+- NUOVO `tools/sim/meta-band-aggregator.js`: data una lista di run-result (`runFullLoop`
+  output), calcola le 5 metriche meta + le confronta coi range provisional (sotto). JSONL
+  per-run + `summary.json` aggregato (mirror di `batch-ai-runner.js`).
+- `full-loop-runner.js`: arricchire il return con la telemetria per-run necessaria
+  (gia' presenti: chapters/outcome/finalRoster/recruited/economyRecruited/offspring;
+  aggiungere quanto serve a economy_flow [PE guadagnati vs PI spesi] -- leggere dal
+  debrief/advance del backend, NON inventare).
+- NUOVO `tools/sim/full-loop-batch.js` (o estendere `batch-ai-runner` pattern): gira K run
+  con seed diversi -> aggregatore -> summary. Provenance per run: seed + commit + policy +
+  scenario-chain + flag-test (spec §10 DoD).
+
+**Le 5 band-metriche** (spec §7, range derivati+citati -- `(WARN Claude-derived, pending
+master-dd ratify post-N=40)`):
+
+| Metrica                 | Definizione                                    | Range iniziale (fonte)                                                                                        |
+| ----------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `completion_rate`       | % campagne completate su N run                 | **40-70%** (XCOM Long War 2: completabile-ma-dura)                                                            |
+| `roster_attrition`      | survivors / roster-iniziale sull'arco          | **>0 & <100%** (XCOM-LW2 attrition + AI War scaling)                                                          |
+| `economy_flow`          | PE guadagnati vs PI spesi + drift build-power  | PE->PI **5:1**, PI baseline **7/9/11**, PE tier **3/5/8/12** (`26-ECONOMY` + Machinations + Hades/StS)        |
+| `relationship_progress` | rate recruit + trust/affinity buildup + mating | progressione monotona non-stallo (wesnoth + `27-MATING_NIDO`: Aff>=0&Trust>=2 recruit / Trust>=3+nest mating) |
+| `offspring_viability`   | offspring generati vs vitali                   | vitali >= soglia, diversita' lineage non-collassata (Niche + Spore complexity-budget)                         |
+
+**Anti-pattern (spec §7)**: NON ottimizzare a single-best (collassa la diversita',
+Quality-Diversity). Le band tengono lo spazio sano.
+
+**DoD 2b**: aggregatore testato su run sintetici + reali; JSONL+summary prodotti; band
+provisional calcolate (NON ancora ratificate).
+
+### fase-2c -- N=40 + mbtiPolicy + GAP-C routing + ratifica
+
+**Design (DECISO)**:
+
+- **Policy pluggable**: rifattorizzare la policy in un'interfaccia comune (spec §4:
+  `choosePath/chooseRecruits/chooseMatings/spendAffinity` -- mappare l'attuale
+  greedy-policy `chooseRecruits/chooseCourtship/chooseMating` su questa interfaccia) +
+  NUOVO `mbtiPolicy` (scelte meta guidate dal temperamento: INTJ recluta/accoppia != ESFP
+  -> testa P4 nel meta-loop; fondato Triangle Strategy recruit-gating + Disco micro-reactivity).
+- **GAP-C routing test-context**: girare con env `META_NETWORK_ROUTING=true` (NON `=1` --
+  `campaign.js:215` checka `=== 'true'`) per coprire il routing-graph (`selectNextNodes`)
+  in test SENZA accenderlo nel gioco live. (Sblocco in PROD = verdetto master-dd separato.)
+- **N=40 batch** (L-069 ratify): girare N=40 (eredita l'infra batch di 2b), calcolare band
+  placement, confrontare ai range provisional §7. Se si usa MAP-Elites/Optuna per tarare,
+  **objective N >= ratify** (L-073: optimizer-on-noise).
+
+**GATE master-dd (owner)**: i **numeri band ESATTI** li ratifica master-dd post-N=40 (come le
+band combat). Questo goal definisce il PROCESSO + i range provisional; la ratifica e' un
+verdetto umano, NON automatizzabile (L-069).
+
+**DoD 2c**: mbtiPolicy + greedy + (random) girano N=40; band-summary prodotto; report in
+`docs/playtest/<date>-full-loop-band/`; presentato a master-dd per ratifica.
+
+## Decisioni risolte (autonome, reversibili) vs gated (master-dd)
+
+**Risolte (procedo)**:
+
+- Architettura = Option B (moduli `tools/sim/`, ai-driven-sim intoccato).
+- 2a enemy source = encounter YAML (`buildEnemiesFromYaml` portato) + fallback debole-fisso su YAML mancante.
+- 2b metriche = le 5 di spec §7, con i range provisional citati.
+- biome mating = 'badlands' (coerente col pool recruit badlands).
+
+**Gated (STOP, owner-gated)**:
+
+- **Ratifica band numbers ESATTI** = master-dd post-N=40 (L-069).
+- **`META_NETWORK_ROUTING` in PROD** = verdetto master-dd data-driven (il runner lo
+  de-rischia esercitandolo in test-context).
+- **offspring -> combat** (risolvere offspring a unita' combattente): genetica offspring->stat,
+  deferred (oltre fase-2 o slice dedicata).
+- **affinity campaign-scoped** (`/affinity` accetti `campaign_id`) = ENGINE change -- fuori
+  band-safe, gated.
+
+## Sequencing + dipendenze
+
+```
+2a scaled enemy  (foundation: combat puo' perdere)
+   -> 2b band-metriche + aggregatore  (misura: ora le metriche hanno senso)
+      -> 2c N=40 + mbtiPolicy + routing-test  (calibra + ratifica master-dd)
+```
+
+2b dipende da 2a (senza difficolta' vera le metriche sono degeneri). 2c dipende da 2b
+(serve l'aggregatore per N=40). mbtiPolicy puo' partire in parallelo a 2b (e' policy pura)
+ma si verifica meglio dopo 2a.
+
+## Metodo + constraints (invarianti per OGNI slice)
+
+- **TDD** red->green; harness `createApp({databasePath:null})` + supertest.
+- **Worktree ISOLATO** off origin/main (`git -C C:/dev/Game worktree add C:/dev/_gamewt-<x>
+-b claude/<x> origin/main` + `npm ci`). MAI committare sul main checkout `C:/dev/Game`.
+- **Band-safe** = ZERO engine change (solo `tools/sim/` + `tests/sim/` + docs). Gate-5
+  eccezione methodology-tooling.
+- **ADR-0011 trailer** (`Coding-Agent: claude-opus-4.8` + `Trace-Id` uuidv7, NO Co-Authored-By);
+  commit lowercase <=72 no-em-dash; prettier pre-commit; governance `--strict` errors=0.
+- **NO forbidden paths**: `.github/workflows`, `migrations`, `packages/contracts`, `services/generation`.
+- **Babysit Codex** per ogni PR (~2 nudge `@codex review`, ~8min; address P1/P2 + reply +
+  resolveReviewThread graphql); auto-merge L3 a CI verde + thread risolti.
+- **Post-merge**: `git worktree remove` + `branch -D` + `pull --ff-only`; COLLISION check
+  (`git worktree list` + `gh pr list`) PRIMA.
+- Gotcha: `node --test tests/sim/*.test.js` (glob, node v24); `.gitignore Lib/` cattura
+  `tools/sim/lib/` (usa flat); `META_NETWORK_ROUTING=true` NON `=1`.
+
+## Resume trigger (`/goal`)
+
+> _"Leggi docs/planning/2026-06-02-full-loop-fase2-goal.md + memory project_full_loop. Costruisci
+> fase-2a (scaled-enemy: porta buildEnemiesFromYaml in tools/sim/scenario-enemies.js, mappa shape,
+> fallback su YAML mancante; verify-first il probe shape PRIMA) -> poi 2b (meta-band-aggregator +
+> batch) -> poi 2c (mbtiPolicy + META_NETWORK_ROUTING=true + N=40, band provisional §7, ratifica
+> master-dd). TDD, worktree isolato off origin/main, band-safe, babysit Codex, auto-merge L3."_

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -111,6 +111,19 @@ test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -
     `at least one earned-gate (no-bypass) recruit, got ${res.economyRecruited.length}`,
   );
   assert.ok(res.offspring >= 1, `at least one mating offspring rolled, got ${res.offspring}`);
+  // fase-2a scaled enemies: covered cave_path chapters (enc_tutorial_01/02, savana_01,
+  // caverna_02) load real wave-1 rosters from YAML; the uncovered ones (tutorial_03/04/05,
+  // tutorial_06_hardcore) fall back to the weak-fixed enemy. Assert BOTH paths run -> the
+  // scenario loader is wired and the fallback keeps the loop completing.
+  const sources = res.chapters.map((c) => c.enemiesSource);
+  assert.ok(
+    sources.includes('scenario'),
+    `scaled enemies used on covered chapters; sources=${sources}`,
+  );
+  assert.ok(
+    sources.includes('fallback'),
+    `fallback used on uncovered chapters; sources=${sources}`,
+  );
 });
 
 test('runFullLoop: does NOT recruit when /campaign/advance rejects a victory chapter (Codex #2563 P2)', async () => {

--- a/tests/sim/scenarioEnemies.test.js
+++ b/tests/sim/scenarioEnemies.test.js
@@ -1,7 +1,12 @@
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { buildScenarioEnemies, TIER_HP, TIER_MOD } = require('../../tools/sim/scenario-enemies');
+const {
+  buildScenarioEnemies,
+  TIER_HP,
+  TIER_MOD,
+  GRID_SAFE_MAX,
+} = require('../../tools/sim/scenario-enemies');
 
 test('buildScenarioEnemies: loads a real encounter YAML -> scaled sistema units in runner shape', () => {
   // enc_tutorial_01 wave-1 = 2x predoni_nomadi (tier base).
@@ -18,6 +23,10 @@ test('buildScenarioEnemies: loads a real encounter YAML -> scaled sistema units 
   // runner enemy shape (same fields the weak-fixed enemy + combat-adapter use).
   assert.ok(e.ap >= 1 && e.mod >= 1 && e.dc > 0 && e.attack_range >= 1, 'combat-ready stats');
   assert.ok(e.position && typeof e.position.x === 'number' && typeof e.position.y === 'number');
+  assert.ok(
+    e.position.x <= GRID_SAFE_MAX && e.position.y <= GRID_SAFE_MAX,
+    `positions clamped on-grid (<= ${GRID_SAFE_MAX}), got ${JSON.stringify(e.position)}`,
+  );
   assert.deepEqual(e.status, {});
   assert.notEqual(enemies[0].id, enemies[1].id, 'distinct ids');
 });
@@ -29,6 +38,10 @@ test('buildScenarioEnemies: tiers scale hp/mod (base < elite < apex)', () => {
 
 test('buildScenarioEnemies: missing or unsupported YAML -> null (runner falls back)', () => {
   assert.equal(buildScenarioEnemies('enc_does_not_exist_zzz'), null, 'missing -> null');
-  // enc_escort_01 has an escort objective (unsupported by this loader) -> null -> fallback.
-  assert.equal(buildScenarioEnemies('enc_escort_01'), null, 'unsupported objective -> null');
+  // Only elimination is supported (the combat-adapter resolves victory = all foes dead).
+  // Non-elimination objectives -> null -> fallback, so we never misreport a survival/
+  // capture encounter as an elimination 'scenario' fight (Codex #2567 P2).
+  assert.equal(buildScenarioEnemies('enc_escort_01'), null, 'escort -> null');
+  assert.equal(buildScenarioEnemies('enc_tutorial_02'), null, 'survival -> null');
+  assert.equal(buildScenarioEnemies('enc_caverna_02'), null, 'capture_point -> null');
 });

--- a/tests/sim/scenarioEnemies.test.js
+++ b/tests/sim/scenarioEnemies.test.js
@@ -1,0 +1,34 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildScenarioEnemies, TIER_HP, TIER_MOD } = require('../../tools/sim/scenario-enemies');
+
+test('buildScenarioEnemies: loads a real encounter YAML -> scaled sistema units in runner shape', () => {
+  // enc_tutorial_01 wave-1 = 2x predoni_nomadi (tier base).
+  const enemies = buildScenarioEnemies('enc_tutorial_01');
+  assert.ok(
+    Array.isArray(enemies) && enemies.length === 2,
+    `2 wave-1 units, got ${enemies && enemies.length}`,
+  );
+  const e = enemies[0];
+  assert.equal(e.controlled_by, 'sistema');
+  assert.equal(e.species, 'predoni_nomadi');
+  assert.equal(e.hp, TIER_HP.base, 'base-tier hp from the scaling table');
+  assert.equal(e.max_hp, e.hp);
+  // runner enemy shape (same fields the weak-fixed enemy + combat-adapter use).
+  assert.ok(e.ap >= 1 && e.mod >= 1 && e.dc > 0 && e.attack_range >= 1, 'combat-ready stats');
+  assert.ok(e.position && typeof e.position.x === 'number' && typeof e.position.y === 'number');
+  assert.deepEqual(e.status, {});
+  assert.notEqual(enemies[0].id, enemies[1].id, 'distinct ids');
+});
+
+test('buildScenarioEnemies: tiers scale hp/mod (base < elite < apex)', () => {
+  assert.ok(TIER_HP.base < TIER_HP.elite && TIER_HP.elite < TIER_HP.apex, 'hp scales by tier');
+  assert.ok(TIER_MOD.base < TIER_MOD.elite && TIER_MOD.elite < TIER_MOD.apex, 'mod scales by tier');
+});
+
+test('buildScenarioEnemies: missing or unsupported YAML -> null (runner falls back)', () => {
+  assert.equal(buildScenarioEnemies('enc_does_not_exist_zzz'), null, 'missing -> null');
+  // enc_escort_01 has an escort objective (unsupported by this loader) -> null -> fallback.
+  assert.equal(buildScenarioEnemies('enc_escort_01'), null, 'unsupported objective -> null');
+});

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -16,6 +16,7 @@ const { checkInvariants } = require('./full-loop-invariants');
 const greedyPolicy = require('./greedy-policy');
 const { resolveRecruitUnit } = require('./recruit-resolver');
 const { applyNidoEconomy } = require('./nido-economy');
+const { buildScenarioEnemies } = require('./scenario-enemies');
 
 // Nido meta-step on a cleared chapter: the greedy policy recruits NPCs via the meta
 // seam (POST /api/meta/recruit, affinity_at_recruit bypass -> getOrCreate NPC), then
@@ -130,9 +131,16 @@ async function runFullLoop(http, opts = {}) {
       break;
     }
 
+    // fase-2a scaled enemies: load the chapter's real encounter roster from YAML; fall
+    // back to the weak-fixed enemy when the encounter has no YAML (cave_path: tutorial_03/
+    // 04/05 + tutorial_06_hardcore) or an unsupported objective, so the loop still runs.
+    const scaledEnemies = buildScenarioEnemies(enc);
+    const enemies = scaledEnemies && scaledEnemies.length ? scaledEnemies : enemiesForChapter(step);
+    const enemiesSource = scaledEnemies && scaledEnemies.length ? 'scenario' : 'fallback';
+
     const combat = await runEncounter(http, {
       roster: aliveRoster,
-      enemies: enemiesForChapter(step),
+      enemies,
       scenarioId: enc,
       seed: seed ? `${seed}-${step}` : undefined,
       maxRounds: 40,
@@ -157,6 +165,8 @@ async function runFullLoop(http, opts = {}) {
       outcome: combat.outcome,
       survivors: aliveIds.length,
       rosterIds: combat.rosterIds,
+      enemiesSource,
+      rounds: combat.rounds,
     });
 
     // Nido meta-step on a TRULY cleared chapter (Codex #2563 P2: gated on a 200 advance,

--- a/tools/sim/scenario-enemies.js
+++ b/tools/sim/scenario-enemies.js
@@ -29,9 +29,18 @@ const TIER_HP = { base: 7, elite: 10, apex: 14 };
 const TIER_MOD = { base: 1, elite: 2, apex: 4 };
 const TIER_DC = { base: 10, elite: 11, apex: 12 };
 
-// Objectives this loader can stage as a plain elimination-style fight. escort/capture
-// need extra unit materialization + policy support (deferred) -> null -> fallback.
-const SUPPORTED_OBJECTIVES = new Set(['elimination', 'survival']);
+// The sim sizes the grid from the PLAYER count (gridSizeFor), NOT the YAML grid_size, so
+// authored spawn points can land off-grid (e.g. x:7 on the 2-player 6x6). Clamp positions
+// to a conservative on-grid bound so the fight is well-formed. The authored per-encounter
+// grid is a fase-2c concern (would need modulation wiring).
+const GRID_SAFE_MAX = 5;
+
+// Only ELIMINATION encounters become scaled 'scenario' fights: the combat-adapter resolves
+// victory = all sistema dead (= elimination), so a survival/capture/escort encounter would
+// be a DIFFERENT fight than authored. We return null (-> fallback to the weak-fixed enemy)
+// instead of misreporting it as an elimination 'scenario' fight (Codex #2567 P2). Faithful
+// survival/capture staging + the authored grid are deferred to fase-2c.
+const SUPPORTED_OBJECTIVES = new Set(['elimination']);
 
 function buildScenarioEnemies(scenarioId) {
   const yamlPath = path.join(ENCOUNTER_DIR, `${scenarioId}.yaml`);
@@ -62,6 +71,8 @@ function buildScenarioEnemies(scenarioId) {
       const pos = spawnPoints[spIdx % spawnPoints.length];
       spIdx += 1;
       const hp = TIER_HP[tier] || TIER_HP.base;
+      const px = Math.min(GRID_SAFE_MAX, Math.max(0, (pos && pos[0]) || 0));
+      const py = Math.min(GRID_SAFE_MAX, Math.max(0, (pos && pos[1]) || 0));
       enemies.push({
         id: `sis_${scenarioId}_${enemies.length + 1}`,
         species,
@@ -71,7 +82,7 @@ function buildScenarioEnemies(scenarioId) {
         mod: TIER_MOD[tier] || TIER_MOD.base,
         dc: TIER_DC[tier] || TIER_DC.base,
         attack_range: 1,
-        position: { x: pos[0], y: pos[1] },
+        position: { x: px, y: py },
         controlled_by: 'sistema',
         status: {},
       });
@@ -80,4 +91,4 @@ function buildScenarioEnemies(scenarioId) {
   return enemies.length ? enemies : null;
 }
 
-module.exports = { buildScenarioEnemies, TIER_HP, TIER_MOD, TIER_DC };
+module.exports = { buildScenarioEnemies, TIER_HP, TIER_MOD, TIER_DC, GRID_SAFE_MAX };

--- a/tools/sim/scenario-enemies.js
+++ b/tools/sim/scenario-enemies.js
@@ -1,0 +1,83 @@
+'use strict';
+// fase-2a scaled enemies. Loads a real encounter YAML and builds the wave-1 sistema
+// roster, so the full-loop combat is a genuine fight (not the weak-fixed always-win
+// placeholder) -- the precondition for any meaningful meta band metric (fase-2b).
+//
+// Ported from tests/smoke/ai-driven-sim.js:buildEnemiesFromYaml (itself a port of
+// tools/py/batch_calibrate_non_elim.py:encounter_to_units), extracted here as a pure,
+// testable module (ai-driven-sim is coop-coupled). Self-contained tier-stat table (the
+// encounter YAML species often lack hp/mod/dc -- this is exactly why the combat-sim uses
+// a tier table rather than deriveCombatStats for encounter enemies).
+//
+// Output is MAPPED to the runner's enemy shape (id/species/hp/max_hp/ap/mod/dc/
+// attack_range/position/controlled_by/status) -- the same shape the weak-fixed enemy and
+// the combat-adapter kill-wire /session/start path already consume. Returns null on any
+// load failure (missing file, malformed, unsupported objective) so the runner falls back
+// to the weak-fixed enemy and the loop still completes (cave_path has 4/8 encounters
+// without a YAML: tutorial_03/04/05 + tutorial_06_hardcore).
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const ENCOUNTER_DIR = path.resolve(__dirname, '..', '..', 'docs', 'planning', 'encounters');
+
+// Tier -> base combat stats (mirrors ai-driven-sim buildEnemiesFromYaml hp/mod table;
+// dc scales with tier so higher tiers are also harder to hit). Calibration of the exact
+// difficulty band is fase-2c (N=40), not this slice.
+const TIER_HP = { base: 7, elite: 10, apex: 14 };
+const TIER_MOD = { base: 1, elite: 2, apex: 4 };
+const TIER_DC = { base: 10, elite: 11, apex: 12 };
+
+// Objectives this loader can stage as a plain elimination-style fight. escort/capture
+// need extra unit materialization + policy support (deferred) -> null -> fallback.
+const SUPPORTED_OBJECTIVES = new Set(['elimination', 'survival']);
+
+function buildScenarioEnemies(scenarioId) {
+  const yamlPath = path.join(ENCOUNTER_DIR, `${scenarioId}.yaml`);
+  if (!fs.existsSync(yamlPath)) return null;
+
+  let parsed;
+  try {
+    parsed = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || !Array.isArray(parsed.waves) || parsed.waves.length === 0) return null;
+  const objectiveType = (parsed.objective && parsed.objective.type) || 'elimination';
+  if (!SUPPORTED_OBJECTIVES.has(objectiveType)) return null;
+
+  // Initial spawn = the wave with the smallest turn_trigger.
+  const wave1 = [...parsed.waves].sort((a, b) => (a.turn_trigger || 0) - (b.turn_trigger || 0))[0];
+  const spawnPoints =
+    Array.isArray(wave1.spawn_points) && wave1.spawn_points.length ? wave1.spawn_points : [[7, 3]];
+
+  const enemies = [];
+  let spIdx = 0;
+  for (const unitDef of wave1.units || []) {
+    const tier = unitDef.tier || 'base';
+    const count = unitDef.count || 1;
+    const species = unitDef.species || 'predoni_nomadi';
+    for (let i = 0; i < count; i += 1) {
+      const pos = spawnPoints[spIdx % spawnPoints.length];
+      spIdx += 1;
+      const hp = TIER_HP[tier] || TIER_HP.base;
+      enemies.push({
+        id: `sis_${scenarioId}_${enemies.length + 1}`,
+        species,
+        hp,
+        max_hp: hp,
+        ap: 2,
+        mod: TIER_MOD[tier] || TIER_MOD.base,
+        dc: TIER_DC[tier] || TIER_DC.base,
+        attack_range: 1,
+        position: { x: pos[0], y: pos[1] },
+        controlled_by: 'sistema',
+        status: {},
+      });
+    }
+  }
+  return enemies.length ? enemies : null;
+}
+
+module.exports = { buildScenarioEnemies, TIER_HP, TIER_MOD, TIER_DC };


### PR DESCRIPTION
## fase-2a scaled enemies + fase-2 goal plan

Two commits: the **fase-2 goal plan** (planning doc, the `/goal` reference for the balance phase) + **fase-2a scaled enemies** (the first build slice).

### fase-2 goal plan (`docs/planning/2026-06-02-full-loop-fase2-goal.md`)
Self-contained executable goal for the balance phase: 3 slices (2a scaled enemy -> 2b band-metriche + aggregator -> 2c N=40 + mbtiPolicy + GAP-C routing + ratify), the 5 meta band-metrics with source-cited provisional targets (spec #2559 §7), decided vs master-dd-gated items, and a resume trigger.

### fase-2a scaled enemies
The full-loop combat now loads the chapter's **real wave-1 enemy roster** from `docs/planning/encounters/<id>.yaml` (tier-scaled hp/mod/dc) instead of the weak-fixed always-win placeholder. Combat is now a real multi-round fight (probe: **12-16 rounds** vs ~1-2). This is the precondition for meaningful band metrics; difficulty/band **calibration is fase-2c** (not this slice).

- **`scenario-enemies.js`** (new) — `buildScenarioEnemies(scenarioId)` ported from `ai-driven-sim.buildEnemiesFromYaml` into a pure module, **mapped to the runner enemy shape**. Returns `null` on missing/malformed/unsupported-objective YAML.
- **`full-loop-runner.js`** — loads scaled enemies per chapter; **falls back to the weak-fixed enemy** when the YAML is absent (cave_path: `tutorial_03/04/05` + `tutorial_06_hardcore` = 4/8) so the loop still completes. Records `enemiesSource` + `rounds` per chapter.

### Verification
- `node --test tests/sim/*.test.js` -> **27/27**. e2e asserts BOTH `scenario` (covered chapters) and `fallback` (uncovered) run + loop completes; scenario-enemies unit covers shape/tiers/null. Verify-first probe confirmed scaled enemies load, positions on-grid, real engagement.
- prettier clean; governance `--strict` errors=0 (goal doc frontmatter).

### Scope / band safety
- **Band-safe**: zero engine change (only `tools/sim/` + `tests/sim/` + docs). Gate-5 = methodology-tooling.
- Honest scope: `enc_tutorial_01` is difficulty 1/5, so the AI still wins covered tutorial chapters; landing completion at 40-70% is fase-2c (harder encounter mix / realistic roster / N=40).

### Rollback (03A)
`git revert` the PR (squash). Pure tooling + planning doc, no engine/schema/data change.