### PR TITLE
feat(sim): pluggable meta-policy + mbtiPolicy for full-loop (fase-2c)

### DIFF
--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -206,6 +206,8 @@ test('resolvePolicy: string -> policy object + label (greedy / mbti / mbti:TYPE)
   assert.equal(mDefault.policy.mbti, 'INTJ'); // default archetype
   const bad = resolvePolicy('nonsense');
   assert.equal(bad.label, 'greedy'); // graceful fallback
+  const badMbti = resolvePolicy('mbti:XXXX');
+  assert.equal(badMbti.label, 'mbti:INTJ', 'invalid mbti type normalized to the played archetype');
 });
 
 test('runBatch: --policy mbti:ESFP INJECTS the temperament policy + labels provenance (fase-2c)', async () => {

--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -17,6 +17,7 @@ const {
   buildReport,
   runBatch,
   writeArtifacts,
+  resolvePolicy,
 } = require('../../tools/sim/full-loop-batch');
 
 // Synthetic run-result (runFullLoop shape) for the pure-assembly tests.
@@ -192,4 +193,39 @@ test('runBatch: real in-process smoke (K=2) -> real run-results aggregate (fase-
   // flags "too easy" until enemy scaling/calibration (fase-2c) brings it into range.
   assert.equal(summary.metrics.completion_rate.value, 1);
   assert.equal(summary.metrics.completion_rate.in_band, false);
+});
+
+test('resolvePolicy: string -> policy object + label (greedy / mbti / mbti:TYPE)', () => {
+  const g = resolvePolicy('greedy');
+  assert.equal(typeof g.policy.chooseRecruits, 'function');
+  assert.equal(g.label, 'greedy');
+  const m = resolvePolicy('mbti:ESFP');
+  assert.equal(m.policy.mbti, 'ESFP');
+  assert.equal(m.label, 'mbti:ESFP');
+  const mDefault = resolvePolicy('mbti');
+  assert.equal(mDefault.policy.mbti, 'INTJ'); // default archetype
+  const bad = resolvePolicy('nonsense');
+  assert.equal(bad.label, 'greedy'); // graceful fallback
+});
+
+test('runBatch: --policy mbti:ESFP INJECTS the temperament policy + labels provenance (fase-2c)', async () => {
+  const seen = [];
+  const fakeRunOne = async (runOpts) => {
+    seen.push(runOpts.policy);
+    return synthRun();
+  };
+  const results = await runBatch({ runs: 1, policy: 'mbti:ESFP', runOne: fakeRunOne });
+  assert.equal(seen[0].mbti, 'ESFP', 'the mbti policy object reaches runFullLoop');
+  assert.equal(results[0].provenance.policy, 'mbti:ESFP', 'provenance records the policy label');
+});
+
+test('runBatch: --policy greedy injects the greedy policy object', async () => {
+  const seen = [];
+  const fakeRunOne = async (runOpts) => {
+    seen.push(runOpts.policy);
+    return synthRun();
+  };
+  const results = await runBatch({ runs: 1, policy: 'greedy', runOne: fakeRunOne });
+  assert.equal(typeof seen[0].chooseRecruits, 'function', 'greedy policy object injected');
+  assert.equal(results[0].provenance.policy, 'greedy');
 });

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const request = require('supertest');
 const { createApp } = require('../../apps/backend/app');
 const { runFullLoop } = require('../../tools/sim/full-loop-runner');
+const { makeMbtiPolicy } = require('../../tools/sim/mbti-policy');
 
 function supertestHttp(app) {
   return {
@@ -340,4 +341,149 @@ test('runFullLoop: aggregates per-run economy telemetry from the backend advance
   );
   assert.equal(res.economy.mpEarnedTotal, 3, 'MP earned summed from advance mp_grants');
   assert.equal(res.economy.piSpentTotal, 0, 'no PI sink wired in the loop yet (surfaced gap)');
+});
+
+test('runFullLoop: drives the INJECTED opts.policy for the meta-step (fase-2c pluggable)', async () => {
+  // A 2-chapter fake: chapter 1 victory (not completed) -> the Nido meta-step fires and MUST
+  // use opts.policy (not the hardcoded greedy). Chapter 2 completes. A spy policy records its
+  // calls; the spy's recruit id surfacing in res.recruited proves the runner used it.
+  const calls = { recruits: 0, courtship: 0, mating: 0 };
+  const spyPolicy = {
+    chooseRecruits({ step }) {
+      calls.recruits += 1;
+      return [{ npcId: `spy_r${step}`, speciesId: 'dune-stalker' }];
+    },
+    chooseCourtship({ step, runId }) {
+      calls.courtship += 1;
+      return {
+        npcId: `spy_c_${runId}_${step}`,
+        speciesId: 'dune-stalker',
+        affinityDelta: 1,
+        trustDelta: 2,
+      };
+    },
+    chooseMating({ step }) {
+      calls.mating += 1;
+      return null;
+    },
+  };
+  let chapter = 0;
+  const http = {
+    post: async (path) => {
+      if (path === '/api/campaign/start') return { status: 201, body: { campaign: { id: 'c' } } };
+      if (path === '/api/session/start') return { status: 200, body: { session_id: 's' } };
+      if (path === '/api/campaign/advance') {
+        chapter += 1;
+        return { status: 200, body: { campaign_completed: chapter >= 2 } };
+      }
+      if (path === '/api/meta/recruit')
+        return { status: 200, body: { success: true, npc: { recruited: true } } };
+      if (path === '/api/meta/trust') return { status: 200, body: { can_recruit: true } };
+      return { status: 200, body: {} };
+    },
+    get: async (path) => {
+      if (path === '/api/session/state')
+        return {
+          status: 200,
+          body: {
+            units: [{ id: 'hero_a', controlled_by: 'player', hp: 30 }],
+            active_unit: 'hero_a',
+          },
+        };
+      if (path === '/api/campaign/summary')
+        return { status: 200, body: { current_encounter: { encounter_id: 'e1' } } };
+      return { status: 200, body: {} };
+    },
+  };
+  const res = await runFullLoop(http, {
+    playerId: 'p',
+    roster: [
+      {
+        id: 'hero_a',
+        max_hp: 30,
+        job: 'stalker',
+        position: { x: 1, y: 1 },
+        controlled_by: 'player',
+      },
+    ],
+    policy: spyPolicy,
+    maxChapters: 3,
+  });
+  assert.equal(res.completed, true);
+  assert.ok(calls.recruits >= 1, 'injected policy.chooseRecruits used');
+  assert.ok(calls.courtship >= 1, 'injected policy.chooseCourtship used');
+  assert.ok(
+    res.recruited.includes('spy_r1'),
+    `recruited via the injected policy, not greedy; got ${JSON.stringify(res.recruited)}`,
+  );
+});
+
+test('runFullLoop: a mbtiPolicy plays the real cave_path campaign end-to-end (fase-2c)', async (t) => {
+  // The temperament-guided policy must satisfy the same runner contract as greedy: complete
+  // the campaign, recruit via the Nido seam, prove the earned-affinity gate. This is what the
+  // N=40 band-batch will run for each MBTI archetype to test P4 in the meta-loop.
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+  const res = await runFullLoop(http, {
+    playerId: 'fl_mbti_esfp',
+    roster: [
+      {
+        id: 'hero_a',
+        species: 'dune_stalker',
+        job: 'stalker',
+        hp: 30,
+        max_hp: 30,
+        ap: 3,
+        mod: 20,
+        attack_range: 2,
+        initiative: 18,
+        position: { x: 1, y: 1 },
+        controlled_by: 'player',
+        status: {},
+      },
+      {
+        id: 'hero_b',
+        species: 'velox',
+        job: 'stalker',
+        hp: 30,
+        max_hp: 30,
+        ap: 3,
+        mod: 18,
+        attack_range: 2,
+        initiative: 16,
+        position: { x: 1, y: 2 },
+        controlled_by: 'player',
+        status: {},
+      },
+    ],
+    branchKey: 'cave_path',
+    seed: 'fl2c-esfp',
+    policy: makeMbtiPolicy('ESFP'),
+    maxChapters: 15,
+  });
+  assert.equal(res.completed, true, `mbti campaign completed; chapters=${res.chapters.length}`);
+  assert.deepEqual(
+    res.violations,
+    [],
+    `no invariant violations: ${JSON.stringify(res.violations)}`,
+  );
+  assert.ok(
+    res.recruited.length >= 5,
+    `mbti policy recruited across chapters, got ${res.recruited.length}`,
+  );
+  assert.equal(res.economyAffinityProven, true, 'earned-affinity gate fired under the mbti policy');
 });

--- a/tests/sim/mbtiPolicy.test.js
+++ b/tests/sim/mbtiPolicy.test.js
@@ -70,3 +70,13 @@ test('mbtiPolicy: unknown/garbage mbti defaults gracefully (no throw, canonical 
   const pick = p.chooseRecruits({ step: 1 })[0];
   assert.ok(RECRUIT_SPECIES_POOL.includes(pick.speciesId));
 });
