### PR TITLE
feat(worldgen): meta-network live campaign routing + player-vote (slice A+C)

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -240,6 +240,19 @@ function createCampaignRouter(options = {}) {
     const defDoc = loadCampaignDef(campaign.campaignDefId);
     if (!defDoc) return res.status(500).json({ error: 'campaign def mancante' });
     const summary = summariseCampaign(campaign, defDoc);
+    // Slice A (Codex P2 #2582): in graph mode the campaign record still carries the static
+    // currentChapter, so the engine summary would report the static tutorial encounter.
+    // Override current_encounter with the current graph node's served encounter so a client
+    // polling /summary sees what /advance actually serves. Flag OFF -> summary unchanged.
+    if (_metaRoutingOn() && campaign.currentNode) {
+      const graph = metaNetworkResolver.getNetwork();
+      summary.current_encounter = {
+        encounter_id: encounterForNode(graph, campaign.currentNode),
+        node_id: campaign.currentNode,
+        is_choice_node: false,
+        choice: null,
+      };
+    }
     return res.json(summary);
   });
 
@@ -576,6 +589,16 @@ function createCampaignRouter(options = {}) {
       const clearedNodes = Array.isArray(graphCampaign.clearedNodes)
         ? graphCampaign.clearedNodes
         : [];
+      // Slice C victory-gate (Codex P2 #2582): a route choice is pending ONLY when the
+      // current node was just cleared -- the >1-candidate /advance marks it cleared WITHOUT
+      // advancing currentNode. Without this guard a client could /choose right after /start
+      // (clearedNodes []) and skip the node's encounter, jumping to the terminal route.
+      const clearedSet = new Set(clearedNodes.map(_normNode));
+      if (!clearedSet.has(_normNode(graphNode))) {
+        return res
+          .status(409)
+          .json({ error: `nessuna scelta di rotta pendente per il nodo ${graphNode}` });
+      }
       const route = selectNextNodes(graphNode, { graph, clearedNodes, season });
       const chosen = route.candidates.find((c) => _normNode(c.node_id) === _normNode(node_id));
       if (!chosen) {

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -58,7 +58,26 @@ const seasonalContentLoader = require('../services/campaign/seasonalContentLoade
 // arc-conditions (data gate) are POST-MVP — see spec
 // docs/superpowers/specs/2026-05-31-worldgen-gapc-meta-network-routing-design.md.
 const metaNetworkResolver = require('../services/worldgen/metaNetworkResolver');
-const { selectNextNodes } = require('../services/worldgen/metaNetworkRouting');
+const {
+  selectNextNodes,
+  encounterForNode,
+  isTerminal,
+} = require('../services/worldgen/metaNetworkRouting');
+
+// Slice A/C (live routing): is graph-routed campaign flow active? Read at request time
+// (the flag may flip between requests in tests). OFF (default) -> /start, /advance, /choose
+// behave exactly as the static chain (band-safe, reversible).
+function _metaRoutingOn() {
+  return process.env.META_NETWORK_ROUTING === 'true';
+}
+
+// Case-insensitive node id compare (mirrors metaNetworkRouting._norm) for cleared-set
+// membership + candidate validation.
+function _normNode(value) {
+  return String(value == null ? '' : value)
+    .trim()
+    .toLowerCase();
+}
 
 // In-memory seasonal state Map<campaign_id, state>. Per POC. Resettable via
 // _resetSeasonalState() per test isolation. Future iteration: integrate con
@@ -158,6 +177,29 @@ function createCampaignRouter(options = {}) {
     }
 
     const campaign = createCampaign(player_id, defId, { onboardingChoice, acquiredTraits });
+
+    // Slice A (live routing, flag ON): a graph-routed run begins at the authored
+    // start_node and serves its encounter from the graph; the static onboarding chain is
+    // skipped. Falls through to the static response below when the flag is OFF or the
+    // graph names no start_node (band-safe). currentNode/clearedNodes are additive fields.
+    if (_metaRoutingOn()) {
+      const graph = metaNetworkResolver.getNetwork();
+      const startNode = graph && graph.start_node ? graph.start_node : null;
+      if (startNode) {
+        const updated = updateCampaign(campaign.id, { currentNode: startNode, clearedNodes: [] });
+        return res.status(201).json({
+          campaign: updated,
+          next_encounter_id: encounterForNode(graph, startNode),
+          campaign_def: {
+            name: defDoc.name,
+            narrative_hook: defDoc.narrative_hook,
+            total_acts: defDoc.total_acts,
+            onboarding: onboarding || null,
+          },
+        });
+      }
+    }
+
     const firstAct = defDoc.acts[0];
     const firstEnc = (firstAct?.encounters || []).find((e) => !e.is_choice_node);
     return res.status(201).json({
@@ -265,11 +307,21 @@ function createCampaignRouter(options = {}) {
     const act = defDoc.acts.find((a) => a.act_idx === campaign.currentAct);
     if (!act) return res.status(500).json({ error: 'act corrente non trovato in def' });
 
+    // Slice A (live routing): in graph mode the "current" encounter is the one the current
+    // graph node serves (not the static chapter), so recordChapter + the defeat/timeout
+    // retry stay coherent. Flag OFF -> the static chapter encounter (byte-identical).
+    const graphMode = _metaRoutingOn();
+    const graph = graphMode ? metaNetworkResolver.getNetwork() : null;
+    const graphNode = graphMode && graph ? campaign.currentNode || graph.start_node : null;
+
     // Find current encounter in act via chapter_idx
     const currentEncEntry = (act.encounters || []).find(
       (e) => e.chapter_idx === campaign.currentChapter,
     );
-    const currentEncId = currentEncEntry?.encounter_id || null;
+    const currentEncId =
+      graphMode && graph
+        ? encounterForNode(graph, graphNode)
+        : currentEncEntry?.encounter_id || null;
 
     // Record chapter outcome
     const lastBranch =
@@ -374,6 +426,60 @@ function createCampaignRouter(options = {}) {
       });
     }
 
+    // Slice A (live routing, flag ON): traverse the graph instead of the static chain.
+    // Flag OFF -> falls through to the static act.encounters logic below (byte-identical).
+    if (graphMode && graph && graphNode) {
+      const clearedNodes = Array.isArray(campaign.clearedNodes) ? [...campaign.clearedNodes] : [];
+      if (!clearedNodes.some((c) => _normNode(c) === _normNode(graphNode))) {
+        clearedNodes.push(graphNode);
+      }
+      const season = campaignSeasonalState.get(id)?.current_season;
+      const route = selectNextNodes(graphNode, { graph, clearedNodes, season });
+      // Terminal climax OR no eligible next-node -> finish the run (reuse completion path).
+      if (isTerminal(graph, graphNode) || route.candidates.length === 0) {
+        updated = updateCampaign(id, {
+          finalState: 'completed',
+          completionPct: 1.0,
+          clearedNodes,
+          currentNode: graphNode,
+        });
+        return res.json({
+          campaign: updated,
+          next_encounter_id: null,
+          campaign_completed: true,
+          ...evolveFlags,
+          ...xpGrantsPayload,
+          ...mpGrantsPayload,
+        });
+      }
+      // Exactly one eligible node -> auto-advance + serve its encounter.
+      if (route.candidates.length === 1) {
+        const nextNode = route.candidates[0].node_id;
+        updated = updateCampaign(id, { currentNode: nextNode, clearedNodes });
+        return res.json({
+          campaign: updated,
+          next_encounter_id: encounterForNode(graph, nextNode),
+          ...evolveFlags,
+          ...xpGrantsPayload,
+          ...mpGrantsPayload,
+          ...dayPacingPayload,
+        });
+      }
+      // >1 eligible -> the players choose (co-op vote / solo / sim policy). Mark the node
+      // cleared but DON'T advance currentNode; /choose resolves against fresh candidates.
+      updated = updateCampaign(id, { clearedNodes, currentNode: graphNode });
+      return res.json({
+        campaign: updated,
+        next_encounter_id: null,
+        choice_required: true,
+        route_choice: { candidates: route.candidates },
+        ...evolveFlags,
+        ...xpGrantsPayload,
+        ...mpGrantsPayload,
+        ...dayPacingPayload,
+      });
+    }
+
     // Victory: advance chapter
     const nextChapterIdx = campaign.currentChapter + 1;
     const allEncounters = act.encounters || [];
@@ -449,8 +555,48 @@ function createCampaignRouter(options = {}) {
 
   // POST /api/campaign/choose
   router.post('/campaign/choose', (req, res) => {
-    const { id, branch_key } = req.body || {};
+    const { id, branch_key, node_id } = req.body || {};
     if (!id) return res.status(400).json({ error: 'id richiesto' });
+
+    // Slice C (live routing, flag ON + node_id present): the players chose a graph route
+    // node (co-op vote winner / solo pick / sim policy). Validate it is a current candidate
+    // of the campaign's graph node, then advance to it. Handled BEFORE the branch_key
+    // contract so the legacy path stays byte-identical when node_id is absent.
+    if (_metaRoutingOn() && node_id != null) {
+      const graphCampaign = getCampaign(id);
+      if (!graphCampaign) return res.status(404).json({ error: 'campaign non trovato' });
+      if (graphCampaign.finalState) {
+        return res
+          .status(409)
+          .json({ error: `campaign finalizzata (${graphCampaign.finalState})` });
+      }
+      const graph = metaNetworkResolver.getNetwork();
+      const graphNode = graphCampaign.currentNode || (graph && graph.start_node) || null;
+      const season = campaignSeasonalState.get(id)?.current_season;
+      const clearedNodes = Array.isArray(graphCampaign.clearedNodes)
+        ? graphCampaign.clearedNodes
+        : [];
+      const route = selectNextNodes(graphNode, { graph, clearedNodes, season });
+      const chosen = route.candidates.find((c) => _normNode(c.node_id) === _normNode(node_id));
+      if (!chosen) {
+        return res
+          .status(400)
+          .json({ error: `node_id "${node_id}" non valido per il nodo ${graphNode}` });
+      }
+      const prevChoices = Array.isArray(graphCampaign.routeChoices)
+        ? graphCampaign.routeChoices
+        : [];
+      const updated = updateCampaign(id, {
+        currentNode: chosen.node_id,
+        routeChoices: [...prevChoices, chosen.node_id],
+      });
+      return res.json({
+        campaign: updated,
+        next_encounter_id: encounterForNode(graph, chosen.node_id),
+        node_id: chosen.node_id,
+      });
+    }
+
     if (!branch_key) return res.status(400).json({ error: 'branch_key richiesto' });
     const campaign = getCampaign(id);
     if (!campaign) return res.status(404).json({ error: 'campaign non trovato' });

--- a/apps/backend/services/worldgen/metaNetworkResolver.js
+++ b/apps/backend/services/worldgen/metaNetworkResolver.js
@@ -60,6 +60,12 @@ function _load() {
     biome_id: n.biome_id != null ? String(n.biome_id).trim() : null,
     path: n.path != null ? String(n.path) : null,
     weight: Number.isFinite(Number(n.weight)) ? Number(n.weight) : 0,
+    // Slice A (live routing): the encounter(s) a node serves (MVP N=1 -> the first id
+    // is the node's encounter) + a terminal climax flag. Additive + defaulted so the
+    // graph stays back-compatible when the data is absent (mirrors the conditions
+    // strip fix below: without this the mapper would silently drop encounters).
+    encounters: Array.isArray(n.encounters) ? n.encounters.map((x) => String(x)) : [],
+    terminal: !!n.terminal,
   }));
   const edges = (Array.isArray(net.edges) ? net.edges : []).map((e) => ({
     from: String(e.from || '').trim(),
@@ -86,7 +92,15 @@ function _load() {
   }
 
   _cache = {
-    network: { id: net.id || null, label: net.label || null, nodes, edges },
+    network: {
+      id: net.id || null,
+      label: net.label || null,
+      // Slice A: where a graph-routed run begins (network-level, additive). Trim to a
+      // string id; null when unset -> graph routing falls back to the static chain.
+      start_node: net.start_node != null ? String(net.start_node).trim() : null,
+      nodes,
+      edges,
+    },
     nodeIndex,
     edgesBySource,
   };

--- a/apps/backend/services/worldgen/metaNetworkRouting.js
+++ b/apps/backend/services/worldgen/metaNetworkRouting.js
@@ -194,4 +194,27 @@ function selectNextNodes(currentNodeId, ctx = {}) {
   return { applied: true, from: currentNodeId, candidates, excluded, blocked, reason };
 }
 
-module.exports = { selectNextNodes };
+// --- TKT-WORLDGEN-GAPC slice A (live routing) — node->encounter + terminal lookups.
+// Pure helpers over a resolved graph (metaNetworkResolver shape: nodes carry
+// encounters[] + terminal). selectNextNodes decides WHERE to go; these decide WHAT a
+// node serves and whether the run ends there.
+
+// The encounter a node serves. MVP N=1: the first id is the node's encounter (node =
+// region, 1:N, default N=1 — master-dd verdict). Case-insensitive on the node id;
+// null on a missing graph/node or an encounter-less node (fail-closed: surfaced, no serve).
+function encounterForNode(graph, nodeId) {
+  if (!graph || !Array.isArray(graph.nodes) || !nodeId) return null;
+  const n = graph.nodes.find((x) => _norm(x.id) === _norm(nodeId));
+  return n && Array.isArray(n.encounters) && n.encounters.length ? n.encounters[0] : null;
+}
+
+// Whether a node is the terminal climax (reaching + clearing it ends the run). Case-
+// insensitive; false on a missing graph/node (a graph that can strand a run is a data
+// bug caught by the completability assertion, not a crash here).
+function isTerminal(graph, nodeId) {
+  if (!graph || !Array.isArray(graph.nodes) || !nodeId) return false;
+  const n = graph.nodes.find((x) => _norm(x.id) === _norm(nodeId));
+  return !!(n && n.terminal);
+}
+
+module.exports = { selectNextNodes, encounterForNode, isTerminal };

--- a/docs/superpowers/plans/2026-06-03-meta-network-live-routing-ac.md
+++ b/docs/superpowers/plans/2026-06-03-meta-network-live-routing-ac.md
@@ -1,0 +1,210 @@
+# Meta-network live routing + player-vote (slice A+C) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `META_NETWORK_ROUTING=true`, the live campaign routes via the meta-network graph (each node serves an encounter; >1 candidate → player/co-op/policy chooses); flag OFF behaves byte-identical to today.
+
+**Architecture:** Additive, flag-gated overlay. Resolver maps new node fields; routing gains pure helpers; `/advance` traverses the graph (flag ON only); `/choose` accepts `node_id`; co-op `world_vote` and the full-loop sim resolve the choice. Spec: [`2026-06-03-worldgen-gapc-live-routing-player-vote-design.md`](../specs/2026-06-03-worldgen-gapc-live-routing-player-vote-design.md).
+
+**Tech Stack:** Node (Express routes, `js-yaml`), `node:test` + `supertest`, the existing `metaNetworkResolver`/`metaNetworkRouting`/`coopOrchestrator`/`tools/sim` modules.
+
+**Invariants (every task):** TDD red→green; worktree `C:/dev/_gamewt-metanet-ac` (prettier 3.8.3 from `npm ci`); AI 500/500 + sim green; ADR-0011 commit trailer (`Coding-Agent: claude-opus-4.8` + uuidv7 `Trace-Id`, lowercase subject ≤72); owner-gated merge (data + live-flow). Allowed zone: `apps/backend` + `tools/sim` + `tests` + the network YAML. Forbidden: `.github/workflows`, `migrations`, `packages/contracts`, `services/generation`.
+
+---
+
+## File Structure
+
+- Modify `apps/backend/services/worldgen/metaNetworkResolver.js` — map `encounters`/`terminal` per node + network `start_node` (Task 1).
+- Modify `apps/backend/services/worldgen/metaNetworkRouting.js` — add `encounterForNode` + `isTerminal` pure helpers (Task 2).
+- Modify `packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml` — additive `encounters`/`terminal`/`start_node` + trace_hash (Task 3, owner-gated data).
+- Modify `apps/backend/routes/campaign.js` — `/advance` graph traversal + `/choose` `node_id` (Tasks 4-5).
+- Test `tests/api/coopWorldVoteRoute.test.js` (or extend co-op tests) — vote→/choose bridge (Task 6).
+- Modify `tools/sim/full-loop-runner.js` + `tools/sim/meta-network-driver.js` — graph-routed sim walk (Task 7).
+- Tests: `tests/server/metaNetworkResolver.spec.js`, `tests/server/metaNetworkRouting.spec.js` (or wherever the #2483/#2509 tests live — locate with `git grep -l metaNetworkRouting tests`), `tests/api/campaignMetaNetwork*.test.js`, `tests/sim/*.test.js`.
+
+---
+
+### Task 1: Resolver maps `encounters` / `terminal` / `start_node`
+
+**Files:**
+
+- Modify: `apps/backend/services/worldgen/metaNetworkResolver.js` (node map `:58-63`; network object `:89`)
+- Test: the existing resolver spec (locate: `git grep -l "metaNetworkResolver" tests`)
+
+- [ ] **Step 1: Write failing tests** — after `_resetCache()`, with a node carrying `encounters` + `terminal` and a network `start_node` in a fixture (or assert against the real YAML once Task 3 lands; for Task 1 use a temp fixture via `_resetCache` + a stubbed read, OR assert the mapper shape on the real file's first node which will gain fields in Task 3 — prefer a unit asserting the MAP logic):
+
+```js
+const resolver = require('../../apps/backend/services/worldgen/metaNetworkResolver');
+test('resolver maps node.encounters + node.terminal (additive, defaulted)', () => {
+  resolver._resetCache();
+  const net = resolver.getNetwork();
+  const node = net.nodes[0];
+  assert.ok(Array.isArray(node.encounters), 'encounters is always an array');
+  assert.equal(typeof node.terminal, 'boolean', 'terminal is always boolean');
+});
+test('resolver exposes network.start_node (string|null)', () => {
+  resolver._resetCache();
+  const net = resolver.getNetwork();
+  assert.ok(net.start_node === null || typeof net.start_node === 'string');
+});
+```
+
+- [ ] **Step 2: Run** `node --test <resolver-spec>` → FAIL (`encounters` undefined / `start_node` undefined).
+- [ ] **Step 3: Implement** — in the node `.map` (`:58-63`) add:
+
+```js
+encounters: Array.isArray(n.encounters) ? n.encounters.map((x) => String(x)) : [],
+terminal: !!n.terminal,
+```
+
+and in the network object (`:89`) add `start_node: net.start_node != null ? String(net.start_node).trim() : null,`.
+
+- [ ] **Step 4: Run** the spec → PASS. Also `node --test tests/server/*.spec.js` (or the worldgen specs) stay green.
+- [ ] **Step 5: Commit** `feat(worldgen): resolver maps node encounters/terminal + start_node` (+ ADR-0011 trailer).
+
+---
+
+### Task 2: Routing helpers `encounterForNode` + `isTerminal`
+
+**Files:**
+
+- Modify: `apps/backend/services/worldgen/metaNetworkRouting.js` (add helpers + export)
+- Test: the existing routing spec
+
+- [ ] **Step 1: Write failing tests:**
+
+```js
+const {
+  encounterForNode,
+  isTerminal,
+} = require('../../apps/backend/services/worldgen/metaNetworkRouting');
+const graph = {
+  nodes: [
+    { id: 'A', encounters: ['enc_x'], terminal: false },
+    { id: 'Z', encounters: ['enc_boss'], terminal: true },
+  ],
+};
+test('encounterForNode returns the node primary encounter (N=1)', () => {
+  assert.equal(encounterForNode(graph, 'A'), 'enc_x');
+  assert.equal(encounterForNode(graph, 'a'), 'enc_x'); // case-insensitive
+  assert.equal(encounterForNode(graph, 'MISSING'), null);
+});
+test('isTerminal reflects node.terminal', () => {
+  assert.equal(isTerminal(graph, 'Z'), true);
+  assert.equal(isTerminal(graph, 'A'), false);
+  assert.equal(isTerminal(graph, 'MISSING'), false);
+});
+```
+
+- [ ] **Step 2: Run** → FAIL (helpers undefined).
+- [ ] **Step 3: Implement** (reuse the module's existing `_norm` if present, else inline lowercase-trim):
+
+```js
+function encounterForNode(graph, nodeId) {
+  if (!graph || !Array.isArray(graph.nodes) || !nodeId) return null;
+  const n = graph.nodes.find((x) => _norm(x.id) === _norm(nodeId));
+  return n && Array.isArray(n.encounters) && n.encounters.length ? n.encounters[0] : null;
+}
+function isTerminal(graph, nodeId) {
+  if (!graph || !Array.isArray(graph.nodes) || !nodeId) return false;
+  const n = graph.nodes.find((x) => _norm(x.id) === _norm(nodeId));
+  return !!(n && n.terminal);
+}
+```
+
+Add both to `module.exports`.
+
+- [ ] **Step 4: Run** → PASS; routing spec green.
+- [ ] **Step 5: Commit** `feat(worldgen): encounterForNode + isTerminal routing helpers`.
+
+---
+
+### Task 3: Data — `encounters`/`terminal`/`start_node` in the network YAML (owner-gated)
+
+**Files:**
+
+- Modify: `packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml`
+- Test: `tests/scripts/test_trace_hashes.py` (only flags literal `to-fill`); network validators `packs/.../tools/py/validate_ecosistema_v2_0.py` + `validate_cross_foodweb_v1_0.py`
+
+- [ ] **Step 1** Add `start_node: DESERTO_CALDO` at the `network:` level. Add per-node (spec §4 starter assignment — master-dd ratifies):
+  - DESERTO_CALDO: `encounters: [enc_savana_01]`
+  - BADLANDS: `encounters: [enc_tutorial_03]`
+  - FORESTA_TEMPERATA: `encounters: [enc_caverna_02]`
+  - CRYOSTEPPE: `encounters: [enc_tutorial_04]`
+  - ROVINE_PLANARI: `encounters: [enc_tutorial_05, enc_tutorial_06_hardcore]` + `terminal: true`
+- [ ] **Step 2** Recompute `trace_hash` via the inline `_stable_digest` pattern (NOT the repo-wide tool — #2509 gotcha): `yaml.safe_load` → strip `trace_hash` recursively → `json.dumps(sort_keys=True, ensure_ascii=False, separators=(',',':'))` → sha256 → Edit the `receipt.trace_hash` line.
+- [ ] **Step 3: Run** the network validators (`python packs/evo_tactics_pack/tools/py/run_all_validators.py` or the two validators directly) + `python -m pytest tests/scripts/test_trace_hashes.py` → PASS (2.1 schema, no `==2.0` pin).
+- [ ] **Step 4** Resolver re-read assert: `node --test` Task 1 spec now sees real `encounters`/`start_node` on the real file.
+- [ ] **Step 5: Commit** `feat(worldgen): node->encounter map + start_node/terminal in meta_network (data-gate)`.
+
+---
+
+### Task 4: `/advance` graph traversal (flag ON), flag-OFF byte-identical
+
+**Files:**
+
+- Modify: `apps/backend/routes/campaign.js` (`/advance` `:248-447`; flag read like `:215`)
+- Modify: the campaign store (`getCampaign`/`updateCampaign` — `git grep -n "function updateCampaign" apps/backend`) for additive `currentNode`/`clearedNodes`
+- Test: `tests/api/campaignMetaNetworkRouting.test.js` (new)
+
+- [ ] **Step 1: Write failing tests** (supertest, `createApp({databasePath:null})`; set `process.env.META_NETWORK_ROUTING='true'` in one test, unset in the regression test):
+  - flag OFF: start a campaign, `/advance` victory → `next_encounter_id` equals the static-chain value (assert it matches today's behaviour exactly — snapshot the response shape).
+  - flag ON: start → campaign has `currentNode === 'DESERTO_CALDO'`; `/advance` victory at a single-candidate node → response `next_encounter_id === encounterForNode(next)`; at a multi-candidate node → `choice_required === true` + `route_choice.candidates.length > 1`; at the terminal node → campaign completes.
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement** — guard the new path on `process.env.META_NETWORK_ROUTING === 'true'`. On campaign start (where the campaign record is created), when flag ON set `currentNode = graph.start_node`, `clearedNodes = []`. In `/advance` on `outcome === 'victory'` when flag ON: push `currentNode` to `clearedNodes`; `const r = selectNextNodes(currentNode, { graph, clearedNodes, season })`; if `isTerminal(graph, currentNode)` or `r.candidates.length === 0` → finalize (reuse the existing completion branch); if `1` → `updateCampaign(id, { currentNode: r.candidates[0].<idField> })` + respond `next_encounter_id: encounterForNode(graph, nextNode)`; if `>1` → respond `{ choice_required: true, route_choice: { candidates: r.candidates } }` (do NOT advance currentNode yet). Flag OFF → the existing `act.encounters`/`chapter_idx` code path UNCHANGED. (Verify the candidate id field name from `selectNextNodes` — likely `node_id` or `to`; read `metaNetworkRouting.js:~150-194`.)
+- [ ] **Step 4: Run** → PASS; flag-OFF regression test green; `node --test tests/api/*.test.js` green.
+- [ ] **Step 5: Commit** `feat(campaign): graph-routed /advance behind META_NETWORK_ROUTING (flag off = static)`.
+
+---
+
+### Task 5: `/choose` accepts `node_id` (back-compat with `branch_key`)
+
+**Files:**
+
+- Modify: `apps/backend/routes/campaign.js` (`/choose` `:451-487`)
+- Test: `tests/api/campaignMetaNetworkRouting.test.js`
+
+- [ ] **Step 1: Write failing tests:** flag ON, after a `choice_required` advance, `POST /campaign/choose { id, node_id }` with a valid candidate → campaign `currentNode === node_id`, response `next_encounter_id === encounterForNode(node_id)`; an invalid `node_id` (not a current candidate) → 400; `branch_key` path still works (existing test green).
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement** — at the top of `/choose`, if `req.body.node_id` is present: validate it is a candidate of `currentNode` via `selectNextNodes` (recompute), else 400; on success `updateCampaign(id, { currentNode: node_id, routeChoices: [...] })` + respond `next_encounter_id: encounterForNode(graph, node_id)`. If `node_id` absent → existing `branch_key` logic verbatim.
+- [ ] **Step 4: Run** → PASS; existing `/choose` branch_key test green.
+- [ ] **Step 5: Commit** `feat(campaign): /choose accepts node_id for graph routing (branch_key back-compat)`.
+
+---
+
+### Task 6: Co-op `world_vote` → `/choose` bridge test (reuse, decoupled)
+
+**Files:**
+
+- Test: `tests/api/coopWorldVoteRouting.test.js` (new) — locate the co-op route + orchestrator: `apps/backend/routes/coop.js`, `apps/backend/services/coop/coopOrchestrator.js`
+- (No production change expected if the campaign side is choice-agnostic — this task PROVES the bridge; add a thin adapter only if the test shows a gap.)
+
+- [ ] **Step 1: Write failing test:** drive `coopOrchestrator.worldVote(playerId, node_id, true)` for a quorum → `worldTally` returns the winning `node_id`; submit that to `POST /campaign/choose { id, node_id }` → campaign advances to that node. Assert the winner from `worldTally` is a valid candidate for the campaign's `currentNode`.
+- [ ] **Step 2: Run** → FAIL (or reveal the gap).
+- [ ] **Step 3: Implement** — if a gap exists, add a thin mapping (candidates → vote options) on the co-op side; otherwise the test documents the reuse. Keep campaign routing choice-agnostic.
+- [ ] **Step 4: Run** → PASS.
+- [ ] **Step 5: Commit** `test(coop): world_vote winner resolves a graph route choice via /choose`.
+
+---
+
+### Task 7: Full-loop sim walks the graph (flag ON, policy picks at branches)
+
+**Files:**
+
+- Modify: `tools/sim/full-loop-runner.js` (graph-routed branch) + `tools/sim/meta-network-driver.js` (#2572)
+- Test: `tests/sim/fullLoopRunner.test.js` / `tests/sim/metaNetworkDriver.test.js`
+
+- [ ] **Step 1: Write failing test:** with `META_NETWORK_ROUTING='true'`, `runFullLoop` walks the graph: each step serves `encounterForNode(currentNode)` → real combat → on `choice_required`, the injected POLICY picks a candidate `node_id` → `/choose`; run reaches the terminal node + completes. Assert the route (sequence of `currentNode`) is POLICY-SENSITIVE (greedy vs mbti pick a different node at a multi-candidate branch).
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement** — in `full-loop-runner`, when flag ON, drive `/advance`→ if `choice_required`, call `policy.chooseRoute({ candidates, step })` (add a default `chooseRoute` to greedy = weight-desc/id-asc first; mbti = temperament-ordered by the node's biome/role) → `/choose { node_id }`. Reuse `meta-network-driver` for the graph reads. Keep flag-OFF path (today's static walk) unchanged.
+- [ ] **Step 4: Run** `node --test tests/sim/*.test.js` → PASS; AI 500/500 green.
+- [ ] **Step 5: Commit** `feat(sim): full-loop walks the meta-network graph (flag on), policy-routed`.
+
+---
+
+## Self-review notes
+
+- Spec coverage: §4 data → Task 3; §5 resolver/routing/advance/choose → Tasks 1,2,4,5; §6 co-op → Task 6; §8 sim → Task 7; §7 edge cases → assertions in Tasks 4-5 (fail-closed, 400, terminal). ✓
+- The candidate id field name in `selectNextNodes` output is verified at Task 4 Step 3 (read `metaNetworkRouting.js:150-194` — `node_id` vs `to`). Use that exact field in Tasks 4/5/7.
+- `chooseRoute` policy method (Task 7) is NEW on the policy interface; greedy + mbti both implement it; default = weight-desc/id-asc (deterministic).
+- Owner-gated: Task 3 (data) + the merge. Flag stays OFF (no PROD flip here).

--- a/docs/superpowers/specs/2026-06-03-worldgen-gapc-live-routing-player-vote-design.md
+++ b/docs/superpowers/specs/2026-06-03-worldgen-gapc-live-routing-player-vote-design.md
@@ -1,0 +1,150 @@
+---
+title: 'GAP-C meta-network: live campaign routing + player-vote at the branch (slice A+C)'
+doc_status: active
+doc_owner: master-dd
+workstream: flow
+last_verified: '2026-06-03'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# GAP-C meta-network — live routing + player-vote (slice A+C)
+
+> Brainstormed + master-dd-approved 2026-06-03. Fuses slice **A** (wire the meta-network graph
+> into live campaign routing) and slice **C** (player-choice / co-op vote at the branch). Slice
+> **B** (Sistema-pressure gates, Q-F Opt2) stays a separate later PR. This spec is the input to
+> `writing-plans`; the implementation is TDD, flag-gated, owner-gated merge (data + live-flow).
+
+## 1. Problem / current state (verified on origin/main `a6dd1611`)
+
+The meta-network graph (`meta_network_alpha.yaml`, 5 biome-nodes / 12 edges, schema 2.1) is today
+**read-only diagnostic only**: `GET /api/campaign/meta-network/next` (`campaign.js:214`, flag
+`META_NETWORK_ROUTING`) returns eligible next-node `candidates[]` via
+`metaNetworkRouting.selectNextNodes`, but **the live campaign does not route via the graph**.
+`POST /api/campaign/advance` (`campaign.js:248`) advances the **static `act.encounters` chain**
+(`chapter_idx`), and `POST /api/campaign/choose` (`:451`) resolves the one authored binary branch
+(`branch_key` → `resolveBranch`). The graph nodes carry **no encounter reference** and there is no
+node→encounter mapping (spec `2026-05-31-...-meta-network-routing-design.md` §7 stage 2, line 73).
+
+`cave_path` (`default_campaign_mvp`) and the graph were authored independently: the campaign's
+biomes (savana / caverna / pozza / rovine / cattedrale-boss) only partially overlap the 5 node
+biome_ids → no clean 1:1 retrofit. The encounter ORDER is the substrate of the just-ratified band
+calibration (`docs/playtest/2026-06-02-full-loop-band-report.md`), so the static path must stay
+byte-identical when the flag is off.
+
+## 2. Goal / scope
+
+When `META_NETWORK_ROUTING=true`, the live campaign **routes via the graph**: each node serves an
+encounter, and at a node with >1 eligible next-node the **players choose** (co-op vote or, solo/sim,
+the player/policy picks). When the flag is OFF (default), `/advance` + `/choose` behave **exactly as
+today** (static chain) — reversible, calibration-safe. Verifiable end-to-end in the full-loop sim.
+
+**In scope (one cohesive PR):** node→encounter data + resolver mapping; graph traversal in
+`/advance`; `node_id` choice in `/choose`; choice emission at multi-candidate branches; co-op
+`world_vote`→`/choose` reuse; sim + co-op tests.
+
+**Out of scope (deferred):** slice B Sistema-pressure gates (`min/max_pressure`, `campaignPressure`
+Q-F Opt2); the PROD flag flip (`META_NETWORK_ROUTING=true` live) = separate owner verdict; Godot
+map-ahead UI (fase-3, separate repo); generative grammar (fase-4); multi-encounter-per-node (N>1).
+
+## 3. Approach — graph as a routing LAYER (chosen 2026-06-03, over full re-author)
+
+Additive, flag-gated overlay. The static campaign def is untouched; the graph drives encounter
+selection only when the flag is on. The campaign def stays the source of encounter CONTENT; the
+graph becomes the routing TOPOLOGY over it.
+
+## 4. Data changes (`meta_network_alpha.yaml`, owner-gated; schema 2.1 already live)
+
+Additive per-node fields (the resolver currently strips unknown fields — must be extended):
+
+- `encounters: [<encounter_id>, ...]` — the encounter(s) the node serves. MVP **N=1** (master-dd
+  verdict: node=region 1:N, default N=1) → the first id is the node's encounter.
+- `terminal: true` — on the climax node; reaching + clearing it ends the campaign run (reuse the
+  existing completion / `exit_condition`).
+- `start_node: <node_id>` (network-level, additive) — where a graph-routed run begins. MVP: graph
+  mode routes the **5-node main arc**; the onboarding tutorials (`enc_tutorial_01/02`) stay
+  static-only (not graph-routed in this slice) — not every encounter lives on the graph.
+
+**Proposed starter assignment** (biome-aligned where it fits, fuzzy otherwise — master-dd ratifies
+at the data-gate merge, exactly like #2509's `conditions:` write):
+
+| Node (biome_id)                       | encounter                                                       | note                                    |
+| ------------------------------------- | --------------------------------------------------------------- | --------------------------------------- |
+| DESERTO_CALDO (savana)                | `enc_savana_01`                                                 | start node (savana)                     |
+| BADLANDS (canyons_risonanti)          | `enc_tutorial_03`                                               | "caverna risonante" ~ canyons           |
+| FORESTA_TEMPERATA (foresta_miceliale) | `enc_caverna_02`                                                | fuzzy                                   |
+| CRYOSTEPPE (mezzanotte_orbitale)      | `enc_tutorial_04`                                               | fuzzy; winter-gated edge already exists |
+| ROVINE_PLANARI (rovine_planari)       | `enc_tutorial_05`, then **terminal** `enc_tutorial_06_hardcore` | climax/boss                             |
+
+`trace_hash` recomputed (single-file inline `_stable_digest`, NOT the repo-wide tool — see #2509
+gotcha). Network validators (`validate_ecosistema_v2_0.py` + `validate_cross_foodweb_v1_0.py` in `packs/.../tools/py/`) have no `==2.0` pin → 2.1 passes.
+
+## 5. Code changes (`apps/backend`, the allowed zone)
+
+- **`metaNetworkResolver.js`** (mapper ~`:63-70`): add `encounters: n.encounters ?? []` +
+  `terminal: !!n.terminal` (mirrors the `conditions` fix from #2509 — the load-bearing strip).
+- **`metaNetworkRouting.js`**: a pure helper `encounterForNode(graph, nodeId) -> encounter_id|null`
+  (+ `isTerminal`). `selectNextNodes` already returns `candidates[]` — unchanged.
+- **`campaign.js` `/advance`** (flag ON only; flag OFF → today's code path verbatim):
+  - campaign gains `currentNode` (graph position) + `clearedNodes[]`. On start (flag ON),
+    `currentNode = graph.start_node` (authored, §4); the static onboarding chapters are skipped in
+    graph mode.
+  - on victory at `currentNode`: mark cleared; `selectNextNodes(currentNode, {graph, clearedNodes,
+season})` → - `candidates.length === 0` OR `isTerminal(currentNode)` → terminal (reuse completion path); - `=== 1` → auto-advance: `currentNode = candidate`, serve `encounterForNode`; - `> 1` → emit `{ choice_required: true, route_choice: { candidates } }` (reuse the
+    `choice_node` response shape) and WAIT for `/choose`.
+  - defeat/timeout → existing handling (one-attempt semantics unchanged).
+- **`campaign.js` `/choose`**: accept `node_id` (alongside `branch_key`). When `node_id` is a valid
+  candidate from the current node → set `currentNode = node_id`, append to a `routeChoices[]`,
+  serve `encounterForNode`. `branch_key` path unchanged (back-compat).
+- **campaign store**: `currentNode`, `clearedNodes`, `routeChoices` are additive fields, only
+  written in flag-ON mode.
+
+## 6. Co-op vote integration (slice C — reuse, don't reinvent)
+
+The co-op `world_vote` / `world_tally` already exist (`coopOrchestrator.js`: `worldVotes` Map,
+`worldVote(playerId, scenarioId, accept)` → `worldTally`). Integration is **thin + decoupled**:
+the campaign emits `route_choice.candidates`; the co-op layer runs the vote over those candidates
+and submits the winning `node_id` to `/campaign/choose`. The campaign routing stays
+choice-agnostic (it does not run the tally). Solo / sim resolve the same `/choose` directly (the
+chooser is the player or the full-loop policy) → **graph routing is POLICY-SENSITIVE** (greedy vs
+mbti pick different nodes → ties into P4 / the band metrics).
+
+## 7. Edge cases / errors
+
+- Flag OFF → **zero behavioural change** (regression-locked by a test asserting the static chain).
+- Node with no `encounters` → fail-closed (no serve; surfaced, not a crash).
+- `selectNextNodes` 0 candidates with no `terminal` → treat as terminal (run ends) AND log — a
+  graph that can strand a run is a data bug; **Dormans completability check** (≥1 non-gated path to
+  a terminal node) is a validator/test assertion on the authored graph.
+- `/choose node_id` not in the current node's candidates → 400 (invalid route choice).
+- Unknown / absent season → season-gated edges fail-closed (already the case, #2509).
+
+## 8. Verification (TDD)
+
+- **Unit** (`metaNetworkResolver`): maps `encounters` + `terminal`; tolerates absent (back-compat).
+- **Unit** (`metaNetworkRouting`): `encounterForNode` / `isTerminal`; (re-uses existing
+  `selectNextNodes` tests).
+- **Integration** (supertest, `createApp({databasePath:null})`):
+  - flag ON: `/advance` walks the graph start→terminal; a multi-candidate node emits
+    `choice_required`; `/choose node_id` advances to the chosen node + serves its encounter.
+  - flag OFF: `/advance` + `/choose` byte-identical to today (regression lock).
+  - `/choose node_id` not-a-candidate → 400.
+- **Co-op** (supertest/orchestrator): a `worldTally` winner submitted to `/choose` advances the
+  route (the vote→route bridge).
+- **Sim** (`tools/sim/full-loop-runner` + `meta-network-driver`, #2572): flag ON, the runner walks
+  the graph, the **policy** picks at branches (policy-sensitive path), real combat per node, run
+  completes at the terminal. Extends the existing routing-coverage harness.
+- Baselines preserved: AI 500/500, sim green, prettier + governance + network validators green.
+
+## 9. Flag / rollout
+
+`META_NETWORK_ROUTING` stays OFF by default → live + the ratified band report unchanged. The PROD
+flip is a **separate** owner verdict (after this lands + is exercised in the sim). Merge of THIS PR
+is owner-gated (data + live-flow change), not auto-L3.
+
+## 10. Open decisions for master-dd (ratify at the data-gate merge)
+
+1. The encounter→node assignment (§4 table) — starter proposal; ratify or edit.
+2. Which node is `terminal` (proposed ROVINE_PLANARI with the boss as its terminal encounter).
+3. Start node (proposed DESERTO_CALDO / savana).

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: daa14cfa4bcc63136485c46c1b99275980b5d66865477d6b72990c826afeb1e3
+  trace_hash: da178eebe5b6abbd1fe59775d99edd80b3a7a0ee30d1da4d41fd2b8a03b2d92a
 links:
   ecosystems:
   - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -14,27 +14,39 @@ links:
 network:
   id: ET_NET_ALPHA
   label: Evo-Tactics Meta‑Ecosystem Alpha
+  # Slice A (live routing, owner-gated): where a graph-routed run begins. The onboarding
+  # tutorials (enc_tutorial_01/02) stay static-only; graph mode routes the 5-node main arc.
+  start_node: DESERTO_CALDO
   nodes:
+  # Per-node `encounters` = the encounter(s) a node serves (MVP N=1 -> first id). `terminal`
+  # marks the climax: reaching + clearing it ends a graph-routed run. Starter assignment
+  # (spec section 4, biome-aligned where it fits) — master-dd ratifies at the data-gate merge.
   - id: BADLANDS
     biome_id: canyons_risonanti
     path: packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
     weight: 0.45
+    encounters: [enc_tutorial_03]
   - id: FORESTA_TEMPERATA
     biome_id: foresta_miceliale
     path: packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
     weight: 0.55
+    encounters: [enc_caverna_02]
   - id: DESERTO_CALDO
     biome_id: savana
     path: packs/evo_tactics_pack/data/ecosystems/deserto_caldo.ecosystem.yaml
     weight: 0.4
+    encounters: [enc_savana_01]
   - id: CRYOSTEPPE
     biome_id: mezzanotte_orbitale
     path: packs/evo_tactics_pack/data/ecosystems/cryosteppe.ecosystem.yaml
     weight: 0.4
+    encounters: [enc_tutorial_04]
   - id: ROVINE_PLANARI
     biome_id: rovine_planari
     path: packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml
     weight: 0.5
+    encounters: [enc_tutorial_05, enc_tutorial_06_hardcore]
+    terminal: true
   edges:
   - from: BADLANDS
     to: FORESTA_TEMPERATA

--- a/tests/api/campaignMetaNetworkRouting.test.js
+++ b/tests/api/campaignMetaNetworkRouting.test.js
@@ -189,3 +189,37 @@ test('choose: flag ON without node_id falls through to the branch_key contract (
   assert.equal(ch.status, 400);
   assert.match(ch.body.error || '', /branch_key/, 'branch_key path executed, not node_id');
 });
+
+// Codex P2 (#2582): /choose node_id must require a PENDING route choice (the current node
+// just cleared), else a client could skip the start encounter and jump straight to the
+// terminal -> a victory-gate bypass. Right after /start clearedNodes is [] -> reject.
+test('choose: flag ON node_id with no pending choice (encounter not cleared) -> 409, no bypass', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  const id = s.body.campaign.id;
+  // No /advance victory yet -> DESERTO_CALDO not cleared -> a choice is NOT pending.
+  const ch = await post(`${url}/api/campaign/choose`, { id, node_id: 'ROVINE_PLANARI' });
+  assert.equal(ch.status, 409, 'no pending route choice -> rejected');
+  // The campaign did NOT jump to the terminal route.
+  const st = await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' });
+  assert.equal(st.body.campaign.currentNode, 'DESERTO_CALDO', 'still at start, not bypassed');
+});
+
+// Codex P2 (#2582): /campaign/summary must reflect the GRAPH encounter in graph mode (not
+// the static tutorial chapter the campaign record still carries) so a client polling the
+// summary after /start sees what /advance actually serves.
+test('summary: flag ON reflects the current graph node encounter (not the static chapter)', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  const id = s.body.campaign.id;
+  const sum = await req('GET', `${url}/api/campaign/summary?id=${id}`);
+  assert.equal(sum.status, 200);
+  assert.equal(
+    sum.body.current_encounter.encounter_id,
+    'enc_savana_01',
+    'summary serves the start node encounter, not enc_tutorial_01',
+  );
+  assert.equal(sum.body.current_encounter.node_id, 'DESERTO_CALDO');
+});

--- a/tests/api/campaignMetaNetworkRouting.test.js
+++ b/tests/api/campaignMetaNetworkRouting.test.js
@@ -1,0 +1,191 @@
+// TKT-WORLDGEN-GAPC slice A+C — live campaign routing via the meta-network graph.
+// Flag-gated behind META_NETWORK_ROUTING: ON -> /advance + /choose walk the graph
+// (each node serves an encounter; >1 eligible -> the players choose); OFF (default) ->
+// the static act.encounters chain, byte-identical. Owner-gated (data + live flow).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createCampaignRouter } = require('../../apps/backend/routes/campaign');
+
+function startTestServer(t) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter());
+  const server = app.listen(0);
+  const port = server.address().port;
+  t.after(() => server.close());
+  return `http://127.0.0.1:${port}`;
+}
+
+function req(method, url, body) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = body != null ? JSON.stringify(body) : null;
+    const r = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        method,
+        headers: payload
+          ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) }
+          : {},
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () => {
+          let parsedBody = null;
+          try {
+            parsedBody = data ? JSON.parse(data) : null;
+          } catch {
+            parsedBody = data;
+          }
+          resolve({ status: res.statusCode, body: parsedBody });
+        });
+      },
+    );
+    r.on('error', reject);
+    if (payload) r.end(payload);
+    else r.end();
+  });
+}
+
+const post = (url, body) => req('POST', url, body);
+
+function enableFlag(t) {
+  process.env.META_NETWORK_ROUTING = 'true';
+  t.after(() => {
+    delete process.env.META_NETWORK_ROUTING;
+  });
+}
+
+async function startCampaign(url) {
+  return post(`${url}/api/campaign/start`, { player_id: 'meta_route_p' });
+}
+
+// --- flag OFF: byte-identical to the static chain (regression lock) ------------------
+
+test('advance: flag OFF -> static chain, no graph fields (regression lock)', async (t) => {
+  delete process.env.META_NETWORK_ROUTING;
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  assert.equal(s.status, 201);
+  // Static start: the first non-choice encounter of the def; NO graph position written.
+  assert.ok(typeof s.body.next_encounter_id === 'string' && s.body.next_encounter_id.length > 0);
+  assert.equal(s.body.campaign.currentNode, undefined, 'no graph currentNode in static mode');
+  const adv = await post(`${url}/api/campaign/advance`, {
+    id: s.body.campaign.id,
+    outcome: 'victory',
+  });
+  assert.equal(adv.status, 200);
+  assert.equal(adv.body.choice_required ?? false, false, 'no graph choice in static mode');
+  assert.equal(adv.body.route_choice, undefined, 'no route_choice in static mode');
+});
+
+// --- flag ON: graph-routed start + advance ------------------------------------------
+
+test('start: flag ON -> begins at the authored start_node, serves its encounter', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  assert.equal(s.status, 201);
+  assert.equal(s.body.campaign.currentNode, 'DESERTO_CALDO', 'starts at start_node');
+  assert.deepEqual(s.body.campaign.clearedNodes, []);
+  assert.equal(s.body.next_encounter_id, 'enc_savana_01', 'serves the start node encounter');
+});
+
+test('advance: flag ON multi-candidate node -> choice_required + candidates, currentNode unchanged', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  const adv = await post(`${url}/api/campaign/advance`, {
+    id: s.body.campaign.id,
+    outcome: 'victory',
+  });
+  assert.equal(adv.status, 200);
+  assert.equal(adv.body.choice_required, true);
+  assert.ok(adv.body.route_choice && Array.isArray(adv.body.route_choice.candidates));
+  const ids = adv.body.route_choice.candidates.map((c) => c.node_id);
+  assert.equal(ids.length, 2, 'DESERTO_CALDO -> BADLANDS + ROVINE_PLANARI');
+  assert.ok(ids.includes('BADLANDS') && ids.includes('ROVINE_PLANARI'));
+  assert.equal(adv.body.campaign.currentNode, 'DESERTO_CALDO', 'does not advance until /choose');
+  assert.deepEqual(
+    adv.body.campaign.clearedNodes,
+    ['DESERTO_CALDO'],
+    'current node marked cleared',
+  );
+});
+
+test('advance: flag ON single-candidate node -> auto-advances + serves the next encounter', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  const id = s.body.campaign.id;
+  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // -> choice
+  await post(`${url}/api/campaign/choose`, { id, node_id: 'BADLANDS' }); // -> BADLANDS
+  // BADLANDS -> { FORESTA_TEMPERATA (eligible), DESERTO_CALDO (cleared) } = ONE candidate.
+  const adv = await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' });
+  assert.equal(adv.status, 200);
+  assert.equal(adv.body.choice_required ?? false, false, 'single candidate -> no choice');
+  assert.equal(adv.body.campaign.currentNode, 'FORESTA_TEMPERATA', 'auto-advanced');
+  assert.equal(adv.body.next_encounter_id, 'enc_caverna_02');
+});
+
+test('advance: flag ON at the terminal node -> campaign completes', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  const id = s.body.campaign.id;
+  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // -> choice
+  await post(`${url}/api/campaign/choose`, { id, node_id: 'ROVINE_PLANARI' }); // terminal
+  const adv = await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' });
+  assert.equal(adv.status, 200);
+  assert.equal(adv.body.campaign_completed, true);
+  assert.equal(adv.body.campaign.finalState, 'completed');
+  assert.equal(adv.body.next_encounter_id, null);
+});
+
+// --- /choose node_id (slice C) ------------------------------------------------------
+
+test('choose: flag ON node_id advances to the chosen node + serves its encounter', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  const id = s.body.campaign.id;
+  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // -> choice
+  const ch = await post(`${url}/api/campaign/choose`, { id, node_id: 'BADLANDS' });
+  assert.equal(ch.status, 200);
+  assert.equal(ch.body.campaign.currentNode, 'BADLANDS');
+  assert.equal(ch.body.node_id, 'BADLANDS');
+  assert.equal(ch.body.next_encounter_id, 'enc_tutorial_03', 'serves the chosen node encounter');
+  assert.deepEqual(ch.body.campaign.routeChoices, ['BADLANDS']);
+});
+
+test('choose: flag ON node_id that is not a current candidate -> 400', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  const id = s.body.campaign.id;
+  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // candidates: BADLANDS, ROVINE_PLANARI
+  const ch = await post(`${url}/api/campaign/choose`, { id, node_id: 'CRYOSTEPPE' });
+  assert.equal(ch.status, 400, 'CRYOSTEPPE is not reachable from DESERTO_CALDO');
+});
+
+test('choose: flag ON without node_id falls through to the branch_key contract (back-compat)', async (t) => {
+  enableFlag(t);
+  const url = startTestServer(t);
+  const s = await startCampaign(url);
+  // node_id absent -> the legacy branch_key path runs; a bogus key 400s via resolveBranch
+  // (NOT the node_id validator), proving the fall-through is byte-identical.
+  const ch = await post(`${url}/api/campaign/choose`, {
+    id: s.body.campaign.id,
+    branch_key: 'bogus_key',
+  });
+  assert.equal(ch.status, 400);
+  assert.match(ch.body.error || '', /branch_key/, 'branch_key path executed, not node_id');
+});

