### PR TITLE
feat(worldgen): meta-network graph-topology tuning (1A trophic edge + 2B terminal gate)

### DIFF
--- a/docs/playtest/2026-06-03-meta-network-route-report.md
+++ b/docs/playtest/2026-06-03-meta-network-route-report.md
@@ -63,3 +63,31 @@ Both are **data-only** (YAML) tuning and are scoped in
 
 Routing works and is meaningful for P4. Safe to consider for staging. Recommend the graph-topology
 tuning (free, YAML-only) before the prod flag flip, which remains a separate owner verdict.
+
+## Post-tuning update (same PR set — graph-topology follow-up applied)
+
+The two notes above were addressed as **data-only** YAML edits to `meta_network_alpha.yaml`:
+
+- **1A** — added a `trophic_spillover` edge `DESERTO_CALDO → FORESTA_TEMPERATA`, so the start branch
+  now exposes `corridor` (BADLANDS) + `trophic_spillover` (FORESTA).
+- **2B** — gated the direct `DESERTO_CALDO → ROVINE_PLANARI` edge behind
+  `prior_node_cleared: [BADLANDS, FORESTA_TEMPERATA]`, closing the 2-node shortcut to the terminal.
+  (Only that edge is gated — gating `FORESTA → ROVINE` too would strand BADLANDS, a dead end, so the
+  terminal stays reachable via the arc.)
+
+Re-running the same 5-policy sim (all complete, 0 violations):
+
+| Policy    | Route (nodes)                                                 | Recruits |
+| --------- | ------------------------------------------------------------- | -------- |
+| greedy    | DESERTO_CALDO → FORESTA_TEMPERATA → ROVINE_PLANARI            | 2        |
+| ENFP (NF) | DESERTO_CALDO → FORESTA_TEMPERATA → ROVINE_PLANARI            | 2        |
+| ESFP (SP) | DESERTO_CALDO → FORESTA_TEMPERATA → ROVINE_PLANARI            | 2        |
+| INTJ (NT) | DESERTO_CALDO → BADLANDS → FORESTA_TEMPERATA → ROVINE_PLANARI | 3        |
+| ISTJ (SJ) | DESERTO_CALDO → BADLANDS → FORESTA_TEMPERATA → ROVINE_PLANARI | 3        |
+
+Outcome: **the 2-node shortcut is gone** (every route is now ≥3 nodes and passes through the
+mid-arc), and start divergence is `corridor` (NT/SJ → BADLANDS) vs `trophic` (greedy/NF/SP →
+FORESTA). Recruit spread tightened to 2-vs-3 (was 1-vs-3). A true simultaneous 3-way branch (all
+three edge types eligible at once) is still not present — the sparse 5-node graph can't host it
+without a dead-end risk; that is a larger graph-expansion item, not a tuning. **Recommendation:** the
+graph is now flip-ready for staging; the prod flag flip remains a separate owner verdict.

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: da178eebe5b6abbd1fe59775d99edd80b3a7a0ee30d1da4d41fd2b8a03b2d92a
+  trace_hash: c77628ef680d8cf839212497b701a399f4ded7ccafd4ae93652aa19c9c1d845f
 links:
   ecosystems:
   - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -127,6 +127,20 @@ network:
     resistance: 0.65
     seasonality: notte
     notes: Carovane planari sfruttano la quiete notturna per trasferire risorse.
+    # Topology follow-up 2B (data-only): il varco diretto al climax si apre solo dopo
+    # aver ripulito l'arco intermedio -> elimina la scorciatoia di 2 nodi al terminale.
+    # Il terminale resta raggiungibile via FORESTA_TEMPERATA -> ROVINE (no stranding).
+    conditions:
+      prior_node_cleared: [BADLANDS, FORESTA_TEMPERATA]
+  # Topology follow-up 1A (data-only): edge trophic dalla savana alla foresta, cosi' il
+  # bivio di partenza espone corridor(BADLANDS) + trophic(FORESTA) -> NT/SJ e NF/SP
+  # divergono al primo bivio (prima collassavano tutti su BADLANDS).
+  - from: DESERTO_CALDO
+    to: FORESTA_TEMPERATA
+    type: trophic_spillover
+    resistance: 0.5
+    seasonality: episodico
+    notes: Spore e detrito eolico dalla savana alimentano i margini miceliali.
   bridge_species_map:
   - species_id: echo-wing
     roles:

--- a/tests/api/campaignMetaNetworkRouting.test.js
+++ b/tests/api/campaignMetaNetworkRouting.test.js
@@ -111,8 +111,12 @@ test('advance: flag ON multi-candidate node -> choice_required + candidates, cur
   assert.equal(adv.body.choice_required, true);
   assert.ok(adv.body.route_choice && Array.isArray(adv.body.route_choice.candidates));
   const ids = adv.body.route_choice.candidates.map((c) => c.node_id);
-  assert.equal(ids.length, 2, 'DESERTO_CALDO -> BADLANDS + ROVINE_PLANARI');
-  assert.ok(ids.includes('BADLANDS') && ids.includes('ROVINE_PLANARI'));
+  // Topology tuning: DESERTO_CALDO -> BADLANDS (corridor) + FORESTA_TEMPERATA (trophic, 1A).
+  // ROVINE_PLANARI is NOT a start candidate -- its direct edge is gated prior_node_cleared
+  // [BADLANDS, FORESTA_TEMPERATA] (2B) so the 2-node shortcut to the terminal is closed.
+  assert.equal(ids.length, 2, 'DESERTO_CALDO -> BADLANDS + FORESTA_TEMPERATA');
+  assert.ok(ids.includes('BADLANDS') && ids.includes('FORESTA_TEMPERATA'));
+  assert.ok(!ids.includes('ROVINE_PLANARI'), 'terminal shortcut gated (2B)');
   assert.equal(adv.body.campaign.currentNode, 'DESERTO_CALDO', 'does not advance until /choose');
   assert.deepEqual(
     adv.body.campaign.clearedNodes,
@@ -136,13 +140,20 @@ test('advance: flag ON single-candidate node -> auto-advances + serves the next 
   assert.equal(adv.body.next_encounter_id, 'enc_caverna_02');
 });
 
-test('advance: flag ON at the terminal node -> campaign completes', async (t) => {
+test('advance: flag ON reaches the terminal via the mid-arc -> campaign completes', async (t) => {
   enableFlag(t);
   const url = startTestServer(t);
   const s = await startCampaign(url);
   const id = s.body.campaign.id;
-  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // -> choice
-  await post(`${url}/api/campaign/choose`, { id, node_id: 'ROVINE_PLANARI' }); // terminal
+  // The terminal is gated (2B): a direct ROVINE choice from the start is rejected (not a
+  // candidate of DESERTO_CALDO until BADLANDS + FORESTA are cleared).
+  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // choice @ DESERTO
+  const shortcut = await post(`${url}/api/campaign/choose`, { id, node_id: 'ROVINE_PLANARI' });
+  assert.equal(shortcut.status, 400, 'terminal shortcut from start is gated');
+  // Walk the arc: DESERTO -> FORESTA -> (choice BADLANDS|ROVINE) -> ROVINE (terminal).
+  await post(`${url}/api/campaign/choose`, { id, node_id: 'FORESTA_TEMPERATA' });
+  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // choice @ FORESTA
+  await post(`${url}/api/campaign/choose`, { id, node_id: 'ROVINE_PLANARI' }); // now reachable
   const adv = await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' });
   assert.equal(adv.status, 200);
   assert.equal(adv.body.campaign_completed, true);

--- a/tests/sim/fullLoopRouting.test.js
+++ b/tests/sim/fullLoopRouting.test.js
@@ -102,11 +102,12 @@ test('runFullLoop: flag ON walks the graph start->terminal, policy picks at the 
   assert.ok(Array.isArray(greedy.route), 'graph run records the node route');
   assert.equal(greedy.route[0], 'DESERTO_CALDO', 'starts at start_node');
   assert.equal(greedy.chapters[0].encounter, 'enc_savana_01', 'serves the start node encounter');
-  // greedy takes the weight-desc first candidate at the DESERTO_CALDO branch (ROVINE_PLANARI
-  // w0.5 > BADLANDS w0.45) -> the terminal climax -> a short route.
+  // Topology tuning: the terminal shortcut is gated (2B) and a trophic edge to FORESTA was
+  // added (1A). greedy now takes the weight-desc first candidate at DESERTO_CALDO =
+  // FORESTA_TEMPERATA (w0.55 > BADLANDS w0.45); ROVINE is no longer a start candidate.
   assert.equal(
     greedy.route[1],
-    'ROVINE_PLANARI',
+    'FORESTA_TEMPERATA',
     `greedy picks the strongest open route; route=${greedy.route}`,
   );
 
@@ -126,7 +127,7 @@ test('runFullLoop: flag ON walks the graph start->terminal, policy picks at the 
     `no invariant violations: ${JSON.stringify(intj.violations)}`,
   );
   assert.equal(intj.route[0], 'DESERTO_CALDO', 'same start node');
-  // The NT temperament prefers the corridor edge -> BADLANDS, NOT greedy's ROVINE_PLANARI.
+  // The NT temperament prefers the corridor edge -> BADLANDS, NOT greedy's FORESTA_TEMPERATA.
   assert.equal(intj.route[1], 'BADLANDS', `NT prefers the corridor route; route=${intj.route}`);
 
   // POLICY-SENSITIVE: the two policies walk DIFFERENT routes from the same start.

--- a/tests/worldgen/metaNetworkResolver.test.js
+++ b/tests/worldgen/metaNetworkResolver.test.js
@@ -131,3 +131,21 @@ test('getNetwork: real alpha graph carries the authored start_node + node encoun
   // Non-terminal nodes default false.
   assert.equal(byId.DESERTO_CALDO.terminal, false);
 });
+
+// Topology tuning (data-only follow-up): 1A adds a trophic edge DESERTO_CALDO -> FORESTA so
+// the start branch exposes corridor + trophic; 2B gates the direct DESERTO_CALDO -> ROVINE
+// (the terminal shortcut) behind prior_node_cleared [BADLANDS, FORESTA_TEMPERATA].
+test('getOutgoingEdges: DESERTO_CALDO has the 1A trophic edge to FORESTA + the 2B gated ROVINE edge', () => {
+  _resetCache();
+  const edges = getOutgoingEdges('DESERTO_CALDO');
+  const toForesta = edges.find((e) => e.to === 'FORESTA_TEMPERATA');
+  assert.ok(toForesta, 'new trophic edge DESERTO_CALDO -> FORESTA_TEMPERATA present (1A)');
+  assert.equal(toForesta.type, 'trophic_spillover');
+  const toRovine = edges.find((e) => e.to === 'ROVINE_PLANARI');
+  assert.ok(toRovine && toRovine.conditions, 'direct ROVINE edge carries a conditions gate (2B)');
+  assert.deepEqual(toRovine.conditions.prior_node_cleared, ['BADLANDS', 'FORESTA_TEMPERATA']);
+  // The corridor to BADLANDS stays ungated.
+  const toBadlands = edges.find((e) => e.to === 'BADLANDS');
+  assert.ok(toBadlands && toBadlands.type === 'corridor');
+  assert.equal(toBadlands.conditions, null);
+});


### PR DESCRIPTION
## What

Data-only YAML tuning of `meta_network_alpha.yaml`, scoped in [`...graph-topology-followup.md`](docs/superpowers/specs/2026-06-03-meta-network-graph-topology-followup.md) (merged #2583). Pre-flip hardening of the GAP-C live routing (PR #2582). Flag `META_NETWORK_ROUTING` stays **OFF**.

- **1A** — add `trophic_spillover` edge `DESERTO_CALDO → FORESTA_TEMPERATA`. Start branch now exposes `corridor` (BADLANDS) + `trophic` (FORESTA) → NT/SJ and greedy/NF/SP diverge at the first branch (before: all collapsed to BADLANDS).
- **2B** — gate the direct `DESERTO_CALDO → ROVINE_PLANARI` edge behind `prior_node_cleared: [BADLANDS, FORESTA_TEMPERATA]` → closes the 2-node shortcut to the terminal. **Only that edge** is gated (gating `FORESTA → ROVINE` too would strand BADLANDS = dead end; terminal stays reachable via the arc).

## Effect (re-run 5-policy sim, all complete, 0 violations)

| | greedy / ENFP / ESFP | INTJ / ISTJ |
|---|---|---|
| route | DESERTO → FORESTA → ROVINE (3) | DESERTO → BADLANDS → FORESTA → ROVINE (4) |
| recruits | 2 | 3 |

2-node shortcut **gone**; every route ≥3 nodes through the mid-arc. Route report updated (`docs/playtest/2026-06-03-meta-network-route-report.md`).

## Verify

- `trace_hash` recomputed (inline `_stable_digest`); network validators + `test_trace_hashes` (208) green.
- Tests updated to new topology + a resolver lock for the edge/gate. AI 500/500, sim 112/112, campaign regression 50/50, governance errors=0, prettier clean.

## Gate

Owner-gated (data shapes the live route once the flag flips). Ratify the 1A/2B verdicts at merge. Forbidden paths: none touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)