+
+test('mbtiPolicy: invalid MBTI normalizes the recorded label (Codex #2569 P2)', () => {
+  // A mistyped type already falls back to the NT ordering, but it must NOT be recorded as a
+  // fake archetype: the .mbti label has to reflect the type actually PLAYED (INTJ default),
+  // so provenance/reports never show a nonexistent 'XXXX' archetype.
+  assert.equal(makeMbtiPolicy('XXXX').mbti, 'INTJ', 'garbage 4-char normalized');
+  assert.equal(makeMbtiPolicy('xyz').mbti, 'INTJ', 'malformed normalized');
+  assert.equal(makeMbtiPolicy('ESFP').mbti, 'ESFP', 'valid type preserved');
+  assert.equal(makeMbtiPolicy('esfp').mbti, 'ESFP', 'valid type case-normalized');
+});

--- a/tests/sim/mbtiPolicy.test.js
+++ b/tests/sim/mbtiPolicy.test.js
@@ -1,0 +1,72 @@
+'use strict';
+// fase-2c mbtiPolicy: a pluggable meta-policy whose Nido choices are guided by MBTI
+// temperament (Keirsey group -> role_class ordering of the canonical recruit pool), so the
+// full-loop band-batch can measure whether temperament moves the meta-loop (tests P4). Same
+// contract as greedy-policy; the divergence is WHICH species each temperament prioritises.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { makeMbtiPolicy, temperamentOf } = require('../../tools/sim/mbti-policy');
+const { RECRUIT_SPECIES_POOL } = require('../../tools/sim/greedy-policy');
+
+test('makeMbtiPolicy: returns the policy contract (3 methods + mbti tag)', () => {
+  const p = makeMbtiPolicy('INTJ');
+  assert.equal(p.mbti, 'INTJ');
+  assert.equal(typeof p.chooseRecruits, 'function');
+  assert.equal(typeof p.chooseCourtship, 'function');
+  assert.equal(typeof p.chooseMating, 'function');
+});
+
+test('temperamentOf: maps the 4 Keirsey groups', () => {
+  assert.equal(temperamentOf('INTJ'), 'NT'); // Analyst
+  assert.equal(temperamentOf('ENFP'), 'NF'); // Diplomat
+  assert.equal(temperamentOf('ISTJ'), 'SJ'); // Sentinel
+  assert.equal(temperamentOf('ESFP'), 'SP'); // Explorer
+});
+
+test('mbtiPolicy: different temperaments recruit different species at the same step (P4)', () => {
+  const intj = makeMbtiPolicy('INTJ'); // NT -> power-first (APEX)
+  const esfp = makeMbtiPolicy('ESFP'); // SP -> opportunistic (HAZARD)
+  const a = intj.chooseRecruits({ step: 1 })[0].speciesId;
+  const b = esfp.chooseRecruits({ step: 1 })[0].speciesId;
+  assert.notEqual(a, b, 'temperaments diverge on the first recruit');
+  // both still draw from the canonical pool (no invented species).
+  assert.ok(RECRUIT_SPECIES_POOL.includes(a), `${a} in canonical pool`);
+  assert.ok(RECRUIT_SPECIES_POOL.includes(b), `${b} in canonical pool`);
+});
+
+test('mbtiPolicy: same temperament group -> identical ordering (deterministic)', () => {
+  const intj = makeMbtiPolicy('INTJ');
+  const entj = makeMbtiPolicy('ENTJ'); // also NT
+  assert.equal(
+    intj.chooseRecruits({ step: 1 })[0].speciesId,
+    entj.chooseRecruits({ step: 1 })[0].speciesId,
+  );
+  assert.equal(
+    intj.chooseRecruits({ step: 3 })[0].speciesId,
+    entj.chooseRecruits({ step: 3 })[0].speciesId,
+  );
+});
+
+test('mbtiPolicy: chooseCourtship keeps the canonical recruit gate satisfiable + run-scoped', () => {
+  for (const t of ['INTJ', 'ENFP', 'ISTJ', 'ESFP']) {
+    const c = makeMbtiPolicy(t).chooseCourtship({ step: 2, runId: 'run9' });
+    assert.ok(c.trustDelta >= 2, `${t} trustDelta satisfies RECRUIT_TRUST_MIN`);
+    assert.ok(c.affinityDelta >= 0, `${t} affinityDelta satisfies RECRUIT_AFFINITY_MIN`);
+    assert.ok(c.npcId.includes('run9'), `${t} courtship id is run-scoped (no cross-run collision)`);
+    assert.ok(RECRUIT_SPECIES_POOL.includes(c.speciesId), `${t} courts a canonical species`);
+  }
+});
+
+test('mbtiPolicy: chooseMating null at step 1, run-scoped distinct parents at step>=2', () => {
+  const p = makeMbtiPolicy('INTJ');
+  assert.equal(p.chooseMating({ step: 1, runId: 'run9' }), null);
+  const m = p.chooseMating({ step: 2, runId: 'run9' });
+  assert.notEqual(m.parentA, m.parentB, 'distinct parents');
+  assert.ok(m.parentA.includes('run9') && m.parentB.includes('run9'), 'run-scoped parents');
+});
+
+test('mbtiPolicy: unknown/garbage mbti defaults gracefully (no throw, canonical pick)', () => {
+  const p = makeMbtiPolicy('XYZ');
+  const pick = p.chooseRecruits({ step: 1 })[0];
+  assert.ok(RECRUIT_SPECIES_POOL.includes(pick.speciesId));
+});

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -18,6 +18,8 @@ const path = require('node:path');
 const os = require('node:os');
 const { runFullLoop } = require('./full-loop-runner');
 const { aggregate, PROVISIONAL_BANDS } = require('./meta-band-aggregator');