--- a/tests/api/coopWorldVoteRouting.test.js
+++ b/tests/api/coopWorldVoteRouting.test.js
@@ -1,0 +1,91 @@
+// TKT-WORLDGEN-GAPC slice C — co-op world_vote -> /campaign/choose route bridge.
+// Proves the REUSE seam (no production change): the campaign emits route_choice
+// candidates; the co-op layer runs its existing accept-vote over the proposed route
+// node; the agreed winner (worldTally.scenario_id) is a valid candidate and, submitted
+// to POST /campaign/choose { node_id }, advances the campaign. Campaign routing stays
+// choice-agnostic (it never runs the tally) -> co-op + solo/sim share the same /choose.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createCampaignRouter } = require('../../apps/backend/routes/campaign');
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+
+function startTestServer(t) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter());
+  const server = app.listen(0);
+  const port = server.address().port;
+  t.after(() => server.close());
+  return `http://127.0.0.1:${port}`;
+}
+
+function post(url, body) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = JSON.stringify(body);
+    const r = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () =>
+          resolve({ status: res.statusCode, body: data ? JSON.parse(data) : null }),
+        );
+      },
+    );
+    r.on('error', reject);
+    r.end(payload);
+  });
+}
+
+test('co-op world_vote winner resolves a graph route choice via /choose', async (t) => {
+  process.env.META_NETWORK_ROUTING = 'true';
+  t.after(() => {
+    delete process.env.META_NETWORK_ROUTING;
+  });
+  const url = startTestServer(t);
+
+  // 1. Campaign reaches a multi-candidate branch (DESERTO_CALDO -> BADLANDS + ROVINE_PLANARI).
+  const s = await post(`${url}/api/campaign/start`, { player_id: 'coop_route_p' });
+  const id = s.body.campaign.id;
+  const adv = await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' });
+  assert.equal(adv.body.choice_required, true);
+  const candidates = adv.body.route_choice.candidates.map((c) => c.node_id);
+  assert.ok(candidates.length > 1, 'a genuine multi-candidate choice');
+
+  // 2. The co-op party runs its EXISTING accept-vote over a proposed route node (the
+  //    party's preferred candidate). Quorum accept -> the agreed scenario = that node.
+  const chosen = candidates.includes('BADLANDS') ? 'BADLANDS' : candidates[0];
+  const allPlayerIds = ['p_host', 'p_two'];
+  const co = new CoopOrchestrator({ roomCode: 'ROUTE', hostId: 'p_host' });
+  co.startRun({ scenarioStack: [chosen] }); // current run scenario = the proposed route node
+  co._setPhase('world_setup');
+  co.voteWorld('p_host', { scenarioId: chosen, accept: true, allPlayerIds });
+  const tally = co.voteWorld('p_two', { scenarioId: chosen, accept: true, allPlayerIds });
+
+  // 3. The vote reached quorum and the agreed node is a valid campaign candidate.
+  assert.equal(tally.accept, 2, 'both players accepted (quorum)');
+  assert.equal(tally.pending, 0);
+  assert.equal(tally.scenario_id, chosen, 'tally surfaces the agreed route node');
+  assert.ok(candidates.includes(tally.scenario_id), 'the winner is a valid route candidate');
+
+  // 4. The bridge: submit the co-op winner to the campaign's /choose -> it advances.
+  const ch = await post(`${url}/api/campaign/choose`, { id, node_id: tally.scenario_id });
+  assert.equal(ch.status, 200);
+  assert.equal(ch.body.campaign.currentNode, chosen, 'campaign routed to the voted node');
+  assert.ok(ch.body.next_encounter_id, 'the chosen node serves its encounter');
+});

