### PR TITLE
feat(sim): graph-mode difficulty re-calibration + ratified band-verify (staging)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -8538,6 +8538,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/playtest/2026-06-03-meta-network-graphmode-band-verify.md",
+      "title": "Meta-network graph-mode band-verify + difficulty re-calibration (staging)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "ops-qa",
+      "last_verified": "2026-06-03",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
     }
   ]
 }

--- a/docs/playtest/2026-06-03-meta-network-graphmode-band-verify.md
+++ b/docs/playtest/2026-06-03-meta-network-graphmode-band-verify.md
@@ -1,0 +1,81 @@
+---
+title: 'Meta-network graph-mode band-verify + difficulty re-calibration (staging)'
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-03'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Meta-network graph-mode band-verify (staging)
+
+> Staging gate before the `META_NETWORK_ROUTING` prod flip. The graph routing + 6-node expansion
+> (PR #2582/#2585/#2587) is exercised in the full-loop band-verify (`tools/sim/full-loop-batch.js`,
+> N=40, `--isolate`) under graph mode, the difficulty re-calibrated for the shorter graph routes,
+> and the graph-mode bands ratified by master-dd. The flag stays **OFF** in prod — this is a
+> sim-only calibration; the prod flip remains a separate verdict.
+
+## 1. Why re-calibration was needed
+
+The static-chain calibration (`calibrationScaling` countMult 5 / hpAdd 3, ratified
+`docs/playtest/2026-06-02-full-loop-band-report.md`) was tuned over the long cave_path mission
+chain. Graph routes are **shorter** (greedy 3 nodes, ESFP 5) so the same enemy scaling left
+completion too high — initial graph-mode N=40: greedy **0.9**, ESFP **0.825** (band 0.4-0.7, OOB).
+
+## 2. Calibration sweep (graph-mode greedy, completion_rate vs `hpAdd`)
+
+| hpAdd                 | completion_rate (graph-mode greedy)        | note                           |
+| --------------------- | ------------------------------------------ | ------------------------------ |
+| 3 (static default)    | 0.9                                        | too easy (short route)         |
+| **4 (graph default)** | **0.5 (N=20) / 0.65 (N=40) / 0.85 (N=40)** | band centre, **high variance** |
+| 5                     | 0.2                                        | too hard                       |
+| 10                    | 0.0                                        | unwinnable                     |
+
+**The HP curve is razor-steep** (1 HP/unit swings completion ~0.3-0.65) so completion has high
+run-to-run variance near the band — no integer `hpAdd` pins it tightly. `hpAdd 4` is the band
+centre (mean ~0.65) and is shipped as the **graph-mode default** (`META_NETWORK_ROUTING=true`);
+the static default stays `3` so the ratified static bands are untouched. Reversible via `FL_ENEMY_*`.
+
+## 3. Ratified graph-mode bands (master-dd, 2026-06-03)
+
+Graph routes legitimately differ from the static chain (shorter ⇒ fewer mission gates + fewer
+breeding cycles), so master-dd ratified **wider graph-mode bands** (the bands are PROVISIONAL per
+L-069; these supersede the static values for graph-mode runs only):
+
+- **completion_rate: 0.4 – 0.85** (was 0.4-0.7) — absorbs the razor-steep variance + the short-route
+  ceiling.
+- **lineage_diversity: ≥ 2** (was ≥3) — graph routes accumulate fewer distinct breeding crosses.
+- All other bands: unchanged from the static report.
+
+## 4. N=40 placement (graph-mode, hpAdd 4, --isolate) vs the ratified graph-mode bands
+
+| Metric              | Graph band | greedy (3-node route) | ESFP (5-node route) |
+| ------------------- | ---------- | --------------------- | ------------------- |
+| completion_rate     | 0.4 – 0.85 | 0.65 – 0.85 ✅        | 0.75 ✅             |
+| roster_attrition    | 0 – 1      | 0.55 ✅               | 0.51 ✅             |
+| economy_flow        | 0.5 – 2    | 1.0 ✅                | 1.0 ✅              |
+| relationship        | composite  | ✅                    | ✅                  |
+| offspring_viability | ≥ 1        | 0.65 ⚠️               | 1.5 ✅              |
+| lineage_diversity   | ≥ 2        | 1 ⚠️                  | 2 ✅                |
+| roster_composition  | ≥ 3        | 2 ⚠️                  | 3 ✅                |
+
+## 5. Finding: the greedy short-route floor
+
+Completion is calibrated (both policies in the wider band). The meta-loop **volume** metrics
+(offspring / lineage / composition) are **route-length dependent**, not difficulty dependent:
+
+- **ESFP (5-node route via Atollo)** meets every band — the longer route runs more recruit/mate
+  cycles.
+- **greedy (3-node route)** under-produces offspring (0.65) / lineage (1) / composition (2): the
+  shortest route is structurally minimal for breeding + recruiting. This is a property of the
+  "rush" policy, not a balance bug — a player who beelines the terminal gets a thinner Nido.
+
+## 6. Recommendation for the prod flip
+
+Graph-mode is **band-OK for richer-route policies** and completion is calibrated. The residual is
+the greedy rush-route floor on the meta-loop volume metrics (a design property). Master-dd's flip
+decision can weigh: (a) accept the rush-route floor as intended (rush = thin Nido), or (b) defer the
+flip until a future tuning nudges greedy onto a slightly longer route. The flip itself
+(`META_NETWORK_ROUTING=true` in prod) stays a separate, reversible owner verdict.

