### PR TITLE
feat(coop): accept + broadcast recruit_candidates on combat/end

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -358,6 +358,10 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
       survivors = [],
       debrief_payload: debriefPayload = null,
       sistema_observations: sistemaObservations = null,
+      // Task 5 debrief-recruit producer: optional array of NPC candidates for
+      // post-combat recruit (threaded onto run.debrief -> debrief_payload
+      // broadcast to phones alongside per_actor). Back-compat: absent -> null.
+      recruit_candidates: recruitCandidates = null,
     } = req.body || {};
     const room = authHost(code, hostToken);
     if (!room) return res.status(403).json({ error: 'host_auth_failed' });
@@ -370,6 +374,7 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
         survivors,
         debriefPayload,
         sistemaObservations,
+        recruitCandidates,
       });
       broadcastCoopState(room, orch);
       return res.json({ phase: orch.phase, result });

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -844,6 +844,7 @@ class CoopOrchestrator {
     xpEarned = 0,
     debriefPayload = null,
     sistemaObservations = null,
+    recruitCandidates = null,
   } = {}) {
     if (this.phase !== 'combat') throw new Error('not_in_combat');
     this.run.outcome = outcome;
@@ -851,6 +852,13 @@ class CoopOrchestrator {
     this.run.partyXp += xpEarned;
     if (debriefPayload && typeof debriefPayload === 'object') {
       this.run.debrief = debriefPayload;
+    }
+    // Task 5 debrief-recruit producer: thread recruit_candidates onto run.debrief
+    // so it rides the existing debrief_payload broadcast to phones alongside
+    // per_actor. Only stored when a non-empty array is supplied. Back-compat:
+    // absent or empty -> no change to run.debrief.
+    if (Array.isArray(recruitCandidates) && recruitCandidates.length > 0) {
+      this.run.debrief = { ...(this.run.debrief || {}), recruit_candidates: recruitCandidates };
     }
     const emitPayload = { outcome, survivors, xp: xpEarned };
     if (debriefPayload && typeof debriefPayload === 'object') {

--- a/tests/api/coop-recruit-candidates.test.js
+++ b/tests/api/coop-recruit-candidates.test.js
@@ -1,0 +1,210 @@
+// Task 5 debrief-recruit producer slice -- threading recruit_candidates through
+// the co-op debrief broadcast path.
+//
+// The /api/coop/combat/end route accepts an optional recruit_candidates array
+// and stores it on run.debrief so it rides the existing debrief_payload
+// broadcast to phones (alongside per_actor). No new WS message type, no new
+// phase, no recruit/gate logic.
+//
+// Back-compat: absent recruit_candidates -> run.debrief unchanged.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+
+// ---- shared app factory (mirrors coopBroadcastDebriefPayload.test.js) ----
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const broadcasts = [];
+  const origGetRoom = lobby.getRoom.bind(lobby);
+  lobby.getRoom = function (code) {
+    const room = origGetRoom(code);
+    if (room && !room.__broadcastWrapped) {
+      const origBroadcast = room.broadcast.bind(room);
+      room.broadcast = function (msg) {
+        broadcasts.push({ code, msg });
+        return origBroadcast(msg);
+      };
+      room.__broadcastWrapped = true;
+    }
+    return room;
+  };
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app, lobby, coopStore, broadcasts };
+}
+
+async function setupAtCombat(app, broadcasts) {
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'Host', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  r = await request(app).post('/api/lobby/join').send({ code, player_name: 'P1' });
+  const playerId = r.body.player_id;
+  const playerToken = r.body.player_token;
+  await request(app)
+    .post('/api/coop/run/start')
+    .send({ code, host_token: hostToken, scenario_stack: ['enc_demo_01'] });
+  await request(app).post('/api/coop/character/create').send({
+    code,
+    player_id: playerId,
+    player_token: playerToken,
+    name: 'Aria',
+    form_id: 'istj',
+    species_id: 'scagliato',
+    job_id: 'guerriero',
+  });
+  await request(app)
+    .post('/api/coop/world/confirm')
+    .send({ code, host_token: hostToken, scenario_id: 'enc_demo_01' });
+  broadcasts.length = 0;
+  return { code, hostToken };
+}
+
+// ---- orchestrator unit tests (fast, no HTTP) ----
+
+function setupOrchAtCombat() {
+  const co = new CoopOrchestrator({ roomCode: 'TEST', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_demo_01'] });
+  co.submitCharacter(
+    'p_h',
+    { name: 'Hero', form_id: 'istj', species_id: 'scagliato', job_id: 'guerriero' },
+    { allPlayerIds: ['p_h'] },
+  );
+  co.confirmWorld();
+  return co;
+}
+
+test('endCombat: recruit_candidates stored on run.debrief', () => {
+  const co = setupOrchAtCombat();
+  const candidates = [
+    { npc_id: 'sis_a', species_id: 'polpo_araldo_sinaptico', forma: 'ESTJ', display_name: 'S' },
+  ];
+  co.endCombat({ outcome: 'victory', recruitCandidates: candidates });
+  assert.deepEqual(co.run.debrief.recruit_candidates, candidates);
+});
+
+test('endCombat: recruit_candidates merged with existing debriefPayload per_actor', () => {
+  const co = setupOrchAtCombat();
+  const debriefPayload = { per_actor: { pg_a: { sentience_tier: 'T2' } } };
+  const candidates = [{ npc_id: 'sis_b', species_id: 'anguis', forma: 'INTJ', display_name: 'B' }];
+  co.endCombat({ outcome: 'victory', debriefPayload, recruitCandidates: candidates });
+  assert.deepEqual(co.run.debrief.per_actor, debriefPayload.per_actor);
+  assert.deepEqual(co.run.debrief.recruit_candidates, candidates);
+});
+
+test('endCombat: empty array recruit_candidates -- not stored (back-compat)', () => {
+  const co = setupOrchAtCombat();
+  co.endCombat({ outcome: 'victory', recruitCandidates: [] });
+  assert.equal(co.run.debrief, undefined, 'empty recruit_candidates must not set run.debrief');
+});
+
+test('endCombat: absent recruit_candidates -- run.debrief unchanged (back-compat)', () => {
+  const co = setupOrchAtCombat();
+  co.endCombat({ outcome: 'victory' });
+  assert.equal(co.run.debrief, undefined);
+});
+
+test('endCombat: non-array recruit_candidates ignored silently', () => {
+  const co = setupOrchAtCombat();
+  co.endCombat({ outcome: 'victory', recruitCandidates: 'bad' });
+  assert.equal(co.run.debrief, undefined);
+});
+
+test('endCombat: recruit_candidates only (no debriefPayload) sets run.debrief', () => {
+  const co = setupOrchAtCombat();
+  const candidates = [
+    { npc_id: 'sis_c', species_id: 'lupinus_velo', forma: 'INFP', display_name: 'C' },
+  ];
+  co.endCombat({ outcome: 'victory', recruitCandidates: candidates });
+  assert.ok(typeof co.run.debrief === 'object');
+  assert.deepEqual(co.run.debrief.recruit_candidates, candidates);
+  assert.equal('per_actor' in co.run.debrief, false);
+});
+
+// ---- route integration tests (HTTP + broadcast) ----
+
+test('POST /coop/combat/end: recruit_candidates in body stored + broadcast in debrief_payload', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupAtCombat(app, broadcasts);
+  const candidates = [
+    { npc_id: 'sis_a', species_id: 'polpo_araldo_sinaptico', forma: 'ESTJ', display_name: 'S' },
+  ];
+  const res = await request(app).post('/api/coop/combat/end').send({
+    code,
+    host_token: hostToken,
+    outcome: 'victory',
+    recruit_candidates: candidates,
+  });
+  assert.equal(res.status, 200);
+  const dpMsg = broadcasts.find((b) => b.msg.type === 'debrief_payload');
+  assert.ok(dpMsg, 'debrief_payload must be broadcast');
+  assert.deepEqual(dpMsg.msg.payload.recruit_candidates, candidates);
+});
+
+test('POST /coop/combat/end: recruit_candidates + debrief_payload both surface in broadcast', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupAtCombat(app, broadcasts);
+  const perActor = { pg_x: { sentience_tier: 'T3' } };
+  const candidates = [{ npc_id: 'sis_d', species_id: 'anguis', forma: 'ISTP', display_name: 'D' }];
+  await request(app)
+    .post('/api/coop/combat/end')
+    .send({
+      code,
+      host_token: hostToken,
+      outcome: 'victory',
+      debrief_payload: { per_actor: perActor },
+      recruit_candidates: candidates,
+    });
+  const dpMsg = broadcasts.find((b) => b.msg.type === 'debrief_payload');
+  assert.ok(dpMsg, 'debrief_payload must be broadcast');
+  assert.deepEqual(dpMsg.msg.payload.per_actor, perActor);
+  assert.deepEqual(dpMsg.msg.payload.recruit_candidates, candidates);
+});
+
+test('POST /coop/combat/end: absent recruit_candidates -- no debrief_payload broadcast (back-compat)', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupAtCombat(app, broadcasts);
+  const res = await request(app).post('/api/coop/combat/end').send({
+    code,
+    host_token: hostToken,
+    outcome: 'victory',
+  });
+  assert.equal(res.status, 200);
+  const types = broadcasts.map((b) => b.msg.type);
+  assert.equal(
+    types.includes('debrief_payload'),
+    false,
+    `no debrief_payload broadcast expected when absent; got: ${types}`,
+  );
+});
+
+test('POST /coop/combat/end: empty recruit_candidates array -- no debrief_payload broadcast', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupAtCombat(app, broadcasts);
+  const res = await request(app).post('/api/coop/combat/end').send({
+    code,
+    host_token: hostToken,
+    outcome: 'victory',
+    recruit_candidates: [],
+  });
+  assert.equal(res.status, 200);
+  const types = broadcasts.map((b) => b.msg.type);
+  assert.equal(
+    types.includes('debrief_payload'),
+    false,
+    `no debrief_payload broadcast expected for empty array; got: ${types}`,
+  );
+});


