### PR TITLE
feat(worldgen): meta-network expansion PR1 — 3-way branch + completability validator

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -440,6 +440,17 @@ function createApp(options = {}) {
   const deploymentNotifier = deploymentOptions.notifier;
   const app = express();
 
+  // Dev-surface guard (Gate-5): warn once at boot if the shipped meta-network graph can strand a
+  // graph-routed run. Never throws, no request-path impact; the flag-gated routing is unaffected.
+  try {
+    const { completabilityWarning } = require('./services/worldgen/metaNetworkCompletability');
+    const metaNetworkResolver = require('./services/worldgen/metaNetworkResolver');
+    const completabilityWarn = completabilityWarning(metaNetworkResolver.getNetwork());
+    if (completabilityWarn) console.warn(completabilityWarn);
+  } catch {
+    /* boot-time best-effort only */
+  }
+
   app.use(cors({ origin: options.corsOrigin || '*' }));
   app.use(express.json({ limit: '1mb' }));
 

--- a/apps/backend/services/worldgen/metaNetworkCompletability.js
+++ b/apps/backend/services/worldgen/metaNetworkCompletability.js
@@ -1,0 +1,77 @@
+'use strict';
+// Dormans completability validator for the meta-network graph. Pure, no I/O. Guarantees
+// (pre-flight) that the campaign can always reach a terminal node from the start under every
+// season -- a graph that can strand a run is a data bug. Lock-and-key (Dormans): an edge gated
+// by prior_node_cleared opens once its prereq nodes are themselves reachable; we iterate
+// reachability to a fixpoint, so a key that is generated before its lock is honoured.
+
+const { evalEdgeConditions } = require('./metaNetworkRouting');
+
+function _norm(v) {
+  return String(v == null ? '' : v)
+    .trim()
+    .toLowerCase();
+}
+
+// A node is terminal if flagged `terminal` OR it has no outgoing edges (dead-end climax).
+function _isTerminalNode(graph, nodeKey) {
+  const n = graph.nodes.find((x) => _norm(x.id) === nodeKey);
+  if (n && n.terminal) return true;
+  return !graph.edges.some((e) => _norm(e.from) === nodeKey);
+}
+
+// Fixpoint reachable set from `start` under `season`. clearedNodes = everything reachable so far
+// (sound lock-and-key approximation: a prereq is satisfied iff that node is reachable earlier).
+function _reachable(graph, start, season) {
+  const reach = new Set([_norm(start)]);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const e of graph.edges) {
+      const from = _norm(e.from);
+      const to = _norm(e.to);
+      if (!reach.has(from) || reach.has(to)) continue;
+      const ctx = { season, clearedNodes: [...reach] };
+      if (evalEdgeConditions(e.conditions, ctx).ok) {
+        reach.add(to);
+        grew = true;
+      }
+    }
+  }
+  return reach;
+}
+
+// For each (start_node, season) verify a terminal node is reachable. Returns
+// { ok, stranded:[{start, season, reachable}], detail }.
+function checkCompletable(graph, { seasons = [null] } = {}) {
+  if (!graph || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+    return { ok: false, stranded: [{ start: null, season: null }], detail: 'no_graph' };
+  }
+  const start = graph.start_node;
+  if (!start) return { ok: true, stranded: [], detail: 'no start_node (graph routing inactive)' };
+  const stranded = [];
+  for (const season of seasons) {
+    const reach = _reachable(graph, start, season);
+    const hitsTerminal = [...reach].some((k) => _isTerminalNode(graph, k));
+    if (!hitsTerminal) stranded.push({ start, season, reachable: [...reach] });
+  }
+  return {
+    ok: stranded.length === 0,
+    stranded,
+    detail: stranded.length ? 'stranded states' : 'completable',
+  };
+}
+
+// Dev-surface startup warning (never throws). Returns a one-line string or null.
+function completabilityWarning(graph, seasons = [null, 'spring', 'summer', 'autumn', 'winter']) {
+  try {
+    const r = checkCompletable(graph, { seasons });
+    if (r.ok) return null;
+    const states = r.stranded.map((s) => ({ start: s.start, season: s.season }));
+    return `[metaNetworkCompletability] WARN: graph can strand a run: ${JSON.stringify(states)}`;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { checkCompletable, completabilityWarning, _reachable, _isTerminalNode };

--- a/apps/backend/services/worldgen/metaNetworkRouting.js
+++ b/apps/backend/services/worldgen/metaNetworkRouting.js
@@ -54,7 +54,7 @@ function _list(v) {
 }
 
 // Arc-condition evaluators (fase 2, Stage 1). Each is pure: (value, ctx) -> bool.
-// Adding a key here makes it "known"; unknown keys fail closed in _evalEdgeConditions.
+// Adding a key here makes it "known"; unknown keys fail closed in evalEdgeConditions.
 const _COND = {
   // Current campaign season is in the allowed set (EN enum, case-insensitive).
   // Reads ctx.season (e.g. campaignSeasonalState.current_season). Fail-closed
@@ -73,7 +73,7 @@ const _COND = {
 // Evaluate an edge's conditions against ctx. Returns { ok, blocked_by }.
 // No conditions / empty -> ok (passthrough). AND across keys; the first failing
 // or unknown key -> { ok:false, blocked_by:key }.
-function _evalEdgeConditions(conditions, ctx) {
+function evalEdgeConditions(conditions, ctx) {
   if (!conditions || typeof conditions !== 'object') return { ok: true, blocked_by: null };
   const keys = Object.keys(conditions);
   if (keys.length === 0) return { ok: true, blocked_by: null };
@@ -131,7 +131,7 @@ function selectNextNodes(currentNodeId, ctx = {}) {
       clearExcluded.add(e.to);
       continue;
     }
-    const cond = _evalEdgeConditions(e.conditions, ctx);
+    const cond = evalEdgeConditions(e.conditions, ctx);
     if (!cond.ok) {
       // Record once per target; a later parallel edge may still pass (OR).
       if (!condBlockedBy.has(toKey)) {
@@ -217,4 +217,4 @@ function isTerminal(graph, nodeId) {
   return !!(n && n.terminal);
 }
 
-module.exports = { selectNextNodes, encounterForNode, isTerminal };
+module.exports = { selectNextNodes, encounterForNode, isTerminal, evalEdgeConditions };

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -8512,6 +8512,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/superpowers/plans/2026-06-03-meta-network-expansion-pr1-validator-3way.md",
+      "title": "Meta-network expansion PR1 - completability validator + 3-way branch Implementation Plan",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "flow",
+      "last_verified": "2026-06-03",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
     }
   ]
 }

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -8499,6 +8499,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/superpowers/specs/2026-06-03-meta-network-graph-expansion-design.md",
+      "title": "Meta-network graph expansion (3-way branch + Atollo node + completability)",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "flow",
+      "last_verified": "2026-06-03",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
     }
   ]
 }

--- a/docs/playtest/2026-06-03-meta-network-route-report.md
+++ b/docs/playtest/2026-06-03-meta-network-route-report.md
@@ -91,3 +91,21 @@ FORESTA). Recruit spread tightened to 2-vs-3 (was 1-vs-3). A true simultaneous 3
 three edge types eligible at once) is still not present — the sparse 5-node graph can't host it
 without a dead-end risk; that is a larger graph-expansion item, not a tuning. **Recommendation:** the
 graph is now flip-ready for staging; the prod flag flip remains a separate owner verdict.
