### PR TITLE
test(play): W8O-2 regression guard (anti-pattern #10)

### DIFF
--- a/tests/play/abilityPanelW8O2Guard.test.js
+++ b/tests/play/abilityPanelW8O2Guard.test.js
@@ -1,0 +1,53 @@
+// Regression guard -- anti-pattern #10 (silent fix+test drop).
+//
+// History: the W8O-2 clearAbilities token-bump fix first landed in PR #2321.
+// A Jules rewrite (PR #2327, "rewrite ability panel condition") then removed
+// BOTH the `_renderToken += 1` line AND its regression test
+// (tests/play/abilityPanelClearRace.test.js) in a single commit. CI stayed
+// GREEN: deleting a *.test.js never fails the `node --test tests/play/*.test.js`
+// glob, and with the fix's own test gone nothing caught the resurrected
+// "barra si e buggata" race. It was re-applied in PR #2336.
+//
+// This guard makes that exact silent drop go RED. It asserts:
+//   1. the race regression test FILE still exists (so deleting it fails here), and
+//   2. clearAbilities() still bumps the in-flight render token (the fix itself),
+//      so dropping the fix fails here even if the race test is also dropped.
+// Lives in tests/play so the existing CI glob picks it up automatically.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const ABILITY_PANEL = path.join(ROOT, 'apps', 'play', 'src', 'abilityPanel.js');
+const RACE_TEST = path.join(ROOT, 'tests', 'play', 'abilityPanelClearRace.test.js');
+
+describe('W8O-2 regression guard (anti-pattern #10: silent fix+test drop)', () => {
+  test('the clearAbilities race regression test file still exists', () => {
+    assert.ok(
+      fs.existsSync(RACE_TEST),
+      'tests/play/abilityPanelClearRace.test.js was removed -- a future rewrite must ' +
+        'not silently drop the W8O-2 race guard (see PR #2327 regression, #2336 restore).',
+    );
+  });
+
+  test('clearAbilities() still bumps the render token (the W8O-2 fix)', () => {
+    const src = fs.readFileSync(ABILITY_PANEL, 'utf8');
+    const start = src.indexOf('function clearAbilities');
+    assert.notEqual(start, -1, 'clearAbilities() not found in apps/play/src/abilityPanel.js');
+
+    // Window covering the clearAbilities() body (the token bump is its first
+    // statement). Bounded slice keeps this robust to whatever follows.
+    const region = src.slice(start, start + 600);
+    assert.match(
+      region,
+      /_renderToken\s*(\+=\s*1|\+\+)|\+\+\s*_renderToken/,
+      'clearAbilities() no longer invalidates the in-flight render token ' +
+        '(_renderToken bump): this is the W8O-2 "barra si e buggata" resurrection ' +
+        'fix (PR #2321 / #2336). Do not drop it.',
+    );
+  });
+});

--- a/tests/play/abilityPanelW8O2Guard.test.js
+++ b/tests/play/abilityPanelW8O2Guard.test.js
@@ -42,8 +42,14 @@ describe('W8O-2 regression guard (anti-pattern #10: silent fix+test drop)', () =
     // Window covering the clearAbilities() body (the token bump is its first
     // statement). Bounded slice keeps this robust to whatever follows.
     const region = src.slice(start, start + 600);
+    // Strip comments so a commented-out copy of the bump cannot satisfy the
+    // guard (Codex P2 #2577: a future rewrite could leave `// _renderToken += 1`
+    // while dropping the real statement -> false-negative). Match executable code.
+    const code = region
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*/g, '');
     assert.match(
-      region,
+      code,
       /_renderToken\s*(\+=\s*1|\+\+)|\+\+\s*_renderToken/,
       'clearAbilities() no longer invalidates the in-flight render token ' +
         '(_renderToken bump): this is the W8O-2 "barra si e buggata" resurrection ' +

--- a/tests/play/abilityPanelW8O2Guard.test.js
+++ b/tests/play/abilityPanelW8O2Guard.test.js
@@ -45,9 +45,7 @@ describe('W8O-2 regression guard (anti-pattern #10: silent fix+test drop)', () =
     // Strip comments so a commented-out copy of the bump cannot satisfy the
     // guard (Codex P2 #2577: a future rewrite could leave `// _renderToken += 1`
     // while dropping the real statement -> false-negative). Match executable code.
-    const code = region
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/\/\/.*/g, '');
+    const code = region.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '');
     assert.match(
       code,
       /_renderToken\s*(\+=\s*1|\+\+)|\+\+\s*_renderToken/,


### PR DESCRIPTION
## What

Adds a **regression guard** in `tests/play/` for the W8O-2 ability-panel race fix. Test-only; no runtime/game-logic change (freeze-safe).

## Why (anti-pattern #10)

The W8O-2 `clearAbilities()` token-bump fix first landed in **#2321**. Jules **#2327** ("rewrite ability panel condition") then removed **both** the `_renderToken += 1` line **and** its regression test in one commit. CI stayed **green** — deleting a `*.test.js` never fails the `node --test tests/play/*.test.js` glob, and with the fix's own test gone nothing caught the resurrected "barra si e buggata" bug. It was re-applied in **#2336**.

Ground-truth for this PR (verified on `origin/main`):
- fix present (`apps/play/src/abilityPanel.js:109`), race test present + **in CI glob** + **passing**.
- → the bug itself is **already fixed**; the recent Jules "stale render resurrection" flag is **stale**. No Jules dispatch (it broke this exact area once).
- The only missing piece was the anti-recurrence guard that #2336 *suggested* but never built. This PR adds it.

## How

`abilityPanelW8O2Guard.test.js` asserts:
1. `tests/play/abilityPanelClearRace.test.js` still **exists** (dropping it → red), and
2. `clearAbilities()` still **bumps `_renderToken`** (dropping the fix → red, even if the race test is also dropped).

So the exact #2327 silent fix+test drop now goes **CI-red**.

## Verification

- Guard **green** on current `origin/main` (2/2).
- **Negative proof**: simulating the #2327 drop (remove the token bump) → regex no-match → guard RED; missing test file → `existsSync` false → guard RED.

## Merge

Freeze-adjacent (combat/ability area) — **Eduardo reviews/merges**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