--- a/tests/sim/fullLoopRouting.test.js
+++ b/tests/sim/fullLoopRouting.test.js
@@ -1,0 +1,139 @@
+'use strict';
+// TKT-WORLDGEN-GAPC slice A — the full-loop AI runner WALKS the meta-network graph when
+// META_NETWORK_ROUTING is on: each step serves encounterForNode(currentNode) -> REAL
+// combat -> on a multi-candidate branch the injected meta-POLICY picks a node_id ->
+// /campaign/choose -> the run reaches the terminal node + completes. The route is
+// POLICY-SENSITIVE (greedy vs an NT mbti diverge at the first branch) -> graph routing
+// ties into P4. Flag OFF -> the static chapter walk (unchanged, covered by fullLoopRunner).
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runFullLoop } = require('../../tools/sim/full-loop-runner');
+const greedyPolicy = require('../../tools/sim/greedy-policy');
+const { makeMbtiPolicy } = require('../../tools/sim/mbti-policy');
+
+function supertestHttp(app) {
+  return {
+    post: (path, body) =>
+      request(app)
+        .post(path)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (path, query) =>
+      request(app)
+        .get(path)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+function starterRoster() {
+  return [
+    {
+      id: 'hero_a',
+      species: 'dune_stalker',
+      job: 'stalker',
+      hp: 30,
+      max_hp: 30,
+      ap: 3,
+      mod: 20,
+      attack_range: 2,
+      initiative: 18,
+      position: { x: 1, y: 1 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'hero_b',
+      species: 'velox',
+      job: 'stalker',
+      hp: 30,
+      max_hp: 30,
+      ap: 3,
+      mod: 18,
+      attack_range: 2,
+      initiative: 16,
+      position: { x: 1, y: 2 },
+      controlled_by: 'player',
+      status: {},
+    },
+  ];
+}
+
+async function runGraph(app, { playerId, seed, policy }) {
+  process.env.META_NETWORK_ROUTING = 'true';
+  try {
+    return await runFullLoop(supertestHttp(app), {
+      playerId,
+      roster: starterRoster(),
+      seed,
+      policy,
+      maxChapters: 15,
+    });
+  } finally {
+    delete process.env.META_NETWORK_ROUTING;
+  }
+}
+
+test('runFullLoop: flag ON walks the graph start->terminal, policy picks at the branch', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const greedy = await runGraph(app, {
+    playerId: 'fl_route_greedy',
+    seed: 'route-g',
+    policy: greedyPolicy,
+  });
+  assert.equal(
+    greedy.completed,
+    true,
+    `greedy graph run completes; chapters=${JSON.stringify(greedy.chapters)}`,
+  );
+  assert.deepEqual(
+    greedy.violations,
+    [],
+    `no invariant violations: ${JSON.stringify(greedy.violations)}`,
+  );
+  // The run begins at the authored start_node and serves its real encounter.
+  assert.ok(Array.isArray(greedy.route), 'graph run records the node route');
+  assert.equal(greedy.route[0], 'DESERTO_CALDO', 'starts at start_node');
+  assert.equal(greedy.chapters[0].encounter, 'enc_savana_01', 'serves the start node encounter');
+  // greedy takes the weight-desc first candidate at the DESERTO_CALDO branch (ROVINE_PLANARI
+  // w0.5 > BADLANDS w0.45) -> the terminal climax -> a short route.
+  assert.equal(
+    greedy.route[1],
+    'ROVINE_PLANARI',
+    `greedy picks the strongest open route; route=${greedy.route}`,
+  );
+
+  const intj = await runGraph(app, {
+    playerId: 'fl_route_intj',
+    seed: 'route-i',
+    policy: makeMbtiPolicy('INTJ'),
+  });
+  assert.equal(
+    intj.completed,
+    true,
+    `mbti graph run completes; chapters=${JSON.stringify(intj.chapters)}`,
+  );
+  assert.deepEqual(
+    intj.violations,
+    [],
+    `no invariant violations: ${JSON.stringify(intj.violations)}`,
+  );
+  assert.equal(intj.route[0], 'DESERTO_CALDO', 'same start node');
+  // The NT temperament prefers the corridor edge -> BADLANDS, NOT greedy's ROVINE_PLANARI.
+  assert.equal(intj.route[1], 'BADLANDS', `NT prefers the corridor route; route=${intj.route}`);
+
+  // POLICY-SENSITIVE: the two policies walk DIFFERENT routes from the same start.
+  assert.notDeepEqual(greedy.route, intj.route, 'route is policy-sensitive (P4 hook)');
+  assert.notEqual(
+    greedy.route[1],
+    intj.route[1],
+    'the policies diverge at the first multi-candidate branch',
+  );
+});

--- a/tests/worldgen/metaNetworkResolver.test.js
+++ b/tests/worldgen/metaNetworkResolver.test.js
@@ -113,3 +113,21 @@ test('getNetwork: exposes network.start_node (string|null)', () => {
     'start_node is a string id or null',
   );
 });
+
+// Slice A data-gate (owner-gated, spec §4 starter assignment — master-dd ratifies at
+// merge): the REAL alpha graph now names a start_node + a per-node encounter + a
+// terminal climax. Asserts the authored data is wired through the mapper end-to-end.
+test('getNetwork: real alpha graph carries the authored start_node + node encounters + terminal', () => {
+  _resetCache();
+  const net = getNetwork();
+  assert.equal(net.start_node, 'DESERTO_CALDO', 'start node = savana (spec §4)');
+  const byId = Object.fromEntries(net.nodes.map((n) => [n.id, n]));
+  assert.deepEqual(byId.DESERTO_CALDO.encounters, ['enc_savana_01']);
+  assert.deepEqual(byId.BADLANDS.encounters, ['enc_tutorial_03']);
+  assert.deepEqual(byId.FORESTA_TEMPERATA.encounters, ['enc_caverna_02']);
+  assert.deepEqual(byId.CRYOSTEPPE.encounters, ['enc_tutorial_04']);
+  assert.deepEqual(byId.ROVINE_PLANARI.encounters, ['enc_tutorial_05', 'enc_tutorial_06_hardcore']);
+  assert.equal(byId.ROVINE_PLANARI.terminal, true, 'ROVINE_PLANARI is the terminal climax');
+  // Non-terminal nodes default false.
+  assert.equal(byId.DESERTO_CALDO.terminal, false);
+});

--- a/tests/worldgen/metaNetworkResolver.test.js
+++ b/tests/worldgen/metaNetworkResolver.test.js
@@ -90,3 +90,26 @@ test('arc-conditions data: winter seasonal_bridge edges gate on season [winter]'
   assert.ok(toCryo.conditions && Array.isArray(toCryo.conditions.season), 'season list present');
   assert.deepEqual(toCryo.conditions.season, ['winter']);
 });
