### PR TITLE
feat(sim): full-loop band-metrics aggregator + batch runner (fase-2b)

### DIFF
--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -1,0 +1,195 @@
+'use strict';
+// fase-2b full-loop-batch: runs K full-loop sims (different seeds) in-process, aggregates
+// via meta-band-aggregator, and writes JSONL (one line per run) + summary.json + report.md
+// with per-run provenance (seed + commit + policy + scenario-chain + flags, spec §10 DoD).
+// Pure pieces are unit-tested with an injected runOne; one real in-process smoke (K=2)
+// proves the default path against createApp.
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  parseArgs,
+  buildProvenance,
+  buildSummary,
+  buildReport,
+  runBatch,
+  writeArtifacts,
+} = require('../../tools/sim/full-loop-batch');
+
+// Synthetic run-result (runFullLoop shape) for the pure-assembly tests.
+function synthRun(o = {}) {
+  return {
+    completed: o.completed ?? true,
+    chapters: o.chapters || [
+      { step: 1, encounter: 'enc_tutorial_01', outcome: 'victory', xpGranted: 12, mpEarned: 2 },
+      { step: 2, encounter: 'savana_01', outcome: 'victory', xpGranted: 12, mpEarned: 2 },
+    ],
+    violations: [],
+    finalRoster: o.finalRoster ?? ['a', 'b'],
+    recruited: o.recruited ?? ['r1'],
+    economyRecruited: ['e1'],
+    offspring: o.offspring ?? 1,
+    economyAffinityProven: true,
+    initialRosterSize: o.initialRosterSize ?? 2,
+    economy: o.economy || {
+      peEarnedTotal: 6,
+      xpGrantedTotal: 24,
+      mpEarnedTotal: 4,
+      piSpentTotal: 0,
+    },
+  };
+}
+
+test('parseArgs: defaults + flag overrides', () => {
+  const d = parseArgs(['node', 'full-loop-batch.js']);
+  assert.equal(d.runs, 5);
+  assert.equal(d.branch, 'cave_path');
+  assert.equal(d.policy, 'greedy');
+  const o = parseArgs([
+    'node',
+    'x',
+    '--runs',
+    '40',
+    '--branch',
+    'surface_path',
+    '--policy',
+    'mbti',
+    '--seed-base',
+    '500',
+  ]);
+  assert.equal(o.runs, 40);
+  assert.equal(o.branch, 'surface_path');
+  assert.equal(o.policy, 'mbti');
+  assert.equal(o.seedBase, 500);
+});
+
+test('buildProvenance: carries seed + commit + policy + scenario-chain + flags', () => {
+  const p = buildProvenance({
+    runId: 3,
+    seed: '1003',
+    commit: 'abc123',
+    policy: 'greedy',
+    branch: 'cave_path',
+    scenarioChain: ['enc_tutorial_01', 'savana_01'],
+    flags: { META_NETWORK_ROUTING: 'false' },
+  });
+  assert.equal(p.run_id, 3);
+  assert.equal(p.seed, '1003');
+  assert.equal(p.commit, 'abc123');
+  assert.equal(p.policy, 'greedy');
+  assert.equal(p.branch, 'cave_path');
+  assert.deepEqual(p.scenario_chain, ['enc_tutorial_01', 'savana_01']);
+  assert.deepEqual(p.flags, { META_NETWORK_ROUTING: 'false' });
+});
+
+test('runBatch: injected runOne -> N results, deterministic monotonic seeds + provenance', async () => {
+  const seen = [];
+  const fakeRunOne = async (runOpts) => {
+    seen.push(runOpts.seed);
+    return synthRun();
+  };
+  const results = await runBatch({
+    runs: 3,
+    seedBase: 1000,
+    runOne: fakeRunOne,
+    commit: 'c0',
+    policy: 'greedy',
+  });
+  assert.equal(results.length, 3);
+  assert.deepEqual(seen, ['1000', '1001', '1002']); // monotonic, deterministic
+  assert.equal(results[0].provenance.run_id, 0);
+  assert.equal(results[2].provenance.seed, '1002');
+  assert.equal(results[1].provenance.commit, 'c0');
+  // scenario_chain derived from the run's chapters.
+  assert.deepEqual(results[0].provenance.scenario_chain, ['enc_tutorial_01', 'savana_01']);
+});
+
+test('buildSummary: embeds the 5-metric aggregate over the batch', () => {
+  const results = [synthRun(), synthRun(), synthRun({ completed: false })];
+  const s = buildSummary(results, { runs: 3, policy: 'greedy' });
+  assert.equal(s.n, 3);
+  assert.equal(s.provisional, true);
+  assert.ok(s.metrics.completion_rate, 'completion_rate metric present');
+  assert.ok(s.metrics.offspring_viability, 'offspring_viability metric present');
+  assert.equal(s.completion.completed, 2);
+  assert.equal(s.completion.total, 3);
+});
+
+test('buildReport: markdown with the 5 metric rows + a PROVISIONAL WARN banner', () => {
+  const s = buildSummary([synthRun(), synthRun()], { runs: 2 });
+  const md = buildReport(s);
+  assert.match(md, /provisional|WARN|pending master-dd/i);
+  for (const k of [
+    'completion_rate',
+    'roster_attrition',
+    'economy_flow',
+    'relationship_progress',
+    'offspring_viability',
+  ]) {
+    assert.ok(md.includes(k), `report mentions ${k}`);
+  }
+});
+
+test('writeArtifacts: writes runs.jsonl (one line per run) + summary.json + report.md', () => {
+  const results = [synthRun(), synthRun()].map((r, i) => {
+    r.provenance = buildProvenance({
+      runId: i,
+      seed: String(1000 + i),
+      commit: 'c',
+      policy: 'greedy',
+      branch: 'cave_path',
+      scenarioChain: ['enc_tutorial_01', 'savana_01'],
+      flags: {},
+    });
+    return r;
+  });
+  const summary = buildSummary(results, { runs: 2 });
+  const report = buildReport(summary);
+  const outDir = path.join(os.tmpdir(), 'fl-batch-test-artifacts');
+  fs.rmSync(outDir, { recursive: true, force: true });
+  const paths = writeArtifacts(outDir, { results, summary, report });
+  // runs.jsonl: one parseable JSON object per line, N lines.
+  const jsonl = fs.readFileSync(paths.jsonlPath, 'utf8').split('\n').filter(Boolean);
+  assert.equal(jsonl.length, 2);
+  const first = JSON.parse(jsonl[0]);
+  assert.equal(first.run_id, 0);
+  assert.equal(first.completed, true);
+  assert.ok(first.economy, 'per-run economy in jsonl');
+  assert.ok(first.provenance.seed, 'per-run provenance in jsonl');
+  // summary.json parseable + has the aggregate.
+  const sum = JSON.parse(fs.readFileSync(paths.summaryPath, 'utf8'));
+  assert.equal(sum.n, 2);
+  assert.ok(sum.metrics.completion_rate);
+  // report.md exists.
+  assert.ok(fs.readFileSync(paths.reportPath, 'utf8').length > 0);
+  fs.rmSync(outDir, { recursive: true, force: true });
+});
+
+test('runBatch: real in-process smoke (K=2) -> real run-results aggregate (fase-2b)', async (t) => {
+  // Default runOne path: spin createApp per run, AI plays the whole loop, aggregate. Proves
+  // the batch wiring end-to-end on the real backend (slower than the pure tests).
+  const results = await runBatch({ runs: 2, seedBase: 7000, branch: 'cave_path', commit: 'smoke' });
+  assert.equal(results.length, 2);
+  for (const r of results) {
+    assert.equal(
+      r.completed,
+      true,
+      `real run completed; chapters=${JSON.stringify(r.chapters?.map((c) => c.outcome))}`,
+    );
+    assert.ok(r.economy.peEarnedTotal > 0, 'real PE earned');
+    assert.ok(
+      r.provenance.scenario_chain.length >= 5,
+      'scenario chain captured from real chapters',
+    );
+  }
+  const summary = buildSummary(results, { runs: 2, branch: 'cave_path' });
+  assert.equal(summary.n, 2);
+  // With the current weak/scaled enemies the AI never loses -> completion 1.0, OUT of the
+  // provisional 0.40-0.70 band. That OUT-of-band result is the POINT: the band correctly
+  // flags "too easy" until enemy scaling/calibration (fase-2c) brings it into range.
+  assert.equal(summary.metrics.completion_rate.value, 1);
+  assert.equal(summary.metrics.completion_rate.in_band, false);
+});

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -111,6 +111,20 @@ test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -
     `at least one earned-gate (no-bypass) recruit, got ${res.economyRecruited.length}`,
   );
   assert.ok(res.offspring >= 1, `at least one mating offspring rolled, got ${res.offspring}`);