+
+## Graph expansion PR1 (3-way branch + completability validator)
+
+The "true 3-way branch" noted above as a graph-expansion item is now implemented (spec
+`docs/superpowers/specs/2026-06-03-meta-network-graph-expansion-design.md`): an **ungated
+`DESERTO_CALDO → CRYOSTEPPE` seasonal_bridge** so the start node exposes all three edge types at
+once, plus a pure **Dormans completability validator** (`metaNetworkCompletability.js`) proving the
+graph reaches a terminal in every season. Re-running the sim (all complete, 0 violations):
+
+| Policy    | Route (nodes)                                                              |
+| --------- | -------------------------------------------------------------------------- |
+| greedy    | DESERTO_CALDO → FORESTA_TEMPERATA → ROVINE_PLANARI                         |
+| INTJ (NT) | DESERTO_CALDO → BADLANDS → FORESTA_TEMPERATA → ROVINE_PLANARI              |
+| ESFP (SP) | DESERTO_CALDO → CRYOSTEPPE → BADLANDS → FORESTA_TEMPERATA → ROVINE_PLANARI |
+
+Three policies now pick **three different first nodes** (FORESTA / BADLANDS / CRYOSTEPPE) — a true
+3-way divergence. PR2 (the Atollo Obsidiana 6th node) follows in a separate PR, gated by the
+completability validator. Flag stays OFF; the prod flip awaits the N=40 graph-mode band-verify.