+
+// --- TKT-WORLDGEN-GAPC slice A (live routing) — the node->encounter map. Each node
+// may serve encounter(s) (MVP N=1) + flag a terminal climax; the network may name a
+// start_node. The mapper must DEFAULT these additively (encounters -> [], terminal ->
+// false, start_node -> null) so the graph stays back-compatible when the data is
+// absent — mirrors the conditions strip fix (#2509).
+test('getNetwork: nodes always carry encounters (array) + terminal (boolean), defaulted', () => {
+  _resetCache();
+  const net = getNetwork();
+  for (const node of net.nodes) {
+    assert.ok(Array.isArray(node.encounters), `node ${node.id} encounters is an array`);
+    assert.equal(typeof node.terminal, 'boolean', `node ${node.id} terminal is boolean`);
+  }
+});
+
+test('getNetwork: exposes network.start_node (string|null)', () => {
+  _resetCache();
+  const net = getNetwork();
+  assert.ok(
+    net.start_node === null || typeof net.start_node === 'string',
+    'start_node is a string id or null',
+  );
+});

--- a/tests/worldgen/metaNetworkRouting.test.js
+++ b/tests/worldgen/metaNetworkRouting.test.js
@@ -14,7 +14,11 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { selectNextNodes } = require('../../apps/backend/services/worldgen/metaNetworkRouting');
+const {
+  selectNextNodes,
+  encounterForNode,
+  isTerminal,
+} = require('../../apps/backend/services/worldgen/metaNetworkRouting');
 
 // Minimal injected graph (mirrors meta_network_alpha shape).
 function graph() {
@@ -267,4 +271,37 @@ test('arc-conditions: unknown condition key fails closed (band-safe)', () => {
   });
   assert.equal(res.candidates.length, 0);
   assert.equal(res.blocked[0].blocked_by, 'min_pressure');
+});
+
+// --- TKT-WORLDGEN-GAPC slice A (live routing) — node->encounter + terminal helpers.
+// Pure lookups over the resolved graph: which encounter a node serves (MVP N=1 = the
+// first id) and whether a node is the terminal climax. Case-insensitive on the node id
+// (mirrors selectNextNodes _norm); back-compat null/false on a missing/encounter-less node.
+const routeGraph = {
+  nodes: [
+    { id: 'A', encounters: ['enc_x'], terminal: false },
+    { id: 'B', encounters: [], terminal: false },
+    { id: 'Z', encounters: ['enc_boss'], terminal: true },
+  ],
+};
+
+test('encounterForNode: returns the node primary encounter (N=1), case-insensitive', () => {
+  assert.equal(encounterForNode(routeGraph, 'A'), 'enc_x');
+  assert.equal(encounterForNode(routeGraph, 'a'), 'enc_x');
+  assert.equal(encounterForNode(routeGraph, 'Z'), 'enc_boss');
+});
+
+test('encounterForNode: null on a missing node, encounter-less node, or bad input', () => {
+  assert.equal(encounterForNode(routeGraph, 'MISSING'), null);
+  assert.equal(encounterForNode(routeGraph, 'B'), null, 'node with empty encounters -> null');
+  assert.equal(encounterForNode(routeGraph, null), null);
+  assert.equal(encounterForNode(null, 'A'), null, 'no graph -> null');
+});
+
+test('isTerminal: reflects node.terminal, false on missing / bad input', () => {
+  assert.equal(isTerminal(routeGraph, 'Z'), true);
+  assert.equal(isTerminal(routeGraph, 'z'), true, 'case-insensitive');
+  assert.equal(isTerminal(routeGraph, 'A'), false);
+  assert.equal(isTerminal(routeGraph, 'MISSING'), false);
+  assert.equal(isTerminal(null, 'Z'), false, 'no graph -> false');
 });