+  // fase-2b economy telemetry: the runner aggregates the backend's REAL advance economy
+  // per run (PE earned per cleared chapter + backend-computed XP/MP grants). PI-spent is
+  // 0 because no shop/PI-sink is wired in the loop yet -- surfaced as a real gap, never
+  // invented. These feed meta-band-aggregator's economy_flow metric.
+  assert.equal(res.initialRosterSize, 2, 'initial authored roster size captured');
+  assert.ok(res.economy, 'economy telemetry present');
+  const clearedChapters = res.chapters.filter((c) => c.outcome === 'victory').length;
+  assert.equal(
+    res.economy.peEarnedTotal,
+    3 * clearedChapters,
+    `PE earned = peEarned(3) x cleared chapters(${clearedChapters})`,
+  );
+  assert.ok(res.economy.xpGrantedTotal > 0, 'XP granted accrued from real victories');
+  assert.equal(res.economy.piSpentTotal, 0, 'no PI sink wired in the loop yet');
   // fase-2a scaled enemies: covered cave_path chapters (enc_tutorial_01/02, savana_01,
   // caverna_02) load real wave-1 rosters from YAML; the uncovered ones (tutorial_03/04/05,
   // tutorial_06_hardcore) fall back to the weak-fixed enemy. Assert BOTH paths run -> the
@@ -262,4 +276,68 @@ test('runFullLoop: repeated runs on one app do not collide on courtship ids (Cod
     );
     assert.ok(r.offspring >= 1, `${label} offspring rolled, got ${r.offspring}`);
   }
+});
+
+test('runFullLoop: aggregates per-run economy telemetry from the backend advance (fase-2b)', async () => {
+  // Fake http with a controlled advance economy payload: a single victory chapter that
+  // COMPLETES the campaign (campaign_completed -> hasNextChapter false -> the meta-step
+  // is skipped), so the runner's economy aggregation is asserted EXACTLY against
+  // backend-shaped xp_grants (sum `amount`) + mp_grants (sum `earned`). No invention.
+  const http = {
+    post: async (path) => {
+      if (path === '/api/campaign/start') return { status: 201, body: { campaign: { id: 'c' } } };
+      if (path === '/api/session/start') return { status: 200, body: { session_id: 's' } };
+      if (path === '/api/campaign/advance')
+        return {
+          status: 200,
+          body: {
+            campaign_completed: true,
+            xp_grants: [
+              { unit_id: 'hero_a', amount: 12 },
+              { unit_id: 'hero_b', amount: 12 },
+            ],
+            mp_grants: [{ unit_id: 'hero_a', earned: 3 }],
+          },
+        };
+      return { status: 200, body: {} };
+    },
+    get: async (path) => {
+      if (path === '/api/session/state')
+        return {
+          status: 200,
+          body: {
+            units: [{ id: 'hero_a', controlled_by: 'player', hp: 30 }],
+            active_unit: 'hero_a',
+          },
+        };
+      if (path === '/api/campaign/summary')
+        return { status: 200, body: { current_encounter: { encounter_id: 'e1' } } };
+      return { status: 200, body: {} };
+    },
+  };
+  const res = await runFullLoop(http, {
+    playerId: 'p',
+    roster: [
+      {
+        id: 'hero_a',
+        max_hp: 30,
+        job: 'stalker',
+        position: { x: 1, y: 1 },
+        controlled_by: 'player',
+      },
+    ],
+    peEarned: 3,
+    maxChapters: 3,
+  });
+  assert.equal(res.completed, true);
+  assert.equal(res.initialRosterSize, 1, 'initial authored roster size captured');
+  assert.ok(res.economy, 'economy telemetry present');
+  assert.equal(res.economy.peEarnedTotal, 3, 'PE earned summed over cleared chapters (3 x 1)');
+  assert.equal(
+    res.economy.xpGrantedTotal,
+    24,
+    'XP granted summed from advance xp_grants (12 + 12)',
+  );
+  assert.equal(res.economy.mpEarnedTotal, 3, 'MP earned summed from advance mp_grants');
+  assert.equal(res.economy.piSpentTotal, 0, 'no PI sink wired in the loop yet (surfaced gap)');
 });

