### PR TITLE
feat(sim): wire PI sink (hybrid perk pick) into economy_flow (fase-2c)

### DIFF
--- a/docs/playtest/2026-06-02-full-loop-band-report.md
+++ b/docs/playtest/2026-06-02-full-loop-band-report.md
@@ -80,11 +80,26 @@ sink side of the economy is never tested (surfaced honestly, not invented). buil
 (XP+MP) accrues flat (drift 1.25, in band). `mpEarnedTotal` is 0 because the runner does not
 send `encounter_meta` tier on advance — MP grants stay at the floor; XP carries the build power.
 
+> **UPDATE (since this baseline):** the PI sink is now **wired** — the runner attempts a hybrid
+> perk pick (`POST /api/progression/:unitId/pick`) for each leveled survivor with a PE-derived
+> PI budget (5:1). It still spends 0 in the canonical sim, but that is now **measured**, not
+> assumed: `pi_pick_attempts > 0` with `pi_insufficient = 0` → the picks are **blocked**, not
+> unaffordable. Verify-first found the cause: the sim roster's job (`stalker`) is not a perk-job
+> (perks.yaml covers skirmisher/vanguard/warden/artificer/invoker/ranger/harvester), so picks
+> 409; and at PE→PI 5:1 the budget would 402 anyway. → to actually exercise the sink, future
+> work needs a perk-job sim roster + a PE rate that affords the 5-PI pick.
+
 **4. `META_NETWORK_ROUTING` coverage is a no-op for the current runner.** The runner chooses
 paths via `driver.choose(branchKey)` → `/api/campaign/choose`, NOT the meta-network diagnostic
 endpoint that the `META_NETWORK_ROUTING` flag gates (`campaign.js:215`). Setting the flag does
 not change the runner. Routing-graph (`selectNextNodes`) coverage needs the runner wired to it
 — a separate slice, not a flag flip.
+
+> **UPDATE (since this baseline):** addressed by `tools/sim/meta-network-driver.js` — a
+> traversal harness walks the routing graph via the flag-gated endpoint, so with
+> `META_NETWORK_ROUTING=true` the batch report gains a routing-coverage section (the flag is no
+> longer a no-op in test-context). The live act/chapter campaign is unchanged; the PROD-enable
+> verdict stays master-dd's.
 
 ## For master-dd (ratify gate — L-069)
 

--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -135,6 +135,26 @@ test('buildReport: markdown with the 5 metric rows + a PROVISIONAL WARN banner',
   }
 });
 
