### PR TITLE
feat(sim): calibrate full-loop completion into band + exercise PI sink (fase-2)

### DIFF
--- a/docs/playtest/2026-06-02-full-loop-band-report.md
+++ b/docs/playtest/2026-06-02-full-loop-band-report.md
@@ -1,9 +1,9 @@
 ---
-title: 'Full-loop meta band-metrics - N=40 baseline (fase-2c)'
+title: 'Full-loop meta band-metrics - N=40 baseline + calibration (fase-2c)'
 doc_status: active
 doc_owner: master-dd
 workstream: ops-qa
-last_verified: '2026-06-02'
+last_verified: '2026-06-03'
 source_of_truth: false
 language: en
 review_cycle_days: 30
@@ -24,7 +24,105 @@ N=40 measurement of that loop against the 5 provisional band-metrics.
 - Spec: [`docs/superpowers/specs/2026-06-02-full-loop-ai-playtest-runner-design.md`](../superpowers/specs/2026-06-02-full-loop-ai-playtest-runner-design.md) §7
 - Shipped: band aggregator + batch ([#2568](https://github.com/MasterDD-L34D/Game/pull/2568)), pluggable policy + mbtiPolicy ([#2569](https://github.com/MasterDD-L34D/Game/pull/2569))
 
-## Method
+---
+
+## CALIBRATION UPDATE (2026-06-03) — completion_rate brought into band + PI sink exercised
+
+> This section supersedes the **placements** of the baseline below (kept as the historical
+> record). The provisional band RANGES are unchanged and remain master-dd's to ratify (L-069).
+
+The baseline found `completion_rate = 1.00` with zero variance (Finding 1). Calibrating it into
+band turned out to need more than "tune the enemy stats" — three structural facts about the
+full-loop combat were in the way, each now addressed (all **band-safe**: `tools/sim/` +
+`tests/sim/` + this doc only, zero engine change):
+
+1. **The 30-HP starter party is effectively un-wipeable by the scaled enemies.** Per-hit damage
+   is ~1-3 and the authored enemies spawn far from the party (clamped grid), so they spend most
+   of a fight walking into range while the range-2 starters shoot them down. Raising enemy HP
+   just produced 40-round **timeouts** (a stalemate), never a defeat. → the only completion-
+   failure mode available is "mission not cleared in time", not "party wiped".
+2. **Infinite mission-retry made `completion_rate` degenerate.** The old runner re-fought a
+   non-cleared chapter every step (up to `maxChapters`), so a timeout never failed the campaign
+   — every run eventually completed → 1.00. **Fix:** one attempt per mission — a chapter the
+   party fails to clear (timeout/defeat) ends the campaign run (`full-loop-runner.js`). This is
+   what makes `completion_rate` a meaningful, tunable metric (P(clear the gating missions)).
+3. **The completion curve is steep** (combat variance ≈ ±7 HP of total enemy HP), so difficulty
+   is dialed with a **count + per-unit-HP** knob (`scenario-enemies.js` `scaling` param,
+   injected by the batch's `calibrationScaling()`), calibrated N=10 probe → N=40 ratify
+   (L-069/L-072/L-073).
+
+**Calibration (baked into `calibrationScaling()`):** `countMult 5 + hpAdd 3` → the two gating
+elimination missions (`enc_tutorial_01` ch1, `enc_savana_01` ch6) spawn **10 sistema units at
+~10 HP (100 total HP)**. The 30-HP party clears ~100 HP inside the 40-round limit ~60% of the
+time; the one-attempt cap turns the rest into campaign failures.
+
+**Windows reproducibility (`--isolate`):** at the calibrated difficulty (10-13 units/fight) the
+in-process batch trips the same native crash the baseline hit (`0xC0000409`, ISTJ 3×); `--isolate`
+runs each seed in its own process (fresh memory) and retries on a crash, so the N=40 batch
+reproduces reliably. Crashed-after-retries seeds are excluded from N and logged (never silently
+counted).
+
+### Results (N=40 per policy, calibrated, `--isolate`)
+
+`greedy` ran a full N=40; `mbti:ESFP` ran N=39 (1 seed hit the native crash on all 3 retries →
+excluded from N + logged, never counted as a non-completion).
+
+| Metric                           | greedy (N=40)                                   | mbti:ESFP (N=39)                                | Provisional band | greedy |
+| -------------------------------- | ----------------------------------------------- | ----------------------------------------------- | ---------------- | :----: |
+| `completion_rate`                | **0.675** (27/40)                               | 0.795 (31/39)                                   | 0.40 – 0.70      |   ✅   |
+| `roster_attrition`               | 0.371                                           | 0.415                                           | (0, 1) excl.     |   ✅   |
+| `economy_flow` (build-pow drift) | 1.044, PI exercised (416 att.)                  | 1.16, PI exercised                              | 0.5 – 2.0        |   ✅   |
+| `relationship_progress`          | recruit 5.98 / aff 1.0 / mate 5.05 (reached 37) | recruit 5.95 / aff 1.0 / mate 5.08 (reached 34) | composite        |   ✅   |
+| `offspring_viability`            | 5.05                                            | 5.08                                            | ≥ 1              |   ✅   |
+| `roster_composition`             | **[APEX, HAZARD]** 5 roles                      | **[HAZARD, PREY]** 5 roles                      | ≥ 3 roles        |   ✅   |
+
+**greedy (the batch default) places ALL SIX metrics in band**, with `completion_rate = 0.675`
+inside the provisional [0.40, 0.70] (Finding 1 resolved). `roster_composition` diverges by
+temperament — greedy dominates `[APEX, HAZARD]`, ESFP `[HAZARD, PREY]` (P4 measurable, the
+headline of fase-2c, now under a calibrated difficulty).
+
+**New finding — `completion_rate` is mildly POLICY-SENSITIVE at calibrated difficulty.** The
+baseline (completion 1.0) reported the quantity metrics as policy-insensitive; under a real
+difficulty that is no longer fully true for completion. The ch1 gate (`enc_tutorial_01`, 2
+starters, no recruits yet) is identical across policies, but the ch6 sub-gate (`enc_savana_01`)
+is fought by the **recruited** party, whose composition differs by temperament — ESFP's recruits
+clear it slightly better, so ESFP completes more often (0.795, just above the band) than greedy
+(0.675). Calibrating greedy to the band centre (~0.55) is a razor's edge (combat variance ≈ ±7
+HP of total enemy HP; 100 HP → 0.675, 104 HP → ~0.3) and risks an L-070 overshoot, so the
+difficulty is left at the greedy-in-band point and the per-policy spread is surfaced for the
+master-dd ratify (it may prefer to widen the band, accept the spread, or set a per-policy band).
+
+### What changed beyond difficulty
+
+- **PI sink now SPENDS** (closes Finding 3, and **corrects its diagnosis**). The baseline blamed
+  the `stalker` job (not a perk-job → assumed 409). The real cause is a **store mismatch**: the
+  progression router (`createProgressionRouter()` in the plugin loader) owns its own store, while
+  campaign `/advance`'s XP auto-seed writes the `progressionApply` singleton — so the pick route
+  **404'd** the campaign-seeded unit regardless of job. **Fix (band-safe, faithful):** the
+  DEFAULT*ROSTER job is now `skirmisher` (a real perk-job in both `perks.yaml` and `jobs.yaml`)
+  **and** the runner seeds the unit via the route API before picking (exactly as a frontend does),
+  with the unit's real accumulated XP. With `peEarned` raised to a rate that affords the 5-PI
+  hybrid pick at the SoT 5:1 rate, `piSpentTotal > 0` and `pi_sink_exercised = true`. *(Unifying
+  the two progression stores is an engine follow-up, out of scope for this band-safe slice.)\_
+- **`affinity_proven_rate` decoupled from completion.** At a calibrated completion (< 0.9 by
+  design) ~40% of runs fail the gate mission before any recruit, so they never exercise the
+  earned-affinity gate. Counting them as "not proven" conflated this metric with
+  `completion_rate` and made the two bands un-satisfiable together. The metric now measures
+  affinity-proof **among runs that reached the Nido step** (≥1 recruit) — testing whether the
+  gate FIRES, not how often the campaign completes.
+
+### Reproduce (calibrated)
+
+```bash
+# calibration is baked into calibrationScaling(); --isolate is required on Windows
+node tools/sim/full-loop-batch.js --runs 40 --policy greedy   --isolate --commit $(git rev-parse --short HEAD)
+node tools/sim/full-loop-batch.js --runs 40 --policy mbti:ESFP --isolate --commit $(git rev-parse --short HEAD)
+# re-calibrate via env, e.g.: FL_ENEMY_COUNT_MULT=6 FL_ENEMY_HP_ADD=1 node ... --isolate
+```
+
+---
+
+## Method (baseline, historical)
 
 - `node tools/sim/full-loop-batch.js --runs 40 --policy <p> --commit 4a711aba` per policy.
 - In-process: a fresh `createApp({databasePath:null})` + supertest per run (hermetic: stub

--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -19,6 +19,9 @@ const {
   writeArtifacts,
   resolvePolicy,
   ROUTING_WALKS,
+  runChildSeed,
+  peEarnedConfig,
+  calibrationScaling,
 } = require('../../tools/sim/full-loop-batch');
 
 // Synthetic run-result (runFullLoop shape) for the pure-assembly tests.
@@ -61,11 +64,104 @@ test('parseArgs: defaults + flag overrides', () => {
     'mbti',
     '--seed-base',
     '500',
+    '--isolate',
+    '--child-seed',
+    '1007',
   ]);
   assert.equal(o.runs, 40);
   assert.equal(o.branch, 'surface_path');
   assert.equal(o.policy, 'mbti');
   assert.equal(o.seedBase, 500);
+  assert.equal(o.isolate, true, '--isolate flag parsed');
+  assert.equal(o.childSeed, '1007', '--child-seed value parsed');
+});
+
+test('parseArgs: isolate defaults off, childSeed null', () => {
+  const d = parseArgs(['node', 'full-loop-batch.js']);
+  assert.equal(d.isolate, false);
+  assert.equal(d.childSeed, null);
+});
+
+test('runChildSeed: retries a crashing child, returns the result once it succeeds', () => {
+  // Simulates the Windows 0xC0000409 native crash: the child throws twice (non-zero exit),
+  // then the 3rd fresh process succeeds. Pure retry logic (spawn + read injected).
+  let calls = 0;
+  const spawn = () => {
+    calls += 1;
+    if (calls < 3) throw new Error('Command failed: 0xC0000409');
+  };
+  const readResult = () => ({ completed: true, seed: 's' });
+  const r = runChildSeed('1000', { spawn, readResult, retries: 3 });
+  assert.equal(r.ok, true);
+  assert.equal(r.attempts, 3, 'retried until the 3rd attempt succeeded');
+  assert.equal(r.result.completed, true);
+});
+
+test('runChildSeed: gives up after `retries` crashes (no infinite loop, error surfaced)', () => {
+  const spawn = () => {
+    throw new Error('persistent crash');
+  };
+  const r = runChildSeed('1000', { spawn, readResult: () => ({}), retries: 3 });
+  assert.equal(r.ok, false);
+  assert.equal(r.attempts, 3);
+  assert.match(r.error, /persistent crash/);
+});
+
+test('runChildSeed: an unparseable/empty child result is retried, not accepted', () => {
+  let calls = 0;
+  const spawn = () => {};
+  const readResult = () => {
+    calls += 1;
+    return calls < 2 ? null : { completed: false };
+  };
+  const r = runChildSeed('x', { spawn, readResult, retries: 3 });
+  assert.equal(r.ok, true);
+  assert.equal(r.attempts, 2, 'first (null) result rejected, second accepted');
+});
+
+test('peEarnedConfig: defaults to an affording rate; FL_PE_EARNED overrides', () => {
+  delete process.env.FL_PE_EARNED;
+  // 5:1 PE->PI, hybrid cost 5 PI -> need >=25 PE over the arc; default must afford a run
+  // that clears >=4 victory chapters (4 * default >= 25).
+  assert.ok(peEarnedConfig() * 4 >= 25, 'default PE affords the hybrid pick within the arc');
+  process.env.FL_PE_EARNED = '12';
+  try {
+    assert.equal(peEarnedConfig(), 12);
+  } finally {
+    delete process.env.FL_PE_EARNED;
+  }
+});
+
+test('calibrationScaling: FL_ENEMY_* env overrides each knob (robust to baked defaults)', () => {
+  for (const k of [
+    'FL_ENEMY_COUNT_MULT',
+    'FL_ENEMY_COUNT_ADD',
+    'FL_ENEMY_HP_MULT',
+    'FL_ENEMY_HP_ADD',
+    'FL_ENEMY_MOD_ADD',
+    'FL_ENEMY_DC_ADD',
+  ]) {
+    delete process.env[k];
+  }
+  // No env -> the BAKED calibration (N=10 probe -> N=40 ratify): countMult 5 + hpAdd 3 =
+  // 10 sistema units at ~10 HP. Locks the calibration so an accidental revert to neutral
+  // (which made completion a degenerate 1.0) is caught.
+  const baked = calibrationScaling();
+  assert.equal(baked.countMult, 5, 'baked countMult (calibration)');
+  assert.equal(baked.hpAdd, 3, 'baked hpAdd (calibration)');
+  process.env.FL_ENEMY_COUNT_MULT = '7';
+  process.env.FL_ENEMY_DC_ADD = '9';
+  try {
+    const s = calibrationScaling();
+    assert.equal(s.countMult, 7);
+    assert.equal(s.dcAdd, 9);
+    for (const k of ['countMult', 'countAdd', 'hpMult', 'hpAdd', 'modAdd', 'dcAdd']) {
+      assert.ok(Number.isFinite(s[k]), `${k} is numeric`);
+    }
+  } finally {
+    delete process.env.FL_ENEMY_COUNT_MULT;
+    delete process.env.FL_ENEMY_DC_ADD;
+  }
 });
 
 test('buildProvenance: carries seed + commit + policy + scenario-chain + flags', () => {
@@ -192,8 +288,17 @@ test('writeArtifacts: writes runs.jsonl (one line per run) + summary.json + repo
 
 test('runBatch: real in-process smoke (K=2) -> real run-results aggregate (fase-2b)', async (t) => {
   // Default runOne path: spin createApp per run, AI plays the whole loop, aggregate. Proves
-  // the batch wiring end-to-end on the real backend (slower than the pure tests).
-  const results = await runBatch({ runs: 2, seedBase: 7000, branch: 'cave_path', commit: 'smoke' });
+  // the batch WIRING end-to-end on the real backend (slower than the pure tests). Pins
+  // `enemyScaling: {}` (faithful, no calibration) so this smoke stays deterministic + tests
+  // wiring, NOT difficulty -- the calibrated difficulty is exercised by the N=40 band batch
+  // (see docs/playtest/2026-06-02-full-loop-band-report.md), not this 2-run smoke.
+  const results = await runBatch({
+    runs: 2,
+    seedBase: 7000,
+    branch: 'cave_path',
+    commit: 'smoke',
+    enemyScaling: {},
+  });
   assert.equal(results.length, 2);
   for (const r of results) {
     assert.equal(
@@ -209,9 +314,10 @@ test('runBatch: real in-process smoke (K=2) -> real run-results aggregate (fase-
   }
   const summary = buildSummary(results, { runs: 2, branch: 'cave_path' });
   assert.equal(summary.n, 2);
-  // With the current weak/scaled enemies the AI never loses -> completion 1.0, OUT of the
-  // provisional 0.40-0.70 band. That OUT-of-band result is the POINT: the band correctly
-  // flags "too easy" until enemy scaling/calibration (fase-2c) brings it into range.
+  // At faithful (un-calibrated) difficulty the AI never loses -> completion 1.0, OUT of the
+  // provisional 0.40-0.70 band. That the band flags this as "too easy" is the POINT; the
+  // baked calibrationScaling() default (asserted separately) is what brings completion into
+  // range for the real band batch.
   assert.equal(summary.metrics.completion_rate.value, 1);
   assert.equal(summary.metrics.completion_rate.in_band, false);
 });

--- a/tests/sim/fullLoopRunner.test.js
+++ b/tests/sim/fullLoopRunner.test.js
@@ -571,3 +571,95 @@ test('runFullLoop: PI sink records insufficient PI when the economy cannot affor
   assert.equal(res.economy.piPickAttempts, 1, 'pick still attempted (sink wired)');
   assert.equal(res.economy.piInsufficient, 1, 'insufficiency surfaced');
 });
+
+test('runFullLoop: a skirmisher (perk-job) roster spends PI on the REAL progression engine (slice b)', async (t) => {
+  // The two PI-sink tests above STUB /pick. This one runs the REAL backend: it proves the
+  // engine accepts a perk-job pick + spends. The canonical sim roster's prior job ('stalker')
+  // is not a perk-job -> /api/progression/:id/pick 409s before the PI gate -> piSpentTotal
+  // stuck at 0 (see the stalker e2e above, line ~130). A real perk-job (skirmisher, present in
+  // BOTH perks.yaml and jobs.yaml) reaches engine.pickPerk; with an affording PE (5:1, hybrid
+  // cost 5 PI) the sink actually spends. This is the slice-b guard against a regression back to
+  // a non-perk job.
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = supertestHttp(app);
+  const skirmisherRoster = starterRoster().map((u) => ({ ...u, job: 'skirmisher' }));
+  const res = await runFullLoop(http, {
+    playerId: 'fl_pi_skirmisher',
+    roster: skirmisherRoster,
+    branchKey: 'cave_path',
+    seed: 'fl-pi-skirm',
+    peEarned: 30, // floor(30/5)=6 >= the 5-PI hybrid cost after the first victory
+    maxChapters: 15,
+  });
+  assert.ok(
+    res.economy.piSpentTotal >= 5,
+    `skirmisher reaches the real pickPerk -> at least one 5-PI hybrid pick spent; economy=${JSON.stringify(res.economy)}`,
+  );
+  assert.ok(res.economy.piPickAttempts > 0, 'hybrid picks attempted for leveled survivors');
+  // piInsufficient may be >0 transiently (two starters reach level 2 the same chapter; the
+  // PE->PI budget affords one, the other picks once PE refills next chapter) -- the point is
+  // the sink SPENDS, not that every attempt lands the same turn.
+});
+
+test('runFullLoop: an unclearable mission (timeout) ENDS the run -- one attempt, no infinite retry (slice a)', async () => {
+  // Calibrated scaled-enemy difficulty makes a mission unwinnable in 40 rounds -> timeout.
+  // The OLD runner re-fought the same chapter every step (up to maxChapters), so a timeout
+  // never failed the campaign -> completion_rate degenerately 1.0. The capped runner ends the
+  // campaign after a non-victory mission, so the scaled difficulty sets P(clear the gating
+  // missions) and completion_rate becomes a meaningful, tunable band metric.
+  let advances = 0;
+  const http = {
+    post: async (path) => {
+      if (path === '/api/campaign/start') return { status: 201, body: { campaign: { id: 'c' } } };
+      if (path === '/api/session/start') return { status: 200, body: { session_id: 's' } };
+      if (path === '/api/campaign/advance') {
+        advances += 1;
+        return { status: 200, body: {} }; // paused (non-victory) -> would retry under the old loop
+      }
+      return { status: 200, body: {} };
+    },
+    get: async (path) => {
+      if (path === '/api/session/state') {
+        // A foe that never dies -> runEncounter never reaches victory -> timeout at maxRounds.
+        return {
+          status: 200,
+          body: {
+            units: [
+              { id: 'hero_a', controlled_by: 'player', hp: 30, position: { x: 1, y: 1 } },
+              { id: 'foe', controlled_by: 'sistema', hp: 99, position: { x: 4, y: 4 } },
+            ],
+            active_unit: 'hero_a',
+          },
+        };
+      }
+      if (path === '/api/campaign/summary') {
+        return { status: 200, body: { current_encounter: { encounter_id: 'e1' } } };
+      }
+      return { status: 200, body: {} };
+    },
+  };
+  const res = await runFullLoop(http, {
+    playerId: 'p',
+    roster: [
+      {
+        id: 'hero_a',
+        max_hp: 30,
+        job: 'skirmisher',
+        position: { x: 1, y: 1 },
+        controlled_by: 'player',
+      },
+    ],
+    maxChapters: 15,
+  });
+  assert.equal(res.completed, false, 'an unclearable mission fails the campaign');
+  assert.equal(
+    res.chapters.length,
+    1,
+    'exactly ONE mission attempt -- no 15x retry of the same chapter',
+  );
+  assert.equal(res.chapters[0].outcome, 'timeout');
+  assert.equal(advances, 1, 'advance called once (the run ended, it did not retry)');
+});

--- a/tests/sim/metaBandAggregator.test.js
+++ b/tests/sim/metaBandAggregator.test.js
@@ -198,6 +198,34 @@ test('aggregate: relationship_progress stalled (no recruit, no affinity) flagged
   assert.equal(r.metrics.relationship_progress.in_band, false);
 });
 
+test('aggregate: affinity_proven_rate is conditional on reaching the Nido step (decoupled from completion)', () => {
+  // A CALIBRATED batch (completion ~0.55) has runs that fail the gate mission before any
+  // recruit -> they never reach the Nido step. Those must NOT drag affinity_proven_rate down:
+  // the metric tests whether the earned-affinity gate FIRES when reached, not how often the
+  // campaign completes (that is completion_rate's job). Otherwise relationship_progress would
+  // be un-satisfiable whenever completion is intentionally < 0.9 (the two bands would conflict).
+  const reached = synthRun({
+    completed: true,
+    recruited: ['r1', 'r2'],
+    economyAffinityProven: true,
+  });
+  const failedEarly = synthRun({
+    completed: false,
+    recruited: [],
+    economyRecruited: [],
+    economyAffinityProven: false,
+    offspring: 0,
+  });
+  const r = aggregate([reached, failedEarly, failedEarly]); // 1 reached the step, 2 failed early
+  const rp = r.metrics.relationship_progress;
+  assert.equal(
+    rp.affinity_proven_rate,
+    1,
+    'proven among runs that reached the step (1/1), not 1/3',
+  );
+  assert.equal(rp.in_band, true, 'relationship band holds even when ~2/3 of runs fail the gate');
+});
+
 test('aggregate: offspring_viability in band when offspring rolled (>=1 avg)', () => {
   const r = aggregate([synthRun(), synthRun()]);
   const ov = r.metrics.offspring_viability;

--- a/tests/sim/scenarioEnemies.test.js
+++ b/tests/sim/scenarioEnemies.test.js
@@ -5,6 +5,7 @@ const {
   buildScenarioEnemies,
   TIER_HP,
   TIER_MOD,
+  TIER_DC,
   GRID_SAFE_MAX,
 } = require('../../tools/sim/scenario-enemies');
 
@@ -44,4 +45,43 @@ test('buildScenarioEnemies: missing or unsupported YAML -> null (runner falls ba
   assert.equal(buildScenarioEnemies('enc_escort_01'), null, 'escort -> null');
   assert.equal(buildScenarioEnemies('enc_tutorial_02'), null, 'survival -> null');
   assert.equal(buildScenarioEnemies('enc_caverna_02'), null, 'capture_point -> null');
+});
+
+// fase-2c difficulty calibration (Finding 1: completion_rate 1.0 OOB). The authored
+// encounters are 2-base-unit fights a 30-HP party crushes deterministically; the band
+// needs a tunable difficulty knob. `scaling` is the injected calibration the band batch
+// applies (faithful default = no scaling), kept here as a pure, testable param (no env
+// global). Count is the decisive lever (damage is ~1-3/hit, so 2 units can never out-race
+// a 60-HP party; more units can), with hp/mod/dc deltas for the fine knife-edge.
+
+test('buildScenarioEnemies: scaling.countMult multiplies the wave-1 unit count', () => {
+  // enc_tutorial_01 wave-1 = 2 units. x3 -> 6 distinct scaled units.
+  const enemies = buildScenarioEnemies('enc_tutorial_01', { countMult: 3 });
+  assert.equal(enemies.length, 6, '2 authored units x3 = 6 scaled');
+  assert.equal(new Set(enemies.map((e) => e.id)).size, 6, 'ids stay distinct after scaling');
+});
+
+test('buildScenarioEnemies: scaling.countAdd adds flat units per unitDef', () => {
+  assert.equal(buildScenarioEnemies('enc_tutorial_01', { countAdd: 2 }).length, 4, '2 + 2 = 4');
+});
+
+test('buildScenarioEnemies: scaling hp/mod/dc deltas tune the tier stats', () => {
+  const e = buildScenarioEnemies('enc_tutorial_01', {
+    hpMult: 2,
+    hpAdd: 1,
+    modAdd: 5,
+    dcAdd: 4,
+  })[0]; // base tier
+  assert.equal(e.hp, TIER_HP.base * 2 + 1, 'hp = base*hpMult + hpAdd');
+  assert.equal(e.max_hp, e.hp, 'max_hp tracks scaled hp');
+  assert.equal(e.mod, TIER_MOD.base + 5, 'mod = base + modAdd');
+  assert.equal(e.dc, TIER_DC.base + 4, 'dc = base + dcAdd');
+});
+
+test('buildScenarioEnemies: no scaling -> faithful authored count + tier defaults', () => {
+  const enemies = buildScenarioEnemies('enc_tutorial_01');
+  assert.equal(enemies.length, 2, 'no count scaling by default');
+  assert.equal(enemies[0].hp, TIER_HP.base, 'default base hp');
+  assert.equal(enemies[0].mod, TIER_MOD.base, 'default base mod');
+  assert.equal(enemies[0].dc, TIER_DC.base, 'default base dc');
 });

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -25,19 +25,22 @@ process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH =
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const { execFileSync } = require('node:child_process');
 const { runFullLoop } = require('./full-loop-runner');
 const { aggregate, PROVISIONAL_BANDS } = require('./meta-band-aggregator');
 const greedyPolicy = require('./greedy-policy');
 const { makeMbtiPolicy } = require('./mbti-policy');
 const { traverse } = require('./meta-network-driver');
 
-// Canonical cave_path starter party (mirrors tests/sim/fullLoopRunner.test.js): a
-// dune_stalker + velox authored squad. The Nido recruits grow it as chapters clear.
+// Canonical cave_path starter party: a dune_stalker + velox authored squad. The Nido
+// recruits grow it as chapters clear. job = `skirmisher` (slice b): a real perk-job
+// (perks.yaml AND jobs.yaml) so the PI sink reaches the engine pick (the prior `stalker` was
+// neither -> /api/progression/:id/pick 409'd before the PI gate, piSpentTotal stuck at 0).
 const DEFAULT_ROSTER = [
   {
     id: 'hero_a',
     species: 'dune_stalker',
-    job: 'stalker',
+    job: 'skirmisher',
     hp: 30,
     max_hp: 30,
     ap: 3,
@@ -51,7 +54,7 @@ const DEFAULT_ROSTER = [
   {
     id: 'hero_b',
     species: 'velox',
-    job: 'stalker',
+    job: 'skirmisher',
     hp: 30,
     max_hp: 30,
     ap: 3,
@@ -73,6 +76,10 @@ function parseArgs(argv) {
     maxChapters: 15,
     out: '',
     commit: process.env.GIT_COMMIT || 'unknown',
+    // --isolate: run each seed in its own child process (Windows native-crash mitigation).
+    // --child-seed <n>: internal -- the per-seed child entry the isolate parent spawns.
+    isolate: false,
+    childSeed: null,
   };
   for (let i = 2; i < argv.length; i += 1) {
     const tok = argv[i];
@@ -98,6 +105,12 @@ function parseArgs(argv) {
         break;
       case '--commit':
         args.commit = next();
+        break;
+      case '--isolate':
+        args.isolate = true;
+        break;
+      case '--child-seed':
+        args.childSeed = next();
         break;
       default:
         if (tok && tok.startsWith('--')) console.warn(`unknown arg: ${tok}`);
@@ -178,6 +191,8 @@ async function runBatch(opts = {}) {
     roster = DEFAULT_ROSTER,
     playerPrefix = 'fl_batch',
     flags = currentFlags(),
+    enemyScaling = calibrationScaling(),
+    peEarned = peEarnedConfig(),
     runOne = runOneReal,
     onProgress,
   } = opts;
@@ -192,6 +207,8 @@ async function runBatch(opts = {}) {
       seed,
       maxChapters,
       policy: policyImpl,
+      enemyScaling,
+      peEarned,
     };
     const res = await runOne(runOpts);
     const scenarioChain = (res.chapters || []).map((c) => c.encounter);
@@ -208,6 +225,132 @@ async function runBatch(opts = {}) {
     if (typeof onProgress === 'function') onProgress(i + 1, runs, res);
   }
   return results;
+}
+
+// fase-2c difficulty calibration (band-report Finding 1: completion_rate 1.0 OOB). The band
+// batch fights the scaled-enemy chapters (enc_tutorial_01 + enc_savana_01, both 2x base) at
+// this difficulty so completion_rate lands in the provisional 0.4-0.7 band -- the faithful
+// 2-unit fight is crushed deterministically by the 30-HP starter party. The numbers below
+// are baked (the band report reproduces with `node full-loop-batch.js`, no special env);
+// each FL_ENEMY_* env var overrides one knob for the N=10->N=40 bisection (L-069/L-072/L-073:
+// N=10 probes direction, N=40 ratifies). Count is the decisive lever (damage ~1-3/hit means
+// 2 units can never out-race a 60-HP party; more units can).
+function calibrationScaling() {
+  const num = (name, d) => {
+    const v = Number(process.env[name]);
+    return Number.isFinite(v) ? v : d;
+  };
+  // Baked calibration (N=10 probe -> N=40 ratify, L-069): countMult 5 + hpAdd 3 = the gating
+  // elimination missions (enc_tutorial_01 + enc_savana_01, both 2x base) spawn 10 sistema
+  // units at ~10 HP (= 100 total HP). The 30-HP starter party clears ~100 HP within the
+  // 40-round mission limit ~60% of the time; the one-attempt-per-mission cap (full-loop-runner)
+  // turns the other ~40% (a mission that runs out the clock) into a campaign failure ->
+  // completion_rate lands in the provisional 0.4-0.7 band. Each FL_ENEMY_* env var overrides
+  // one knob for re-calibration. (hpAdd not hpMult: integer per-unit HP is the natural dial.)
+  return {
+    countMult: num('FL_ENEMY_COUNT_MULT', 5),
+    countAdd: num('FL_ENEMY_COUNT_ADD', 0),
+    hpMult: num('FL_ENEMY_HP_MULT', 1),
+    hpAdd: num('FL_ENEMY_HP_ADD', 3),
+    modAdd: num('FL_ENEMY_MOD_ADD', 0),
+    dcAdd: num('FL_ENEMY_DC_ADD', 0),
+  };
+}
+
+// fase-2c PI sink (slice b): the per-victory PE the runner converts to PI (SoT 5:1) to spend
+// on a hybrid perk pick. The faithful runner default (3) never affords the 5-PI pick over the
+// arc; the band batch raises it (FL_PE_EARNED, default 8) so a run clearing >=4 chapters
+// accrues >=32 PE = 6 PI >= cost. Paired with the skirmisher (perk-job) DEFAULT_ROSTER the
+// sink is actually exercised (the non-perk 'stalker' 409'd before reaching the PI gate).
+function peEarnedConfig() {
+  const v = Number(process.env.FL_PE_EARNED);
+  return Number.isFinite(v) && v > 0 ? v : 8;
+}
+
+// --- Subprocess isolation (Windows native-crash mitigation, --isolate) ------------------
+// The in-process batch spins a fresh createApp per run; at the calibrated difficulty (6-8
+// sistema units/fight) the accumulated per-round trait-effect + AI work trips a Windows
+// native crash (0xC0000409 STATUS_STACK_BUFFER_OVERRUN) mid-batch -- the same flakiness the
+// N=40 baseline hit (band report, ISTJ 3x). `--isolate` runs each seed in its OWN node
+// process (fresh memory == immune to the accumulation) and retries on a crash, so the band
+// batch reproduces reliably at the calibrated difficulty. Pure retry/collect logic (spawn +
+// read injected) is unit-tested; the real spawn re-invokes this file in `--child-seed` mode.
+function runChildSeed(seed, { spawn, readResult, retries = 3 } = {}) {
+  let lastErr = null;
+  for (let attempt = 1; attempt <= retries; attempt += 1) {
+    try {
+      spawn(seed); // throws (non-zero child exit) on a native crash
+      const result = readResult(seed);
+      if (result && typeof result === 'object') return { ok: true, result, attempts: attempt };
+      lastErr = new Error('child produced no parseable result');
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  return { ok: false, attempts: retries, error: String((lastErr && lastErr.message) || lastErr) };
+}
+
+// runOne replacement (injected into runBatch) that runs each seed in an isolated child
+// process. Returns the runFullLoop result shape on success; a crash-after-retries sentinel
+// (completed:false + _crashed) that main() filters OUT of N (logged, never silently counted).
+function makeChildRunOne({ policyLabel = 'greedy', branch = 'cave_path', maxChapters = 15 } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fl-iso-'));
+  return async (runOpts) => {
+    const seed = String(runOpts.seed);
+    const outFile = path.join(dir, `run-${seed}.json`);
+    const spawn = () => {
+      try {
+        fs.rmSync(outFile, { force: true });
+      } catch {
+        /* fresh slate per attempt */
+      }
+      // Inherit env so the child sees the same FL_ENEMY_*/FL_PE_EARNED calibration; drop the
+      // child's stdio (backend logs are noise + the result travels via the out file).
+      execFileSync(
+        process.execPath,
+        [
+          __filename,
+          '--child-seed',
+          seed,
+          '--policy',
+          policyLabel,
+          '--branch',
+          branch,
+          '--max-chapters',
+          String(maxChapters),
+          '--out',
+          outFile,
+        ],
+        { env: process.env, stdio: 'ignore', maxBuffer: 64 * 1024 * 1024 },
+      );
+    };
+    const readResult = () => JSON.parse(fs.readFileSync(outFile, 'utf8'));
+    const r = runChildSeed(seed, { spawn, readResult });
+    if (r.ok) return r.result;
+    console.warn(
+      `[isolate] seed ${seed} crashed after ${r.attempts} attempts (${r.error}) -- EXCLUDED from N (logged, not silently counted)`,
+    );
+    return { completed: false, _crashed: true, chapters: [], economy: {} };
+  };
+}
+
+// The per-seed child entry the isolate parent spawns: one full loop, result written as JSON
+// to --out (the parent reads it back). Same config path as the in-process runOne (calibration
+// + PE from env), so an isolated batch is identical to the in-process one minus the crash.
+async function runChildOnce(args) {
+  const { policy: policyImpl } = resolvePolicy(args.policy);
+  const res = await runOneReal({
+    playerId: `fl_iso_${args.childSeed}`,
+    roster: DEFAULT_ROSTER,
+    branchKey: args.branch,
+    seed: String(args.childSeed),
+    maxChapters: args.maxChapters,
+    policy: policyImpl,
+    enemyScaling: calibrationScaling(),
+    peEarned: peEarnedConfig(),
+  });
+  const out = args.out || path.join(os.tmpdir(), `fl-child-${args.childSeed}.json`);
+  fs.writeFileSync(out, JSON.stringify(res));
 }
 
 // The env flags the report should record alongside each run: the fase-2c routing test-
@@ -389,7 +532,11 @@ function writeArtifacts(outDir, { results, summary, report }) {
 
 async function main() {
   const args = parseArgs(process.argv);
+  // Isolate child entry: run ONE seed + write its result; the parent reads it back.
+  if (args.childSeed != null) return runChildOnce(args);
   const flags = currentFlags();
+  const enemyScaling = calibrationScaling();
+  const peEarned = peEarnedConfig();
   const outDir =
     args.out ||
     path.join(
@@ -398,21 +545,43 @@ async function main() {
       `batch-${new Date().toISOString().replace(/[:.]/g, '-')}`,
     );
   console.log(
-    `FULL-LOOP BATCH: ${args.runs} runs | branch=${args.branch} policy=${args.policy} seedBase=${args.seedBase} commit=${args.commit} flags=${JSON.stringify(flags)}`,
+    `FULL-LOOP BATCH: ${args.runs} runs | branch=${args.branch} policy=${args.policy} seedBase=${args.seedBase} commit=${args.commit} isolate=${args.isolate} peEarned=${peEarned} flags=${JSON.stringify(flags)} enemyScaling=${JSON.stringify(enemyScaling)}`,
   );
   const t0 = Date.now();
-  const results = await runBatch({
+  const runOne = args.isolate
+    ? makeChildRunOne({
+        policyLabel: args.policy,
+        branch: args.branch,
+        maxChapters: args.maxChapters,
+      })
+    : runOneReal;
+  const rawResults = await runBatch({
     ...args,
     flags,
+    enemyScaling,
+    peEarned,
+    runOne,
     onProgress: (done, total, res) => {
-      const outcome = res.completed
-        ? 'completed'
-        : (res.chapters || []).slice(-1)[0]?.outcome || 'incomplete';
+      const outcome = res._crashed
+        ? 'CRASHED'
+        : res.completed
+          ? 'completed'
+          : (res.chapters || []).slice(-1)[0]?.outcome || 'incomplete';
       process.stdout.write(
         `[${done}/${total}] ${outcome} chapters=${(res.chapters || []).length}\n`,
       );
     },
   });
+  // Crashed-after-retries seeds are EXCLUDED from N (logged, never silently counted as a
+  // non-completion -- that would bias completion_rate down). With fresh-process retries this
+  // is ~0; surfaced honestly when not.
+  const crashed = rawResults.filter((r) => r && r._crashed).length;
+  const results = rawResults.filter((r) => !(r && r._crashed));
+  if (crashed) {
+    console.warn(
+      `[isolate] ${crashed}/${rawResults.length} seeds crashed after retries -> EXCLUDED from N (N=${results.length}); re-run those seeds to fill the batch`,
+    );
+  }
   // fase-2c: when the routing flag is on, exercise the meta-network graph (test-context)
   // so the flag is no longer a no-op for the report (band-report Finding 4).
   let routing;
@@ -430,6 +599,7 @@ async function main() {
       policy: args.policy,
       commit: args.commit,
       flags,
+      enemyScaling,
     },
     routing,
   );
@@ -469,4 +639,8 @@ module.exports = {
   writeArtifacts,
   runToJsonl,
   DEFAULT_ROSTER,
+  calibrationScaling,
+  peEarnedConfig,
+  runChildSeed,
+  makeChildRunOne,
 };

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -600,6 +600,10 @@ async function main() {
       commit: args.commit,
       flags,
       enemyScaling,
+      // Persist the PE-per-victory calibration too (Codex #2576 P2): FL_PE_EARNED changes PE
+      // totals + pi_sink affordability, so summary.config must carry it or two reports with
+      // the same enemyScaling could not be told apart / reproduced from summary.json.
+      peEarned,
     },
     routing,
   );

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -110,7 +110,10 @@ const PICK_LEVEL = 2;
 // budget can't afford returns 402 insufficient_pi -> surfaced (not hidden), so a too-tight
 // economy reads honestly instead of leaving piSpentTotal a hardcoded 0. Returns the spend
 // tally; `pickedLevels` (a Set of unit ids) carries across chapters to avoid double-picks.
-async function applyProgressionSpend(http, { id, xpGrants, availablePi, pickedLevels }) {
+async function applyProgressionSpend(
+  http,
+  { id, xpGrants, availablePi, pickedLevels, jobById, xpByUnit },
+) {
   let spent = 0;
   let attempts = 0;
   let insufficient = 0;
@@ -120,6 +123,24 @@ async function applyProgressionSpend(http, { id, xpGrants, availablePi, pickedLe
     if (!unitId || pickedLevels.has(unitId)) continue;
     if (!(Number(g.level_after) >= PICK_LEVEL)) continue;
     attempts += 1;
+    // Seed the unit in the ROUTE store before picking. campaign /advance auto-seeds in the
+    // progressionApply singleton, but createProgressionRouter() owns a SEPARATE store
+    // (pluginLoader injects none) -> the pick route would 404 the campaign-seeded unit (this,
+    // NOT the job, is why piSpentTotal was stuck at 0). A real frontend seeds progression via
+    // this same route, so the runner mirrors that faithful step. Seed with the unit's REAL
+    // accumulated XP so its level (= pick eligibility) is faithful; the job must be a perk-job
+    // (skirmisher) for /seed to accept it. (Unifying the two stores is an engine follow-up,
+    // out of scope for this band-safe sim slice.)
+    const job = jobById && typeof jobById.get === 'function' ? jobById.get(unitId) : null;
+    const xpTotal =
+      xpByUnit && typeof xpByUnit.get === 'function' ? Number(xpByUnit.get(unitId)) || 0 : 0;
+    if (job) {
+      await http.post(`/api/progression/${unitId}/seed`, {
+        job,
+        xp_total: xpTotal,
+        campaign_id: id,
+      });
+    }
     const pick = await http.post(`/api/progression/${unitId}/pick`, {
       level: PICK_LEVEL,
       choice: 'hybrid',
@@ -148,6 +169,10 @@ async function runFullLoop(http, opts = {}) {
     // fase-2c: pluggable meta-policy (greedy by default). mbtiPolicy swaps in temperament-
     // guided recruit/courtship/mating choices to test P4 across the band-batch.
     policy = greedyPolicy,
+    // fase-2c difficulty calibration: the scaling overlay applied to the scaled-enemy
+    // chapters (scenario-enemies). Faithful default = {} (no scaling); the band batch passes
+    // the calibrated knobs so completion_rate lands in band (Finding 1).
+    enemyScaling = {},
   } = opts;
   // Roster GROWS as the Nido recruits: it starts as the authored party and gains a
   // faithful combat unit per cleared chapter. knownIds is the matching id universe so a
@@ -209,6 +234,9 @@ async function runFullLoop(http, opts = {}) {
   let piPickAttempts = 0;
   let piInsufficient = 0;
   const pickedLevels = new Set();
+  // Per-unit accumulated XP (sum of advance xp_grants[].amount), so the route-store seed
+  // before each pick reflects the unit's REAL level (= pick eligibility), not a fake value.
+  const xpByUnit = new Map();
 
   for (let step = 1; step <= maxChapters; step += 1) {
     const sum = await driver.summary(http, id);
@@ -222,7 +250,7 @@ async function runFullLoop(http, opts = {}) {
     // fase-2a scaled enemies: load the chapter's real encounter roster from YAML; fall
     // back to the weak-fixed enemy when the encounter has no YAML (cave_path: tutorial_03/
     // 04/05 + tutorial_06_hardcore) or an unsupported objective, so the loop still runs.
-    const scaledEnemies = buildScenarioEnemies(enc);
+    const scaledEnemies = buildScenarioEnemies(enc, enemyScaling);
     const enemies = scaledEnemies && scaledEnemies.length ? scaledEnemies : enemiesForChapter(step);
     const enemiesSource = scaledEnemies && scaledEnemies.length ? 'scenario' : 'fallback';
 
@@ -255,6 +283,12 @@ async function runFullLoop(http, opts = {}) {
     if (combat.outcome === 'victory') peEarnedTotal += peEarned;
     xpGrantedTotal += xpGranted;
     mpEarnedTotal += mpEarned;
+    // Accumulate per-unit XP from this advance so the pick-seed reflects the real level.
+    for (const g of (adv.body && adv.body.xp_grants) || []) {
+      if (g && g.unit_id) {
+        xpByUnit.set(g.unit_id, (xpByUnit.get(g.unit_id) || 0) + (Number(g.amount) || 0));
+      }
+    }
     // PI sink: spend PE-derived PI (5:1) on a hybrid perk pick for any survivor that just
     // reached the pick level. Runs on victory (xp_grants + level-ups only happen there).
     if (combat.outcome === 'victory') {
@@ -264,6 +298,8 @@ async function runFullLoop(http, opts = {}) {
         xpGrants: adv.body && adv.body.xp_grants,
         availablePi,
         pickedLevels,
+        jobById: new Map(roster.map((u) => [u.id, u.job])),
+        xpByUnit,
       });
       piSpentTotal += spend.spent;
       piPickAttempts += spend.attempts;
@@ -280,6 +316,14 @@ async function runFullLoop(http, opts = {}) {
       xpGranted,
       mpEarned,
     });
+
+    // One attempt per mission (slice a): a chapter the party fails to clear (timeout or
+    // defeat) ENDS the campaign run -- no infinite retry of the same chapter. With infinite
+    // retries every run eventually completes -> completion_rate is degenerately 1.0; capping
+    // it makes completion_rate a MEANINGFUL, tunable band metric (the scaled-enemy difficulty
+    // sets P(clear the gating missions) into the 0.4-0.7 band). Weak/faithful chapters always
+    // win first try, so this only bites at calibrated difficulty.
+    if (combat.outcome !== 'victory') break;
 
     // Nido meta-step on a TRULY cleared chapter (Codex #2563 P2: gated on a 200 advance,
     // not just victory). Skipped on the campaign-completing chapter (Codex #2565 P2): a

--- a/tools/sim/meta-band-aggregator.js
+++ b/tools/sim/meta-band-aggregator.js
@@ -148,16 +148,28 @@ function aggregate(runs) {
   // 4. relationship_progress: recruit rate + earned-affinity proof + mating, all firing =
   // monotonic, non-stall.
   const recruitRate = round(mean(list.map((r) => ((r && r.recruited) || []).length)));
+  // affinity_proven_rate is CONDITIONAL on reaching the Nido step (a run with >=1 combat
+  // recruit ran the earned-affinity gate). A calibrated batch (completion < 0.9 by design)
+  // has runs that fail the gate mission BEFORE any recruit -> they never exercise the
+  // affinity gate, so counting them as "not proven" would conflate this metric with
+  // completion_rate (and make the two bands un-satisfiable together). Decoupled: among runs
+  // that reached the step, did the earned-affinity gate fire? (1.0 = always, the healthy case.)
+  const reachedStep = list.filter(
+    (r) => r && Array.isArray(r.recruited) && r.recruited.length > 0,
+  ).length;
   const affinityProvenRate =
-    n === 0 ? 0 : round(list.filter((r) => r && r.economyAffinityProven === true).length / n);
+    reachedStep === 0
+      ? 0
+      : round(list.filter((r) => r && r.economyAffinityProven === true).length / reachedStep);
   const matingRate = round(mean(list.map((r) => Number(r && r.offspring) || 0)));
   const relationship_progress = {
     recruit_rate: recruitRate,
     affinity_proven_rate: affinityProvenRate,
+    reached_step: reachedStep,
     mating_rate: matingRate,
     range: null,
     in_band: n > 0 && recruitRate > 0 && affinityProvenRate >= 0.9 && matingRate > 0,
-    note: 'recruit + earned-affinity gate + mating all fire (monotonic, non-stall)',
+    note: 'recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire',
   };
 
   // 5. offspring_viability: mean offspring per run >= threshold. Lineage diversity is NOT

--- a/tools/sim/scenario-enemies.js
+++ b/tools/sim/scenario-enemies.js
@@ -23,8 +23,9 @@ const yaml = require('js-yaml');
 const ENCOUNTER_DIR = path.resolve(__dirname, '..', '..', 'docs', 'planning', 'encounters');
 
 // Tier -> base combat stats (mirrors ai-driven-sim buildEnemiesFromYaml hp/mod table;
-// dc scales with tier so higher tiers are also harder to hit). Calibration of the exact
-// difficulty band is fase-2c (N=40), not this slice.
+// dc scales with tier so higher tiers are also harder to hit). These are the FAITHFUL
+// per-tier defaults; the band batch tunes difficulty on top via the `scaling` param below
+// (fase-2c calibration, Finding 1: completion_rate 1.0 OOB) -- never by mutating these.
 const TIER_HP = { base: 7, elite: 10, apex: 14 };
 const TIER_MOD = { base: 1, elite: 2, apex: 4 };
 const TIER_DC = { base: 10, elite: 11, apex: 12 };
@@ -42,7 +43,21 @@ const GRID_SAFE_MAX = 5;
 // survival/capture staging + the authored grid are deferred to fase-2c.
 const SUPPORTED_OBJECTIVES = new Set(['elimination']);
 
-function buildScenarioEnemies(scenarioId) {
+// `scaling` is the band-batch calibration overlay (fase-2c). Faithful default = {} (no
+// scaling = the authored 2-base-unit fight). countMult/countAdd scale the roster SIZE (the
+// decisive lever: damage is ~1-3/hit, so 2 units can never out-race a 60-HP party -- more
+// units can); hpMult/hpAdd + modAdd/dcAdd tune the per-unit knife-edge. Pure DI (no env
+// global) so it stays unit-testable + the batch records the values in provenance.
+function buildScenarioEnemies(scenarioId, scaling = {}) {
+  const s = scaling || {};
+  const num = (v, d) => (Number.isFinite(Number(v)) ? Number(v) : d);
+  const countMult = num(s.countMult, 1);
+  const countAdd = num(s.countAdd, 0);
+  const hpMult = num(s.hpMult, 1);
+  const hpAdd = num(s.hpAdd, 0);
+  const modAdd = num(s.modAdd, 0);
+  const dcAdd = num(s.dcAdd, 0);
+
   const yamlPath = path.join(ENCOUNTER_DIR, `${scenarioId}.yaml`);
   if (!fs.existsSync(yamlPath)) return null;
 
@@ -65,12 +80,15 @@ function buildScenarioEnemies(scenarioId) {
   let spIdx = 0;
   for (const unitDef of wave1.units || []) {
     const tier = unitDef.tier || 'base';
-    const count = unitDef.count || 1;
+    const authoredCount = unitDef.count || 1;
+    const count = Math.max(1, Math.round(authoredCount * countMult) + countAdd);
     const species = unitDef.species || 'predoni_nomadi';
+    const hp = Math.max(1, Math.round((TIER_HP[tier] || TIER_HP.base) * hpMult) + hpAdd);
+    const mod = (TIER_MOD[tier] || TIER_MOD.base) + modAdd;
+    const dc = (TIER_DC[tier] || TIER_DC.base) + dcAdd;
     for (let i = 0; i < count; i += 1) {
       const pos = spawnPoints[spIdx % spawnPoints.length];
       spIdx += 1;
-      const hp = TIER_HP[tier] || TIER_HP.base;
       const px = Math.min(GRID_SAFE_MAX, Math.max(0, (pos && pos[0]) || 0));
       const py = Math.min(GRID_SAFE_MAX, Math.max(0, (pos && pos[1]) || 0));
       enemies.push({
@@ -79,8 +97,8 @@ function buildScenarioEnemies(scenarioId) {
         hp,
         max_hp: hp,
         ap: 2,
-        mod: TIER_MOD[tier] || TIER_MOD.base,
-        dc: TIER_DC[tier] || TIER_DC.base,
+        mod,
+        dc,
         attack_range: 1,
         position: { x: px, y: py },
         controlled_by: 'sistema',


### PR DESCRIPTION
## What

Resumes the fase-2 full-loop AI-playtest goal: bring `completion_rate` into the provisional `0.40–0.70` band (it was a degenerate **1.00**) and make the **PI sink actually spend**. Band-safe — `tools/sim/` + `tests/sim/` + the band report only, **zero engine change**.

**Result (N=40 greedy, `--isolate`): `completion_rate = 0.675`, all 6 metrics in band.** `pi_sink_exercised = true` (416 pick attempts). Band report: [`docs/playtest/2026-06-02-full-loop-band-report.md`](https://github.com/MasterDD-L34D/Game/blob/claude/fase2-calibration/docs/playtest/2026-06-02-full-loop-band-report.md).

## Why it needed more than "tune the tier table"

The goal assumed scaling enemy stats would move completion. Three structural facts about the full-loop combat were in the way (all surfaced + addressed in `tools/sim/`):

1. **The 30-HP starter party is effectively un-wipeable** by the scaled enemies — per-hit damage is ~1–3 and enemies spawn far (clamped grid), so they walk into range while the range-2 starters shoot them. Raising HP only produced 40-round **timeouts**, never a defeat. → the only failure mode is "mission not cleared in time".
2. **Infinite mission-retry made completion degenerate** — the runner re-fought a non-cleared chapter every step, so a timeout never failed the campaign. **Fix: one attempt per mission** (a non-cleared chapter ends the run). This is what makes `completion_rate` a tunable metric.
3. **The completion curve is steep** (combat variance ≈ ±7 HP) → calibrated `countMult 5 + hpAdd 3` (10 units × ~10 HP = 100 total) via N=10 probe → N=40 ratify (L-069/L-072/L-073).

## Slice (b): PI sink — and a corrected diagnosis

The baseline blamed the `stalker` job (→ assumed 409). The real cause is a **progression store mismatch**: `createProgressionRouter()` owns its own store, while campaign `/advance` seeds the `progressionApply` singleton → the pick route **404'd** the campaign-seeded unit regardless of job. **Fix (band-safe, faithful):** `skirmisher` (a real perk-job in `perks.yaml` AND `jobs.yaml`) DEFAULT_ROSTER + the runner **seeds the unit via the route API before picking** (exactly as a frontend does) + `peEarned` that affords the 5-PI hybrid pick at the SoT 5:1 rate. _(Unifying the two stores is an engine follow-up, out of scope here.)_

## Other changes

- **`affinity_proven_rate` decoupled from completion** — at a calibrated completion (< 0.9 by design) ~40% of runs fail before any recruit, so they never exercise the affinity gate; counting them made the relationship + completion bands un-satisfiable together. Now measured among runs that **reached the Nido step**.
- **`--isolate`** — each seed in its own process (fresh memory) + retry, mitigating the Windows native crash (`0xC0000409`) the in-process batch hits at calibrated difficulty; crashed-after-retries seeds are excluded from N + **logged** (never silently counted).

## Findings for master-dd (ratify — L-069)

- The band RANGES stay **PROVISIONAL** — master-dd ratifies the exact numbers.
- **New**: `completion_rate` is **mildly policy-sensitive** at calibrated difficulty — greedy 0.675 (in band), `mbti:ESFP` 0.795 (just above): the ch1 gate is identical, but the ch6 sub-gate is fought by the recruited party whose composition differs by temperament. Centering greedy at ~0.55 is a razor's edge (risks an L-070 overshoot), so the difficulty is left at the greedy-in-band point and the spread is surfaced.
- The **one-attempt-per-mission** cap is a deliberate campaign-model change (reversible) — flagged for visibility.

## Test

- `node --test tests/sim/*.test.js` → **100/100** (TDD red→green for the scaling param, retry-cap, seed-before-pick, isolate retry, affinity decoupling).
- Prettier + `check_docs_governance.py --strict` (errors=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
