### PR TITLE
feat(worldgen): candidate preview encounter_id + terminal for route UI

### DIFF
--- a/apps/backend/services/worldgen/metaNetworkRouting.js
+++ b/apps/backend/services/worldgen/metaNetworkRouting.js
@@ -3,7 +3,8 @@
 // Pure next-node selection over the meta-network graph. Q4 verdict =
 // player-choice (Into the Breach / Slay the Spire): given the current node and
 // campaign context, return the ELIGIBLE next-node candidates WITH preview
-// (biome, weight, edge type/resistance) for the player to pick — never an
+// (biome, weight, edge type/resistance, the encounter served + a terminal flag)
+// for the player to pick -- never an
 // auto-pick. The Godot HUD renders the choice (fase 3); the backend supplies the
 // candidates + a deterministic order so tests + replays are stable.
 //
@@ -36,7 +37,7 @@
 // Pure: graph + context injected; no I/O. Mirrors foodwebFilter's thin-transform
 // role. Returns:
 //   { applied, from, candidates:[{node_id, biome_id, weight, edge_type,
-//     resistance, seasonality, edge_types}], excluded:[node_id],
+//     resistance, seasonality, edge_types, encounter_id, terminal}], excluded:[node_id],
 //     blocked:[{node_id, blocked_by}], reason }
 //   reason ∈ no_graph | no_node | terminal | all_cleared | all_blocked |
 //            filtered | eligible
@@ -152,6 +153,12 @@ function selectNextNodes(currentNodeId, ctx = {}) {
         resistance,
         seasonality: e.seasonality ?? null,
         edge_types: [edgeType],
+        // Preview enrichment (fase-3 UI telegraph): the encounter this node serves
+        // (N=1 = first id) + terminal-climax flag. Node-derived -> stable across
+        // parallel edges (set once on creation); null/false when the node is
+        // missing or carries no encounters/terminal flag (back-compat).
+        encounter_id: encounterForNode(graph, e.to),
+        terminal: isTerminal(graph, e.to),
       });
       continue;
     }

--- a/tests/worldgen/metaNetworkRouting.test.js
+++ b/tests/worldgen/metaNetworkRouting.test.js
@@ -159,6 +159,66 @@ test('selectNextNodes: single edge still exposes edge_types as a 1-element array
   assert.deepEqual(res.candidates[0].edge_types, ['corridor']);
 });
 