+const greedyPolicy = require('./greedy-policy');
+const { makeMbtiPolicy } = require('./mbti-policy');
 
 // Canonical cave_path starter party (mirrors tests/sim/fullLoopRunner.test.js): a
 // dune_stalker + velox authored squad. The Nido recruits grow it as chapters clear.
@@ -134,9 +136,27 @@ async function runOneReal(runOpts) {
   }
 }
 
+// Resolve the --policy value into a { policy (object), label (string) } pair. Accepts a
+// string ('greedy' | 'mbti' | 'mbti:ESFP') or an already-built policy object. Anything
+// unrecognised falls back to greedy (never throws).
+function resolvePolicy(p) {
+  if (p && typeof p === 'object' && typeof p.chooseRecruits === 'function') {
+    return { policy: p, label: p.mbti ? `mbti:${p.mbti}` : 'custom' };
+  }
+  const s = String(p || 'greedy').toLowerCase();
+  if (s === 'mbti' || s.startsWith('mbti:')) {
+    const type = s.includes(':') ? String(p).split(':')[1].toUpperCase() : 'INTJ';
+    const policy = makeMbtiPolicy(type);
+    return { policy, label: `mbti:${policy.mbti}` };
+  }
+  return { policy: greedyPolicy, label: 'greedy' };
+}
+
 // Run K sims with monotonic deterministic seeds. `runOne` is injectable (tests pass a fake;