--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -165,6 +165,27 @@ test('calibrationScaling: FL_ENEMY_* env overrides each knob (robust to baked de
   }
 });
 
+// Graph-mode re-calibration: shorter graph routes leave completion too high at the static hpAdd 3,
+// so META_NETWORK_ROUTING=true bumps the baked hpAdd to 4 (band centre); the static default stays 3.
+test('calibrationScaling: graph-mode (META_NETWORK_ROUTING) bumps baked hpAdd 3 -> 4', () => {
+  for (const k of ['FL_ENEMY_HP_ADD', 'FL_ENEMY_COUNT_MULT']) delete process.env[k];
+  const prev = process.env.META_NETWORK_ROUTING;
+  try {
+    delete process.env.META_NETWORK_ROUTING;
+    assert.equal(calibrationScaling().hpAdd, 3, 'static-chain default unchanged');
+    process.env.META_NETWORK_ROUTING = 'true';
+    assert.equal(calibrationScaling().hpAdd, 4, 'graph-mode re-calibrated default');
+    assert.equal(calibrationScaling().countMult, 5, 'countMult unchanged in graph mode');
+    // env override still wins over the graph-mode default.
+    process.env.FL_ENEMY_HP_ADD = '9';
+    assert.equal(calibrationScaling().hpAdd, 9, 'env override beats the graph-mode default');
+  } finally {
+    delete process.env.FL_ENEMY_HP_ADD;
+    if (prev === undefined) delete process.env.META_NETWORK_ROUTING;
+    else process.env.META_NETWORK_ROUTING = prev;
+  }
+});
+
 test('buildProvenance: carries seed + commit + policy + scenario-chain + flags', () => {
   const p = buildProvenance({
     runId: 3,

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -247,11 +247,19 @@ function calibrationScaling() {
   // turns the other ~40% (a mission that runs out the clock) into a campaign failure ->
   // completion_rate lands in the provisional 0.4-0.7 band. Each FL_ENEMY_* env var overrides
   // one knob for re-calibration. (hpAdd not hpMult: integer per-unit HP is the natural dial.)
+  //
+  // Graph-mode re-calibration (META_NETWORK_ROUTING=true): the graph routes are SHORTER than the
+  // static cave_path (greedy 3 nodes, ESFP 5) so the static hpAdd 3 leaves completion too high
+  // (greedy 0.9 / ESFP 0.825, OOB). hpAdd 4 (graph-mode default) re-centres it (greedy ~0.65 in
+  // band; ESFP ~0.75 -- its recruit-snowball over the longer route keeps it marginally above 0.7,
+  // a known route-length effect). The HP curve is razor-steep (hpAdd 3->0.9, 4->0.65, 5->0.2),
+  // so 4 is the band centre. The static default (3) is unchanged -> the ratified static bands hold.
+  const graphMode = process.env.META_NETWORK_ROUTING === 'true';
   return {
     countMult: num('FL_ENEMY_COUNT_MULT', 5),
     countAdd: num('FL_ENEMY_COUNT_ADD', 0),
     hpMult: num('FL_ENEMY_HP_MULT', 1),
-    hpAdd: num('FL_ENEMY_HP_ADD', 3),
+    hpAdd: num('FL_ENEMY_HP_ADD', graphMode ? 4 : 3),
     modAdd: num('FL_ENEMY_MOD_ADD', 0),
     dcAdd: num('FL_ENEMY_DC_ADD', 0),
   };


### PR DESCRIPTION
## What

Staging gate for the `META_NETWORK_ROUTING` prod flip. Re-calibrates the full-loop **band-verify** difficulty for the shorter graph routes + records the master-dd-ratified graph-mode bands. Sim-only (band-verify enemy scaling, NOT game difficulty); flag stays **OFF** in prod.

- **Calibration** (`tools/sim/full-loop-batch.js`): `META_NETWORK_ROUTING=true` bakes `hpAdd 4` (was 3). Static-chain default stays 3 → the ratified static bands are untouched. Reversible via `FL_ENEMY_*`.
- **Band-verify report** (`docs/playtest/2026-06-03-meta-network-graphmode-band-verify.md`): the sweep, the **razor-steep HP curve / high-variance** finding (hpAdd 4 → completion 0.5/0.65/0.85 across batches), the ratified **wider graph-mode bands** (completion 0.4-0.85, lineage_diversity ≥2), and the N=40 placement.

## Findings (N=40, graph-mode, --isolate)

- Initial graph-mode (static scaling): greedy 0.9 / ESFP 0.825 completion — OOB (too easy, short routes).
- After hpAdd 4: completion lands in the wider band; **ESFP (5-node route) meets every band**; **greedy (3-node rush route) floors** offspring/lineage/composition — a route-length design property, not a balance bug.

## Why wider bands

Graph routes are legitimately shorter than the static cave_path (fewer mission gates + breeding cycles). Bands are PROVISIONAL (L-069); master-dd ratified the graph-mode values 2026-06-03.

## Verify

AI 500/500, sim 113/113 (incl. new graph-mode calibration test), governance errors=0, prettier clean. Forbidden paths: none.

## Gate / next

Owner-gated. After merge, the **prod flip** (`META_NETWORK_ROUTING=true`) is the final separate verdict — the report §6 lays out the rush-route-floor consideration. Reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)