+// --- TKT-WORLDGEN-GAPC candidate preview enrichment: each candidate carries the encounter
+// the target node serves (encounter_id, MVP N=1 = first id) + its terminal-climax flag, so the
+// fase-3 Godot choice-UI can telegraph the destination (Into the Breach full-information) without
+// a second lookup. Node-derived (not edge-derived) -> computed once per target, parallel-edge safe.
+function previewGraph() {
+  return {
+    nodes: [
+      { id: 'A', weight: 0 },
+      { id: 'B', biome_id: 'biome_b', weight: 0.55, encounters: ['enc_b'], terminal: false },
+      {
+        id: 'Z',
+        biome_id: 'biome_z',
+        weight: 0.5,
+        encounters: ['enc_boss', 'enc_b2'],
+        terminal: true,
+      },
+      { id: 'N', biome_id: 'biome_n', weight: 0.4 }, // no encounters / no terminal flag
+    ],
+    edges: [
+      { from: 'A', to: 'B', type: 'corridor', resistance: 0.5 },
+      { from: 'A', to: 'Z', type: 'corridor', resistance: 0.5 },
+      { from: 'A', to: 'N', type: 'corridor', resistance: 0.5 },
+    ],
+  };
+}
+
+test('candidate preview: each candidate carries encounter_id (N=1) + terminal from the target node', () => {
+  const res = selectNextNodes('A', { graph: previewGraph(), clearedNodes: [] });
+  const byId = Object.fromEntries(res.candidates.map((c) => [c.node_id, c]));
+  assert.equal(byId.B.encounter_id, 'enc_b');
+  assert.equal(byId.B.terminal, false);
+  // N=1: the FIRST encounter is the node's encounter
+  assert.equal(byId.Z.encounter_id, 'enc_boss');
+  assert.equal(byId.Z.terminal, true, 'terminal climax flag surfaced for the UI');
+});
+
+test('candidate preview: encounter-less / flagless node -> encounter_id null + terminal false (back-compat)', () => {
+  const res = selectNextNodes('A', { graph: previewGraph(), clearedNodes: [] });
+  const n = res.candidates.find((c) => c.node_id === 'N');
+  assert.equal(n.encounter_id, null);
+  assert.equal(n.terminal, false);
+});
+
+test('candidate preview: parallel edges compute encounter_id/terminal once from the node', () => {
+  const g = {
+    nodes: [
+      { id: 'A', weight: 0 },
+      { id: 'B', weight: 0.5, encounters: ['enc_b'], terminal: true },
+    ],
+    edges: [
+      { from: 'A', to: 'B', type: 'trophic_spillover', resistance: 0.7 },
+      { from: 'A', to: 'B', type: 'corridor', resistance: 0.5 },
+    ],
+  };
+  const res = selectNextNodes('A', { graph: g, clearedNodes: [] });
+  assert.equal(res.candidates.length, 1);
+  assert.equal(res.candidates[0].encounter_id, 'enc_b');
+  assert.equal(res.candidates[0].terminal, true);
+});
+
 // --- TKT-WORLDGEN-GAPC fase 2 (arc-conditions, Stage 1) — ADR-2026-05-31 ACCEPTED.
 // Edge `conditions:` block = Dormans lock-and-key. Semantics (ADR D1): AND across
 // keys, OR within a list-value, fail-closed on missing state / unknown key,


### PR DESCRIPTION
## What
Enriches each meta-network routing candidate (`selectNextNodes`) with two node-derived preview fields:
- `encounter_id` -- the encounter the target node serves (MVP N=1 = first id), via the tested `encounterForNode` helper.
- `terminal` -- the climax-node flag, via `isTerminal`.

Both flow automatically to the two surfaces that pass candidates through: the `GET /api/campaign/meta-network/next` diagnostic endpoint and the graph-mode `/advance` `route_choice.candidates`. No `campaign.js` change needed.

## Why
Toward the (deferred) `META_NETWORK_ROUTING` prod flip: the fase-3 Godot route-choice UI needs Into-the-Breach full-information telegraph -- show the player WHAT they fight at each destination + mark the climax -- without a second lookup. Candidates previously exposed `node_id/biome_id/weight/edge_type/resistance/seasonality` but not the destination encounter or terminal flag. Scoped in `docs/planning/2026-06-02-gapc-fase3-4-build-vs-gate.md` + museum M-2026-06-02-001.

## Verify-first finding (data gap, surfaced not fabricated)
Of the 6 node-encounters only 2 have authored YAML on main (`enc_savana_01`, `enc_caverna_02`); the other 4 (`enc_tutorial_03/04/05/06_hardcore/07_hardcore_pod_rush`) have no file. So a RICH threat/reward telegraph (difficulty_rating + wave tiers + reward) is blocked on encounter authoring -- a separate content/design task. This PR ships the honest minimal preview (encounter_id + terminal, available for all 6 nodes); threat/reward is the documented follow-up.

## Safety
- Additive + back-compat (null/false when a node lacks encounters/terminal).
- Flag-gated: only graph mode (`META_NETWORK_ROUTING=true`) consumes it; flag stays OFF by default -> zero live-campaign impact. Does NOT flip the flag.
- Node-derived -> stable across parallel edges (computed once per target).
- Band-safe: AI 500/500, sim 113/113, worldgen+endpoint 74/74 (incl 3 new candidate-preview tests). Prettier clean. No forbidden paths, no new deps.

## Owner-gated
Part of the meta-network live-routing arc (master-dd has merged each PR). Not auto-merging -- say `vai` to merge.