-// CLI uses runOneReal). Attaches provenance to each result. Sequential: each run owns a
-// fresh app, so there is no shared-store contention.
+// CLI uses runOneReal). Resolves the policy ONCE and injects the policy object into each
+// run (so --policy mbti:ESFP actually plays as ESFP), recording the label in provenance.
+// Attaches provenance to each result. Sequential: each run owns a fresh app, so there is no
+// shared-store contention.
 async function runBatch(opts = {}) {
   const {
     runs = 5,
@@ -151,6 +171,7 @@ async function runBatch(opts = {}) {
     runOne = runOneReal,
     onProgress,
   } = opts;
+  const { policy: policyImpl, label: policyLabel } = resolvePolicy(policy);
   const results = [];
   for (let i = 0; i < runs; i += 1) {
     const seed = String(seedBase + i);
@@ -160,6 +181,7 @@ async function runBatch(opts = {}) {
       branchKey: branch,
       seed,
       maxChapters,
+      policy: policyImpl,
     };
     const res = await runOne(runOpts);
     const scenarioChain = (res.chapters || []).map((c) => c.encounter);
@@ -167,7 +189,7 @@ async function runBatch(opts = {}) {
       runId: i,
       seed,
       commit,
-      policy,
+      policy: policyLabel,
       branch,
       scenarioChain,
       flags,
@@ -347,6 +369,7 @@ if (require.main === module) {
 module.exports = {
   parseArgs,
   buildProvenance,
+  resolvePolicy,
   runBatch,
   runOneReal,
   buildSummary,

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -18,16 +18,17 @@ const { resolveRecruitUnit } = require('./recruit-resolver');
 const { applyNidoEconomy } = require('./nido-economy');
 const { buildScenarioEnemies } = require('./scenario-enemies');
 
-// Nido meta-step on a cleared chapter: the greedy policy recruits NPCs via the meta
-// seam (POST /api/meta/recruit, affinity_at_recruit bypass -> getOrCreate NPC), then
+// Nido meta-step on a cleared chapter: the meta policy (greedy by default, mbti in fase-2c)
+// recruits NPCs via the meta seam (POST /api/meta/recruit, affinity_at_recruit bypass ->
+// getOrCreate NPC), then
 // each recruit is resolved to a battle-ready PLAYER unit (recruit-resolver, faithful
 // canonical stats) so it can join combat next mission (attrition replacement). Returns
 // recruited ids + the resolved combat units + failures.
-async function applyMetaStep(http, { id, step, rosterSize = 0 }) {
+async function applyMetaStep(http, { id, step, rosterSize = 0, policy = greedyPolicy }) {
   const recruited = [];
   const units = [];
   const failures = [];
-  const picks = greedyPolicy.chooseRecruits({ step });
+  const picks = policy.chooseRecruits({ step });
   for (let i = 0; i < picks.length; i += 1) {
     const { npcId, speciesId } = picks[i];
     const r = await http.post('/api/meta/recruit', {
@@ -97,7 +98,16 @@ function sumGrants(arr, field) {
 }
 
 async function runFullLoop(http, opts = {}) {
-  const { playerId, branchKey = 'cave_path', seed, peEarned = 3, maxChapters = 15 } = opts;
+  const {
+    playerId,
+    branchKey = 'cave_path',
+    seed,
+    peEarned = 3,
+    maxChapters = 15,
+    // fase-2c: pluggable meta-policy (greedy by default). mbtiPolicy swaps in temperament-
+    // guided recruit/courtship/mating choices to test P4 across the band-batch.
+    policy = greedyPolicy,
+  } = opts;
   // Roster GROWS as the Nido recruits: it starts as the authored party and gains a
   // faithful combat unit per cleared chapter. knownIds is the matching id universe so a
   // recruited survivor is never flagged as a "foreign" combatant by the identity
@@ -209,7 +219,7 @@ async function runFullLoop(http, opts = {}) {
     // feedback loop closed.
     const hasNextChapter = !(adv.body && adv.body.campaign_completed);
     if (adv.status === 200 && combat.outcome === 'victory' && hasNextChapter) {
-      const meta = await applyMetaStep(http, { id, step, rosterSize: roster.length });
+      const meta = await applyMetaStep(http, { id, step, rosterSize: roster.length, policy });
       recruited.push(...meta.recruited);
       for (const u of meta.units) {
         roster.push(u);
@@ -221,7 +231,7 @@ async function runFullLoop(http, opts = {}) {
       // Nido economy + breeding seams (fase-1b-3b): earn affinity/trust -> recruit via
       // the canonical gate (no bypass) + roll a mating offspring. Default-store NPCs,
       // separate from the combat-recruit; offspring not resolved into combat (deferred).
-      const econ = await applyNidoEconomy(http, { step, biomeId: 'badlands', runId: id });
+      const econ = await applyNidoEconomy(http, { step, biomeId: 'badlands', runId: id, policy });
       economyRecruited.push(...econ.earnedRecruits);
       offspring += econ.offspring;
       if (econ.affinityProven) economyAffinityProven = true;

--- a/tools/sim/greedy-policy.js
+++ b/tools/sim/greedy-policy.js
@@ -57,4 +57,10 @@ function chooseMating({ step, runId } = {}) {
   return { parentA: courtshipId(runId, step - 1), parentB: courtshipId(runId, step) };
 }
 
-module.exports = { chooseRecruits, chooseCourtship, chooseMating, RECRUIT_SPECIES_POOL };
+module.exports = {
+  chooseRecruits,
+  chooseCourtship,
+  chooseMating,
+  courtshipId,
+  RECRUIT_SPECIES_POOL,
+};

--- a/tools/sim/mbti-policy.js
+++ b/tools/sim/mbti-policy.js
@@ -47,13 +47,21 @@ function orderedPool(mbti) {
   return [...RECRUIT_SPECIES_POOL].sort((a, b) => rank(a) - rank(b));
 }
 
+// A well-formed MBTI type: [E/I][N/S][T/F][J/P].
+const VALID_MBTI = /^[EI][NS][TF][JP]$/;
+
 // Build a policy bound to one MBTI type. Implements the same seam as greedy-policy, so it
-// drops into runFullLoop({ policy }) / applyNidoEconomy({ policy }) unchanged.
+// drops into runFullLoop({ policy }) / applyNidoEconomy({ policy }) unchanged. A mistyped
+// type is NORMALIZED to the default archetype (INTJ) so the recorded `.mbti` label always
+// reflects the temperament actually played -- never a fake 'XXXX' in provenance/reports
+// (Codex #2569 P2). orderedPool already falls back to NT for anything unrecognised.
 function makeMbtiPolicy(mbtiType = 'INTJ') {
-  const pool = orderedPool(mbtiType);
+  const raw = String(mbtiType || 'INTJ').toUpperCase();
+  const mbti = VALID_MBTI.test(raw) ? raw : 'INTJ';
+  const pool = orderedPool(mbti);
   const speciesForStep = (step) => pool[(step - 1) % pool.length];
   return {
-    mbti: String(mbtiType || 'INTJ').toUpperCase(),
+    mbti,
     chooseRecruits({ step } = {}) {
       return [{ npcId: `recruit_s${step}`, speciesId: speciesForStep(step) }];
     },

--- a/tools/sim/mbti-policy.js
+++ b/tools/sim/mbti-policy.js
@@ -1,0 +1,78 @@
+'use strict';
+// fase-2c mbtiPolicy: a pluggable meta-policy whose Nido choices are guided by MBTI
+// temperament -> lets the full-loop band-batch test P4 (temperament) in the meta-loop.
+// Same contract as greedy-policy (chooseRecruits / chooseCourtship / chooseMating); the
+// divergence is WHICH species each temperament prioritises: the Keirsey group maps to a
+// role_class ordering of the canonical badlands recruit pool. Grounded: Triangle Strategy
+// recruit-gating + Disco Elysium micro-reactivity (docs/guide/games-source-index.md).
+// Deterministic, no RNG -> two runs of the same type make identical choices.
+
+const { RECRUIT_SPECIES_POOL, courtshipId } = require('./greedy-policy');
+
+// Canonical pool tagged by role_class (from greedy-policy RECRUIT_SPECIES_POOL comments).
+const SPECIES_ROLE = {
+  'dune-stalker': 'APEX',
+  'nano-rust-bloom': 'HAZARD',
+  'ferrocolonia-magnetotattica': 'PREDATOR',
+  'sand-burrower': 'PREY',
+  'rust-scavenger': 'SUPPORT',
+};
+
+// Keirsey temperament -> role_class priority. Each temperament weights the roster
+// differently: Analyst (NT) power-first, Diplomat (NF) cohesion-first, Sentinel (SJ)
+// stability-first, Explorer (SP) variety/opportunistic-first.
+const TEMPERAMENT_PRIORITY = {
+  NT: ['APEX', 'PREDATOR', 'HAZARD', 'SUPPORT', 'PREY'],
+  NF: ['SUPPORT', 'PREY', 'PREDATOR', 'APEX', 'HAZARD'],
+  SJ: ['SUPPORT', 'PREDATOR', 'APEX', 'PREY', 'HAZARD'],
+  SP: ['HAZARD', 'PREY', 'APEX', 'SUPPORT', 'PREDATOR'],
+};
+
+// 4-letter MBTI -> Keirsey group. Malformed input falls back to NT (never throws).
+function temperamentOf(mbti) {
+  const t = String(mbti || '').toUpperCase();
+  if (t[1] === 'N') return t[2] === 'F' ? 'NF' : 'NT';
+  if (t[1] === 'S') return t[3] === 'P' ? 'SP' : 'SJ';
+  return 'NT';
+}
+
+// Reorder the canonical pool by the temperament's role priority. Stable sort (V8): species
+// with equal rank (e.g. an unknown role) keep their pool order.
+function orderedPool(mbti) {
+  const priority = TEMPERAMENT_PRIORITY[temperamentOf(mbti)];
+  const rank = (sp) => {
+    const idx = priority.indexOf(SPECIES_ROLE[sp]);
+    return idx === -1 ? priority.length : idx;
+  };
+  return [...RECRUIT_SPECIES_POOL].sort((a, b) => rank(a) - rank(b));
+}
+
+// Build a policy bound to one MBTI type. Implements the same seam as greedy-policy, so it
+// drops into runFullLoop({ policy }) / applyNidoEconomy({ policy }) unchanged.
+function makeMbtiPolicy(mbtiType = 'INTJ') {
+  const pool = orderedPool(mbtiType);
+  const speciesForStep = (step) => pool[(step - 1) % pool.length];
+  return {
+    mbti: String(mbtiType || 'INTJ').toUpperCase(),
+    chooseRecruits({ step } = {}) {
+      return [{ npcId: `recruit_s${step}`, speciesId: speciesForStep(step) }];
+    },
+    // Same gate-satisfying deltas as greedy (RECRUIT_AFFINITY_MIN=0, RECRUIT_TRUST_MIN=2);
+    // temperament changes the courted SPECIES, not the gate, so the earned-recruit economy
+    // stays exercised. runId scopes ids per run (Codex #2566 P2).
+    chooseCourtship({ step, runId } = {}) {
+      return {
+        npcId: courtshipId(runId, step),
+        speciesId: speciesForStep(step),
+        affinityDelta: 1,
+        trustDelta: 2,
+      };
+    },
+    chooseMating({ step, runId } = {}) {
+      if (!(step >= 2)) return null;
+      return { parentA: courtshipId(runId, step - 1), parentB: courtshipId(runId, step) };
+    },
+  };
+}
+
+module.exports = { makeMbtiPolicy, temperamentOf, orderedPool, TEMPERAMENT_PRIORITY, SPECIES_ROLE };

--- a/tools/sim/nido-economy.js
+++ b/tools/sim/nido-economy.js
@@ -16,13 +16,16 @@
 
 const greedyPolicy = require('./greedy-policy');
 
-async function applyNidoEconomy(http, { step, biomeId, runId } = {}) {
+// fase-2c: `policy` is pluggable (greedy by default). mbtiPolicy varies the courted species
+// per temperament while keeping the same gate-satisfying deltas, so the earned-affinity
+// economy + breeding seams stay exercised under any policy.
+async function applyNidoEconomy(http, { step, biomeId, runId, policy = greedyPolicy } = {}) {
   const out = { earnedRecruits: [], offspring: 0, affinityProven: false, failures: [] };
 
   // (1) Affinity economy: earn affinity + trust, then recruit through the EARNED gate.
   // runId scopes the courtship ids per run (Codex #2566 P2) so repeated sims on one
   // process don't collide on the default meta store.
-  const c = greedyPolicy.chooseCourtship({ step, runId });
+  const c = policy.chooseCourtship({ step, runId });
   await http.post('/api/meta/affinity', { npc_id: c.npcId, delta: c.affinityDelta });
   const tr = await http.post('/api/meta/trust', { npc_id: c.npcId, delta: c.trustDelta });
   // can_recruit flipped true purely from the earned affinity/trust (no bypass involved).
@@ -48,7 +51,7 @@ async function applyNidoEconomy(http, { step, biomeId, runId } = {}) {
   }
 
   // (2) Breeding: roll a squad-mate mating once two courtship NPCs exist (step >= 2).
-  const mating = greedyPolicy.chooseMating({ step, runId });
+  const mating = policy.chooseMating({ step, runId });
   if (mating) {
     const m = await http.post('/api/meta/mating/roll', {
       parent_a: { id: mating.parentA },


### PR DESCRIPTION
## fase-2c (step 1) — pluggable meta-policy + mbtiPolicy

Continues fase-2 ([goal doc](docs/planning/2026-06-02-full-loop-fase2-goal.md) §2c). fase-2b shipped the band aggregator + batch ([#2568](https://github.com/MasterDD-L34D/Game/pull/2568)); this makes the full-loop meta-policy **pluggable** and adds a temperament-guided **`mbtiPolicy`** so the band-batch can test **P4 (MBTI)** in the meta-loop.

### What
- **`runFullLoop` + `applyNidoEconomy`** accept `opts.policy` (default `greedyPolicy`); the Nido meta-step + economy use it. **Behaviour-preserving for the default** (greedy path unchanged → all prior tests stay green).
- **`mbti-policy.js`** (new) — `makeMbtiPolicy(type)` maps the Keirsey group (NT/NF/SJ/SP) → a role_class ordering of the canonical badlands recruit pool. Different temperaments recruit/court **different species** (measurable P4 divergence) while keeping the same gate-satisfying deltas + run-scoped courtship ids. `greedy-policy` exports `courtshipId` for reuse.
- **`full-loop-batch.js`** — `resolvePolicy('greedy' | 'mbti' | 'mbti:ESFP')` selects the policy object + **injects** it into each run (so `--policy mbti:ESFP` actually plays as ESFP), recording the label in provenance.

### Proof
- TDD red→green. A **spy policy** test proves the runner drives `opts.policy` (not the hardcoded greedy). `resolvePolicy` + injection tested with a fake `runOne`.
- Real `--policy mbti:ESFP` K=2 smoke: 2/2 complete, provenance `policy: mbti:ESFP`.
- `tests/sim` **60/60**, AI **500/500**.

### Next (fase-2c remainder, separate)
- `META_NETWORK_ROUTING=true` test-context coverage.
- N=40 batch (greedy + mbti archetypes) → `docs/playtest/` band-summary report → **master-dd ratifies the exact band numbers (GATED, L-069)**.

### Safety
band-safe: `tools/sim/` + `tests/sim/` only, **zero engine change**, no forbidden paths, no new deps. **Rollback**: revert — additive tooling, nothing downstream depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