--- a/tests/sim/metaBandAggregator.test.js
+++ b/tests/sim/metaBandAggregator.test.js
@@ -1,0 +1,148 @@
+'use strict';
+// fase-2b meta-band-aggregator: pure aggregation of N full-loop run-results into the 5
+// meta band-metrics (spec §7) + placement vs the PROVISIONAL ranges. Tested on synthetic
+// run-results so each metric + in-band flag is asserted exactly; the real-run wiring is
+// covered by the fullLoopBatch integration test.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { aggregate, PROVISIONAL_BANDS } = require('../../tools/sim/meta-band-aggregator');
+
+// Minimal full-loop run-result shaped like runFullLoop's return, with only the fields the
+// aggregator reads. `chapters` carry per-chapter build-power (xpGranted + mpEarned).
+function synthRun(o = {}) {
+  const chapters = o.chapters || [
+    { outcome: 'victory', xpGranted: 12, mpEarned: 2 },
+    { outcome: 'victory', xpGranted: 12, mpEarned: 2 },
+    { outcome: 'victory', xpGranted: 12, mpEarned: 2 },
+  ];
+  return {
+    completed: o.completed ?? true,
+    chapters,
+    finalRoster: o.finalRoster ?? ['a', 'b'],
+    recruited: o.recruited ?? ['r1', 'r2'],
+    economyRecruited: o.economyRecruited ?? ['e1'],
+    offspring: o.offspring ?? 1,
+    economyAffinityProven: o.economyAffinityProven ?? true,
+    initialRosterSize: o.initialRosterSize ?? 4,
+    economy: o.economy || {
+      peEarnedTotal: 9,
+      xpGrantedTotal: 36,
+      mpEarnedTotal: 6,
+      piSpentTotal: 0,
+    },
+  };
+}
+
+test('aggregate: completion_rate = completed/N, in-band at 0.40-0.70', () => {
+  // 2 of 4 completed -> 0.50, inside the provisional 0.40-0.70 band.
+  const runs = [
+    synthRun(),
+    synthRun(),
+    synthRun({ completed: false }),
+    synthRun({ completed: false }),
+  ];
+  const r = aggregate(runs);
+  assert.equal(r.n, 4);
+  assert.equal(r.provisional, true);
+  assert.equal(r.metrics.completion_rate.value, 0.5);
+  assert.deepEqual(r.metrics.completion_rate.range, PROVISIONAL_BANDS.completion_rate);
+  assert.equal(r.metrics.completion_rate.in_band, true);
+});
+
+test('aggregate: completion_rate above band (all completed = too easy) flagged out', () => {
+  const runs = [synthRun(), synthRun(), synthRun()];
+  const r = aggregate(runs);
+  assert.equal(r.metrics.completion_rate.value, 1);
+  assert.equal(r.metrics.completion_rate.in_band, false);
+});
+
+test('aggregate: roster_attrition = survivors / units-that-fought, in (0,1)', () => {
+  // initial 4, 0 combat-recruits, 2 survivors -> 0.5 survivor ratio -> in band.
+  const lossy = synthRun({ initialRosterSize: 4, recruited: [], finalRoster: ['a', 'b'] });
+  const r = aggregate([lossy]);
+  assert.equal(r.metrics.roster_attrition.value, 0.5);
+  assert.equal(r.metrics.roster_attrition.in_band, true);
+});
+
+test('aggregate: roster_attrition = 1.0 (no losses) flagged out of band', () => {
+  // initial 2 + 2 combat-recruits = 4 fought, all 4 survive -> ratio 1.0 -> too easy.
+  const noLoss = synthRun({
+    initialRosterSize: 2,
+    recruited: ['r1', 'r2'],
+    finalRoster: ['a', 'b', 'r1', 'r2'],
+  });
+  const r = aggregate([noLoss]);
+  assert.equal(r.metrics.roster_attrition.value, 1);
+  assert.equal(r.metrics.roster_attrition.in_band, false);
+});
+
+test('aggregate: economy_flow build-power drift ~1.0 (flat) in band + pi_sink gap surfaced', () => {
+  const r = aggregate([synthRun(), synthRun()]);
+  const ef = r.metrics.economy_flow;
+  assert.equal(ef.pe_earned_avg, 9);
+  assert.equal(ef.build_power_avg, 42); // 36 xp + 6 mp
+  assert.equal(ef.build_power_drift, 1); // flat per-chapter build power
+  assert.equal(ef.pi_sink_exercised, false); // no PI sink wired in the loop yet
+  assert.equal(ef.in_band, true);
+});
+
+test('aggregate: economy_flow runaway build-power drift (>2x) flagged out', () => {
+  const creep = synthRun({
+    chapters: [
+      { outcome: 'victory', xpGranted: 10, mpEarned: 0 },
+      { outcome: 'victory', xpGranted: 20, mpEarned: 0 },
+      { outcome: 'victory', xpGranted: 30, mpEarned: 0 },
+    ],
+  });
+  const r = aggregate([creep]);
+  assert.equal(r.metrics.economy_flow.build_power_drift, 3); // 30 / 10
+  assert.equal(r.metrics.economy_flow.in_band, false);
+});
+
+test('aggregate: relationship_progress in band when recruit + earned-affinity + mating all fire', () => {
+  const r = aggregate([synthRun(), synthRun()]);
+  const rp = r.metrics.relationship_progress;
+  assert.equal(rp.recruit_rate, 2); // 2 combat-recruits per run
+  assert.equal(rp.affinity_proven_rate, 1); // every run proved the earned gate
+  assert.equal(rp.mating_rate, 1); // 1 offspring per run
+  assert.equal(rp.in_band, true);
+});
+
+test('aggregate: relationship_progress stalled (no recruit, no affinity) flagged out', () => {
+  const stalled = synthRun({
+    recruited: [],
+    economyRecruited: [],
+    economyAffinityProven: false,
+    offspring: 0,
+  });
+  const r = aggregate([stalled]);
+  assert.equal(r.metrics.relationship_progress.in_band, false);
+});
+
+test('aggregate: offspring_viability in band when offspring rolled (>=1 avg)', () => {
+  const r = aggregate([synthRun(), synthRun()]);
+  const ov = r.metrics.offspring_viability;
+  assert.equal(ov.offspring_avg, 1);
+  assert.equal(ov.in_band, true);
+});
+
+test('aggregate: offspring_viability out of band when no breeding happens', () => {
+  const r = aggregate([synthRun({ offspring: 0 }), synthRun({ offspring: 0 })]);
+  assert.equal(r.metrics.offspring_viability.offspring_avg, 0);
+  assert.equal(r.metrics.offspring_viability.in_band, false);
+});
+
+test('aggregate: empty input -> n=0, every metric out of band, never throws', () => {
+  const r = aggregate([]);
+  assert.equal(r.n, 0);
+  for (const k of Object.keys(r.metrics)) {
+    assert.equal(r.metrics[k].in_band, false, `${k} out of band on empty input`);
+  }
+});
+
+test('PROVISIONAL_BANDS: documents WARN provenance (Claude-derived, pending master-dd)', () => {
+  // The bands are provisional ranges, not ratified numbers (L-069: master-dd ratifies the
+  // exact band post-N=40). The module must say so to prevent a downstream reader treating
+  // them as canon.
+  assert.match(PROVISIONAL_BANDS.note || '', /WARN|provisional|pending master-dd/i);
+});