--- a/docs/superpowers/plans/2026-06-03-meta-network-expansion-pr1-validator-3way.md
+++ b/docs/superpowers/plans/2026-06-03-meta-network-expansion-pr1-validator-3way.md
@@ -1,0 +1,384 @@
+# Meta-network expansion PR1 — completability validator + 3-way branch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a pure Dormans completability validator + a true 3-way start branch (DESERTO_CALDO exposes corridor/trophic/seasonal to three distinct nodes), flag-gated, graph never strands.
+
+**Architecture:** Additive. Share the edge-condition evaluator between routing and a new completability module (lock-and-key fixpoint reachability). One data edge (`DESERTO_CALDO → CRYOSTEPPE`, seasonal_bridge, ungated). A dev-surface server-start warn. Flag `META_NETWORK_ROUTING` OFF → zero behavioural change.
+
+**Tech Stack:** Node, `js-yaml`, `node:test` + `supertest`, the existing `metaNetworkResolver`/`metaNetworkRouting` modules + the `meta_network_alpha.yaml` network.
+
+**Invariants (every task):** TDD red→green; worktree `C:/dev/_gamewt-metanet-expand` (prettier 3.8.3 from `npm ci`); AI `node --test tests/ai/*.test.js` 500/500; sim `node --test tests/sim/*.test.js` green (node v24 — use the `*.test.js` GLOB, not a dir arg); ADR-0011 trailer (`Coding-Agent: claude-opus-4.8` + uuidv7 `Trace-Id`, lowercase subject ≤72); owner-gated merge. Touch the YAML → recompute `trace_hash` via the single-file inline `_stable_digest` (NOT the repo-wide tool) + run network validators (`run_all_validators.py`) + `tests/scripts/test_trace_hashes.py`. Touch docs → `python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict` (errors=0) + `git checkout -- reports/docs/governance_drift_report.json` before commit. Forbidden: `.github/workflows`, `migrations`, `packages/contracts`, `services/generation`. Spec: [`2026-06-03-meta-network-graph-expansion-design.md`](../specs/2026-06-03-meta-network-graph-expansion-design.md).
+
+---
+
+## File Structure
+
+- Modify `apps/backend/services/worldgen/metaNetworkRouting.js` — export the pure `evalEdgeConditions` (Task 1; today it is the internal `_evalEdgeConditions`).
+- Create `apps/backend/services/worldgen/metaNetworkCompletability.js` — pure `checkCompletable` + `completabilityWarning` (Task 2).
+- Modify `packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml` — +1 edge + trace_hash (Task 3, owner-gated data).
+- Modify `apps/backend/app.js` (or the boot module that builds the app) — server-start warn (Task 6).
+- Tests: `tests/worldgen/metaNetworkRouting.test.js` (Task 1), `tests/worldgen/metaNetworkCompletability.test.js` (new, Task 2 + 4), `tests/api/campaignMetaNetworkRouting.test.js` (Task 4), `tests/sim/fullLoopRouting.test.js` (Task 5).
+- Doc: `docs/playtest/2026-06-03-meta-network-route-report.md` — append a PR1 post-3way section (Task 5).
+
+---
+
+### Task 1: Export the shared `evalEdgeConditions` from routing
+
+**Files:**
+
+- Modify: `apps/backend/services/worldgen/metaNetworkRouting.js` (internal `_evalEdgeConditions` ~`:76`; `module.exports` ~`:197`)
+- Test: `tests/worldgen/metaNetworkRouting.test.js`
+
+- [ ] **Step 1: Write the failing test** (append at end of file):
+
+```js
+const { evalEdgeConditions } = require('../../apps/backend/services/worldgen/metaNetworkRouting');
+
+test('evalEdgeConditions: exported, shared gate eval (season + prior_node_cleared)', () => {
+  // no conditions -> passthrough ok
+  assert.deepEqual(evalEdgeConditions(null, {}), { ok: true, blocked_by: null });
+  // season gate
+  assert.equal(evalEdgeConditions({ season: ['winter'] }, { season: 'winter' }).ok, true);
+  assert.equal(evalEdgeConditions({ season: ['winter'] }, { season: 'summer' }).ok, false);
+  // prior_node_cleared gate
+  assert.equal(evalEdgeConditions({ prior_node_cleared: ['X'] }, { clearedNodes: ['X'] }).ok, true);
+  assert.equal(evalEdgeConditions({ prior_node_cleared: ['X'] }, { clearedNodes: [] }).ok, false);
+  // unknown key fails closed
+  assert.equal(evalEdgeConditions({ min_pressure: 3 }, {}).ok, false);
+});
+```
+
+- [ ] **Step 2: Run** `node --test tests/worldgen/metaNetworkRouting.test.js` → FAIL (`evalEdgeConditions` undefined).
+- [ ] **Step 3: Implement** — in `metaNetworkRouting.js`, rename the internal function to a public name and keep behaviour identical. Change the declaration `function _evalEdgeConditions(conditions, ctx) {` to `function evalEdgeConditions(conditions, ctx) {`, update its one caller inside `selectNextNodes` (`const cond = _evalEdgeConditions(e.conditions, ctx);` → `const cond = evalEdgeConditions(e.conditions, ctx);`), and add it to the exports: `module.exports = { selectNextNodes, encounterForNode, isTerminal, evalEdgeConditions };`
+- [ ] **Step 4: Run** `node --test tests/worldgen/metaNetworkRouting.test.js` → PASS (new test + all 23 existing routing tests green).
+- [ ] **Step 5: Commit** `refactor(worldgen): export shared evalEdgeConditions for completability` (+ ADR-0011 trailer).
+
+---
+
+### Task 2: Completability validator module (pure, fixtures)
+
+**Files:**
+
+- Create: `apps/backend/services/worldgen/metaNetworkCompletability.js`
+- Test: `tests/worldgen/metaNetworkCompletability.test.js` (new)
+
+- [ ] **Step 1: Write the failing test** (new file):
+
+```js
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  checkCompletable,
+  completabilityWarning,
+} = require('../../apps/backend/services/worldgen/metaNetworkCompletability');
+
+// Completable: start A -> B (corridor) -> T (terminal, no outgoing).
+const okGraph = {
+  start_node: 'A',
+  nodes: [{ id: 'A' }, { id: 'B' }, { id: 'T', terminal: true }],
+  edges: [
+    { from: 'A', to: 'B', type: 'corridor' },
+    { from: 'B', to: 'T', type: 'corridor' },
+  ],
+};
+
+// Stranded: T only reachable via a prior_node_cleared[Z] gate, but Z is never reachable.
+const strandGraph = {
+  start_node: 'A',
+  nodes: [{ id: 'A' }, { id: 'T', terminal: true }],
+  edges: [{ from: 'A', to: 'T', type: 'corridor', conditions: { prior_node_cleared: ['Z'] } }],
+};
+
+test('checkCompletable: a graph with a clear path to a terminal -> ok', () => {
+  const r = checkCompletable(okGraph, { seasons: [null, 'winter'] });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.stranded, []);
+});
+
+test('checkCompletable: a graph that can strand a run -> not ok, reports the state', () => {
+  const r = checkCompletable(strandGraph, { seasons: [null] });
+  assert.equal(r.ok, false);
+  assert.equal(r.stranded.length, 1);
+  assert.equal(r.stranded[0].start, 'A');
+});
+
+test('checkCompletable: no start_node -> ok (graph routing inactive)', () => {
+  const r = checkCompletable({ nodes: [{ id: 'A' }], edges: [] }, {});
+  assert.equal(r.ok, true);
+});
+
+test('completabilityWarning: null when ok, string when stranded', () => {
+  assert.equal(completabilityWarning(okGraph, [null]), null);
+  const w = completabilityWarning(strandGraph, [null]);
+  assert.ok(typeof w === 'string' && /strand/i.test(w));
+});
+```
+
+- [ ] **Step 2: Run** `node --test tests/worldgen/metaNetworkCompletability.test.js` → FAIL (module not found).
+- [ ] **Step 3: Implement** (new file `metaNetworkCompletability.js`):
+
+```js
+'use strict';
+// Dormans completability validator for the meta-network graph. Pure, no I/O. Guarantees
+// (pre-flight) that the campaign can always reach a terminal node from the start under every
+// season -- a graph that can strand a run is a data bug. Lock-and-key (Dormans): an edge gated
+// by prior_node_cleared opens once its prereq nodes are themselves reachable; we iterate
+// reachability to a fixpoint, so a key that is generated before its lock is honoured.
+
+const { evalEdgeConditions } = require('./metaNetworkRouting');
+
+function _norm(v) {
+  return String(v == null ? '' : v)
+    .trim()
+    .toLowerCase();
+}
+
+// A node is terminal if flagged `terminal` OR it has no outgoing edges (dead-end climax).
+function _isTerminalNode(graph, nodeKey) {
+  const n = graph.nodes.find((x) => _norm(x.id) === nodeKey);
+  if (n && n.terminal) return true;
+  return !graph.edges.some((e) => _norm(e.from) === nodeKey);
+}
+
+// Fixpoint reachable set from `start` under `season`. clearedNodes = everything reachable so far
+// (sound lock-and-key approximation: a prereq satisfied iff that node is reachable earlier).
+function _reachable(graph, start, season) {
+  const reach = new Set([_norm(start)]);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const e of graph.edges) {
+      const from = _norm(e.from);
+      const to = _norm(e.to);
+      if (!reach.has(from) || reach.has(to)) continue;
+      const ctx = { season, clearedNodes: [...reach] };
+      if (evalEdgeConditions(e.conditions, ctx).ok) {
+        reach.add(to);
+        grew = true;
+      }
+    }
+  }
+  return reach;
+}
+
+// For each (start_node, season) verify a terminal node is reachable. Returns
+// { ok, stranded:[{start, season, reachable}], detail }.
+function checkCompletable(graph, { seasons = [null] } = {}) {
+  if (!graph || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+    return { ok: false, stranded: [{ start: null, season: null }], detail: 'no_graph' };
+  }
+  const start = graph.start_node;
+  if (!start) return { ok: true, stranded: [], detail: 'no start_node (graph routing inactive)' };
+  const stranded = [];
+  for (const season of seasons) {
+    const reach = _reachable(graph, start, season);
+    const hitsTerminal = [...reach].some((k) => _isTerminalNode(graph, k));
+    if (!hitsTerminal) stranded.push({ start, season, reachable: [...reach] });
+  }
+  return {
+    ok: stranded.length === 0,
+    stranded,
+    detail: stranded.length ? 'stranded states' : 'completable',
+  };
+}
+
+// Dev-surface startup warning (never throws). Returns a one-line string or null.
+function completabilityWarning(graph, seasons = [null, 'spring', 'summer', 'autumn', 'winter']) {
+  try {
+    const r = checkCompletable(graph, { seasons });
+    if (r.ok) return null;
+    const states = r.stranded.map((s) => ({ start: s.start, season: s.season }));
+    return `[metaNetworkCompletability] WARN: graph can strand a run: ${JSON.stringify(states)}`;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { checkCompletable, completabilityWarning, _reachable, _isTerminalNode };
+```
+
+- [ ] **Step 4: Run** `node --test tests/worldgen/metaNetworkCompletability.test.js` → PASS.
+- [ ] **Step 5: Commit** `feat(worldgen): Dormans completability validator (pure, lock-and-key)`.
+
+---
+
+### Task 3: Data — `DESERTO_CALDO → CRYOSTEPPE` seasonal_bridge (ungated)
+
+**Files:**
+
+- Modify: `packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml`
+- Test: `tests/worldgen/metaNetworkResolver.test.js`
+
+- [ ] **Step 1: Write the failing test** (append to the resolver spec):
+
+```js
+test('getOutgoingEdges: DESERTO_CALDO has the ungated seasonal_bridge to CRYOSTEPPE (3-way)', () => {
+  _resetCache();
+  const edges = getOutgoingEdges('DESERTO_CALDO');
+  const toCryo = edges.find((e) => e.to === 'CRYOSTEPPE');
+  assert.ok(toCryo, 'new DESERTO_CALDO -> CRYOSTEPPE edge present');
+  assert.equal(toCryo.type, 'seasonal_bridge');
+  assert.equal(toCryo.conditions, null, 'ungated (perennial) so the 3-way works year-round');
+  // start node now exposes 3 distinct edge types
+  const types = new Set(edges.map((e) => e.type));
+  assert.ok(
+    types.has('corridor') && types.has('trophic_spillover') && types.has('seasonal_bridge'),
+  );
+});
+```
+
+- [ ] **Step 2: Run** `node --test tests/worldgen/metaNetworkResolver.test.js` → FAIL (no CRYOSTEPPE edge).
+- [ ] **Step 3: Implement** — in `meta_network_alpha.yaml`, add this edge to the `edges:` list (after the existing DESERTO_CALDO edges, ASCII notes only):
+
+```yaml
+# Expansion PR1 (1A 3-way, ungated): perennial passage savana -> mezzanotte orbitale, so the
+# start node exposes corridor(BADLANDS) + trophic(FORESTA) + seasonal_bridge(CRYOSTEPPE) at once
+# -> NT/SJ, NF and SP each pick a different node. No `conditions` => always eligible.
+- from: DESERTO_CALDO
+  to: CRYOSTEPPE
+  type: seasonal_bridge
+  resistance: 0.6
+  seasonality: perenne
+  notes: Correnti ascensionali notturne aprono un valico stabile verso la mezzanotte orbitale.
+```
+
+- [ ] **Step 4: Recompute `trace_hash`** — run:
+
+```bash
+python -c "import importlib.util,sys; from pathlib import Path; import yaml; spec=importlib.util.spec_from_file_location('uth',Path('tools/py/update_trace_hashes.py')); m=importlib.util.module_from_spec(spec); sys.modules['uth']=m; spec.loader.exec_module(m); p=Path('packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml'); pl=yaml.safe_load(p.read_text(encoding='utf-8')); print(m._stable_digest(pl))"
+```
+
+Edit the `receipt.trace_hash:` line to the printed digest.
+
+- [ ] **Step 5: Run** the resolver test (PASS) + network validators + trace_hash pytest:
+
+```bash
+node --test tests/worldgen/metaNetworkResolver.test.js
+python packs/evo_tactics_pack/tools/py/run_all_validators.py >/dev/null; echo "validators exit=$?"
+python -m pytest tests/scripts/test_trace_hashes.py -q
+```
+
+Expected: resolver PASS; validators exit 0; pytest all passed.
+
+- [ ] **Step 6: Commit** `feat(worldgen): DESERTO->CRYOSTEPPE seasonal edge for a 3-way start (data-gate)`.
+
+---
+
+### Task 4: Integration — 3-way `/advance` + completability on the real graph
+
+**Files:**
+
+- Test: `tests/api/campaignMetaNetworkRouting.test.js`, `tests/worldgen/metaNetworkCompletability.test.js`
+
+- [ ] **Step 1: Write the failing tests.** In `tests/worldgen/metaNetworkCompletability.test.js` add (top: `const resolver = require('../../apps/backend/services/worldgen/metaNetworkResolver');`):
+
+```js
+test('checkCompletable: the REAL alpha graph reaches a terminal in every season', () => {
+  resolver._resetCache();
+  const net = resolver.getNetwork();
+  const r = checkCompletable(net, { seasons: [null, 'spring', 'summer', 'autumn', 'winter'] });
+  assert.equal(r.ok, true, `alpha graph completable; stranded=${JSON.stringify(r.stranded)}`);
+});
+```
+
+In `tests/api/campaignMetaNetworkRouting.test.js`, update the multi-candidate test (currently asserts BADLANDS + FORESTA_TEMPERATA, length 2) to the 3-way:
+
+```js
+// 3-way start (expansion PR1): corridor(BADLANDS) + trophic(FORESTA) + seasonal(CRYOSTEPPE).
+assert.equal(ids.length, 3, 'DESERTO_CALDO -> BADLANDS + FORESTA_TEMPERATA + CRYOSTEPPE');
+assert.ok(
+  ids.includes('BADLANDS') && ids.includes('FORESTA_TEMPERATA') && ids.includes('CRYOSTEPPE'),
+);
+assert.ok(!ids.includes('ROVINE_PLANARI'), 'terminal shortcut still gated (2B)');
+```
+
+- [ ] **Step 2: Run** `node --test tests/worldgen/metaNetworkCompletability.test.js tests/api/campaignMetaNetworkRouting.test.js` → the completability-real test PASSES (edge from Task 3); the campaign 3-way test FAILS only if Task 3 not applied — with Task 3 applied it PASSES. If the campaign test still expects length 2, fix the assertion as above.
+- [ ] **Step 3: No new impl** — Task 3's data already produces the 3rd candidate; this task locks it. Confirm the flag-OFF regression test in the same file is untouched and green.
+- [ ] **Step 4: Run** `node --test tests/api/*.test.js` → green (campaign regression byte-identical with flag OFF).
+- [ ] **Step 5: Commit** `test(worldgen): lock 3-way start branch + real-graph completability`.
+
+---
+
+### Task 5: Sim — full-loop 3-way policy divergence + route report
+
+**Files:**
+
+- Test: `tests/sim/fullLoopRouting.test.js`
+- Doc: `docs/playtest/2026-06-03-meta-network-route-report.md`
+
+- [ ] **Step 1: Write/extend the failing test.** In `tests/sim/fullLoopRouting.test.js`, after the greedy + INTJ runs, add an ESFP (SP) run and assert SP diverges to CRYOSTEPPE (add `makeMbtiPolicy` is already imported):
+
+```js
+const esfp = await runGraph(app, {
+  playerId: 'fl_route_esfp',
+  seed: 'route-e',
+  policy: makeMbtiPolicy('ESFP'),
+});
+assert.equal(
+  esfp.completed,
+  true,
+  `SP graph run completes; chapters=${JSON.stringify(esfp.chapters)}`,
+);
+assert.equal(esfp.route[0], 'DESERTO_CALDO');
+// SP prefers the seasonal_bridge -> CRYOSTEPPE: a THIRD distinct first pick (greedy->FORESTA,
+// NT->BADLANDS, SP->CRYOSTEPPE) = a true 3-way branch.
+assert.equal(esfp.route[1], 'CRYOSTEPPE', `SP prefers the seasonal route; route=${esfp.route}`);
+assert.ok(
+  new Set([greedy.route[1], intj.route[1], esfp.route[1]]).size === 3,
+  'three policies pick three different first nodes (3-way)',
+);
+```
+
+(Also: greedy.route[1] stays `FORESTA_TEMPERATA`; intj.route[1] stays `BADLANDS` — both unchanged by the new ungated edge since neither prefers seasonal.)
+
+- [ ] **Step 2: Run** `node --test tests/sim/fullLoopRouting.test.js` → FAIL first if the run doesn't reach CRYOSTEPPE; then with Task 3's edge it PASSES. Verify the route empirically if needed by logging `esfp.route`.
+- [ ] **Step 3: Update the route report** — append a "PR1 3-way" section to `docs/playtest/2026-06-03-meta-network-route-report.md` with the new ESFP route (DESERTO_CALDO -> CRYOSTEPPE -> ...). Then run governance: `python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict` (errors=0) and `git checkout -- reports/docs/governance_drift_report.json`.
+- [ ] **Step 4: Run** `node --test tests/sim/*.test.js` (green) + `node --test tests/ai/*.test.js` (500/500).
+- [ ] **Step 5: Commit** `feat(sim): full-loop 3-way policy divergence (SP -> CRYOSTEPPE) + report`.
+
+---
+
+### Task 6: Server-start completability warn (dev surface, never throws)
+
+**Files:**
+
+- Modify: `apps/backend/app.js` (locate `createApp`: `git grep -n "function createApp\|createApp =" apps/backend/app.js`)
+- Test: `tests/worldgen/metaNetworkCompletability.test.js` (the pure `completabilityWarning` is already covered in Task 2 — this task only wires the call)
+
+- [ ] **Step 1: Confirm the pure helper is tested** (Task 2 Step 1 already asserts `completabilityWarning` returns null/string). No new test for the `console.warn` side-effect (untestable cheaply); the wiring is a thin guarded call.
+- [ ] **Step 2: Implement the wiring** — near the top of `createApp` (after requires, before returning the app), add:
+
+```js
+// Dev-surface guard (Gate-5): warn once at boot if the shipped meta-network graph can strand a
+// graph-routed run. Never throws, no request-path impact; the flag-gated routing is unaffected.
+try {
+  const { completabilityWarning } = require('./services/worldgen/metaNetworkCompletability');
+  const metaNetworkResolver = require('./services/worldgen/metaNetworkResolver');
+  const warn = completabilityWarning(metaNetworkResolver.getNetwork());
+  if (warn) console.warn(warn);
+} catch {
+  /* boot-time best-effort only */
+}
+```
+
+(If `metaNetworkResolver` / a worldgen module is already required at the top of `app.js`, reuse that require instead of a local one.)
+
+- [ ] **Step 3: Run** the full app test suite to confirm no boot regression: `node --test tests/api/*.test.js` → green (the warn is null for the real graph, so nothing prints).
+- [ ] **Step 4: Verify no stray output** — the real alpha graph is completable (Task 4), so boot prints nothing. Optionally confirm by temporarily breaking the graph in a scratch test (not committed).
+- [ ] **Step 5: Commit** `feat(backend): warn at boot if the meta-network graph can strand a run`.
+
+---
+
+## After all tasks
+
+- Full gate: `node --test tests/ai/*.test.js` (500/500), `node --test tests/sim/*.test.js`, `node --test tests/worldgen/*.test.js tests/api/campaignMetaNetworkRouting.test.js`, prettier `--check` on changed files, `run_all_validators.py` exit 0, `test_trace_hashes.py`, governance errors=0 (checkout the drift artifact).
+- Open PR (`gh pr create --base main --head claude/meta-network-graph-expansion`), link the spec + this plan, babysit Codex (~2 nudges; address P1/P2; reply on-thread + resolve). Owner-gated merge — build green + Codex-clean, then STOP and hand back for master-dd.
+- **PR2 (Atollo node)** gets its own plan after PR1 merges (it depends on the post-PR1 graph + the validator as its merge gate).
+
+## Self-review notes
+
+- Spec coverage: §3 PR1 data → Task 3; validator → Task 2 (+ shared eval Task 1); 3-way → Tasks 3-5; completability real-graph → Task 4; server-start warn → Task 6; sim divergence + report → Task 5. ✓
+- `evalEdgeConditions` is defined/exported in Task 1 and consumed in Task 2 (same name). `checkCompletable`/`completabilityWarning` defined in Task 2, consumed in Tasks 4/6. ✓
+- No placeholders: all test + impl code is inline. Owner-gated data = the one new edge (Task 3) + (PR2) the node.