--- a/tools/sim/campaign-driver.js
+++ b/tools/sim/campaign-driver.js
@@ -27,4 +27,10 @@ function choose(http, { id, branchKey } = {}) {
   return http.post('/api/campaign/choose', { id, branch_key: branchKey });
 }
 
-module.exports = { start, summary, advance, choose };
+// Slice C (live routing): resolve a meta-network branch by node_id (the co-op/solo/policy
+// pick), distinct from the legacy binary branch_key choose above.
+function chooseNode(http, { id, nodeId } = {}) {
+  return http.post('/api/campaign/choose', { id, node_id: nodeId });
+}
+
+module.exports = { start, summary, advance, choose, chooseNode };

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -207,6 +207,17 @@ async function runFullLoop(http, opts = {}) {
   }
   const id = startRes.body.campaign.id;
 
+  // Slice A (live routing, flag ON): the runner WALKS the meta-network graph instead of the
+  // static chapter chain. The encounter for each step comes from the campaign responses
+  // (start / advance / choose), and the meta-policy picks a node at a multi-candidate branch.
+  // Flag OFF -> graphMode false -> the static summary-driven walk below is unchanged.
+  const graphMode = process.env.META_NETWORK_ROUTING === 'true';
+  let graphNode = graphMode ? startRes.body.campaign?.currentNode || null : null;
+  let graphNextEnc = graphMode ? startRes.body.next_encounter_id || null : null;
+  // The ordered node route the run walked (graph mode) -> POLICY-SENSITIVE (P4): greedy vs
+  // an mbti temperament diverge at a branch. Empty in static mode.
+  const route = [];
+
   let aliveIds = [...knownIds];
   const chapters = [];
   const violations = [];
