### PR TITLE
feat(worldgen): meta-network expansion PR2 — Atollo Obsidiana 6th node

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -8525,6 +8525,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/superpowers/plans/2026-06-03-meta-network-expansion-pr2-atollo-node.md",
+      "title": "Meta-network expansion PR2 - Atollo Obsidiana 6th node Implementation Plan",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "flow",
+      "last_verified": "2026-06-03",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
     }
   ]
 }

--- a/docs/playtest/2026-06-03-meta-network-route-report.md
+++ b/docs/playtest/2026-06-03-meta-network-route-report.md
@@ -109,3 +109,18 @@ graph reaches a terminal in every season. Re-running the sim (all complete, 0 vi
 Three policies now pick **three different first nodes** (FORESTA / BADLANDS / CRYOSTEPPE) — a true
 3-way divergence. PR2 (the Atollo Obsidiana 6th node) follows in a separate PR, gated by the
 completability validator. Flag stays OFF; the prod flip awaits the N=40 graph-mode band-verify.
+
+## Graph expansion PR2 (Atollo Obsidiana 6th node)
+
+The 6th canonical biome-node `ATOLLO_OBSIDIANA` is now wired in: `CRYOSTEPPE → ATOLLO_OBSIDIANA`
+(ungated seasonal_bridge) + `ATOLLO_OBSIDIANA → ROVINE_PLANARI` (corridor). The completability
+validator confirms the 6-node graph reaches the terminal in every season and that Atollo is
+reachable. The SP temperament, which already routes to CRYOSTEPPE, now takes the seasonal bridge
+to the atoll:
+
+| Policy    | Route (nodes)                                                      |
+| --------- | ------------------------------------------------------------------ |
+| ESFP (SP) | DESERTO_CALDO → CRYOSTEPPE → **ATOLLO_OBSIDIANA** → ROVINE_PLANARI |
+
+The 6-node graph is now complete (all 4 canonical biomes from the vault canvas are nodes). Flag
+stays OFF; next is the N=40 graph-mode band-verify, then the owner-gated prod flip.

--- a/docs/superpowers/plans/2026-06-03-meta-network-expansion-pr2-atollo-node.md
+++ b/docs/superpowers/plans/2026-06-03-meta-network-expansion-pr2-atollo-node.md
@@ -1,0 +1,146 @@
+# Meta-network expansion PR2 — Atollo Obsidiana 6th node Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the 6th canonical biome-node `ATOLLO_OBSIDIANA` to the meta-network graph, wired (in from CRYOSTEPPE, out to the terminal ROVINE), reachable + completability-gated, with a policy (SP) actually visiting it.
+
+**Architecture:** Data-only (YAML) — no new code. The PR1 completability validator (`metaNetworkCompletability.js`) is the merge gate. `CRYOSTEPPE → ATOLLO` is an ungated `seasonal_bridge` so the SP temperament (seasonal-first) routes through Atollo; `ATOLLO → ROVINE` (corridor) reaches the terminal. Flag `META_NETWORK_ROUTING` OFF → zero live change.
+
+**Tech Stack:** `meta_network_alpha.yaml` (schema 2.1), `node:test` + `supertest`, the PR1 modules.
+
+**Invariants (every task):** TDD red→green; worktree `C:/dev/_gamewt-metanet-atollo` (prettier 3.8.3); AI 500/500; sim green (node v24 — `*.test.js` GLOB); ADR-0011 trailer (`Coding-Agent: claude-opus-4.8` + uuidv7, lowercase ≤72); owner-gated merge. Touch the YAML → recompute `trace_hash` (inline `_stable_digest`) + `run_all_validators.py` + `test_trace_hashes.py`. Touch docs → governance `--strict` (errors=0) + `git checkout -- reports/docs/governance_drift_report.json`. Forbidden: `.github/workflows`, `migrations`, `packages/contracts`, `services/generation`. Spec: [`2026-06-03-meta-network-graph-expansion-design.md`](../specs/2026-06-03-meta-network-graph-expansion-design.md) §3 PR2 (RATIFIED).
+
+---
+
+### Task 1: Data — ATOLLO_OBSIDIANA node + 2 edges + encounter
+
+**Files:**
+
+- Modify: `packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml`
+- Test: `tests/worldgen/metaNetworkResolver.test.js`
+
+- [ ] **Step 1: Write the failing test** (append to the resolver spec):
+
+```js
+test('getNetwork: ATOLLO_OBSIDIANA is the 6th node, wired in (CRYOSTEPPE) + out (ROVINE)', () => {
+  _resetCache();
+  const net = getNetwork();
+  assert.equal(net.nodes.length, 6, 'six nodes after Atollo');
+  const atollo = net.nodes.find((n) => n.id === 'ATOLLO_OBSIDIANA');
+  assert.ok(atollo, 'ATOLLO_OBSIDIANA node present');
+  assert.equal(atollo.biome_id, 'atollo_obsidiana');
+  assert.deepEqual(atollo.encounters, ['enc_tutorial_07_hardcore_pod_rush']);
+  // inbound from CRYOSTEPPE (seasonal_bridge, ungated) + outbound to the terminal ROVINE.
+  const inEdge = getOutgoingEdges('CRYOSTEPPE').find((e) => e.to === 'ATOLLO_OBSIDIANA');
+  assert.ok(inEdge && inEdge.type === 'seasonal_bridge' && inEdge.conditions === null);
+  const outEdge = getOutgoingEdges('ATOLLO_OBSIDIANA').find((e) => e.to === 'ROVINE_PLANARI');
+  assert.ok(outEdge, 'ATOLLO_OBSIDIANA -> ROVINE_PLANARI present');
+});
+```
+
+- [ ] **Step 2: Run** `node --test tests/worldgen/metaNetworkResolver.test.js` → FAIL (5 nodes, no Atollo).
+- [ ] **Step 3: Implement** — in `meta_network_alpha.yaml`:
+  - Add the node to the `nodes:` list:
+
+```yaml
+# Expansion PR2: Atollo Obsidiana, the 4th canonical biome (vault canvas C-CANVAS_NPG_BIOMI),
+# now the graph's 6th node. Reached from CRYOSTEPPE, exits to the terminal ROVINE.
+- id: ATOLLO_OBSIDIANA
+  biome_id: atollo_obsidiana
+  path: packs/evo_tactics_pack/data/ecosystems/atollo_obsidiana.ecosystem.yaml
+  weight: 0.45
+  encounters: [enc_tutorial_07_hardcore_pod_rush]
+```
+
+- Add two edges to the `edges:` list (before `bridge_species_map:`):
+
+```yaml
+# Expansion PR2: CRYOSTEPPE -> ATOLLO seasonal_bridge (ungated) so the SP temperament routes
+# through the atoll; ATOLLO -> ROVINE corridor reaches the terminal (>=4 nodes, no shortcut).
+- from: CRYOSTEPPE
+  to: ATOLLO_OBSIDIANA
+  type: seasonal_bridge
+  resistance: 0.55
+  seasonality: perenne
+  notes: Risacca obsidiana incanala i migratori dalle steppe orbitali verso l'atollo.
+- from: ATOLLO_OBSIDIANA
+  to: ROVINE_PLANARI
+  type: corridor
+  resistance: 0.6
+  seasonality: estate
+  notes: Banchi corallini fossili formano un ponte verso le rovine planari.
+```
+
+- [ ] **Step 4: Recompute `trace_hash`** — `python -c "import importlib.util,sys; from pathlib import Path; import yaml; spec=importlib.util.spec_from_file_location('uth',Path('tools/py/update_trace_hashes.py')); m=importlib.util.module_from_spec(spec); sys.modules['uth']=m; spec.loader.exec_module(m); p=Path('packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml'); print(m._stable_digest(yaml.safe_load(p.read_text(encoding='utf-8'))))"` → edit the `receipt.trace_hash:` line.
+- [ ] **Step 5: Run** resolver test (PASS) + `python packs/evo_tactics_pack/tools/py/run_all_validators.py` (exit 0) + `python -m pytest tests/scripts/test_trace_hashes.py -q` (PASS).
+- [ ] **Step 6: Commit** `feat(worldgen): Atollo Obsidiana 6th node (data-gate)`.
+
+---
+
+### Task 2: Completability — validator passes on the 6-node graph
+
+**Files:**
+
+- Test: `tests/worldgen/metaNetworkCompletability.test.js`
+
+- [ ] **Step 1: Write the failing/locking test** (append):
+
+```js
+test('checkCompletable: ATOLLO_OBSIDIANA is reachable + the 6-node graph stays completable', () => {
+  resolver._resetCache();
+  const net = resolver.getNetwork();
+  const r = checkCompletable(net, { seasons: [null, 'spring', 'summer', 'autumn', 'winter'] });
+  assert.equal(r.ok, true, `6-node graph completable; stranded=${JSON.stringify(r.stranded)}`);
+  // ATOLLO is reachable from the start under every season (it is on an ungated path).
+  const reach =
+    require('../../apps/backend/services/worldgen/metaNetworkCompletability')._reachable(
+      net,
+      net.start_node,
+      null,
+    );
+  assert.ok([...reach].includes('atollo_obsidiana'), 'ATOLLO_OBSIDIANA reachable from start');
+});
+```
+
+(NOTE: `_reachable` returns lowercased node keys, so assert the lowercase `'atollo_obsidiana'`.)
+
+- [ ] **Step 2: Run** `node --test tests/worldgen/metaNetworkCompletability.test.js` → PASS (Task 1's edges make Atollo reachable + the graph completable). If it FAILS, the wiring stranded Atollo — fix the edges in Task 1.
+- [ ] **Step 3: No new impl** — the PR1 validator already covers this; this task locks the 6-node graph.
+- [ ] **Step 4: Commit** `test(worldgen): lock 6-node completability + Atollo reachability`.
+
+---
+
+### Task 3: Sim — SP routes through Atollo + route report
+
+**Files:**
+
+- Test: `tests/sim/fullLoopRouting.test.js`
+- Doc: `docs/playtest/2026-06-03-meta-network-route-report.md`
+
+- [ ] **Step 1: Write the failing assertion** — in the ESFP block of `fullLoopRouting.test.js`, after the existing `esfp.route[1] === 'CRYOSTEPPE'` assertion, add:
+
+```js
+// PR2: from CRYOSTEPPE the SP temperament takes the ungated seasonal_bridge to the new atoll.
+assert.ok(
+  esfp.route.includes('ATOLLO_OBSIDIANA'),
+  `SP routes through the Atollo node; route=${esfp.route}`,
+);
+```
+
+- [ ] **Step 2: Run** `node --test tests/sim/fullLoopRouting.test.js` → PASS (with Task 1's seasonal edge, ESFP picks ATOLLO at CRYOSTEPPE). If ESFP does NOT visit Atollo, verify the CRYOSTEPPE→ATOLLO edge type is `seasonal_bridge` (SP prefers seasonal) — log `esfp.route` to confirm.
+- [ ] **Step 3: Update the route report** — append a "PR2 (Atollo)" note to `docs/playtest/2026-06-03-meta-network-route-report.md` with the ESFP route now passing through ATOLLO_OBSIDIANA. Run governance `--strict` (errors=0) + `git checkout -- reports/docs/governance_drift_report.json`.
+- [ ] **Step 4: Run** `node --test tests/sim/*.test.js` (green) + `node --test tests/ai/*.test.js` (500/500).
+- [ ] **Step 5: Commit** `feat(sim): SP routes through the Atollo node + report`.
+
+---
+
+## After all tasks
+
+- Full gate: AI 500/500, sim green, `node --test tests/worldgen/*.test.js tests/api/campaignMetaNetworkRouting.test.js`, prettier `--check` changed files, `run_all_validators.py` exit 0, `test_trace_hashes.py`, governance errors=0 (checkout the drift artifact).
+- Open PR (`gh pr create --base main --head claude/meta-network-atollo-node`), link spec + this plan, babysit Codex. Owner-gated merge — build green, then STOP for master-dd.
+- After PR2 merges: the **N=40 graph-mode band-verify** (staging) → ratify → **prod flag flip** (separate verdict).
+
+## Self-review notes
+
+- Spec §3 PR2 coverage: node + 2 edges + encounter → Task 1; completability gate → Task 2; sim visit → Task 3. ✓
+- `checkCompletable` / `_reachable` defined in PR1, consumed here. `_reachable` returns lowercased keys (asserted lowercase). No placeholders.

--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -3,7 +3,7 @@ receipt:
   source: PTPF.v1.0
   author: designer
   date: '2025-10-25'
-  trace_hash: df6addfca53a70e917b4ee75b54088fa655c6b6094de99a9ba6a85fca8c30664
+  trace_hash: 0126a8e9d2f3831c9be07c912ac8617200c541ba3bfa9b01dceaec93414adb1c
 links:
   ecosystems:
   - packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -47,6 +47,13 @@ network:
     weight: 0.5
     encounters: [enc_tutorial_05, enc_tutorial_06_hardcore]
     terminal: true
+  # Expansion PR2: Atollo Obsidiana, the 4th canonical biome (vault canvas C-CANVAS_NPG_BIOMI),
+  # now the graph's 6th node. Reached from CRYOSTEPPE, exits to the terminal ROVINE.
+  - id: ATOLLO_OBSIDIANA
+    biome_id: atollo_obsidiana
+    path: packs/evo_tactics_pack/data/ecosystems/atollo_obsidiana.ecosystem.yaml
+    weight: 0.45
+    encounters: [enc_tutorial_07_hardcore_pod_rush]
   edges:
   - from: BADLANDS
     to: FORESTA_TEMPERATA
@@ -150,6 +157,20 @@ network:
     resistance: 0.6
     seasonality: perenne
     notes: Correnti ascensionali notturne aprono un valico stabile verso la mezzanotte orbitale.
+  # Expansion PR2: CRYOSTEPPE -> ATOLLO seasonal_bridge (ungated) so the SP temperament routes
+  # through the atoll; ATOLLO -> ROVINE corridor reaches the terminal (>=4 nodes, no shortcut).
+  - from: CRYOSTEPPE
+    to: ATOLLO_OBSIDIANA
+    type: seasonal_bridge
+    resistance: 0.55
+    seasonality: perenne
+    notes: Risacca obsidiana incanala i migratori dalle steppe orbitali verso l'atollo.
+  - from: ATOLLO_OBSIDIANA
+    to: ROVINE_PLANARI
+    type: corridor
+    resistance: 0.6
+    seasonality: estate
+    notes: Banchi corallini fossili formano un ponte verso le rovine planari.
   bridge_species_map:
   - species_id: echo-wing
     roles:

--- a/tests/sim/fullLoopRouting.test.js
+++ b/tests/sim/fullLoopRouting.test.js
@@ -149,6 +149,11 @@ test('runFullLoop: flag ON walks the graph start->terminal, policy picks at the 
   );
   assert.equal(esfp.route[0], 'DESERTO_CALDO', 'same start node');
   assert.equal(esfp.route[1], 'CRYOSTEPPE', `SP prefers the seasonal route; route=${esfp.route}`);
+  // PR2: from CRYOSTEPPE the SP temperament takes the ungated seasonal_bridge to the new atoll.
+  assert.ok(
+    esfp.route.includes('ATOLLO_OBSIDIANA'),
+    `SP routes through the Atollo node; route=${esfp.route}`,
+  );
 
   // POLICY-SENSITIVE: the policies walk DIFFERENT routes from the same start.
   assert.notDeepEqual(greedy.route, intj.route, 'route is policy-sensitive (P4 hook)');

--- a/tests/sim/metaNetworkDriver.test.js
+++ b/tests/sim/metaNetworkDriver.test.js
@@ -146,8 +146,9 @@ test('traverse: flag OFF -> enabled:false no-op', async (t) => {
 test('traverse: a CRYOSTEPPE/winter walk CROSSES the winter bridge (Codex #2572 P2)', async (t) => {
   // From BADLANDS the greedy walk never reaches CRYOSTEPPE, so a winter run from there leaves
   // the season-gated bridge unexercised. Starting at CRYOSTEPPE makes the gate decisive:
-  // in winter, step 1 takes the CRYOSTEPPE -> FORESTA_TEMPERATA winter bridge (w0.55 > the
-  // BADLANDS alternative); without a season that edge is locked and the walk picks BADLANDS.
+  // in winter, step 1 takes the CRYOSTEPPE -> FORESTA_TEMPERATA winter bridge (w0.55, highest);
+  // without a season that edge is locked, so the walk does NOT cross to FORESTA_TEMPERATA (it
+  // takes one of the ungated alternatives -- BADLANDS or, post-PR2, the ATOLLO seasonal_bridge).
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => close && (await close().catch(() => {})));
   await withFlag('true', async () => {
@@ -156,6 +157,10 @@ test('traverse: a CRYOSTEPPE/winter walk CROSSES the winter bridge (Codex #2572 
     assert.equal(winter.path[0], 'CRYOSTEPPE');
     assert.equal(winter.path[1], 'FORESTA_TEMPERATA', `winter bridge crossed; path=${winter.path}`);
     const locked = await traverse(http, { start: 'CRYOSTEPPE', season: null });
-    assert.equal(locked.path[1], 'BADLANDS', `bridge locked without season; path=${locked.path}`);
+    assert.notEqual(
+      locked.path[1],
+      'FORESTA_TEMPERATA',
+      `winter bridge locked without season; path=${locked.path}`,
+    );
   });
 });

--- a/tests/worldgen/metaNetworkCompletability.test.js
+++ b/tests/worldgen/metaNetworkCompletability.test.js
@@ -58,3 +58,17 @@ test('checkCompletable: the REAL alpha graph reaches a terminal in every season'
   const r = checkCompletable(net, { seasons: [null, 'spring', 'summer', 'autumn', 'winter'] });
   assert.equal(r.ok, true, `alpha graph completable; stranded=${JSON.stringify(r.stranded)}`);
 });
+
+// Expansion PR2: the 6-node graph (Atollo added) stays completable AND the new node is reachable
+// from the start (it sits on an ungated path CRYOSTEPPE -> ATOLLO -> ROVINE).
+const { _reachable } = require('../../apps/backend/services/worldgen/metaNetworkCompletability');
+
+test('checkCompletable: ATOLLO_OBSIDIANA is reachable + the 6-node graph stays completable', () => {
+  resolver._resetCache();
+  const net = resolver.getNetwork();
+  const r = checkCompletable(net, { seasons: [null, 'spring', 'summer', 'autumn', 'winter'] });
+  assert.equal(r.ok, true, `6-node graph completable; stranded=${JSON.stringify(r.stranded)}`);
+  const reach = _reachable(net, net.start_node, null);
+  // _reachable returns lowercased node keys.
+  assert.ok([...reach].includes('atollo_obsidiana'), 'ATOLLO_OBSIDIANA reachable from start');
+});

--- a/tests/worldgen/metaNetworkResolver.test.js
+++ b/tests/worldgen/metaNetworkResolver.test.js
@@ -19,7 +19,7 @@ test('getNetwork: loads the alpha network graph', () => {
   const net = getNetwork();
   assert.ok(net, 'network loaded');
   assert.equal(net.id, 'ET_NET_ALPHA');
-  assert.ok(Array.isArray(net.nodes) && net.nodes.length === 5, '5 nodes');
+  assert.ok(Array.isArray(net.nodes) && net.nodes.length === 6, '6 nodes (Atollo added, PR2)');
   assert.ok(Array.isArray(net.edges) && net.edges.length >= 10, '>=10 edges');
 });
 
@@ -165,4 +165,20 @@ test('getOutgoingEdges: DESERTO_CALDO has the ungated seasonal_bridge to CRYOSTE
     types.has('corridor') && types.has('trophic_spillover') && types.has('seasonal_bridge'),
     'start node exposes all 3 edge types',
   );
+});
+
+// Expansion PR2: Atollo Obsidiana (4th canonical biome) becomes the 6th graph node, wired in from
+// CRYOSTEPPE (ungated seasonal_bridge) and out to the terminal ROVINE_PLANARI.
+test('getNetwork: ATOLLO_OBSIDIANA is the 6th node, wired in (CRYOSTEPPE) + out (ROVINE)', () => {
+  _resetCache();
+  const net = getNetwork();
+  assert.equal(net.nodes.length, 6, 'six nodes after Atollo');
+  const atollo = net.nodes.find((n) => n.id === 'ATOLLO_OBSIDIANA');
+  assert.ok(atollo, 'ATOLLO_OBSIDIANA node present');
+  assert.equal(atollo.biome_id, 'atollo_obsidiana');
+  assert.deepEqual(atollo.encounters, ['enc_tutorial_07_hardcore_pod_rush']);
+  const inEdge = getOutgoingEdges('CRYOSTEPPE').find((e) => e.to === 'ATOLLO_OBSIDIANA');
+  assert.ok(inEdge && inEdge.type === 'seasonal_bridge' && inEdge.conditions === null);
+  const outEdge = getOutgoingEdges('ATOLLO_OBSIDIANA').find((e) => e.to === 'ROVINE_PLANARI');
+  assert.ok(outEdge, 'ATOLLO_OBSIDIANA -> ROVINE_PLANARI present');
 });


### PR DESCRIPTION
## What (PR2 of 2)

Adds the **6th canonical biome-node** `ATOLLO_OBSIDIANA` to the meta-network graph — the 4th canonical biome from the vault canvas (`C-CANVAS_NPG_BIOMI`), now completing the node roster. Builds on PR1 ([#2585](https://github.com/MasterDD-L34D/Game/pull/2585)); spec [`...graph-expansion-design.md`](docs/superpowers/specs/2026-06-03-meta-network-graph-expansion-design.md) §3 PR2 (master-dd ratified). **Data-only** — no new code; the PR1 completability validator is the merge gate. Flag `META_NETWORK_ROUTING` stays **OFF**.

- Node `ATOLLO_OBSIDIANA` (`biome_id: atollo_obsidiana`, weight 0.45, `enc_tutorial_07_hardcore_pod_rush`).
- Wired: `CRYOSTEPPE → ATOLLO_OBSIDIANA` (ungated `seasonal_bridge`) + `ATOLLO_OBSIDIANA → ROVINE_PLANARI` (corridor). ≥4 nodes to the terminal, no shortcut.

## Effect

- **Completability validator** (PR1): the 6-node graph reaches the terminal in **every season** + Atollo is reachable from the start.
- **Routing**: the SP temperament (already routing to CRYOSTEPPE) now takes the seasonal bridge to the atoll — `DESERTO_CALDO → CRYOSTEPPE → ATOLLO_OBSIDIANA → ROVINE_PLANARI` — so the new node is actually visited. Report updated.

## Verify

- AI 500/500, sim 112/112, worldgen+campaign+coop+endpoint 82/82, network validators exit 0, `test_trace_hashes` 208, governance errors=0, prettier clean.
- `trace_hash` recomputed (inline `_stable_digest`). Flag-OFF byte-identical. Forbidden paths: none.

## Gate / next

Owner-gated (data): ratify the Atollo node + edges + encounter at merge. After merge: the **N=40 graph-mode band-verify** (staging) → ratify → the owner-gated **prod flag flip**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)