### PR TITLE
docs(governance): baseline-policy areas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ Node 18+ (22.19.0 rec) + npm 11+; Python 3.10+. Install: `npm ci` (root) + `npm 
 ## Contribution gates (from CONTRIBUTING.md)
 
 - PRs reference a passing release validator report; regressions block merge.
-- **Master DD approval** documented (comment/issue link) before merge — EXCEPT auto-merge L3 (below).
+- **Master DD approval** documented (comment/issue link) before merge — EXCEPT auto-merge L3 (below). **PR review (pre-merge, MANDATORY)**: leggi i commenti review (`gh api repos/MasterDD-L34D/Game/pulls/<N>/comments`) + triage P1 (block, fix obbligatorio) / P2 (should) / P3 (nice). No silent-merge senza risolvere i P1.
 - Include changelog entry + **03A rollback plan** in PR notes. Run `npm run format:check` + `npm run test` locally; frontend → also `npm run build` + `npm run preview`.
 - No binary archives under `reports/backups/**` (`npm run lint:backups` enforces) — upload externally + update `manifest.txt` per `docs/planning/REF_BACKUP_AND_ROLLBACK.md`, log in `logs/agent_activity.md`.
 - Husky Prettier pre-commit on staged files; re-run `npm run prepare` after fresh checkout.


### PR DESCRIPTION
## Governance reorg Fase 5 -- baseline-policy areas in CLAUDE.md

Added **only** the genuinely-missing baseline area; everything else already lives in CLAUDE.md (no duplication).

### Added (1)
- **PR review (pre-merge, MANDATORY)**: read review comments via `gh api repos/MasterDD-L34D/Game/pulls/<N>/comments` + triage **P1** (block, fix obbligatorio) / **P2** (should) / **P3** (nice); no silent-merge without resolving P1. Folded into the existing `Contribution gates` -> "Master DD approval before merge" bullet (logical grouping with the merge-gate rules).

### Skipped -- already present (no duplication)
- **DoD**: `Verify Before Claim Done` + `Definition of Done (ogni sprint)` sections already exist.
- **Testing**: the verify rule + `Common commands` already document the real lint/test commands (`npm run ci:stack` = lint:stack + test:backend; `pytest` for Python; `tsc` via tools/ts build).
- **Dependency**: `Nuove dipendenze npm/pip: approvazione esplicita` (Guardrail sprint) + auto-merge gate 7 "no new npm/pip deps".
- **Secret**: `API Keys & Secrets` section (per repo note, secret skipped).

### Anti-rebloat
- before: **199** lines -> after: **199** lines (net-0; `<200` respected via in-place fold, no new block).

### Notes
- All existing content preserved; single-line modification.
- Added text is ASCII-only (Italian, no accented chars).
- External self-governed repo: PROPOSE only, **do not merge** (Eduardo merges).

Coding-Agent: claude-opus-4-8