### PR TITLE
docs(worldgen): meta-network route report + graph-topology follow-up

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "1.0.0",
   "generated_at": "2026-05-07T23:34:13Z",
   "language_policy": "IT+EN",
@@ -8470,6 +8470,32 @@
       "last_verified": "2026-06-02",
       "source_of_truth": false,
       "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
+    },
+    {
+      "path": "docs/playtest/2026-06-03-meta-network-route-report.md",
+      "title": "Meta-network live routing - full-loop route report (flag ON)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "ops-qa",
+      "last_verified": "2026-06-03",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
+    },
+    {
+      "path": "docs/superpowers/specs/2026-06-03-meta-network-graph-topology-followup.md",
+      "title": "Meta-network graph-topology follow-up (3-edge branches + shortcut cost)",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "flow",
+      "last_verified": "2026-06-03",
+      "source_of_truth": false,
+      "language": "en",
       "review_cycle_days": 30,
       "primary": false,
       "track": "new"

--- a/docs/playtest/2026-06-03-meta-network-route-report.md
+++ b/docs/playtest/2026-06-03-meta-network-route-report.md
@@ -1,0 +1,65 @@
+---
+title: 'Meta-network live routing - full-loop route report (flag ON)'
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-03'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Meta-network live routing — full-loop route report
+
+> Exercise of GAP-C slice A+C ([PR #2582](https://github.com/MasterDD-L34D/Game/pull/2582),
+> merged `4bc421c0`) with `META_NETWORK_ROUTING=true` in the full-loop AI sim. Goal: confirm
+> graph-routed campaign flow works end-to-end with REAL combat and is **policy-sensitive**
+> BEFORE any prod flag flip. The flag stays **OFF** in prod — this is a sim-only exercise.
+
+## Setup
+
+- Runner: `tools/sim/full-loop-runner.js` (`runFullLoop`, flag ON), real combat per node, one
+  attempt per mission, Nido recruit on each cleared non-terminal node.
+- Graph: `meta_network_alpha.yaml` (5 nodes / 12 edges, schema 2.1). Start node `DESERTO_CALDO`,
+  terminal `ROVINE_PLANARI`.
+- Roster: 2 starters (dune_stalker + velox, hp30/mod20, job stalker). Deterministic per-policy seed.
+- Policies: greedy + 4 MBTI temperaments (one per Keirsey group). Route pick at a multi-candidate
+  branch = `policy.chooseRoute(candidates)`.
+
+## Results (5 runs, all completed, 0 invariant violations)
+
+| Policy    | Route (nodes)                                                 | Encounters played                                  | Recruits |
+| --------- | ------------------------------------------------------------- | -------------------------------------------------- | -------- |
+| greedy    | DESERTO_CALDO → ROVINE_PLANARI                                | savana_01 → tutorial_05                            | 1        |
+| ESFP (SP) | DESERTO_CALDO → ROVINE_PLANARI                                | savana_01 → tutorial_05                            | 1        |
+| INTJ (NT) | DESERTO_CALDO → BADLANDS → FORESTA_TEMPERATA → ROVINE_PLANARI | savana_01 → tutorial_03 → caverna_02 → tutorial_05 | 3        |
+| ENFP (NF) | DESERTO_CALDO → BADLANDS → FORESTA_TEMPERATA → ROVINE_PLANARI | (idem)                                             | 3        |
+| ISTJ (SJ) | DESERTO_CALDO → BADLANDS → FORESTA_TEMPERATA → ROVINE_PLANARI | (idem)                                             | 3        |
+
+## Findings
+
+1. **Graph routing is solid end-to-end.** 5/5 runs complete with real combat, zero invariant
+   violations. The graph drives the whole loop (campaign → combat → advance → Nido recruit → next).
+2. **Routing is policy-sensitive (P4 hook).** Two route clusters emerge from the same start:
+   - **Shortcut (2 nodes):** greedy (weight-max) + ESFP/SP (prefers `seasonal_bridge`) → straight to
+     the terminal `ROVINE_PLANARI`.
+   - **Scenic (4 nodes):** NT / NF / SJ (prefer `corridor`) → DESERTO → BADLANDS → FORESTA → ROVINE.
+3. **Emergent meta-loop effect.** The scenic route clears 3 extra nodes → **3 recruits** vs the
+   shortcut's **1**. Temperament changes how much the Nido grows — a real P4 signal in the
+   meta-loop, not just cosmetic path choice.
+
+## Two notes before a prod flip (graph-topology follow-up)
+
+- **Divergence at the start branch is binary.** `DESERTO_CALDO` only offers `corridor` (BADLANDS) +
+  `seasonal_bridge` (ROVINE) — no `trophic_spillover` — so NF cannot diverge from NT/SJ there.
+  Richer per-temperament divergence needs branches that expose all three edge types.
+- **The shortcut reaches the terminal in 2 nodes**, skipping BADLANDS + FORESTA and arriving at the
+  boss cheaply. Design question: should the climax be that cheap to reach?
+
+Both are **data-only** (YAML) tuning and are scoped in
+[`docs/superpowers/specs/2026-06-03-meta-network-graph-topology-followup.md`](../superpowers/specs/2026-06-03-meta-network-graph-topology-followup.md).
+
+## Verdict
+
+Routing works and is meaningful for P4. Safe to consider for staging. Recommend the graph-topology
+tuning (free, YAML-only) before the prod flag flip, which remains a separate owner verdict.

--- a/docs/superpowers/specs/2026-06-03-meta-network-graph-topology-followup.md
+++ b/docs/superpowers/specs/2026-06-03-meta-network-graph-topology-followup.md
@@ -1,0 +1,83 @@
+---
+title: 'Meta-network graph-topology follow-up (3-edge branches + shortcut cost)'
+doc_status: draft
+doc_owner: master-dd
+workstream: flow
+last_verified: '2026-06-03'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Meta-network graph-topology follow-up
+
+> Scoping (no implementation) for two **data-only** tuning items surfaced by the live-routing route
+> report ([`docs/playtest/2026-06-03-meta-network-route-report.md`](../../playtest/2026-06-03-meta-network-route-report.md)).
+> Both touch only `packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml` (schema
+> 2.1) + its `trace_hash`. No engine change. Owner-gated (data + it shapes the live route once the
+> flag flips). Master-dd ratifies the verdicts; a follow-up PR implements the chosen options.
+
+## Context (verified on `4bc421c0`)
+
+GAP-C slice A+C wired the graph into live campaign routing (flag `META_NETWORK_ROUTING`, OFF by
+default). The route report ran the full-loop sim flag-ON across greedy + 4 MBTI temperaments: all
+complete, routing is policy-sensitive (greedy/SP take a 2-node shortcut to the terminal; NT/NF/SJ
+take a 4-node scenic route → 3 recruits vs 1). Two topology weaknesses surfaced.
+
+## Item 1 — Start branch can't show 3-way temperament divergence
+
+**Problem.** `DESERTO_CALDO` (start) has 2 outgoing edges: `corridor` → BADLANDS, `seasonal_bridge`
+→ ROVINE_PLANARI. The MBTI `chooseRoute` ranks by edge-type preference (NT/SJ → corridor, NF →
+trophic_spillover, SP → seasonal_bridge). With no `trophic_spillover` candidate at the start, NF
+falls back to its 2nd preference (corridor) and routes identically to NT/SJ. So the start branch
+collapses to a binary (corridor-cluster vs seasonal-cluster) — temperament divergence is
+under-expressed.
+
+**Goal.** At least one early multi-candidate branch should expose all three edge types
+(`corridor` + `seasonal_bridge` + `trophic_spillover`) so NT, NF, SP pick three different nodes.
+
+**Options.**
+
+- **A (recommended).** Add a `trophic_spillover` edge from the start node (or an early node) to a
+  third distinct target, so the start branch is genuinely 3-way. Smallest change; directly fixes the
+  collapse. Must keep the graph completable (Dormans: ≥1 non-gated path to a terminal).
+- **B.** Re-home the start node to a node that already has 3 edge types outgoing (e.g. CRYOSTEPPE has
+  corridor + trophic_spillover + seasonal_bridge to BADLANDS/FORESTA). Changes the arc's opening
+  biome — bigger narrative ripple.
+- **C.** Leave as-is; accept binary start divergence (richer divergence emerges deeper in the graph).
+
+**Gate.** Data-only YAML + `trace_hash` recompute (inline `_stable_digest`); network validators +
+`tests/scripts/test_trace_hashes.py`; the resolver/routing tests already assert the field plumbing.
+Add a routing test asserting a 3-way branch yields 3 distinct temperament picks.
+
+## Item 2 — Terminal reachable in 2 nodes (cheap shortcut)
+
+**Problem.** `DESERTO_CALDO → ROVINE_PLANARI` is a direct `seasonal_bridge` edge, and ROVINE_PLANARI
+is `terminal`. So greedy + SP clear the start encounter then jump straight to the boss — 2 nodes, 2
+encounters, 1 recruit — skipping BADLANDS + FORESTA. The climax is reachable very cheaply.
+
+**Goal.** Make reaching the terminal require meaningful progression (unless a fast "speedrun" route
+is intentionally desired).
+
+**Options.**
+
+- **A.** Drop the direct `DESERTO_CALDO → ROVINE_PLANARI` edge → the terminal is reached only via the
+  BADLANDS/FORESTA arc. Simplest gate; removes the shortcut entirely.
+- **B (recommended).** Keep the edge but gate it with an arc-condition (the fase-2 mechanism already
+  live): `conditions: { prior_node_cleared: [BADLANDS, FORESTA_TEMPERATA] }` on the ROVINE approach,
+  so the terminal opens only after the mid-arc is cleared. Reversible, expressive, reuses
+  `_evalEdgeConditions`.
+- **C.** Add a `min_cleared` style gate on the terminal node (needs a new condition evaluator =
+  small engine change → out of "data-only" scope; defer).
+- **D.** Leave as designed — treat the 2-node path as an intentional high-risk speedrun route.
+
+**Gate.** Same as Item 1 (data + trace_hash + validators). Option B is data-only and reuses the
+existing condition evaluator; re-run the route report to confirm greedy/SP no longer shortcut and
+the band metrics stay sane.
+
+## Open decisions for master-dd
+
+1. Item 1 — option A / B / C?
+2. Item 2 — option A / B / C / D? (B recommended: data-only, reversible, reuses arc-conditions.)
+3. Sequencing vs the prod flag flip: do these land BEFORE enabling `META_NETWORK_ROUTING` in prod
+   (recommended) or after a first staged run?


### PR DESCRIPTION
## What

Two docs from exercising GAP-C live routing (PR #2582, merged `4bc421c0`) in the full-loop sim:

1. **Route report** (`docs/playtest/2026-06-03-meta-network-route-report.md`) — ran `runFullLoop` with `META_NETWORK_ROUTING=true` across greedy + 4 MBTI temperaments. All 5 complete, 0 violations, routing is **policy-sensitive**: greedy/SP take a 2-node shortcut to the terminal; NT/NF/SJ take the 4-node scenic route (3 recruits vs 1).
2. **Graph-topology follow-up scoping** (`docs/superpowers/specs/2026-06-03-meta-network-graph-topology-followup.md`) — two **data-only** (YAML) tuning items for master-dd to verdict: (1) start branch can't show 3-way temperament divergence (no `trophic_spillover` edge there); (2) terminal reachable in 2 nodes (cheap shortcut). Both owner-gated, recommended before any prod flag flip.

## Notes

- Doc-only. Flag `META_NETWORK_ROUTING` stays OFF (sim-only exercise, no prod change).
- Registry + governance updated atomically (errors=0); prettier clean.
- Follow-up items are **scoping only** (no impl) — they await your verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)