### PR DESCRIPTION
## Co-op: accept + broadcast `recruit_candidates` on `/combat/end`

Game/ side of the **debrief-recruit producer** slice (paired with Godot-v2 PR `feat/debrief-recruit-producer`). At co-op debrief, the host ships a list of defeated-enemy recruit candidates; this PR makes the backend accept + broadcast them so phones can render the recruit list.

### Change (minimal, additive, coop layer only)
- `apps/backend/routes/coop.js` `/combat/end`: reads optional `recruit_candidates` from the body, passes to `coopOrchestrator.endCombat`.
- `apps/backend/services/coop/coopOrchestrator.js` `endCombat`: when `recruit_candidates` is a non-empty array, merges it onto `run.debrief` (`{...run.debrief, recruit_candidates}`) — so it rides the **existing** `debrief_payload` broadcast (same path as `per_actor`). No new WS message type, no new phase.
- **No new recruit/gate logic** — the `/api/meta/recruit` + species-threading seam is already on `main` (#2536). This PR only threads the candidate list through the debrief broadcast.

### Scope / safety
- Coop layer only — **no** sim / worldgen / combat-engine files touched (clear of the active fase-2 / od-058 streams).
- Back-compat: `recruit_candidates` absent → `run.debrief` unchanged.

### Tests
- New `tests/api/coop-recruit-candidates.test.js` (6 orchestrator + 4 route) + full coop suite **131/131** pass. Prettier `--check` clean on all touched files.

### Deploy ordering (important)
Merge + deploy this **before** the paired Godot-v2 PR: GGv2 sends `recruit_candidates` to a backend that won't broadcast them until this is live → phones would receive no candidates. Live end-to-end verification = co-op playtest post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
