### PR TITLE
feat(sim): roster_composition metric makes P4 measurable (fase-2c)

### DIFF
--- a/docs/playtest/2026-06-02-full-loop-band-report.md
+++ b/docs/playtest/2026-06-02-full-loop-band-report.md
@@ -68,6 +68,12 @@ identical placement. **P4 (temperament) cannot be detected by these metrics as d
 → detecting P4 needs a **composition/diversity metric** (roster role_class diversity +
 offspring lineage diversity — the `lineage_diversity` field is currently `null`/deferred).
 
+> **UPDATE (since this baseline):** addressed by the `roster_composition` metric — it maps
+> the recruited species to their role_class profile + dominant roles, which **do** diverge by
+> policy (greedy `[APEX, HAZARD]` vs mbti:ESFP `[HAZARD, PREY]`), so P4 is now measurable. The
+> quantity metrics above remain policy-insensitive by design. (offspring `lineage_diversity`
+> still deferred.)
+
 **3. `economy_flow` measures earn + build-power drift only — the PI sink is unexercised.**
 `piSpentTotal = 0` across all runs: the loop has no shop/PI-spend seam wired, so the
 sink side of the economy is never tested (surfaced honestly, not invented). build-power

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -416,6 +416,12 @@ test('runFullLoop: drives the INJECTED opts.policy for the meta-step (fase-2c pl
     res.recruited.includes('spy_r1'),
     `recruited via the injected policy, not greedy; got ${JSON.stringify(res.recruited)}`,
   );