@@ -243,8 +254,17 @@ async function runFullLoop(http, opts = {}) {
   const xpByUnit = new Map();
 
   for (let step = 1; step <= maxChapters; step += 1) {
-    const sum = await driver.summary(http, id);
-    const enc = sum.body?.current_encounter?.encounter_id || `chapter_${step}`;
+    // Graph mode: serve the current node's encounter (carried from the prior advance/choose).
+    // Static mode: the def's current encounter from the summary. Both fall back to a synthetic
+    // id so an unmapped step still drives a combat.
+    let enc;
+    if (graphMode) {
+      if (graphNode) route.push(graphNode);
+      enc = graphNextEnc || `chapter_${step}`;
+    } else {
+      const sum = await driver.summary(http, id);
+      enc = sum.body?.current_encounter?.encounter_id || `chapter_${step}`;
+    }
     const aliveRoster = freshRoster(roster, aliveIds);
     if (aliveRoster.length === 0) {
       violations.push({ step, v: ['roster wiped before chapter'] });
@@ -358,7 +378,25 @@ async function runFullLoop(http, opts = {}) {
       if (econ.failures.length) metaViolations.push({ step, econ: econ.failures });
     }
 
-    if (adv.body && adv.body.choice_required) {
+    if (graphMode) {
+      // The advance either auto-advanced (single candidate) or surfaced a route choice. On a
+      // choice the meta-policy picks a node_id; otherwise carry the auto-advanced node. The
+      // served encounter for the next step is whatever the campaign returns.
+      if (adv.body && adv.body.choice_required && adv.body.route_choice) {
+        const cands = adv.body.route_choice.candidates || [];
+        const pick =
+          (typeof policy.chooseRoute === 'function'
+            ? policy.chooseRoute({ candidates: cands, step })
+            : null) ||
+          (cands[0] && cands[0].node_id);
+        const ch = await driver.chooseNode(http, { id, nodeId: pick });
+        graphNode = ch.body?.campaign?.currentNode || pick;
+        graphNextEnc = ch.body?.next_encounter_id || null;
+      } else {
+        graphNode = adv.body?.campaign?.currentNode || graphNode;
+        graphNextEnc = adv.body?.next_encounter_id || null;
+      }
+    } else if (adv.body && adv.body.choice_required) {
       await driver.choose(http, { id, branchKey });
     }
     if (adv.body && adv.body.campaign_completed) {
@@ -372,6 +410,7 @@ async function runFullLoop(http, opts = {}) {
     completed,
     chapters,
     violations,
+    route,
     finalRoster: aliveIds,
     recruited,
     recruitedSpecies,

--- a/tools/sim/greedy-policy.js
+++ b/tools/sim/greedy-policy.js
@@ -33,6 +33,13 @@ function chooseRecruits({ step } = {}) {
   return [{ npcId: `recruit_s${step}`, speciesId }];
 }
 
+// fase-2c routing: at a multi-candidate meta-network branch (selectNextNodes already orders
+// candidates weight DESC, node_id ASC), greedy takes the FIRST = "the strongest open route".
+// Deterministic, no RNG. Returns a node_id (or null on an empty branch).
+function chooseRoute({ candidates } = {}) {
+  return Array.isArray(candidates) && candidates.length ? candidates[0].node_id : null;
+}
+
 // Courtship NPCs live on the DEFAULT meta store (the affinity/trust endpoints ignore
 // campaign_id), so their ids MUST be scoped per run -- otherwise a second full-loop sim
 // on the same process finds them already-recruited (gate_not_met), breaking repeated
@@ -59,6 +66,7 @@ function chooseMating({ step, runId } = {}) {
 
 module.exports = {
   chooseRecruits,
+  chooseRoute,
   chooseCourtship,
   chooseMating,
   courtshipId,

--- a/tools/sim/mbti-policy.js
+++ b/tools/sim/mbti-policy.js
@@ -22,6 +22,17 @@ const TEMPERAMENT_PRIORITY = {
   SP: ['HAZARD', 'PREY', 'APEX', 'SUPPORT', 'PREDATOR'],
 };
 
+// fase-2c routing: Keirsey temperament -> meta-network edge-type preference. Each
+// temperament favours a different traversal STYLE at a multi-candidate branch -> the route
+// becomes policy-sensitive (P4) without changing WHICH nodes are eligible. NT/SJ favour the
+// direct corridor; NF the ecological trophic_spillover; SP the opportunistic seasonal_bridge.
+const ROUTE_EDGE_PRIORITY = {
+  NT: ['corridor', 'seasonal_bridge', 'trophic_spillover'],
+  NF: ['trophic_spillover', 'corridor', 'seasonal_bridge'],
+  SJ: ['corridor', 'trophic_spillover', 'seasonal_bridge'],
+  SP: ['seasonal_bridge', 'trophic_spillover', 'corridor'],
+};
+
 // 4-letter MBTI -> Keirsey group. Malformed input falls back to NT (never throws).
 function temperamentOf(mbti) {
   const t = String(mbti || '').toUpperCase();
@@ -58,6 +69,18 @@ function makeMbtiPolicy(mbtiType = 'INTJ') {
     mbti,
     chooseRecruits({ step } = {}) {
       return [{ npcId: `recruit_s${step}`, speciesId: speciesForStep(step) }];
+    },
+    // Routing pick: reorder the eligible candidates by this temperament's edge-type
+    // preference, then take the first. A stable sort (V8) keeps selectNextNodes' weight-desc
+    // order within an equal edge-type rank, so the choice stays deterministic.
+    chooseRoute({ candidates } = {}) {
+      if (!Array.isArray(candidates) || !candidates.length) return null;
+      const priority = ROUTE_EDGE_PRIORITY[temperamentOf(mbti)];
+      const rank = (c) => {
+        const idx = priority.indexOf(c.edge_type);
+        return idx === -1 ? priority.length : idx;
+      };
+      return [...candidates].sort((a, b) => rank(a) - rank(b))[0].node_id;
     },
     // Same gate-satisfying deltas as greedy (RECRUIT_AFFINITY_MIN=0, RECRUIT_TRUST_MIN=2);
     // temperament changes the courted SPECIES, not the gate, so the earned-recruit economy


### PR DESCRIPTION
## What

Wires the GAP-C meta-network graph into **live campaign routing**, flag-gated behind `META_NETWORK_ROUTING` (OFF by default → byte-identical to today). Fuses slice **A** (graph drives encounter selection) + slice **C** (player/co-op/policy chooses at a multi-candidate branch).

- **Spec:** `docs/superpowers/specs/2026-06-03-worldgen-gapc-live-routing-player-vote-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-03-meta-network-live-routing-ac.md`

## Tasks (TDD red→green)

1. Resolver maps `encounters` / `terminal` per node + network `start_node` (additive, defaulted).
2. Routing helpers `encounterForNode` + `isTerminal` (pure, case-insensitive, fail-closed).
3. Data: node→encounter map + `start_node`/`terminal` in `meta_network_alpha.yaml` (**owner-gated**, spec §4 starter proposal — master-dd ratifies at merge).
4. `/advance` graph traversal (flag ON); flag OFF → static chain verbatim.
5. `/choose` accepts `node_id` (back-compat with `branch_key`).
6. Co-op `world_vote` → `/choose` bridge test.
7. Full-loop sim walks the graph (policy-routed at branches).

## Gates

- 🚩 Flag `META_NETWORK_ROUTING` stays **OFF** in prod (no flip here). Live + the ratified band report unchanged.
- 🔒 **Owner-gated merge** (data + live-campaign-flow change) — NOT auto-merge L3. Master-dd ratifies the §4 encounter→node assignment at merge.
- Invariants: AI 500/500, sim green, prettier + network validators clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)