--- a/docs/superpowers/specs/2026-06-03-meta-network-graph-expansion-design.md
+++ b/docs/superpowers/specs/2026-06-03-meta-network-graph-expansion-design.md
@@ -75,13 +75,15 @@ Additive, flag-gated, owner-gated merges. Flag OFF → zero behavioural change (
   outgoing edges) is in the reachable set. Reuses the same condition semantics as
   `metaNetworkRouting._evalEdgeConditions` (extract a shared `evalEdgeConditions` or replicate the
   two Stage-1 evaluators — decide in the plan; prefer extract-and-share).
-- **Wiring (Gate-5, no behaviour change):** the validator runs in tests; optionally a server-start
-  `console.warn` if the shipped graph is non-completable (dev surface only, never throws).
+- **Wiring (Gate-5, no behaviour change; RATIFIED):** the validator runs in tests AND emits a
+  server-start `console.warn` if the shipped graph is non-completable (dev surface only, never
+  throws, no request-path impact).
 
 ### PR2 — Atollo Obsidiana node
 
-- **Data:** add node `ATOLLO_OBSIDIANA` (`biome_id: atollo_obsidiana`, weight ~0.45, `encounters:
-[<authored>]` — owner-ratified). Wire ≥1 in + ≥1 out edge so it is neither isolated nor a
+- **Data (RATIFIED):** add node `ATOLLO_OBSIDIANA` (`biome_id: atollo_obsidiana`, weight `0.45`,
+  `encounters: [enc_tutorial_07_hardcore_pod_rush]` — an unused hardcore encounter, thematically a
+  pre-climax atoll trial). Wire ≥1 in + ≥1 out edge so it is neither isolated nor a
   dead-end and the terminal stays reachable: proposed `CRYOSTEPPE → ATOLLO_OBSIDIANA` (corridor or
   trophic) + `ATOLLO_OBSIDIANA → ROVINE_PLANARI` (corridor). The PR1 validator MUST pass with the
   node added (that is the merge gate).