--- a/tests/sim/metaBandAggregator.test.js
+++ b/tests/sim/metaBandAggregator.test.js
@@ -86,6 +86,22 @@ test('aggregate: economy_flow build-power drift ~1.0 (flat) in band + pi_sink ga
   assert.equal(ef.in_band, true);
 });
 
+test('aggregate: economy_flow rejects no-signal runs (Codex #2568 P2)', () => {
+  // Failed runs with NO reward telemetry (empty chapters + zero economy) -> buildPowerDrift
+  // returns the neutral 1, which sits INSIDE the drift band. economy_flow must NOT certify a
+  // healthy economy from zero signal (a backend regression that stops emitting XP/MP/PE, or
+  // an all-failed batch, must read out-of-band, not falsely green).
+  const noSignal = synthRun({
+    completed: false,
+    chapters: [],
+    economy: { peEarnedTotal: 0, xpGrantedTotal: 0, mpEarnedTotal: 0, piSpentTotal: 0 },
+  });
+  const r = aggregate([noSignal, noSignal]);
+  assert.equal(r.metrics.economy_flow.build_power_avg, 0);
+  assert.equal(r.metrics.economy_flow.has_signal, false);
+  assert.equal(r.metrics.economy_flow.in_band, false, 'no economy signal cannot be in band');
+});
+
 test('aggregate: economy_flow runaway build-power drift (>2x) flagged out', () => {
   const creep = synthRun({
     chapters: [

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -1,0 +1,357 @@
+'use strict';
+// fase-2b full-loop-batch. Runs K full-loop AI-playtest sims (different seeds) IN-PROCESS
+// (createApp({databasePath:null}) + supertest -- the runner is in-process testable, unlike
+// the tunnel-based batch-ai-runner.js), aggregates them via meta-band-aggregator, and emits
+// JSONL (one line per run) + summary.json + report.md with per-run provenance (seed +
+// commit + policy + scenario-chain + flags, spec §10 DoD).
+//
+// Usage:
+//   node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy
+//   GIT_COMMIT=$(git rev-parse HEAD) META_NETWORK_ROUTING=true node tools/sim/full-loop-batch.js --runs 40
+//
+// The PROVISIONAL bands (meta-band-aggregator) are NOT ratified: master-dd ratifies the
+// exact numbers post-N=40 (L-069). This batch produces the PLACEMENT + report for that
+// human verdict; it never claims the bands as canon.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { runFullLoop } = require('./full-loop-runner');
+const { aggregate, PROVISIONAL_BANDS } = require('./meta-band-aggregator');
+
+// Canonical cave_path starter party (mirrors tests/sim/fullLoopRunner.test.js): a
+// dune_stalker + velox authored squad. The Nido recruits grow it as chapters clear.
+const DEFAULT_ROSTER = [
+  {
+    id: 'hero_a',
+    species: 'dune_stalker',
+    job: 'stalker',
+    hp: 30,
+    max_hp: 30,
+    ap: 3,
+    mod: 20,
+    attack_range: 2,
+    initiative: 18,
+    position: { x: 1, y: 1 },
+    controlled_by: 'player',
+    status: {},
+  },
+  {
+    id: 'hero_b',
+    species: 'velox',
+    job: 'stalker',
+    hp: 30,
+    max_hp: 30,
+    ap: 3,
+    mod: 18,
+    attack_range: 2,
+    initiative: 16,
+    position: { x: 1, y: 2 },
+    controlled_by: 'player',
+    status: {},
+  },
+];
+
+function parseArgs(argv) {
+  const args = {
+    runs: 5,
+    seedBase: 1000,
+    branch: 'cave_path',
+    policy: 'greedy',
+    maxChapters: 15,
+    out: '',
+    commit: process.env.GIT_COMMIT || 'unknown',
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const tok = argv[i];
+    const next = () => argv[(i += 1)];
+    switch (tok) {
+      case '--runs':
+        args.runs = Math.max(1, Number(next()));
+        break;
+      case '--seed-base':
+        args.seedBase = Number(next());
+        break;
+      case '--branch':
+        args.branch = next();
+        break;
+      case '--policy':
+        args.policy = next();
+        break;
+      case '--max-chapters':
+        args.maxChapters = Math.max(1, Number(next()));
+        break;
+      case '--out':
+        args.out = next();
+        break;
+      case '--commit':
+        args.commit = next();
+        break;
+      default:
+        if (tok && tok.startsWith('--')) console.warn(`unknown arg: ${tok}`);
+    }
+  }
+  return args;
+}
+
+// Per-run provenance (spec §10 DoD): everything needed to reproduce the run + know what
+// was active. flags captures the test-context env (e.g. META_NETWORK_ROUTING for fase-2c).
+function buildProvenance({ runId, seed, commit, policy, branch, scenarioChain, flags } = {}) {
+  return {
+    run_id: runId,
+    seed: String(seed),
+    commit: commit || 'unknown',
+    policy: policy || 'greedy',
+    branch: branch || null,
+    scenario_chain: scenarioChain || [],
+    flags: flags || {},
+  };
+}
+
+// Default real runner: a fresh in-process backend per run (isolated meta/campaign stores),
+// AI plays the whole loop, app closed after. Lazy-requires createApp + supertest so the
+// pure helpers above don't drag the backend in when only they are imported.
+async function runOneReal(runOpts) {
+  const { createApp } = require('../../apps/backend/app');
+  const request = require('supertest');
+  const { app, close } = createApp({ databasePath: null });
+  const http = {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+  try {
+    return await runFullLoop(http, runOpts);
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+// Run K sims with monotonic deterministic seeds. `runOne` is injectable (tests pass a fake;
+// CLI uses runOneReal). Attaches provenance to each result. Sequential: each run owns a
+// fresh app, so there is no shared-store contention.
+async function runBatch(opts = {}) {
+  const {
+    runs = 5,
+    seedBase = 1000,
+    branch = 'cave_path',
+    policy = 'greedy',
+    maxChapters = 15,
+    commit = process.env.GIT_COMMIT || 'unknown',
+    roster = DEFAULT_ROSTER,
+    playerPrefix = 'fl_batch',
+    flags = currentFlags(),
+    runOne = runOneReal,
+    onProgress,
+  } = opts;
+  const results = [];
+  for (let i = 0; i < runs; i += 1) {
+    const seed = String(seedBase + i);
+    const runOpts = {
+      playerId: `${playerPrefix}_${i}`,
+      roster,
+      branchKey: branch,
+      seed,
+      maxChapters,
+    };
+    const res = await runOne(runOpts);
+    const scenarioChain = (res.chapters || []).map((c) => c.encounter);
+    res.provenance = buildProvenance({
+      runId: i,
+      seed,
+      commit,
+      policy,
+      branch,
+      scenarioChain,
+      flags,
+    });
+    results.push(res);
+    if (typeof onProgress === 'function') onProgress(i + 1, runs, res);
+  }
+  return results;
+}
+
+// The fase-2c test-context flags the report should record alongside each run.
+function currentFlags() {
+  return { META_NETWORK_ROUTING: process.env.META_NETWORK_ROUTING || 'false' };
+}
+
+// Compact one run-result into a single JSONL line (per-run record).
+function runToJsonl(r) {
+  const chapters = r.chapters || [];
+  return {
+    run_id: r.provenance && r.provenance.run_id,
+    seed: r.provenance && r.provenance.seed,
+    completed: r.completed === true,
+    chapters: chapters.length,
+    outcome_chain: chapters.map((c) => c.outcome),
+    scenario_chain:
+      (r.provenance && r.provenance.scenario_chain) || chapters.map((c) => c.encounter),
+    initial_roster: r.initialRosterSize,
+    survivors: (r.finalRoster || []).length,
+    recruited: (r.recruited || []).length,
+    economy_recruited: (r.economyRecruited || []).length,
+    offspring: r.offspring,
+    economy: r.economy,
+    violations: r.violations || [],
+    meta_violations: r.metaViolations || [],
+    provenance: r.provenance,
+  };
+}
+
+function buildSummary(results, config = {}) {
+  const agg = aggregate(results);
+  return {
+    config,
+    n: agg.n,
+    provisional: agg.provisional,
+    metrics: agg.metrics,
+    completion: {
+      completed: (results || []).filter((r) => r && r.completed === true).length,
+      total: agg.n,
+    },
+  };
+}
+
+function band(metric) {
+  if (!metric) return '-';
+  if (!metric.range) return 'composite';
+  const [lo, hi] = metric.range;
+  if (hi === null || hi === undefined) return `>= ${lo}`;
+  return `${lo} - ${hi}`;
+}
+
+function metricValue(metric) {
+  if (!metric) return '-';
+  if (metric.value !== undefined) return metric.value;
+  if (metric.build_power_drift !== undefined)
+    return `drift ${metric.build_power_drift} (pe ${metric.pe_earned_avg}, bp ${metric.build_power_avg})`;
+  if (metric.recruit_rate !== undefined)
+    return `recruit ${metric.recruit_rate}, aff ${metric.affinity_proven_rate}, mate ${metric.mating_rate}`;
+  if (metric.offspring_avg !== undefined) return `offspring ${metric.offspring_avg}`;
+  return '-';
+}
+
+function buildReport(summary) {
+  const m = summary.metrics || {};
+  const lines = [];
+  lines.push('# Full-loop meta band-metrics');
+  lines.push('');
+  lines.push(
+    `Runs: **${summary.n}** | Completed: **${summary.completion.completed}/${summary.completion.total}** | Policy: \`${summary.config.policy || 'greedy'}\` | Branch: \`${summary.config.branch || 'cave_path'}\``,
+  );
+  lines.push('');
+  lines.push(`> **PROVISIONAL** -- ${PROVISIONAL_BANDS.note}`);
+  lines.push('');
+  lines.push('| Metric | Value | Provisional band | In band |');
+  lines.push('|---|---|---|:---:|');
+  for (const k of [
+    'completion_rate',
+    'roster_attrition',
+    'economy_flow',
+    'relationship_progress',
+    'offspring_viability',
+  ]) {
+    const metric = m[k];
+    lines.push(
+      `| ${k} | ${metricValue(metric)} | ${band(metric)} | ${metric && metric.in_band ? '✅' : '❌'} |`,
+    );
+  }
+  lines.push('');
+  if (m.economy_flow && m.economy_flow.pi_sink_exercised === false) {
+    lines.push(
+      '> Note: PI sink (shop/build spend) is NOT wired in the loop yet -> economy_flow measures earn + build-power drift only (real gap, surfaced not invented).',
+    );
+    lines.push('');
+  }
+  lines.push('Per-run records: `runs.jsonl`. Aggregate: `summary.json`.');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function writeArtifacts(outDir, { results, summary, report }) {
+  fs.mkdirSync(outDir, { recursive: true });
+  const jsonlPath = path.join(outDir, 'runs.jsonl');
+  const lines = (results || []).map((r) => JSON.stringify(runToJsonl(r)));
+  fs.writeFileSync(jsonlPath, lines.length ? lines.join('\n') + '\n' : '');
+  const summaryPath = path.join(outDir, 'summary.json');
+  fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+  const reportPath = path.join(outDir, 'report.md');
+  fs.writeFileSync(reportPath, report);
+  return { jsonlPath, summaryPath, reportPath };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const flags = currentFlags();
+  const outDir =
+    args.out ||
+    path.join(
+      os.tmpdir(),
+      'full-loop-band',
+      `batch-${new Date().toISOString().replace(/[:.]/g, '-')}`,
+    );
+  console.log(
+    `FULL-LOOP BATCH: ${args.runs} runs | branch=${args.branch} policy=${args.policy} seedBase=${args.seedBase} commit=${args.commit} flags=${JSON.stringify(flags)}`,
+  );
+  const t0 = Date.now();
+  const results = await runBatch({
+    ...args,
+    flags,
+    onProgress: (done, total, res) => {
+      const outcome = res.completed
+        ? 'completed'
+        : (res.chapters || []).slice(-1)[0]?.outcome || 'incomplete';
+      process.stdout.write(
+        `[${done}/${total}] ${outcome} chapters=${(res.chapters || []).length}\n`,
+      );
+    },
+  });
+  const summary = buildSummary(results, {
+    runs: args.runs,
+    branch: args.branch,
+    policy: args.policy,
+    commit: args.commit,
+    flags,
+  });
+  const report = buildReport(summary);
+  const paths = writeArtifacts(outDir, { results, summary, report });
+  const wallSec = ((Date.now() - t0) / 1000).toFixed(1);
+  console.log('\n=== BATCH COMPLETE ===');
+  console.log(`Wall: ${wallSec}s | Out: ${outDir}`);
+  console.log(`Completion: ${summary.completion.completed}/${summary.completion.total}`);
+  for (const k of Object.keys(summary.metrics)) {
+    const metric = summary.metrics[k];
+    console.log(`  ${k}: ${metricValue(metric)} band=${band(metric)} in_band=${metric.in_band}`);
+  }
+  console.log(`\nReport: ${paths.reportPath}`);
+  console.log(
+    'NOTE: bands are PROVISIONAL (Claude-derived) -- master-dd ratifies exact numbers post-N=40 (L-069).',
+  );
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('BATCH FAIL:', e);
+    process.exit(2);
+  });
+}
+
+module.exports = {
+  parseArgs,
+  buildProvenance,
+  runBatch,
+  runOneReal,
+  buildSummary,
+  buildReport,
+  writeArtifacts,
+  runToJsonl,
+  DEFAULT_ROSTER,
+};

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -88,6 +88,14 @@ function enemiesForChapter(step) {
   ];
 }
 
+// fase-2b: sum a backend grants array by a numeric field (advance `xp_grants` -> `amount`,
+// `mp_grants` -> `earned`). Tolerates a missing/empty array (non-victory advances grant
+// nothing) so the economy accrual never invents a value.
+function sumGrants(arr, field) {
+  if (!Array.isArray(arr)) return 0;
+  return arr.reduce((s, g) => s + (Number(g && g[field]) || 0), 0);
+}
+
 async function runFullLoop(http, opts = {}) {
   const { playerId, branchKey = 'cave_path', seed, peEarned = 3, maxChapters = 15 } = opts;
   // Roster GROWS as the Nido recruits: it starts as the authored party and gains a
@@ -96,6 +104,9 @@ async function runFullLoop(http, opts = {}) {
   // invariant (starters U recruited-so-far).
   const roster = [...(opts.roster || [])];
   const knownIds = roster.map((u) => u.id);
+  // fase-2b: the AUTHORED starting party size (before any recruit grows the roster) is
+  // the denominator for roster_attrition (survivors / initial-roster over the arc).
+  const initialRosterSize = roster.length;
 
   const startRes = await driver.start(http, { playerId });
   if (startRes.status !== 201) {
@@ -106,6 +117,8 @@ async function runFullLoop(http, opts = {}) {
       finalRoster: [],
       recruited: [],
       metaViolations: [],
+      initialRosterSize,
+      economy: { peEarnedTotal: 0, xpGrantedTotal: 0, mpEarnedTotal: 0, piSpentTotal: 0 },
     };
   }
   const id = startRes.body.campaign.id;
@@ -121,6 +134,15 @@ async function runFullLoop(http, opts = {}) {
   let offspring = 0;
   let economyAffinityProven = false;
   let completed = false;
+  // fase-2b economy telemetry (read from the REAL advance response, never invented):
+  //   peEarnedTotal  -- PE rewarded per cleared (victory) chapter (campaign-XP currency);
+  //   xpGrantedTotal -- backend-granted survivor XP (advance.xp_grants[].amount);
+  //   mpEarnedTotal  -- backend-granted mutation points (advance.mp_grants[].earned);
+  //   piSpentTotal   -- PI sink (shop/build spend) is NOT wired in the loop yet -> 0
+  //                     (a real surfaced gap for economy_flow, not a fabricated number).
+  let peEarnedTotal = 0;
+  let xpGrantedTotal = 0;
+  let mpEarnedTotal = 0;
 
   for (let step = 1; step <= maxChapters; step += 1) {
     const sum = await driver.summary(http, id);
@@ -159,6 +181,14 @@ async function runFullLoop(http, opts = {}) {
       sourceRosterIds: knownIds,
     });
     if (v.length) violations.push({ step, v });
+    // Accrue per-chapter economy from the real advance payload. PE is the victory reward
+    // (gated on outcome); XP/MP grants are only emitted on victory, so the sums are 0 on
+    // defeat/timeout without a special case.
+    const xpGranted = sumGrants(adv.body && adv.body.xp_grants, 'amount');
+    const mpEarned = sumGrants(adv.body && adv.body.mp_grants, 'earned');
+    if (combat.outcome === 'victory') peEarnedTotal += peEarned;
+    xpGrantedTotal += xpGranted;
+    mpEarnedTotal += mpEarned;
     chapters.push({
       step,
       encounter: enc,
@@ -167,6 +197,8 @@ async function runFullLoop(http, opts = {}) {
       rosterIds: combat.rosterIds,
       enemiesSource,
       rounds: combat.rounds,
+      xpGranted,
+      mpEarned,
     });
 
     // Nido meta-step on a TRULY cleared chapter (Codex #2563 P2: gated on a 200 advance,
@@ -216,7 +248,9 @@ async function runFullLoop(http, opts = {}) {
     economyRecruited,
     offspring,
     economyAffinityProven,
+    initialRosterSize,
+    economy: { peEarnedTotal, xpGrantedTotal, mpEarnedTotal, piSpentTotal: 0 },
   };
 }
 
-module.exports = { runFullLoop, enemiesForChapter };
+module.exports = { runFullLoop, enemiesForChapter, sumGrants };

--- a/tools/sim/meta-band-aggregator.js
+++ b/tools/sim/meta-band-aggregator.js
@@ -105,16 +105,24 @@ function aggregate(runs) {
     (r) => (Number(r && r.economy && r.economy.piSpentTotal) || 0) > 0,
   );
   const [eLo, eHi] = PROVISIONAL_BANDS.economy_flow;
+  // Codex #2568 P2: build-power drift defaults to the neutral 1 when there is nothing to
+  // measure (empty chapters / zero grants), which sits INSIDE the band. Guard on a real
+  // signal so a no-reward batch (backend regression that stops emitting XP/MP/PE, or an
+  // all-failed batch) reads out-of-band instead of falsely certifying a healthy economy.
+  const hasSignal = buildPowerAvg > 0;
   const economy_flow = {
     pe_earned_avg: peEarnedAvg,
     build_power_avg: buildPowerAvg,
     build_power_drift: driftAvg,
     pi_sink_exercised: piSinkExercised,
+    has_signal: hasSignal,
     range: PROVISIONAL_BANDS.economy_flow,
-    in_band: n > 0 && driftAvg >= eLo && driftAvg <= eHi,
-    note: piSinkExercised
-      ? 'PE earned + build-power drift; PI sink exercised'
-      : 'PE earned + build-power drift; PI SINK NOT WIRED in the loop yet (real gap, not invented)',
+    in_band: n > 0 && hasSignal && driftAvg >= eLo && driftAvg <= eHi,
+    note: !hasSignal
+      ? 'NO economy signal across the batch (zero XP/MP/PE) -> cannot certify economy_flow'
+      : piSinkExercised
+        ? 'PE earned + build-power drift; PI sink exercised'
+        : 'PE earned + build-power drift; PI SINK NOT WIRED in the loop yet (real gap, not invented)',
   };
 
   // 4. relationship_progress: recruit rate + earned-affinity proof + mating, all firing =

--- a/tools/sim/meta-band-aggregator.js
+++ b/tools/sim/meta-band-aggregator.js
@@ -1,0 +1,161 @@
+'use strict';
+// fase-2b meta-band-aggregator. PURE: given a list of full-loop run-results (runFullLoop
+// output), computes the 5 meta band-metrics (spec §7) and places each vs a PROVISIONAL
+// range. No I/O, no clock, no randomness -> deterministic + unit-testable.
+//
+// The ranges below are PROVISIONAL (Claude-derived from the cited industry sources in the
+// goal doc / spec §7). They are NOT ratified: master-dd ratifies the EXACT band numbers
+// post-N=40, exactly like the combat bands (L-069). The aggregator's job is the PROCESS
+// (compute + place), not to assert canon. An anti-pattern guard (spec §7): these bands keep
+// the design SPACE healthy (Quality-Diversity) -- do NOT optimize to a single best run.
+
+const PROVISIONAL_BANDS = {
+  // % campaigns completed over N runs. XCOM Long War 2: completable-but-hard.
+  completion_rate: [0.4, 0.7],
+  // survivors / units-that-fought over the arc. Exclusive (>0 & <100%): real losses, no
+  // wipe, not a cake-walk. XCOM-LW2 attrition + AI War scaling.
+  roster_attrition: [0, 1],
+  // build-power drift = (build power per chapter, last third) / (first third). Bounded:
+  // neither runaway power-creep (>2x) nor collapse (<0.5x). Machinations / Hades-StS curve.
+  economy_flow: [0.5, 2.0],
+  // composite (recruit happens + earned-affinity gate fires + mating fires) -> monotonic,
+  // non-stall. wesnoth recruit/retain + SoT 27-MATING_NIDO. No single [lo,hi].
+  relationship_progress: null,
+  // mean offspring per run >= threshold (breeding is exercised). Niche + Spore. >=1.
+  offspring_viability: [1, null],
+  note:
+    'WARN: Claude-derived PROVISIONAL ranges (spec §7) -- pending master-dd ratify post-N=40 ' +
+    '(L-069). NOT canon. Keep the design space healthy (Quality-Diversity); do not optimize ' +
+    'to a single best run.',
+};
+
+function mean(arr) {
+  if (!arr || arr.length === 0) return 0;
+  return arr.reduce((s, x) => s + (Number(x) || 0), 0) / arr.length;
+}
+
+// Build-power drift across one run's chapters: ratio of mean build power per chapter in the
+// last third vs the first third. 1.0 = flat (healthy). Returns 1 when there is too little
+// signal to measure (a single chapter can't drift).
+function buildPowerDrift(chapters) {
+  const bp = (chapters || []).map(
+    (c) => (Number(c && c.xpGranted) || 0) + (Number(c && c.mpEarned) || 0),
+  );
+  if (bp.length < 2) return 1;
+  const third = Math.max(1, Math.floor(bp.length / 3));
+  const firstAvg = mean(bp.slice(0, third));
+  const lastAvg = mean(bp.slice(-third));
+  if (firstAvg === 0) return lastAvg === 0 ? 1 : Infinity;
+  return lastAvg / firstAvg;
+}
+
+function round(x, dp = 3) {
+  if (!Number.isFinite(x)) return x;
+  const f = 10 ** dp;
+  return Math.round(x * f) / f;
+}
+
+// Aggregate N run-results into the 5 band-metrics + placement. Tolerates [] (n=0 -> every
+// metric out of band) and missing fields (treated as 0/empty), never throws.
+function aggregate(runs) {
+  const list = Array.isArray(runs) ? runs : [];
+  const n = list.length;
+
+  // 1. completion_rate
+  const completed = list.filter((r) => r && r.completed === true).length;
+  const completionValue = n === 0 ? 0 : round(completed / n);
+  const [cLo, cHi] = PROVISIONAL_BANDS.completion_rate;
+  const completion_rate = {
+    value: completionValue,
+    range: PROVISIONAL_BANDS.completion_rate,
+    in_band: n > 0 && completionValue >= cLo && completionValue <= cHi,
+    note: 'completed campaigns / N',
+  };
+
+  // 2. roster_attrition = survivors / units-that-fought (initial party + combat-recruits;
+  // economy-recruits do not fight). In (0,1) exclusive.
+  const survivorRatios = list.map((r) => {
+    const fought = (Number(r && r.initialRosterSize) || 0) + ((r && r.recruited) || []).length;
+    const survivors = ((r && r.finalRoster) || []).length;
+    return fought === 0 ? 0 : survivors / fought;
+  });
+  const attritionValue = n === 0 ? 0 : round(mean(survivorRatios));
+  const roster_attrition = {
+    value: attritionValue,
+    range: PROVISIONAL_BANDS.roster_attrition,
+    in_band: n > 0 && attritionValue > 0 && attritionValue < 1,
+    note: 'survivors / units-that-fought (exclusive: real losses, no wipe)',
+  };
+
+  // 3. economy_flow: PE earned + build power (XP + MP) + drift; PI sink surfaced.
+  const peEarnedAvg = round(
+    mean(list.map((r) => Number(r && r.economy && r.economy.peEarnedTotal) || 0)),
+  );
+  const buildPowerAvg = round(
+    mean(
+      list.map(
+        (r) =>
+          (Number(r && r.economy && r.economy.xpGrantedTotal) || 0) +
+          (Number(r && r.economy && r.economy.mpEarnedTotal) || 0),
+      ),
+    ),
+  );
+  const driftAvg = n === 0 ? 1 : round(mean(list.map((r) => buildPowerDrift(r && r.chapters))));
+  const piSinkExercised = list.some(
+    (r) => (Number(r && r.economy && r.economy.piSpentTotal) || 0) > 0,
+  );
+  const [eLo, eHi] = PROVISIONAL_BANDS.economy_flow;
+  const economy_flow = {
+    pe_earned_avg: peEarnedAvg,
+    build_power_avg: buildPowerAvg,
+    build_power_drift: driftAvg,
+    pi_sink_exercised: piSinkExercised,
+    range: PROVISIONAL_BANDS.economy_flow,
+    in_band: n > 0 && driftAvg >= eLo && driftAvg <= eHi,
+    note: piSinkExercised
+      ? 'PE earned + build-power drift; PI sink exercised'
+      : 'PE earned + build-power drift; PI SINK NOT WIRED in the loop yet (real gap, not invented)',
+  };
+
+  // 4. relationship_progress: recruit rate + earned-affinity proof + mating, all firing =
+  // monotonic, non-stall.
+  const recruitRate = round(mean(list.map((r) => ((r && r.recruited) || []).length)));
+  const affinityProvenRate =
+    n === 0 ? 0 : round(list.filter((r) => r && r.economyAffinityProven === true).length / n);
+  const matingRate = round(mean(list.map((r) => Number(r && r.offspring) || 0)));
+  const relationship_progress = {
+    recruit_rate: recruitRate,
+    affinity_proven_rate: affinityProvenRate,
+    mating_rate: matingRate,
+    range: null,
+    in_band: n > 0 && recruitRate > 0 && affinityProvenRate >= 0.9 && matingRate > 0,
+    note: 'recruit + earned-affinity gate + mating all fire (monotonic, non-stall)',
+  };
+
+  // 5. offspring_viability: mean offspring per run >= threshold. Lineage diversity is NOT
+  // tracked yet (offspring species not captured by the runner -> deferred), surfaced honestly.
+  const offspringAvg = round(mean(list.map((r) => Number(r && r.offspring) || 0)));
+  const [oLo] = PROVISIONAL_BANDS.offspring_viability;
+  const offspring_viability = {
+    offspring_avg: offspringAvg,
+    viable_rate: 1, // the runner only counts mating rolls that returned a viable offspring
+    lineage_diversity: null, // deferred: offspring species/lineage not captured by the runner
+    range: PROVISIONAL_BANDS.offspring_viability,
+    in_band: n > 0 && offspringAvg >= oLo,
+    note: 'mean offspring per run >= threshold; lineage diversity not tracked yet (deferred)',
+  };
+
+  return {
+    n,
+    provisional: true,
+    metrics: {
+      completion_rate,
+      roster_attrition,
+      economy_flow,
+      relationship_progress,
+      offspring_viability,
+    },
+  };
+}
+
+module.exports = { aggregate, buildPowerDrift, mean, PROVISIONAL_BANDS };


### PR DESCRIPTION
## fase-2b — full-loop band-metrics aggregator + batch runner

Continues the full-loop AI-playtest runner ([goal doc](docs/planning/2026-06-02-full-loop-fase2-goal.md), spec §7). fase-1b made the AI play the whole meta-loop (campaign → real combat → recruit → Nido economy + breeding); **fase-2b measures that loop's health** with the 5 meta band-metrics over N seeded runs.

### What
- **`full-loop-runner.js`** — enrich the per-run return with economy telemetry read from the **real** advance response: `economy.{peEarnedTotal, xpGrantedTotal, mpEarnedTotal, piSpentTotal}` + `initialRosterSize` + per-chapter `xpGranted/mpEarned`. `piSpentTotal` is `0` because **no PI sink is wired in the loop yet** — surfaced as a real gap, never invented.
- **`meta-band-aggregator.js`** (new, pure) — aggregates N run-results into the 5 metrics (`completion_rate`, `roster_attrition`, `economy_flow`, `relationship_progress`, `offspring_viability`) + placement vs **PROVISIONAL** ranges.
- **`full-loop-batch.js`** (new) — in-process K-seed batch (`createApp` + supertest; the runner is in-process testable, unlike the tunnel-based `batch-ai-runner.js`) → `runs.jsonl` (one line per run) + `summary.json` + `report.md` with per-run provenance (seed, commit, policy, scenario-chain, flags).

### Real K=4 smoke (band placement)
| Metric | Value | Provisional band | In band |
|---|---|---|:---:|
| completion_rate | 1.0 | 0.4–0.7 | ❌ |
| roster_attrition | 0.333 | (0,1) | ✅ |
| economy_flow | drift 1.25 | 0.5–2.0 | ✅ |
| relationship_progress | recruit 7, aff 1, mate 6 | composite | ✅ |
| offspring_viability | 6 | ≥1 | ✅ |

`completion_rate = 1.0` is **OUT of band** — the band correctly flags "too easy"; bringing it into range is calibration (fase-2c). That out-of-band signal is the *point* of fase-2.

### Gated (master-dd, NOT in this PR)
The PROVISIONAL ranges are Claude-derived (cited sources), **not canon**. master-dd ratifies the **exact** band numbers post-N=40 (L-069). This PR ships the *process* (compute + place + report), not the verdict.

### Safety
- **band-safe**: `tools/sim/` + `tests/sim/` only, **zero engine change**, no forbidden paths, no new deps.
- TDD red→green throughout. `tests/sim` **47/47**, AI **500/500**.
- **Rollback**: revert this PR — pure additive tooling, nothing downstream depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