+  // Composition telemetry (fase-2c): the runner records the SPECIES of each combat-recruit
+  // so the aggregator can measure roster role_class composition (P4 divergence).
+  assert.ok(
+    res.recruitedSpecies.includes('dune-stalker'),
+    `recruited species recorded; got ${JSON.stringify(res.recruitedSpecies)}`,
+  );
 });
 
 test('runFullLoop: a mbtiPolicy plays the real cave_path campaign end-to-end (fase-2c)', async (t) => {

--- a/tests/sim/metaBandAggregator.test.js
+++ b/tests/sim/metaBandAggregator.test.js
@@ -186,6 +186,21 @@ test('aggregate: roster_composition out of band when < 3 distinct roles (collaps
   assert.equal(r.metrics.roster_composition.in_band, false);
 });
 
+test('aggregate: roster_composition excludes UNKNOWN from diversity + dominance (Codex #2573 P2)', () => {
+  // An unmapped/typo species (roleOf -> UNKNOWN) must NOT count as a real ecological role:
+  // 2 valid roles + 1 unknown is NOT a healthy 3-role spread. UNKNOWN is tracked separately
+  // (unknown_count) to flag invalid telemetry, never inflating distinct_roles or dominance.
+  const r = aggregate([
+    synthRun({ recruitedSpecies: ['dune-stalker', 'sand-burrower', 'not-a-species'] }),
+  ]);
+  const rc = r.metrics.roster_composition;
+  assert.equal(rc.distinct_roles, 2, 'unknown not counted as a distinct role');
+  assert.equal(rc.unknown_count, 1, 'unknowns tracked separately');
+  assert.ok(!rc.dominant_roles.includes('UNKNOWN'), 'UNKNOWN never dominant');
+  assert.ok(!('UNKNOWN' in rc.role_profile), 'UNKNOWN kept out of the role profile');
+  assert.equal(rc.in_band, false, '2 real roles + 1 unknown is not a healthy 3-role spread');
+});
+
 test('aggregate: empty input -> n=0, every metric out of band, never throws', () => {
   const r = aggregate([]);
   assert.equal(r.n, 0);

--- a/tests/sim/metaBandAggregator.test.js
+++ b/tests/sim/metaBandAggregator.test.js
@@ -20,6 +20,7 @@ function synthRun(o = {}) {
     chapters,
     finalRoster: o.finalRoster ?? ['a', 'b'],
     recruited: o.recruited ?? ['r1', 'r2'],
+    recruitedSpecies: o.recruitedSpecies ?? ['dune-stalker', 'sand-burrower'],
     economyRecruited: o.economyRecruited ?? ['e1'],
     offspring: o.offspring ?? 1,
     economyAffinityProven: o.economyAffinityProven ?? true,
@@ -146,6 +147,43 @@ test('aggregate: offspring_viability out of band when no breeding happens', () =
   const r = aggregate([synthRun({ offspring: 0 }), synthRun({ offspring: 0 })]);
   assert.equal(r.metrics.offspring_viability.offspring_avg, 0);
   assert.equal(r.metrics.offspring_viability.in_band, false);
+});
+
+test('aggregate: roster_composition maps recruited species to role_class profile', () => {
+  // dune-stalker=APEX, ferrocolonia=PREDATOR, nano-rust-bloom=HAZARD -> 3 distinct roles.
+  const r = aggregate([
+    synthRun({
+      recruitedSpecies: ['dune-stalker', 'ferrocolonia-magnetotattica', 'nano-rust-bloom'],
+    }),
+  ]);
+  const rc = r.metrics.roster_composition;
+  assert.deepEqual(rc.role_profile, { APEX: 1, PREDATOR: 1, HAZARD: 1 });
+  assert.equal(rc.distinct_roles, 3);
+  assert.equal(rc.in_band, true); // >= 3 distinct roles = healthy spread
+});
+
+test('aggregate: roster_composition is POLICY-SENSITIVE (the P4 fix, dominant roles diverge)', () => {
+  // The headline finding was that quantity metrics are policy-insensitive. Composition is
+  // NOT: an APEX/PREDATOR-leaning roster and a HAZARD/PREY-leaning one yield DIFFERENT
+  // dominant roles -> P4 (temperament) becomes measurable.
+  const analyst = aggregate([
+    synthRun({ recruitedSpecies: ['dune-stalker', 'dune-stalker', 'ferrocolonia-magnetotattica'] }),
+  ]);
+  const explorer = aggregate([
+    synthRun({ recruitedSpecies: ['nano-rust-bloom', 'nano-rust-bloom', 'sand-burrower'] }),
+  ]);
+  assert.deepEqual(analyst.metrics.roster_composition.dominant_roles, ['APEX']);
+  assert.deepEqual(explorer.metrics.roster_composition.dominant_roles, ['HAZARD']);
+  assert.notDeepEqual(
+    analyst.metrics.roster_composition.dominant_roles,
+    explorer.metrics.roster_composition.dominant_roles,
+  );
+});
+
+test('aggregate: roster_composition out of band when < 3 distinct roles (collapsed)', () => {
+  const r = aggregate([synthRun({ recruitedSpecies: ['dune-stalker', 'dune-stalker'] })]);
+  assert.equal(r.metrics.roster_composition.distinct_roles, 1);
+  assert.equal(r.metrics.roster_composition.in_band, false);
 });
 
 test('aggregate: empty input -> n=0, every metric out of band, never throws', () => {

--- a/tests/sim/speciesRoles.test.js
+++ b/tests/sim/speciesRoles.test.js
@@ -1,0 +1,24 @@
+'use strict';
+// Shared species -> role_class map: single source for mbti-policy (temperament ordering)
+// and meta-band-aggregator (roster composition metric), so they agree on ecological roles.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { SPECIES_ROLE, roleOf } = require('../../tools/sim/species-roles');
+
+test('roleOf: maps every canonical badlands recruit-pool species', () => {
+  assert.equal(roleOf('dune-stalker'), 'APEX');
+  assert.equal(roleOf('nano-rust-bloom'), 'HAZARD');
+  assert.equal(roleOf('ferrocolonia-magnetotattica'), 'PREDATOR');
+  assert.equal(roleOf('sand-burrower'), 'PREY');
+  assert.equal(roleOf('rust-scavenger'), 'SUPPORT');
+});
+
+test('roleOf: unknown species -> UNKNOWN (never throws)', () => {
+  assert.equal(roleOf('not-a-species'), 'UNKNOWN');
+  assert.equal(roleOf(undefined), 'UNKNOWN');
+});
+
+test('SPECIES_ROLE: covers all 5 pool roles distinctly', () => {
+  const roles = new Set(Object.values(SPECIES_ROLE));
+  assert.deepEqual([...roles].sort(), ['APEX', 'HAZARD', 'PREDATOR', 'PREY', 'SUPPORT']);
+});

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -314,6 +314,8 @@ function metricValue(metric) {
   if (metric.recruit_rate !== undefined)
     return `recruit ${metric.recruit_rate}, aff ${metric.affinity_proven_rate}, mate ${metric.mating_rate}`;
   if (metric.offspring_avg !== undefined) return `offspring ${metric.offspring_avg}`;
+  if (metric.dominant_roles !== undefined)
+    return `dominant ${metric.dominant_roles.join('/') || 'none'}, ${metric.distinct_roles} roles`;
   return '-';
 }
 
@@ -336,6 +338,7 @@ function buildReport(summary) {
     'economy_flow',
     'relationship_progress',
     'offspring_viability',
+    'roster_composition',
   ]) {
     const metric = m[k];
     lines.push(

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -26,6 +26,7 @@ const { buildScenarioEnemies } = require('./scenario-enemies');
 // recruited ids + the resolved combat units + failures.
 async function applyMetaStep(http, { id, step, rosterSize = 0, policy = greedyPolicy }) {
   const recruited = [];
+  const species = [];
   const units = [];
   const failures = [];
   const picks = policy.chooseRecruits({ step });
@@ -48,6 +49,7 @@ async function applyMetaStep(http, { id, step, rosterSize = 0, policy = greedyPo
       r.body.npc.recruited === true;
     if (recruitedOk) {
       recruited.push(npcId);
+      species.push(speciesId);
       // Recruits line up in column x:2 (starters/enemies use x:1), distinct rows, so a
       // growing roster never overlaps a starting position.
       const position = { x: 2, y: ((rosterSize + i) % 8) + 1 };
@@ -56,7 +58,7 @@ async function applyMetaStep(http, { id, step, rosterSize = 0, policy = greedyPo
       failures.push({ npcId, status: r.status, success: r.body && r.body.success });
     }
   }
-  return { recruited, units, failures };
+  return { recruited, species, units, failures };
 }
 
 // Fresh per-mission copy of the alive roster: full HP + cleared status, original
@@ -126,6 +128,7 @@ async function runFullLoop(http, opts = {}) {
       violations: [{ step: 0, v: [`start status ${startRes.status} != 201`] }],
       finalRoster: [],
       recruited: [],
+      recruitedSpecies: [],
       metaViolations: [],
       initialRosterSize,
       economy: { peEarnedTotal: 0, xpGrantedTotal: 0, mpEarnedTotal: 0, piSpentTotal: 0 },
@@ -137,6 +140,7 @@ async function runFullLoop(http, opts = {}) {
   const chapters = [];
   const violations = [];
   const recruited = [];
+  const recruitedSpecies = [];
   const metaViolations = [];
   // fase-1b-3b Nido economy + breeding (separate from the combat-recruit above):
   // earned-affinity recruits + mating offspring, proving those seams are AI-played.
@@ -221,6 +225,7 @@ async function runFullLoop(http, opts = {}) {
     if (adv.status === 200 && combat.outcome === 'victory' && hasNextChapter) {
       const meta = await applyMetaStep(http, { id, step, rosterSize: roster.length, policy });
       recruited.push(...meta.recruited);
+      recruitedSpecies.push(...meta.species);
       for (const u of meta.units) {
         roster.push(u);
         aliveIds.push(u.id);
@@ -254,6 +259,7 @@ async function runFullLoop(http, opts = {}) {
     violations,
     finalRoster: aliveIds,
     recruited,
+    recruitedSpecies,
     metaViolations,
     economyRecruited,
     offspring,

--- a/tools/sim/mbti-policy.js
+++ b/tools/sim/mbti-policy.js
@@ -8,15 +8,9 @@
 // Deterministic, no RNG -> two runs of the same type make identical choices.
 
 const { RECRUIT_SPECIES_POOL, courtshipId } = require('./greedy-policy');
-
-// Canonical pool tagged by role_class (from greedy-policy RECRUIT_SPECIES_POOL comments).
-const SPECIES_ROLE = {
-  'dune-stalker': 'APEX',
-  'nano-rust-bloom': 'HAZARD',
-  'ferrocolonia-magnetotattica': 'PREDATOR',
-  'sand-burrower': 'PREY',
-  'rust-scavenger': 'SUPPORT',
-};
+// Canonical pool tagged by role_class -- shared with meta-band-aggregator (roster
+// composition) so both agree on ecological roles (single source).
+const { SPECIES_ROLE } = require('./species-roles');
 
 // Keirsey temperament -> role_class priority. Each temperament weights the roster
 // differently: Analyst (NT) power-first, Diplomat (NF) cohesion-first, Sentinel (SJ)

--- a/tools/sim/meta-band-aggregator.js
+++ b/tools/sim/meta-band-aggregator.js
@@ -163,10 +163,19 @@ function aggregate(runs) {
   // roleOf). POLICY-SENSITIVE -> the dominant role(s) diverge by temperament (mbtiPolicy
   // recruits a different role mix than greedy), so P4 is MEASURABLE here even though the
   // quantity metrics above are policy-insensitive. Band: >= 3 distinct roles = healthy spread.
+  // UNKNOWN (a species outside the canonical role map -> a typo/unmapped recruit) is invalid
+  // telemetry, NOT a real ecological role: it is tracked separately (unknown_count) and kept
+  // OUT of role_profile / distinct_roles / dominance, so it can never inflate diversity or
+  // appear dominant and mask a collapsed roster (Codex #2573 P2).
   const roleProfile = {};
+  let unknownCount = 0;
   for (const r of list) {
     for (const sp of (r && r.recruitedSpecies) || []) {
       const role = roleOf(sp);
+      if (role === 'UNKNOWN') {
+        unknownCount += 1;
+        continue;
+      }
       roleProfile[role] = (roleProfile[role] || 0) + 1;
     }
   }
@@ -180,9 +189,10 @@ function aggregate(runs) {
     role_profile: roleProfile,
     distinct_roles: distinctRoles,
     dominant_roles: dominantRoles,
+    unknown_count: unknownCount,
     range: PROVISIONAL_BANDS.roster_composition,
     in_band: n > 0 && distinctRoles >= rcLo,
-    note: 'role_class profile of the recruited roster; dominant_roles diverge by policy -> P4 measurable (composition, not quantity)',
+    note: 'role_class profile of the recruited roster (UNKNOWN excluded, tracked as unknown_count); dominant_roles diverge by policy -> P4 measurable (composition, not quantity)',
   };
 
   return {

--- a/tools/sim/meta-band-aggregator.js
+++ b/tools/sim/meta-band-aggregator.js
@@ -9,6 +9,8 @@
 // (compute + place), not to assert canon. An anti-pattern guard (spec §7): these bands keep
 // the design SPACE healthy (Quality-Diversity) -- do NOT optimize to a single best run.
 
+const { roleOf } = require('./species-roles');
+
 const PROVISIONAL_BANDS = {
   // % campaigns completed over N runs. XCOM Long War 2: completable-but-hard.
   completion_rate: [0.4, 0.7],
@@ -23,6 +25,10 @@ const PROVISIONAL_BANDS = {
   relationship_progress: null,
   // mean offspring per run >= threshold (breeding is exercised). Niche + Spore. >=1.
   offspring_viability: [1, null],
+  // >= N distinct role_classes across the recruited roster (healthy spread, no collapse).
+  // POLICY-SENSITIVE: the dominant role(s) diverge by temperament -> this is where P4 is
+  // measurable (the quantity metrics above are policy-insensitive). >=3.
+  roster_composition: [3, null],
   note:
     'WARN: Claude-derived PROVISIONAL ranges (spec §7) -- pending master-dd ratify post-N=40 ' +
     '(L-069). NOT canon. Keep the design space healthy (Quality-Diversity); do not optimize ' +
@@ -153,6 +159,32 @@ function aggregate(runs) {
     note: 'mean offspring per run >= threshold; lineage diversity not tracked yet (deferred)',
   };
 
+  // 6. roster_composition: role_class profile of the recruited roster (recruitedSpecies ->
+  // roleOf). POLICY-SENSITIVE -> the dominant role(s) diverge by temperament (mbtiPolicy
+  // recruits a different role mix than greedy), so P4 is MEASURABLE here even though the
+  // quantity metrics above are policy-insensitive. Band: >= 3 distinct roles = healthy spread.
+  const roleProfile = {};
+  for (const r of list) {
+    for (const sp of (r && r.recruitedSpecies) || []) {
+      const role = roleOf(sp);
+      roleProfile[role] = (roleProfile[role] || 0) + 1;
+    }
+  }
+  const distinctRoles = Object.keys(roleProfile).length;
+  const maxFreq = Math.max(0, ...Object.values(roleProfile));
+  const dominantRoles = Object.keys(roleProfile)
+    .filter((k) => roleProfile[k] === maxFreq)
+    .sort();
+  const [rcLo] = PROVISIONAL_BANDS.roster_composition;
+  const roster_composition = {
+    role_profile: roleProfile,
+    distinct_roles: distinctRoles,
+    dominant_roles: dominantRoles,
+    range: PROVISIONAL_BANDS.roster_composition,
+    in_band: n > 0 && distinctRoles >= rcLo,
+    note: 'role_class profile of the recruited roster; dominant_roles diverge by policy -> P4 measurable (composition, not quantity)',
+  };
+
   return {
     n,
     provisional: true,
@@ -162,6 +194,7 @@ function aggregate(runs) {
       economy_flow,
       relationship_progress,
       offspring_viability,
+      roster_composition,
     },
   };
 }

--- a/tools/sim/species-roles.js
+++ b/tools/sim/species-roles.js
@@ -1,0 +1,19 @@
+'use strict';
+// Shared canonical role_class map for the badlands recruit pool. SINGLE source so both
+// mbti-policy (temperament ordering of the pool) and meta-band-aggregator (roster
+// composition metric) agree on which species fills which ecological role. Mirrors the role
+// tags in greedy-policy's RECRUIT_SPECIES_POOL comments.
+const SPECIES_ROLE = {
+  'dune-stalker': 'APEX',
+  'nano-rust-bloom': 'HAZARD',
+  'ferrocolonia-magnetotattica': 'PREDATOR',
+  'sand-burrower': 'PREY',
+  'rust-scavenger': 'SUPPORT',
+};
+
+// role_class for a species id; UNKNOWN for anything outside the canonical pool (never throws).
+function roleOf(speciesId) {
+  return SPECIES_ROLE[speciesId] || 'UNKNOWN';
+}
+
+module.exports = { SPECIES_ROLE, roleOf };


### PR DESCRIPTION
## fase-2c — roster_composition metric (makes P4 measurable)

Directly fixes the band report's **headline finding** (Finding 2): the 5 quantity metrics are policy-insensitive (greedy ≡ every mbti), so P4 (temperament) was not measurable. `roster_composition` is **policy-SENSITIVE**.

### What
- **`tools/sim/species-roles.js`** (new) — shared `species → role_class` map (single source for mbti-policy ordering + the aggregator); mbti-policy imports it (DRY).
- **`full-loop-runner.js`** — records `recruitedSpecies` (the species of each combat-recruit).
- **`meta-band-aggregator.js`** — NEW `roster_composition` metric: `role_profile` + `distinct_roles` + `dominant_roles`; band ≥ 3 distinct roles (healthy spread).
- **`full-loop-batch.js`** — renders the roster_composition row in the report.
- band report: Finding 2 addendum (P4 now measurable).

### Proof (real smoke)
```
greedy    dominant [APEX, HAZARD]  profile {APEX:8, HAZARD:8, PREDATOR:4, PREY:4, SUPPORT:4}
mbti:ESFP dominant [HAZARD, PREY]  profile {HAZARD:8, PREY:8, APEX:4, SUPPORT:4, PREDATOR:4}
```
Different **dominant roles** → P4 visible. Both in-band (≥3 roles = healthy); the *profile* carries the temperament signal. The quantity metrics remain policy-insensitive by design.

TDD red→green (incl. a policy-sensitivity divergence test). `tests/sim` **80/80**, AI **500/500**, governance errors=0.

### Safety
band-safe: `tools/sim/` + `tests/sim/` + the report doc only, **zero engine change**, no forbidden paths, no new deps. **Rollback**: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