@@ -136,11 +138,14 @@ validators + `test_trace_hashes`; re-run the route report; AI 500/500 + sim gree
 (the "staging") → if bands hold, master-dd ratifies → **then** the PROD flag flip (separate PR/verdict;
 reversible by setting the flag OFF). Each PR is owner-gated (data + live-flow), not auto-L3.
 
-## 9. Open decisions for master-dd (ratify at the data-gate merges)
+## 9. Decisions — RATIFIED by master-dd (2026-06-03)
 
-1. PR1: the `DESERTO_CALDO → CRYOSTEPPE` seasonal_bridge being **ungated** (perennial) vs gated by a
-   non-winter season — ungated is required for a year-round 3-way; confirm.
-2. PR2: Atollo's **encounter** (authored from the existing pool, e.g. a hardcore/pod-rush or a fuzzy
-   tutorial id) + its **weight** + which node it attaches to (proposed CRYOSTEPPE in / ROVINE out).
-3. Whether the completability validator should also **warn at server start** (dev surface) or stay
-   test-only.
+1. ✅ `DESERTO_CALDO → CRYOSTEPPE` seasonal_bridge is **ungated** (perennial) — required for a
+   year-round 3-way branch.
+2. ✅ Atollo: `weight 0.45`, `encounters: [enc_tutorial_07_hardcore_pod_rush]`, attaches
+   `CRYOSTEPPE → ATOLLO_OBSIDIANA` (in) + `ATOLLO_OBSIDIANA → ROVINE_PLANARI` (out).
+3. ✅ The completability validator **warns at server start** (dev surface, never throws) in addition
+   to the test-suite checks.
+
+The data values above are still owner-confirmed at each PR's data-gate merge (standard practice),
+but the design intent is locked.

