### PR TITLE
feat(sim): N=40 full-loop band report + hermetic batch env (fase-2c)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -8447,6 +8447,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "active"
+    },
+    {
+      "path": "docs/playtest/2026-06-02-full-loop-band-report.md",
+      "title": "Full-loop meta band-metrics - N=40 baseline (fase-2c)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "ops-qa",
+      "last_verified": "2026-06-02",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
     }
   ]
 }

--- a/docs/playtest/2026-06-02-full-loop-band-report.md
+++ b/docs/playtest/2026-06-02-full-loop-band-report.md
@@ -1,0 +1,104 @@
+---
+title: 'Full-loop meta band-metrics - N=40 baseline (fase-2c)'
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-02'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Full-loop meta band-metrics — N=40 baseline (fase-2c)
+
+> **PROVISIONAL — pending master-dd ratify.** The band ranges below are Claude-derived
+> from the cited sources (goal doc / spec §7). They are **NOT** canon: master-dd ratifies
+> the exact band numbers post-N=40, exactly like the combat bands (L-069). This report
+> produces the PROCESS + the placement + the asks; it does not assert the bands as ratified.
+
+Closes the buildable arc of fase-2 of the full-loop AI-playtest runner: the AI now plays the
+whole meta-loop (campaign → real combat → Nido recruit → economy + breeding), and this is the
+N=40 measurement of that loop against the 5 provisional band-metrics.
+
+- Goal: [`docs/planning/2026-06-02-full-loop-fase2-goal.md`](../planning/2026-06-02-full-loop-fase2-goal.md) §2c
+- Spec: [`docs/superpowers/specs/2026-06-02-full-loop-ai-playtest-runner-design.md`](../superpowers/specs/2026-06-02-full-loop-ai-playtest-runner-design.md) §7
+- Shipped: band aggregator + batch ([#2568](https://github.com/MasterDD-L34D/Game/pull/2568)), pluggable policy + mbtiPolicy ([#2569](https://github.com/MasterDD-L34D/Game/pull/2569))
+
+## Method
+
+- `node tools/sim/full-loop-batch.js --runs 40 --policy <p> --commit 4a711aba` per policy.
+- In-process: a fresh `createApp({databasePath:null})` + supertest per run (hermetic: stub
+  orchestrator + status-refresh disabled so N=40 spins reliably). Seeds 1000–1039, branch
+  `cave_path`, the canonical dune_stalker + velox starter party. Deterministic, no RNG in the
+  aggregator.
+- Policies: `greedy` (baseline) + `mbti:{INTJ,ENFP,ESFP}` (NT / NF / SP temperaments). `ISTJ`
+  (SJ) is identical by construction (the mbtiPolicy ordering is unit-tested) but its N=40 run
+  hit a transient Windows `node` spawn crash (`0xC0000409`, 3×) and is omitted here, not
+  re-run — it does not change any finding (see Finding 2).
+
+## Results (N=40 per policy)
+
+| Policy         | completion_rate | roster_attrition | economy_flow (drift)    | relationship (recruit / aff / mate) | offspring_viability |
+| -------------- | --------------- | ---------------- | ----------------------- | ----------------------------------- | ------------------- |
+| greedy         | 1.00 ❌         | 0.333 ✅         | 1.25 ✅ (pe 24, bp 216) | 7 / 1.0 / 6 ✅                      | 6 ✅                |
+| mbti:INTJ (NT) | 1.00 ❌         | 0.333 ✅         | 1.25 ✅                 | 7 / 1.0 / 6 ✅                      | 6 ✅                |
+| mbti:ENFP (NF) | 1.00 ❌         | 0.333 ✅         | 1.25 ✅                 | 7 / 1.0 / 6 ✅                      | 6 ✅                |
+| mbti:ESFP (SP) | 1.00 ❌         | 0.333 ✅         | 1.25 ✅                 | 7 / 1.0 / 6 ✅                      | 6 ✅                |
+
+| Metric                             | Provisional band                            | Placement                |
+| ---------------------------------- | ------------------------------------------- | ------------------------ |
+| `completion_rate`                  | 0.40 – 0.70                                 | **OUT (1.00, too easy)** |
+| `roster_attrition`                 | (0, 1) exclusive                            | IN (0.333)               |
+| `economy_flow` (build-power drift) | 0.5 – 2.0                                   | IN (1.25)                |
+| `relationship_progress`            | recruit + earned-affinity + mating all fire | IN                       |
+| `offspring_viability`              | offspring_avg ≥ 1                           | IN (6)                   |
+
+## Findings
+
+**1. `completion_rate` is OUT of band (1.00) with zero variance.** Every one of the 160 runs
+completed; the band correctly flags "too easy". Even with fase-2a scaled enemies, the 30-HP
+starter party crushes the cave_path chain deterministically. → **calibration target**: tune
+enemy scaling until completion lands in 0.40–0.70. This is the point of the band.
+
+**2. The 5 band-metrics are policy-INSENSITIVE — every policy places identically.** mbtiPolicy
+_does_ diverge on which species it recruits/courts (verified in `mbtiPolicy.test.js`: INTJ→APEX
+first, ESFP→HAZARD first), but the metrics measure **quantity/rate** (win rate, survivor ratio,
+recruit/mating COUNT, offspring COUNT), not **composition**. Different species, same counts →
+identical placement. **P4 (temperament) cannot be detected by these metrics as defined.**
+→ detecting P4 needs a **composition/diversity metric** (roster role_class diversity +
+offspring lineage diversity — the `lineage_diversity` field is currently `null`/deferred).
+
+**3. `economy_flow` measures earn + build-power drift only — the PI sink is unexercised.**
+`piSpentTotal = 0` across all runs: the loop has no shop/PI-spend seam wired, so the
+sink side of the economy is never tested (surfaced honestly, not invented). build-power
+(XP+MP) accrues flat (drift 1.25, in band). `mpEarnedTotal` is 0 because the runner does not
+send `encounter_meta` tier on advance — MP grants stay at the floor; XP carries the build power.
+
+**4. `META_NETWORK_ROUTING` coverage is a no-op for the current runner.** The runner chooses
+paths via `driver.choose(branchKey)` → `/api/campaign/choose`, NOT the meta-network diagnostic
+endpoint that the `META_NETWORK_ROUTING` flag gates (`campaign.js:215`). Setting the flag does
+not change the runner. Routing-graph (`selectNextNodes`) coverage needs the runner wired to it
+— a separate slice, not a flag flip.
+
+## For master-dd (ratify gate — L-069)
+
+1. **Ratify or adjust** the 5 provisional band ranges (the exact numbers are a human verdict).
+2. **Prioritise the next slices** the findings expose:
+   - difficulty calibration so `completion_rate` enters band (Finding 1);
+   - a composition/diversity metric so P4 is measurable (Finding 2);
+   - a PI-sink seam so `economy_flow` tests the sink (Finding 3);
+   - runner → `selectNextNodes` wiring for routing coverage / a PROD-enable verdict (Finding 4).
+
+The exact band numbers are **not** ratified here. Nothing downstream consumes these ranges yet;
+they are inputs to the human verdict.
+
+## Reproduce
+
+```bash
+node tools/sim/full-loop-batch.js --runs 40 --policy greedy --commit $(git rev-parse --short HEAD)
+node tools/sim/full-loop-batch.js --runs 40 --policy mbti:ESFP --commit $(git rev-parse --short HEAD)
+# -> /tmp/full-loop-band/batch-<ts>/{runs.jsonl, summary.json, report.md}
+```
+
+Provenance: commit `4a711aba`, branch `cave_path`, seeds 1000–1039, hermetic
+(`IDEA_ENGINE_STUB_ORCHESTRATOR=1` + `IDEA_ENGINE_DISABLE_STATUS_REFRESH=1`).

--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -231,3 +231,14 @@ test('runBatch: --policy greedy injects the greedy policy object', async () => {
   assert.equal(typeof seen[0].chooseRecruits, 'function', 'greedy policy object injected');
   assert.equal(results[0].provenance.policy, 'greedy');
 });
+
+test('runBatch: provenance records the hermetic env flags (Codex #2570 P2)', async () => {
+  // Importing full-loop-batch stubs the orchestrator + disables the status refresh, so the
+  // batch runtime differs from an unstubbed run. Provenance must capture that (not just
+  // META_NETWORK_ROUTING) so a reader of runs.jsonl knows the run was hermetic.
+  const results = await runBatch({ runs: 1, runOne: async () => synthRun() });
+  const f = results[0].provenance.flags;
+  assert.ok('IDEA_ENGINE_STUB_ORCHESTRATOR' in f, 'stub-orchestrator flag recorded');
+  assert.ok('IDEA_ENGINE_DISABLE_STATUS_REFRESH' in f, 'status-refresh flag recorded');
+  assert.ok('META_NETWORK_ROUTING' in f, 'routing flag still recorded');
+});

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -13,6 +13,15 @@
 // exact numbers post-N=40 (L-069). This batch produces the PLACEMENT + report for that
 // human verdict; it never claims the bands as canon.
 
+// Make the batch HERMETIC: each run spins a fresh createApp, so at N=40 the per-app status
+// refresh + orchestrator worker pool open enough 127.0.0.1 connections to hit EADDRINUSE
+// mid-batch. Stub the orchestrator (no Python worker spawn -- the full loop never generates
+// species) and disable the status refresh (no background poll) so N>=40 runs reliably. Same
+// gates the test suites set (app.js:341 + app.js:434). Respect an explicit override.
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = process.env.IDEA_ENGINE_STUB_ORCHESTRATOR || '1';
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH =
+  process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH || '1';
+
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -209,9 +209,15 @@ async function runBatch(opts = {}) {
   return results;
 }
 
-// The fase-2c test-context flags the report should record alongside each run.
+// The env flags the report should record alongside each run: the fase-2c routing test-
+// context PLUS the hermetic stubs this batch applies (Codex #2570 P2 -- the stubbed runtime
+// differs from an unstubbed run, so provenance must capture it for reproducibility).
 function currentFlags() {
-  return { META_NETWORK_ROUTING: process.env.META_NETWORK_ROUTING || 'false' };
+  return {
+    META_NETWORK_ROUTING: process.env.META_NETWORK_ROUTING || 'false',
+    IDEA_ENGINE_STUB_ORCHESTRATOR: process.env.IDEA_ENGINE_STUB_ORCHESTRATOR || '0',
+    IDEA_ENGINE_DISABLE_STATUS_REFRESH: process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH || '0',
+  };
 }
 
 // Compact one run-result into a single JSONL line (per-run record).


### PR DESCRIPTION
## fase-2c (endpoint) — N=40 band report + hermetic batch

The buildable arc of fase-2 ends here: the AI plays the whole meta-loop, and this is the **N=40 measurement** vs the 5 provisional band-metrics, packaged for **master-dd ratification** (the exact band numbers are a human verdict, L-069).

### What
- **`tools/sim/full-loop-batch.js`** — make the batch **hermetic**: stub the orchestrator + disable the status refresh (the gates the test suites already set) so the per-run `createApp` doesn't open enough `127.0.0.1` connections to hit **EADDRINUSE** mid-batch at N≥40. Respects an explicit env override.
- **`docs/playtest/2026-06-02-full-loop-band-report.md`** (new) — N=40 results + 4 findings + master-dd asks. Registry entry added (governance `--strict` errors=0).

### Findings (N=40 × greedy + INTJ/ENFP/ESFP)
| Metric | Band | Placement |
|---|---|---|
| completion_rate | 0.40–0.70 | **OUT (1.00, too easy, zero variance)** |
| roster_attrition | (0,1) | IN (0.333) |
| economy_flow (drift) | 0.5–2.0 | IN (1.25) |
| relationship_progress | composite | IN |
| offspring_viability | ≥1 | IN (6) |

1. `completion_rate` OUT (too easy) → difficulty-calibration target.
2. **All policies place IDENTICALLY** — the quantity-based metrics are policy-insensitive. mbtiPolicy diverges on recruited **species** (unit-tested) but **P4 needs a composition/diversity metric** (the deferred `lineage_diversity`).
3. `economy_flow` measures earn + build-power drift only — **PI sink unexercised** (`piSpentTotal=0`).
4. `META_NETWORK_ROUTING` is a **no-op for the runner** (it uses `driver.choose(branchKey)`, not the gated meta-network endpoint) → routing coverage needs runner→`selectNextNodes` wiring.

### For master-dd (the ratify gate)
Ratify/adjust the 5 provisional ranges + prioritise the next slices (difficulty calibration, composition metric, PI-sink, routing wiring). **No exact band numbers are ratified in this PR.**

### Safety
band-safe: `tools/sim/` + `docs/` only, **zero engine change**, no forbidden paths, no new deps. `tests/sim` **61/61**. **Rollback**: revert — additive tooling + a report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