+test('buildReport: PI-sink note reflects the wired/blocked state, never "NOT wired" (Codex #2574 P2)', () => {
+  // The sink is wired now: attempts>0, spent=0, insufficient=0 (canonical blocked case). The
+  // report must reuse the aggregator's honest note, not the stale hard-coded "NOT wired" claim.
+  const results = [
+    synthRun({
+      economy: {
+        peEarnedTotal: 24,
+        xpGrantedTotal: 36,
+        mpEarnedTotal: 6,
+        piSpentTotal: 0,
+        piPickAttempts: 18,
+        piInsufficient: 0,
+      },
+    }),
+  ];
+  const md = buildReport(buildSummary(results, { runs: 1 }));
+  assert.ok(!/NOT wired/i.test(md), 'no stale "NOT wired" claim in the report');
+  assert.match(md, /blocked|WIRED/i, 'report reflects the wired/blocked state');
+});
+
 test('writeArtifacts: writes runs.jsonl (one line per run) + summary.json + report.md', () => {
   const results = [synthRun(), synthRun()].map((r, i) => {
     r.provenance = buildProvenance({

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -112,10 +112,12 @@ test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -
     `at least one earned-gate (no-bypass) recruit, got ${res.economyRecruited.length}`,
   );
   assert.ok(res.offspring >= 1, `at least one mating offspring rolled, got ${res.offspring}`);
-  // fase-2b economy telemetry: the runner aggregates the backend's REAL advance economy
-  // per run (PE earned per cleared chapter + backend-computed XP/MP grants). PI-spent is
-  // 0 because no shop/PI-sink is wired in the loop yet -- surfaced as a real gap, never
-  // invented. These feed meta-band-aggregator's economy_flow metric.
+  // fase-2b/2c economy telemetry: the runner aggregates the backend's REAL advance economy
+  // per run (PE earned per cleared chapter + backend-computed XP/MP grants). The PI SINK is
+  // now WIRED (fase-2c): the runner attempts a hybrid perk pick for leveled survivors. In the
+  // canonical sim it spends 0 -- not invented: the sim roster's job ('stalker') is not a
+  // perk-job, so picks 409 (and the PE->PI 5:1 rate would 402 anyway). That is surfaced
+  // honestly via piPickAttempts (the sink is exercised-as-attempted), not hidden.
   assert.equal(res.initialRosterSize, 2, 'initial authored roster size captured');
   assert.ok(res.economy, 'economy telemetry present');
   const clearedChapters = res.chapters.filter((c) => c.outcome === 'victory').length;
@@ -125,7 +127,11 @@ test('runFullLoop: AI plays the cave_path campaign end-to-end with REAL combat -
     `PE earned = peEarned(3) x cleared chapters(${clearedChapters})`,
   );
   assert.ok(res.economy.xpGrantedTotal > 0, 'XP granted accrued from real victories');
-  assert.equal(res.economy.piSpentTotal, 0, 'no PI sink wired in the loop yet');
+  assert.equal(res.economy.piSpentTotal, 0, 'canonical sim cannot spend PI (job lacks perks)');
+  assert.ok(
+    res.economy.piPickAttempts > 0,
+    'PI sink wired: hybrid picks attempted for leveled survivors',
+  );
   // fase-2a scaled enemies: covered cave_path chapters (enc_tutorial_01/02, savana_01,
   // caverna_02) load real wave-1 rosters from YAML; the uncovered ones (tutorial_03/04/05,
   // tutorial_06_hardcore) fall back to the weak-fixed enemy. Assert BOTH paths run -> the
@@ -492,4 +498,76 @@ test('runFullLoop: a mbtiPolicy plays the real cave_path campaign end-to-end (fa
     `mbti policy recruited across chapters, got ${res.recruited.length}`,
   );
   assert.equal(res.economyAffinityProven, true, 'earned-affinity gate fired under the mbti policy');
+});
+
+// Shared fake http for the PI-sink tests: one victory chapter that COMPLETES the campaign
+// (skips the meta-step), a survivor at level 2 (xp_grants.level_after), and a /pick response
+// the test controls. `peEarned` drives the PE-derived PI budget (SoT 5:1).
+function piSinkHttp({ pickStatus, pickBody }) {
+  return {
+    post: async (path) => {
+      if (path === '/api/campaign/start') return { status: 201, body: { campaign: { id: 'c' } } };
+      if (path === '/api/session/start') return { status: 200, body: { session_id: 's' } };
+      if (path === '/api/campaign/advance') {
+        return {
+          status: 200,
+          body: {
+            campaign_completed: true,
+            xp_grants: [{ unit_id: 'hero_a', amount: 30, level_after: 2, leveled_up: true }],
+          },
+        };
+      }
+      if (path.startsWith('/api/progression/') && path.endsWith('/pick')) {
+        return { status: pickStatus, body: pickBody };
+      }
+      return { status: 200, body: {} };
+    },
+    get: async (path) => {
+      if (path === '/api/session/state')
+        return {
+          status: 200,
+          body: {
+            units: [{ id: 'hero_a', controlled_by: 'player', hp: 30 }],
+            active_unit: 'hero_a',
+          },
+        };
+      if (path === '/api/campaign/summary')
+        return { status: 200, body: { current_encounter: { encounter_id: 'e1' } } };
+      return { status: 200, body: {} };
+    },
+  };
+}
+
+const PI_ROSTER = [
+  { id: 'hero_a', max_hp: 30, job: 'stalker', position: { x: 1, y: 1 }, controlled_by: 'player' },
+];
+
+test('runFullLoop: PI sink spends on an affordable hybrid perk pick (fase-2c)', async () => {
+  // peEarned 30 -> after one victory peEarnedTotal 30 -> PI budget floor(30/5)=6 >= cost 5.
+  // The level-2 survivor's hybrid pick succeeds -> economy.piSpentTotal reflects the SINK.
+  const http = piSinkHttp({ pickStatus: 200, pickBody: { ok: true, pi_cost: 5 } });
+  const res = await runFullLoop(http, {
+    playerId: 'p',
+    roster: PI_ROSTER,
+    peEarned: 30,
+    maxChapters: 3,
+  });
+  assert.equal(res.economy.piSpentTotal, 5, 'PI actually spent on the hybrid pick');
+  assert.equal(res.economy.piPickAttempts, 1, 'one pick attempted');
+  assert.equal(res.economy.piInsufficient, 0);
+});
+
+test('runFullLoop: PI sink records insufficient PI when the economy cannot afford it (fase-2c)', async () => {
+  // peEarned 3 (canonical) -> PI budget floor(3/5)=0 < cost 5 -> /pick 402 insufficient_pi.
+  // The sink is WIRED + attempted; the tight economy is surfaced honestly (not hidden).
+  const http = piSinkHttp({ pickStatus: 402, pickBody: { ok: false, error: 'insufficient_pi' } });
+  const res = await runFullLoop(http, {
+    playerId: 'p',
+    roster: PI_ROSTER,
+    peEarned: 3,
+    maxChapters: 3,
+  });
+  assert.equal(res.economy.piSpentTotal, 0, 'nothing spent when unaffordable');
+  assert.equal(res.economy.piPickAttempts, 1, 'pick still attempted (sink wired)');
+  assert.equal(res.economy.piInsufficient, 1, 'insufficiency surfaced');
 });

--- a/tests/sim/metaBandAggregator.test.js
+++ b/tests/sim/metaBandAggregator.test.js
@@ -116,6 +116,68 @@ test('aggregate: economy_flow runaway build-power drift (>2x) flagged out', () =
   assert.equal(r.metrics.economy_flow.in_band, false);
 });
 
+test('aggregate: economy_flow surfaces PI pick attempts + insufficiency (sink wired, fase-2c)', () => {
+  // The PI sink is now WIRED: a run can attempt hybrid picks but the economy may not afford
+  // them (attempts>0, spent=0, insufficient>0). The aggregator surfaces that honestly.
+  const r = aggregate([
+    synthRun({
+      economy: {
+        peEarnedTotal: 24,
+        xpGrantedTotal: 36,
+        mpEarnedTotal: 6,
+        piSpentTotal: 0,
+        piPickAttempts: 3,
+        piInsufficient: 3,
+      },
+    }),
+  ]);
+  const ef = r.metrics.economy_flow;
+  assert.equal(ef.pi_pick_attempts, 3);
+  assert.equal(ef.pi_insufficient, 3);
+  assert.equal(ef.pi_sink_exercised, false);
+  assert.match(ef.note, /unaffordable|insufficient/i);
+});
+
+test('aggregate: economy_flow reports PI sink exercised when PI is actually spent', () => {
+  const r = aggregate([
+    synthRun({
+      economy: {
+        peEarnedTotal: 30,
+        xpGrantedTotal: 36,
+        mpEarnedTotal: 6,
+        piSpentTotal: 5,
+        piPickAttempts: 1,
+        piInsufficient: 0,
+      },
+    }),
+  ]);
+  assert.equal(r.metrics.economy_flow.pi_sink_exercised, true);
+  assert.match(r.metrics.economy_flow.note, /sink exercised/i);
+});
+
+test('aggregate: economy_flow notes picks BLOCKED when attempted but neither spent nor insufficient', () => {
+  // The real cave_path case: the sim roster's job has no perk pair (409), so picks are
+  // attempted but never resolve -- NOT a PI-budget problem. The note must say "blocked",
+  // not "unaffordable" (the verify-first finding: stalker is not a perk-job).
+  const r = aggregate([
+    synthRun({
+      economy: {
+        peEarnedTotal: 24,
+        xpGrantedTotal: 36,
+        mpEarnedTotal: 6,
+        piSpentTotal: 0,
+        piPickAttempts: 18,
+        piInsufficient: 0,
+      },
+    }),
+  ]);
+  const ef = r.metrics.economy_flow;
+  assert.equal(ef.pi_pick_attempts, 18);
+  assert.equal(ef.pi_insufficient, 0);
+  assert.equal(ef.pi_sink_exercised, false);
+  assert.match(ef.note, /blocked/i);
+});
+
 test('aggregate: relationship_progress in band when recruit + earned-affinity + mating all fire', () => {
   const r = aggregate([synthRun(), synthRun()]);
   const rp = r.metrics.relationship_progress;

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -346,10 +346,11 @@ function buildReport(summary) {
     );
   }
   lines.push('');
-  if (m.economy_flow && m.economy_flow.pi_sink_exercised === false) {
-    lines.push(
-      '> Note: PI sink (shop/build spend) is NOT wired in the loop yet -> economy_flow measures earn + build-power drift only (real gap, surfaced not invented).',
-    );
+  // Reuse the aggregator's economy_flow note (it already distinguishes exercised /
+  // unaffordable / blocked / wired) instead of a hard-coded claim that would go stale
+  // (Codex #2574 P2: the PI sink is now wired, so "NOT wired" was wrong).
+  if (m.economy_flow && m.economy_flow.note) {
+    lines.push(`> Note (economy_flow): ${m.economy_flow.note}`);
     lines.push('');
   }
   if (summary.routing && Array.isArray(summary.routing.runs)) {

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -99,6 +99,45 @@ function sumGrants(arr, field) {
   return arr.reduce((s, g) => s + (Number(g && g[field]) || 0), 0);
 }
 
+// fase-2c PI sink: the first hybrid-pickable perk level (level 2 = 10 XP, reached after the
+// first victory; perks.yaml default hybrid cost = 5 PI).
+const PICK_LEVEL = 2;
+
+// Exercise the economy SINK: for each survivor that has reached PICK_LEVEL (xp_grants
+// level_after) and has not yet picked it, attempt a hybrid perk pick via the existing
+// /api/progression/:unitId/pick endpoint (band-safe: no engine change). `availablePi` is the
+// run's PE-derived PI budget (SoT PE->PI 5:1), decremented as picks land. A pick that the
+// budget can't afford returns 402 insufficient_pi -> surfaced (not hidden), so a too-tight
+// economy reads honestly instead of leaving piSpentTotal a hardcoded 0. Returns the spend
+// tally; `pickedLevels` (a Set of unit ids) carries across chapters to avoid double-picks.
+async function applyProgressionSpend(http, { id, xpGrants, availablePi, pickedLevels }) {
+  let spent = 0;
+  let attempts = 0;
+  let insufficient = 0;
+  let budget = Number.isFinite(Number(availablePi)) ? Number(availablePi) : 0;
+  for (const g of Array.isArray(xpGrants) ? xpGrants : []) {
+    const unitId = g && g.unit_id;
+    if (!unitId || pickedLevels.has(unitId)) continue;
+    if (!(Number(g.level_after) >= PICK_LEVEL)) continue;
+    attempts += 1;
+    const pick = await http.post(`/api/progression/${unitId}/pick`, {
+      level: PICK_LEVEL,
+      choice: 'hybrid',
+      campaign_id: id,
+      available_pi: budget,
+    });
+    if (pick.status === 200) {
+      const cost = Number(pick.body && pick.body.pi_cost) || 0;
+      spent += cost;
+      budget -= cost;
+      pickedLevels.add(unitId);
+    } else if (pick.status === 402) {
+      insufficient += 1;
+    }
+  }
+  return { spent, attempts, insufficient };
+}
+
 async function runFullLoop(http, opts = {}) {
   const {
     playerId,
@@ -131,7 +170,14 @@ async function runFullLoop(http, opts = {}) {
       recruitedSpecies: [],
       metaViolations: [],
       initialRosterSize,
-      economy: { peEarnedTotal: 0, xpGrantedTotal: 0, mpEarnedTotal: 0, piSpentTotal: 0 },
+      economy: {
+        peEarnedTotal: 0,
+        xpGrantedTotal: 0,
+        mpEarnedTotal: 0,
+        piSpentTotal: 0,
+        piPickAttempts: 0,
+        piInsufficient: 0,
+      },
     };
   }
   const id = startRes.body.campaign.id;
@@ -157,6 +203,12 @@ async function runFullLoop(http, opts = {}) {
   let peEarnedTotal = 0;
   let xpGrantedTotal = 0;
   let mpEarnedTotal = 0;
+  // fase-2c economy SINK: PI spent on hybrid perk picks (real now, no longer hardcoded 0).
+  // pickedLevels carries across chapters so a unit picks PICK_LEVEL at most once.
+  let piSpentTotal = 0;
+  let piPickAttempts = 0;
+  let piInsufficient = 0;
+  const pickedLevels = new Set();
 
   for (let step = 1; step <= maxChapters; step += 1) {
     const sum = await driver.summary(http, id);
@@ -203,6 +255,20 @@ async function runFullLoop(http, opts = {}) {
     if (combat.outcome === 'victory') peEarnedTotal += peEarned;
     xpGrantedTotal += xpGranted;
     mpEarnedTotal += mpEarned;
+    // PI sink: spend PE-derived PI (5:1) on a hybrid perk pick for any survivor that just
+    // reached the pick level. Runs on victory (xp_grants + level-ups only happen there).
+    if (combat.outcome === 'victory') {
+      const availablePi = Math.floor(peEarnedTotal / 5) - piSpentTotal;
+      const spend = await applyProgressionSpend(http, {
+        id,
+        xpGrants: adv.body && adv.body.xp_grants,
+        availablePi,
+        pickedLevels,
+      });
+      piSpentTotal += spend.spent;
+      piPickAttempts += spend.attempts;
+      piInsufficient += spend.insufficient;
+    }
     chapters.push({
       step,
       encounter: enc,
@@ -265,7 +331,14 @@ async function runFullLoop(http, opts = {}) {
     offspring,
     economyAffinityProven,
     initialRosterSize,
-    economy: { peEarnedTotal, xpGrantedTotal, mpEarnedTotal, piSpentTotal: 0 },
+    economy: {
+      peEarnedTotal,
+      xpGrantedTotal,
+      mpEarnedTotal,
+      piSpentTotal,
+      piPickAttempts,
+      piInsufficient,
+    },
   };
 }
 

--- a/tools/sim/meta-band-aggregator.js
+++ b/tools/sim/meta-band-aggregator.js
@@ -110,6 +110,14 @@ function aggregate(runs) {
   const piSinkExercised = list.some(
     (r) => (Number(r && r.economy && r.economy.piSpentTotal) || 0) > 0,
   );
+  const piPickAttempts = list.reduce(
+    (s, r) => s + (Number(r && r.economy && r.economy.piPickAttempts) || 0),
+    0,
+  );
+  const piInsufficient = list.reduce(
+    (s, r) => s + (Number(r && r.economy && r.economy.piInsufficient) || 0),
+    0,
+  );
   const [eLo, eHi] = PROVISIONAL_BANDS.economy_flow;
   // Codex #2568 P2: build-power drift defaults to the neutral 1 when there is nothing to
   // measure (empty chapters / zero grants), which sits INSIDE the band. Guard on a real
@@ -121,14 +129,20 @@ function aggregate(runs) {
     build_power_avg: buildPowerAvg,
     build_power_drift: driftAvg,
     pi_sink_exercised: piSinkExercised,
+    pi_pick_attempts: piPickAttempts,
+    pi_insufficient: piInsufficient,
     has_signal: hasSignal,
     range: PROVISIONAL_BANDS.economy_flow,
     in_band: n > 0 && hasSignal && driftAvg >= eLo && driftAvg <= eHi,
     note: !hasSignal
       ? 'NO economy signal across the batch (zero XP/MP/PE) -> cannot certify economy_flow'
       : piSinkExercised
-        ? 'PE earned + build-power drift; PI sink exercised'
-        : 'PE earned + build-power drift; PI SINK NOT WIRED in the loop yet (real gap, not invented)',
+        ? `PE earned + build-power drift; PI sink exercised (${piPickAttempts} attempts)`
+        : piPickAttempts === 0
+          ? 'PE earned + build-power drift; PI sink wired (no pick opportunities this batch)'
+          : piInsufficient > 0
+            ? `PE earned + build-power drift; PI sink WIRED but unaffordable (${piPickAttempts} attempts, ${piInsufficient} insufficient_pi at the PE->PI 5:1 rate)`
+            : `PE earned + build-power drift; PI sink WIRED + attempted (${piPickAttempts}x) but no spend and no insufficiency -> picks blocked elsewhere (e.g. perk-job/level coverage)`,
   };
 
   // 4. relationship_progress: recruit rate + earned-affinity proof + mating, all firing =


### PR DESCRIPTION
## fase-2c — wire the PI sink (closes Finding 3)

The band report's Finding 3 was that the economy **sink side is untested** (`piSpentTotal` a hardcoded 0). Now the runner exercises it.

### What
- **`full-loop-runner.js`** — after a victory, for each survivor that reached the first pick level (2), attempt a **hybrid perk pick** (`POST /api/progression/:unitId/pick`) with a **PE-derived PI budget** (SoT PE→PI 5:1). Real `economy.{piSpentTotal, piPickAttempts, piInsufficient}`.
- **`meta-band-aggregator.js`** — `economy_flow` surfaces `pi_pick_attempts` + `pi_insufficient` and a note distinguishing **exercised** / **unaffordable** (insufficient_pi) / **blocked** (attempted but neither).
- band report: Finding 3 + Finding 4 addenda.

### Verify-first finding (real cave_path)
`piSpentTotal 0, piPickAttempts 18, piInsufficient 0` → the picks are **blocked, not unaffordable**. Cause (verify-first): the sim roster's job (`stalker`) is **not a perk-job** (perks.yaml covers skirmisher/vanguard/warden/artificer/invoker/ranger/harvester) → 409; and at 5:1 the budget (≤4) would 402 anyway. Surfaced honestly, not hidden. To actually *spend*, future work needs a perk-job sim roster + a PE rate that affords the 5-PI pick.

Unit tests prove the wiring both ways: spend-when-affordable (→ piSpentTotal 5) and insufficient (402 → counted). band-safe: existing endpoint, **no engine change**.

`tests/sim` **86/86**, AI **500/500**, governance errors=0.

### Safety
`tools/sim/` + `tests/sim/` + the report doc only, zero engine change, no forbidden paths, no new deps. **Rollback**: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