--- a/docs/superpowers/specs/2026-06-03-meta-network-graph-expansion-design.md
+++ b/docs/superpowers/specs/2026-06-03-meta-network-graph-expansion-design.md
@@ -1,0 +1,146 @@
+---
+title: 'Meta-network graph expansion (3-way branch + Atollo node + completability)'
+doc_status: draft
+doc_owner: master-dd
+workstream: flow
+last_verified: '2026-06-03'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Meta-network graph expansion
+
+> Brainstormed + master-dd-approved 2026-06-03. Expands the GAP-C meta-network beyond the
+> data-only tuning (#2584): a **true 3-way branch**, a **new canonical biome-node**
+> (Atollo Obsidiana), and a **Dormans completability validator** so a bigger/gated graph can
+> never strand a run. Delivered as **2 sequenced PRs**. Flag `META_NETWORK_ROUTING` stays
+> **OFF**; the prod flip is a later owner verdict gated on a fresh graph-mode band-verify.
+> Input to `writing-plans`. TDD, owner-gated merges (data + live-flow).
+
+## 1. Problem / current state (verified on origin/main `93c20e5c`)
+
+The live-routing graph (`meta_network_alpha.yaml`, 5 nodes / 13 edges after #2584) routes the
+campaign when the flag is on. Two limits remain, surfaced by the route report
+(`docs/playtest/2026-06-03-meta-network-route-report.md`):
+
+- **Divergence is at most 2-way.** The start node `DESERTO_CALDO` offers `corridor` (BADLANDS) +
+  `trophic_spillover` (FORESTA) — only two edge types — so the MBTI `chooseRoute` (NT/SJ→corridor,
+  NF→trophic, SP→seasonal) collapses SP onto the trophic cluster. No node exposes all three edge
+  types eligible at once.
+- **No completability guarantee.** There is no validator that the graph can always reach a terminal
+  from the start under every season; a mis-gated edge (e.g. a new node with all-gated inbounds) can
+  strand a run. `metaNetworkRouting` returns `all_blocked`/`all_cleared` at runtime but nothing
+  checks the whole graph up front (ADR-2026-05-31 cites Dormans lock-and-key only as a reference).
+
+The vault canon (`Spaces/Dev/Evo-Tactics/appendici/C-CANVAS_NPG_BIOMI.md`) defines **4 canonical
+biomes**: Canyons Risonanti (=BADLANDS), Foresta Miceliale (=FORESTA_TEMPERATA), Mezzanotte Orbitale
+(=CRYOSTEPPE), and **Atollo Obsidiana** — the only canonical biome not yet a graph node. Its
+ecosystem YAML (`atollo_obsidiana.ecosystem.yaml`, `biome_id: atollo_obsidiana`) already exists. The
+vault roadmap (`evo-state-roadmap-2026-05-26.md`) frames biome-add as infrastructure-gated, not
+content-gated.
+
+## 2. Goal / scope
+
+Richer, more legible routing that stays band-safe and never strands. Concretely:
+
+- A **true 3-way branch** at the start so NT/SJ, NF, and SP each pick a different node.
+- A **6th node** (Atollo Obsidiana) wired into the graph, completing the canonical roster.
+- A **completability validator** (pure, pre-flight) proving every (start, season) reaches a terminal.
+
+**Out of scope (deferred):** the PROD flag flip (separate owner verdict after a graph-mode
+band-verify); new encounter CONTENT for Atollo (it serves an authored existing encounter, owner-
+ratified); `min/max_pressure` arc-conditions (ADR-2026-05-31 v1.1); a 7th+ node.
+
+Design patterns (games-source-index): Dead Cells concept-graph (typed multi-edges from one node),
+Dormans lock-and-key + completability (the validator), Spelunky guaranteed-path.
+
+## 3. Approach — 2 sequenced PRs (data + 1 pure validator)
+
+Additive, flag-gated, owner-gated merges. Flag OFF → zero behavioural change (regression-locked).
+
+### PR1 — completability validator + 3-way start branch (existing 5 nodes)
+
+- **Data:** add edge `DESERTO_CALDO → CRYOSTEPPE`, `type: seasonal_bridge`, **ungated**
+  (`seasonality` is flavor only — an ungated seasonal_bridge is established practice, e.g. the
+  pre-#2584 DESERTO→ROVINE edge). The start node then exposes three edge types to three distinct
+  nodes: `corridor`→BADLANDS, `trophic_spillover`→FORESTA, `seasonal_bridge`→CRYOSTEPPE. The gated
+  `DESERTO_CALDO → ROVINE_PLANARI` (2B, #2584) is unchanged → the terminal shortcut stays closed.
+- **Code:** new `apps/backend/services/worldgen/metaNetworkCompletability.js` (pure, no I/O):
+  `checkCompletable(graph, { seasons }) -> { ok, stranded:[{start, season}], detail }`. For each
+  start (default `graph.start_node`) and each season in `seasons` (the `seasonalEngine` enum +
+  `null`), run a **lock-and-key fixpoint reachability**: a node is reachable if an edge into it
+  passes `season` AND its `prior_node_cleared` prereqs are already in the reachable set; iterate to
+  a fixpoint; the (start, season) is completable iff a terminal node (`terminal === true` or no
+  outgoing edges) is in the reachable set. Reuses the same condition semantics as
+  `metaNetworkRouting._evalEdgeConditions` (extract a shared `evalEdgeConditions` or replicate the
+  two Stage-1 evaluators — decide in the plan; prefer extract-and-share).
+- **Wiring (Gate-5, no behaviour change):** the validator runs in tests; optionally a server-start
+  `console.warn` if the shipped graph is non-completable (dev surface only, never throws).
+
+### PR2 — Atollo Obsidiana node
+
+- **Data:** add node `ATOLLO_OBSIDIANA` (`biome_id: atollo_obsidiana`, weight ~0.45, `encounters:
+[<authored>]` — owner-ratified). Wire ≥1 in + ≥1 out edge so it is neither isolated nor a
+  dead-end and the terminal stays reachable: proposed `CRYOSTEPPE → ATOLLO_OBSIDIANA` (corridor or
+  trophic) + `ATOLLO_OBSIDIANA → ROVINE_PLANARI` (corridor). The PR1 validator MUST pass with the
+  node added (that is the merge gate).
+- **No code change** — the resolver already maps any node; the validator from PR1 guards it.
+
+Both PRs: recompute `trace_hash` (inline `_stable_digest`, NOT the repo-wide tool); network
+validators + `test_trace_hashes`; re-run the route report; AI 500/500 + sim green.
+
+## 4. Data changes (`meta_network_alpha.yaml`, owner-gated; schema 2.1 already live)
+
+- PR1: +1 edge (`DESERTO_CALDO → CRYOSTEPPE`, seasonal_bridge, ungated). 13 → 14 edges.
+- PR2: +1 node (`ATOLLO_OBSIDIANA`) + 2 edges (in + out). 5 → 6 nodes, 14 → 16 edges.
+- `trace_hash` recomputed per PR. `bridge_species_map` updated only if Atollo participates in
+  cross-biome dispersal (optional, owner call).
+
+## 5. Code changes (`apps/backend/services/worldgen`, allowed zone)
+
+- **New** `metaNetworkCompletability.js` — pure `checkCompletable(graph, { seasons })`. Lock-and-key
+  fixpoint reachability; returns the strand report. No I/O, no RNG, deterministic.
+- **`metaNetworkRouting.js`** — if the plan extracts the shared condition evaluator, export
+  `evalEdgeConditions` (pure) so both routing and completability agree on gate semantics (single
+  source of truth). Otherwise the validator replicates the two Stage-1 evaluators (season,
+  prior_node_cleared) verbatim with a test asserting parity.
+
+## 6. Edge cases / errors
+
+- Flag OFF → zero behavioural change (regression test on the static chain).
+- 3-way branch: an ungated `seasonal_bridge` is always eligible (only `conditions.season` gates).
+  Confirm SP picks the seasonal target (CRYOSTEPPE), NT/SJ the corridor (BADLANDS), NF the trophic
+  (FORESTA).
+- Completability: a `prior_node_cleared` lock whose key node is itself only reachable past the lock
+  = unsatisfiable cycle → the fixpoint never adds the terminal → reported stranded (the bug we want
+  to catch). Atollo with a single gated inbound and no key path = stranded → caught by PR1 validator
+  before PR2 merges.
+- Unknown/absent season → season-gated edges fail closed (existing #2509 behaviour, preserved).
+
+## 7. Verification (TDD)
+
+- **Unit** (`metaNetworkCompletability`): a completable fixture → `ok:true`; a synthetic strand
+  graph (terminal only reachable via an unsatisfiable gate) → `ok:false` with the stranded
+  (start, season); the REAL alpha graph (PR1 then PR2) → `ok:true` for every season.
+- **Routing** (`metaNetworkRouting` / campaign): the start branch yields 3 candidates
+  (BADLANDS+FORESTA+CRYOSTEPPE); flag-OFF regression byte-identical.
+- **Sim** (`fullLoopRouting`): under graph mode, greedy/NT/NF/SP walk and the routes are 3-way
+  policy-sensitive (SP now diverges to CRYOSTEPPE); all complete, 0 violations. Re-run the 5-policy
+  route report; update the report doc.
+- Baselines: AI 500/500, sim green, prettier + governance + network validators + trace_hash green.
+
+## 8. Flag / rollout / sequencing
+
+`META_NETWORK_ROUTING` stays OFF. After BOTH PRs merge: run the **N=40 graph-mode band-verify**
+(the "staging") → if bands hold, master-dd ratifies → **then** the PROD flag flip (separate PR/verdict;
+reversible by setting the flag OFF). Each PR is owner-gated (data + live-flow), not auto-L3.
+
+## 9. Open decisions for master-dd (ratify at the data-gate merges)
+
+1. PR1: the `DESERTO_CALDO → CRYOSTEPPE` seasonal_bridge being **ungated** (perennial) vs gated by a
+   non-winter season — ungated is required for a year-round 3-way; confirm.
+2. PR2: Atollo's **encounter** (authored from the existing pool, e.g. a hardcore/pod-rush or a fuzzy
+   tutorial id) + its **weight** + which node it attaches to (proposed CRYOSTEPPE in / ROVINE out).
+3. Whether the completability validator should also **warn at server start** (dev surface) or stay
+   test-only.

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: c77628ef680d8cf839212497b701a399f4ded7ccafd4ae93652aa19c9c1d845f
+  trace_hash: df6addfca53a70e917b4ee75b54088fa655c6b6094de99a9ba6a85fca8c30664
 links:
   ecosystems:
   - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -141,6 +141,15 @@ network:
     resistance: 0.5
     seasonality: episodico
     notes: Spore e detrito eolico dalla savana alimentano i margini miceliali.
+  # Expansion PR1 (1A 3-way, ungated): perennial passage savana -> mezzanotte orbitale, so the
+  # start node exposes corridor(BADLANDS) + trophic(FORESTA) + seasonal_bridge(CRYOSTEPPE) at
+  # once -> NT/SJ, NF and SP each pick a different node. No `conditions` => always eligible.
+  - from: DESERTO_CALDO
+    to: CRYOSTEPPE
+    type: seasonal_bridge
+    resistance: 0.6
+    seasonality: perenne
+    notes: Correnti ascensionali notturne aprono un valico stabile verso la mezzanotte orbitale.
   bridge_species_map:
   - species_id: echo-wing
     roles:

--- a/tests/api/campaignMetaNetworkRouting.test.js
+++ b/tests/api/campaignMetaNetworkRouting.test.js
@@ -111,11 +111,13 @@ test('advance: flag ON multi-candidate node -> choice_required + candidates, cur
   assert.equal(adv.body.choice_required, true);
   assert.ok(adv.body.route_choice && Array.isArray(adv.body.route_choice.candidates));
   const ids = adv.body.route_choice.candidates.map((c) => c.node_id);
-  // Topology tuning: DESERTO_CALDO -> BADLANDS (corridor) + FORESTA_TEMPERATA (trophic, 1A).
-  // ROVINE_PLANARI is NOT a start candidate -- its direct edge is gated prior_node_cleared
-  // [BADLANDS, FORESTA_TEMPERATA] (2B) so the 2-node shortcut to the terminal is closed.
-  assert.equal(ids.length, 2, 'DESERTO_CALDO -> BADLANDS + FORESTA_TEMPERATA');
-  assert.ok(ids.includes('BADLANDS') && ids.includes('FORESTA_TEMPERATA'));
+  // Expansion PR1 (3-way): DESERTO_CALDO -> BADLANDS (corridor) + FORESTA_TEMPERATA (trophic) +
+  // CRYOSTEPPE (seasonal_bridge, ungated). ROVINE_PLANARI is NOT a start candidate -- its direct
+  // edge is gated prior_node_cleared [BADLANDS, FORESTA_TEMPERATA] (2B), shortcut stays closed.
+  assert.equal(ids.length, 3, 'DESERTO_CALDO -> BADLANDS + FORESTA_TEMPERATA + CRYOSTEPPE');
+  assert.ok(
+    ids.includes('BADLANDS') && ids.includes('FORESTA_TEMPERATA') && ids.includes('CRYOSTEPPE'),
+  );
   assert.ok(!ids.includes('ROVINE_PLANARI'), 'terminal shortcut gated (2B)');
   assert.equal(adv.body.campaign.currentNode, 'DESERTO_CALDO', 'does not advance until /choose');
   assert.deepEqual(
@@ -182,9 +184,10 @@ test('choose: flag ON node_id that is not a current candidate -> 400', async (t)
   const url = startTestServer(t);
   const s = await startCampaign(url);
   const id = s.body.campaign.id;
-  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // candidates: BADLANDS, ROVINE_PLANARI
-  const ch = await post(`${url}/api/campaign/choose`, { id, node_id: 'CRYOSTEPPE' });
-  assert.equal(ch.status, 400, 'CRYOSTEPPE is not reachable from DESERTO_CALDO');
+  await post(`${url}/api/campaign/advance`, { id, outcome: 'victory' }); // candidates: BADLANDS, FORESTA, CRYOSTEPPE
+  // ROVINE_PLANARI is gated (prior_node_cleared not met at the start) -> not a current candidate.
+  const ch = await post(`${url}/api/campaign/choose`, { id, node_id: 'ROVINE_PLANARI' });
+  assert.equal(ch.status, 400, 'gated ROVINE_PLANARI is not a candidate from DESERTO_CALDO');
 });
 
 test('choose: flag ON without node_id falls through to the branch_key contract (back-compat)', async (t) => {

--- a/tests/sim/fullLoopRouting.test.js
+++ b/tests/sim/fullLoopRouting.test.js
@@ -130,11 +130,37 @@ test('runFullLoop: flag ON walks the graph start->terminal, policy picks at the 
   // The NT temperament prefers the corridor edge -> BADLANDS, NOT greedy's FORESTA_TEMPERATA.
   assert.equal(intj.route[1], 'BADLANDS', `NT prefers the corridor route; route=${intj.route}`);
 
-  // POLICY-SENSITIVE: the two policies walk DIFFERENT routes from the same start.
+  // Expansion PR1 (3-way): SP prefers the seasonal_bridge -> CRYOSTEPPE, a THIRD distinct first
+  // pick (greedy->FORESTA, NT->BADLANDS, SP->CRYOSTEPPE).
+  const esfp = await runGraph(app, {
+    playerId: 'fl_route_esfp',
+    seed: 'route-e',
+    policy: makeMbtiPolicy('ESFP'),
+  });
+  assert.equal(
+    esfp.completed,
+    true,
+    `SP graph run completes; chapters=${JSON.stringify(esfp.chapters)}`,
+  );
+  assert.deepEqual(
+    esfp.violations,
+    [],
+    `no invariant violations: ${JSON.stringify(esfp.violations)}`,
+  );
+  assert.equal(esfp.route[0], 'DESERTO_CALDO', 'same start node');
+  assert.equal(esfp.route[1], 'CRYOSTEPPE', `SP prefers the seasonal route; route=${esfp.route}`);
+
+  // POLICY-SENSITIVE: the policies walk DIFFERENT routes from the same start.
   assert.notDeepEqual(greedy.route, intj.route, 'route is policy-sensitive (P4 hook)');
   assert.notEqual(
     greedy.route[1],
     intj.route[1],
-    'the policies diverge at the first multi-candidate branch',
+    'greedy and NT diverge at the first multi-candidate branch',
+  );
+  // True 3-way: three policies pick three different first nodes.
+  assert.equal(
+    new Set([greedy.route[1], intj.route[1], esfp.route[1]]).size,
+    3,
+    `3-way branch: ${greedy.route[1]} / ${intj.route[1]} / ${esfp.route[1]}`,
   );
 });

--- a/tests/worldgen/metaNetworkCompletability.test.js
+++ b/tests/worldgen/metaNetworkCompletability.test.js
@@ -1,0 +1,60 @@
+'use strict';
+// Expansion PR1 — Dormans completability validator. Pure pre-flight check that the meta-network
+// graph can always reach a terminal node from the start under every season (a graph that can
+// strand a run is a data bug). Lock-and-key: a prior_node_cleared gate opens once its prereq
+// nodes are reachable (fixpoint).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  checkCompletable,
+  completabilityWarning,
+} = require('../../apps/backend/services/worldgen/metaNetworkCompletability');
+const resolver = require('../../apps/backend/services/worldgen/metaNetworkResolver');
+
+// Completable: start A -> B (corridor) -> T (terminal, no outgoing).
+const okGraph = {
+  start_node: 'A',
+  nodes: [{ id: 'A' }, { id: 'B' }, { id: 'T', terminal: true }],
+  edges: [
+    { from: 'A', to: 'B', type: 'corridor' },
+    { from: 'B', to: 'T', type: 'corridor' },
+  ],
+};
+
+// Stranded: T only reachable via a prior_node_cleared[Z] gate, but Z is never reachable.
+const strandGraph = {
+  start_node: 'A',
+  nodes: [{ id: 'A' }, { id: 'T', terminal: true }],
+  edges: [{ from: 'A', to: 'T', type: 'corridor', conditions: { prior_node_cleared: ['Z'] } }],
+};
+
+test('checkCompletable: a graph with a clear path to a terminal -> ok', () => {
+  const r = checkCompletable(okGraph, { seasons: [null, 'winter'] });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.stranded, []);
+});
+
+test('checkCompletable: a graph that can strand a run -> not ok, reports the state', () => {
+  const r = checkCompletable(strandGraph, { seasons: [null] });
+  assert.equal(r.ok, false);
+  assert.equal(r.stranded.length, 1);
+  assert.equal(r.stranded[0].start, 'A');
+});
+
+test('checkCompletable: no start_node -> ok (graph routing inactive)', () => {
+  const r = checkCompletable({ nodes: [{ id: 'A' }], edges: [] }, {});
+  assert.equal(r.ok, true);
+});
+
+test('completabilityWarning: null when ok, string when stranded', () => {
+  assert.equal(completabilityWarning(okGraph, [null]), null);
+  const w = completabilityWarning(strandGraph, [null]);
+  assert.ok(typeof w === 'string' && /strand/i.test(w));
+});
+
+test('checkCompletable: the REAL alpha graph reaches a terminal in every season', () => {
+  resolver._resetCache();
+  const net = resolver.getNetwork();
+  const r = checkCompletable(net, { seasons: [null, 'spring', 'summer', 'autumn', 'winter'] });
+  assert.equal(r.ok, true, `alpha graph completable; stranded=${JSON.stringify(r.stranded)}`);
+});

--- a/tests/worldgen/metaNetworkResolver.test.js
+++ b/tests/worldgen/metaNetworkResolver.test.js
@@ -149,3 +149,20 @@ test('getOutgoingEdges: DESERTO_CALDO has the 1A trophic edge to FORESTA + the 2
   assert.ok(toBadlands && toBadlands.type === 'corridor');
   assert.equal(toBadlands.conditions, null);
 });
+
+// Expansion PR1 (1A 3-way): add an ungated seasonal_bridge DESERTO_CALDO -> CRYOSTEPPE so the
+// start node exposes all three edge types at once (corridor + trophic + seasonal) -> NT/SJ, NF
+// and SP each pick a different node. `seasonality` is flavor only; no `conditions` gate.
+test('getOutgoingEdges: DESERTO_CALDO has the ungated seasonal_bridge to CRYOSTEPPE (3-way)', () => {
+  _resetCache();
+  const edges = getOutgoingEdges('DESERTO_CALDO');
+  const toCryo = edges.find((e) => e.to === 'CRYOSTEPPE');
+  assert.ok(toCryo, 'new DESERTO_CALDO -> CRYOSTEPPE edge present');
+  assert.equal(toCryo.type, 'seasonal_bridge');
+  assert.equal(toCryo.conditions, null, 'ungated (perennial) so the 3-way works year-round');
+  const types = new Set(edges.map((e) => e.type));
+  assert.ok(
+    types.has('corridor') && types.has('trophic_spillover') && types.has('seasonal_bridge'),
+    'start node exposes all 3 edge types',
+  );
+});

--- a/tests/worldgen/metaNetworkRouting.test.js
+++ b/tests/worldgen/metaNetworkRouting.test.js
@@ -305,3 +305,16 @@ test('isTerminal: reflects node.terminal, false on missing / bad input', () => {
   assert.equal(isTerminal(routeGraph, 'MISSING'), false);
   assert.equal(isTerminal(null, 'Z'), false, 'no graph -> false');
 });
+
+// Expansion PR1: the edge-condition evaluator is now exported (shared with the completability
+// validator) so routing + completability agree on gate semantics (single source of truth).
+const { evalEdgeConditions } = require('../../apps/backend/services/worldgen/metaNetworkRouting');
+
+test('evalEdgeConditions: exported, shared gate eval (season + prior_node_cleared)', () => {
+  assert.deepEqual(evalEdgeConditions(null, {}), { ok: true, blocked_by: null });
+  assert.equal(evalEdgeConditions({ season: ['winter'] }, { season: 'winter' }).ok, true);
+  assert.equal(evalEdgeConditions({ season: ['winter'] }, { season: 'summer' }).ok, false);
+  assert.equal(evalEdgeConditions({ prior_node_cleared: ['X'] }, { clearedNodes: ['X'] }).ok, true);
+  assert.equal(evalEdgeConditions({ prior_node_cleared: ['X'] }, { clearedNodes: [] }).ok, false);
+  assert.equal(evalEdgeConditions({ min_pressure: 3 }, {}).ok, false, 'unknown key fails closed');
+});


### PR DESCRIPTION
## What (PR1 of 2)

Graph-expansion **PR1**: a true 3-way start branch + a Dormans completability validator. Spec [`...graph-expansion-design.md`](docs/superpowers/specs/2026-06-03-meta-network-graph-expansion-design.md), plan [`...pr1-validator-3way.md`](docs/superpowers/plans/2026-06-03-meta-network-expansion-pr1-validator-3way.md) (master-dd approved). Flag `META_NETWORK_ROUTING` stays **OFF**.

- **1A (3-way):** ungated `DESERTO_CALDO → CRYOSTEPPE` `seasonal_bridge` → the start node exposes all three edge types at once. The three Keirsey clusters now pick three different first nodes: greedy/NT/SP → **FORESTA / BADLANDS / CRYOSTEPPE**.
- **Completability validator:** new pure `metaNetworkCompletability.js` (lock-and-key fixpoint reachability) proves the graph reaches a terminal from start under every season. Shared `evalEdgeConditions` (exported from routing) keeps gate semantics single-source. Warns at boot if a shipped graph can strand a run (dev surface, never throws).

## Effect (re-run sim, all complete, 0 violations)

| greedy | INTJ (NT) | ESFP (SP) |
|---|---|---|
| DESERTO→FORESTA→ROVINE | DESERTO→BADLANDS→FORESTA→ROVINE | DESERTO→CRYOSTEPPE→BADLANDS→FORESTA→ROVINE |

Three distinct first picks = true 3-way. Route report updated.

## Verify

- AI 500/500, sim 112/112, worldgen+campaign+coop 70/70, network validators exit 0, `test_trace_hashes` 208, governance errors=0, prettier clean.
- `trace_hash` recomputed (inline `_stable_digest`). Flag-OFF regression byte-identical.

## Gate / sequencing

Owner-gated (data + live-flow): ratify the ungated CRYOSTEPPE edge at merge. Forbidden paths: none. **PR2** (Atollo Obsidiana 6th node) follows in a separate PR, gated by this validator. Prod flip = separate verdict after an N=40 graph-mode band-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)