### PR TITLE
feat(worldgen): node-encounter metadata + decoupled preview threat telegraph

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -63,6 +63,7 @@ const {
   encounterForNode,
   isTerminal,
 } = require('../services/worldgen/metaNetworkRouting');
+const { enrichCandidatesWithThreat } = require('../services/worldgen/encounterThreat');
 
 // Slice A/C (live routing): is graph-routed campaign flow active? Read at request time
 // (the flag may flip between requests in tests). OFF (default) -> /start, /advance, /choose
@@ -297,6 +298,10 @@ function createCampaignRouter(options = {}) {
       enabled: true,
       network_id: graph ? graph.id : null,
       ...routing,
+      // Rich preview (Into the Breach telegraph): each candidate gains `threat` (difficulty +
+      // class + peak tier + spawn count) resolved from the encounter metadata. Additive +
+      // read-only (combat untouched). Overrides the `...routing` candidates spread above.
+      candidates: enrichCandidatesWithThreat(routing.candidates),
     });
   });
 
@@ -485,7 +490,7 @@ function createCampaignRouter(options = {}) {
         campaign: updated,
         next_encounter_id: null,
         choice_required: true,
-        route_choice: { candidates: route.candidates },
+        route_choice: { candidates: enrichCandidatesWithThreat(route.candidates) },
         ...evolveFlags,
         ...xpGrantsPayload,
         ...mpGrantsPayload,

--- a/apps/backend/services/worldgen/encounterThreat.js
+++ b/apps/backend/services/worldgen/encounterThreat.js
@@ -1,0 +1,115 @@
+// Meta-network preview THREAT resolver — TKT-WORLDGEN-GAPC (rich route-choice telegraph).
+//
+// Resolves an encounter's threat metadata (difficulty_rating + encounter_class + peak enemy
+// tier + initial spawn count) so the fase-3 Godot route-choice UI can telegraph each
+// destination Into-the-Breach style. Metadata source = docs/planning/encounters/ (live combat)
+// UNION docs/planning/encounters-draft/ (node-encounter proposals NOT promoted to live combat).
+//
+// METADATA-ONLY: reading the draft dir here does NOT route the drafts into combat. Combat's
+// encounterLoader (apps/backend/services/combat/encounterLoader.js) stays encounters/-only, so
+// the ratified completion bands are untouched. (Promoting the drafts to live combat crashes
+// completion -- 7 sequential gating fights vs the one-attempt-per-mission cap -- see PR #2593;
+// the preview only needs the THREAT NUMBERS, not the live fight.)
+//
+// Pure-ish: filesystem read on first call (cached) + _resetCache test seam. Mirrors
+// metaNetworkResolver's cache + graceful-warn shape.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+// Live combat encounters first, then the not-yet-promoted node-encounter proposals. On an id
+// collision the live dir wins (scanned first). A dir that is absent or a malformed file is
+// skipped gracefully (-> that id resolves to null = no telegraph, never a crash).
+const DIRS = [
+  path.resolve(__dirname, '../../../../docs/planning/encounters'),
+  path.resolve(__dirname, '../../../../docs/planning/encounters-draft'),
+];
+
+const TIER_RANK = { base: 0, elite: 1, apex: 2 };
+const RANK_TIER = ['base', 'elite', 'apex'];
+
+let _cache = null; // Map<encounter_id, threat>
+
+function _norm(v) {
+  return String(v == null ? '' : v).trim();
+}
+
+function _load() {
+  if (_cache) return _cache;
+  _cache = new Map();
+  for (const dir of DIRS) {
+    let files;
+    try {
+      files = fs.readdirSync(dir).filter((f) => f.startsWith('enc_') && f.endsWith('.yaml'));
+    } catch {
+      continue; // dir absent -> skip
+    }
+    for (const fname of files) {
+      let enc;
+      try {
+        enc = yaml.load(fs.readFileSync(path.join(dir, fname), 'utf8'));
+      } catch {
+        continue; // malformed -> skip
+      }
+      if (!enc || !enc.encounter_id) continue;
+      const id = _norm(enc.encounter_id);
+      if (_cache.has(id)) continue; // live dir scanned first -> wins on collision
+      _cache.set(id, _deriveThreat(enc));
+    }
+  }
+  return _cache;
+}
+
+// Threat telegraph from the encounter shape: difficulty (1-5) + class + the PEAK enemy tier
+// across ALL waves (the scariest unit you will face) + the initial spawn count (the wave with
+// the smallest turn_trigger).
+function _deriveThreat(enc) {
+  const waves = Array.isArray(enc.waves) ? enc.waves : [];
+  let maxRank = 0;
+  for (const w of waves) {
+    for (const u of Array.isArray(w.units) ? w.units : []) {
+      const r = TIER_RANK[u.tier] ?? 0;
+      if (r > maxRank) maxRank = r;
+    }
+  }
+  const wave1 = waves.length
+    ? [...waves].sort((a, b) => (a.turn_trigger || 0) - (b.turn_trigger || 0))[0]
+    : null;
+  const wave1Count = wave1
+    ? (Array.isArray(wave1.units) ? wave1.units : []).reduce(
+        (n, u) => n + (Number(u.count) || 0),
+        0,
+      )
+    : 0;
+  const dr = Number(enc.difficulty_rating);
+  return {
+    difficulty_rating: Number.isFinite(dr) ? dr : null,
+    encounter_class: enc.encounter_class || 'standard',
+    max_tier: RANK_TIER[maxRank],
+    wave1_count: wave1Count,
+  };
+}
+
+// Threat metadata for an encounter id, or null (missing / unknown / bad input).
+function encounterThreat(encounterId) {
+  if (!encounterId) return null;
+  const t = _load().get(_norm(encounterId));
+  return t || null;
+}
+
+// Additive: each candidate (selectNextNodes shape, carries encounter_id) gains a `threat`
+// field (the metadata, or null). Non-array input returned as-is (back-compat). Does NOT mutate
+// the input candidates.
+function enrichCandidatesWithThreat(candidates) {
+  if (!Array.isArray(candidates)) return candidates;
+  return candidates.map((c) => ({ ...c, threat: encounterThreat(c && c.encounter_id) }));
+}
+
+function _resetCache() {
+  _cache = null;
+}
+
+module.exports = { encounterThreat, enrichCandidatesWithThreat, _resetCache };

--- a/docs/planning/encounters-draft/enc_tutorial_03.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_03.yaml
@@ -1,0 +1,62 @@
+# =============================================================================
+# DRAFT (Claude-proposed, pending master-dd ratify + band-verify) -- NOT promoted.
+# Lives in encounters-draft/ (inert: no loader/validator/sim reads this dir).
+# Node: BADLANDS (canyons_risonanti), graph weight 0.45 -- early-mid arc.
+# Promote ripple + sequence: see PR body. Schema: schemas/evo/encounter.schema.json
+# Threat proposal: diff 3, standard, elimination. Curve: savana_01(2) -> THIS(3).
+# Species = proven archetype labels (stats from tier table); master-dd may reskin.
+# =============================================================================
+
+encounter_id: enc_tutorial_03
+name: 'Imboscata nei Canyon'
+biome_id: canyons_risonanti
+grid_size: [10, 10]
+difficulty_rating: 3
+estimated_turns: 11
+encounter_class: standard
+
+objective:
+  type: elimination
+
+player_spawn:
+  - [0, 4]
+  - [0, 5]
+  - [1, 4]
+  - [1, 5]
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [9, 3]
+      - [9, 6]
+    units:
+      - species: predoni_nomadi
+        count: 2
+        tier: base
+        ai_profile: aggressive
+      - species: custode_basalto
+        count: 1
+        tier: elite
+        ai_profile: territorial
+  - wave_id: 2
+    turn_trigger: 4
+    spawn_points:
+      - [9, 5]
+      - [8, 8]
+    units:
+      - species: predoni_nomadi
+        count: 2
+        tier: base
+        ai_profile: flanking
+
+conditions:
+  - type: fog_of_war
+    fov_radius: 5
+
+tags: [standard]
+
+visual_mood:
+  mood_tag: tensione_mistero
+  lighting: fredda_obliqua
+  particle_effect: polvere_secca

--- a/docs/planning/encounters-draft/enc_tutorial_04.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_04.yaml
@@ -1,0 +1,65 @@
+# =============================================================================
+# DRAFT (Claude-proposed, pending master-dd ratify + band-verify) -- NOT promoted.
+# Lives in encounters-draft/ (inert: no loader/validator/sim reads this dir).
+# Node: CRYOSTEPPE (mezzanotte_orbitale), graph weight 0.4 -- mid arc.
+# Threat proposal: diff 3, standard, elimination. Curve peer of enc_tutorial_03.
+# Species = proven archetype labels (stats from tier table); master-dd may reskin.
+# =============================================================================
+
+encounter_id: enc_tutorial_04
+name: 'Sentinelle della Mezzanotte'
+biome_id: mezzanotte_orbitale
+grid_size: [10, 10]
+difficulty_rating: 3
+estimated_turns: 12
+encounter_class: standard
+
+objective:
+  type: elimination
+
+player_spawn:
+  - [0, 4]
+  - [0, 5]
+  - [1, 4]
+  - [1, 5]
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [9, 4]
+      - [9, 5]
+    units:
+      - species: cartografi_subsonici
+        count: 2
+        tier: base
+        ai_profile: support
+      - species: guardiani_risonanza
+        count: 1
+        tier: elite
+        ai_profile: territorial
+  - wave_id: 2
+    turn_trigger: 5
+    spawn_points:
+      - [8, 1]
+      - [8, 8]
+    units:
+      - species: guardiani_risonanza
+        count: 1
+        tier: elite
+        ai_profile: aggressive
+      - species: cartografi_subsonici
+        count: 1
+        tier: base
+        ai_profile: cautious
+
+conditions:
+  - type: fog_of_war
+    fov_radius: 4
+
+tags: [standard, night]
+
+visual_mood:
+  mood_tag: astratto_digitale
+  lighting: diffusa_violacea
+  particle_effect: onde_sinaptiche

--- a/docs/planning/encounters-draft/enc_tutorial_05.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_05.yaml
@@ -1,0 +1,69 @@
+# =============================================================================
+# DRAFT (Claude-proposed, pending master-dd ratify + band-verify) -- NOT promoted.
+# Lives in encounters-draft/ (inert: no loader/validator/sim reads this dir).
+# Node: ROVINE_PLANARI (rovine_planari) PRIMARY (N=1), graph weight 0.5 -- pre-climax.
+# Threat proposal: diff 4, standard, elimination (the run-up to the diff-5 boss
+# enc_tutorial_06_hardcore, the terminal node's secondary encounter).
+# Species = proven archetype labels (stats from tier table); master-dd may reskin.
+# =============================================================================
+
+encounter_id: enc_tutorial_05
+name: 'Soglia delle Rovine'
+biome_id: rovine_planari
+grid_size: [10, 10]
+difficulty_rating: 4
+estimated_turns: 13
+encounter_class: standard
+
+objective:
+  type: elimination
+
+player_spawn:
+  - [0, 4]
+  - [0, 5]
+  - [1, 4]
+  - [1, 5]
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [9, 3]
+      - [9, 6]
+    units:
+      - species: guardiani_risonanza
+        count: 2
+        tier: elite
+        ai_profile: territorial
+      - species: predoni_nomadi
+        count: 1
+        tier: base
+        ai_profile: flanking
+  - wave_id: 2
+    turn_trigger: 5
+    spawn_points:
+      - [9, 5]
+      - [5, 0]
+    units:
+      - species: custode_basalto
+        count: 1
+        tier: apex
+        ai_profile: aggressive
+      - species: predoni_nomadi
+        count: 1
+        tier: elite
+        ai_profile: flanking
+
+conditions:
+  - type: fog_of_war
+    fov_radius: 5
+  - type: environmental_mutation
+    trigger_turn: 6
+    effect: planar_flux
+
+tags: [standard]
+
+visual_mood:
+  mood_tag: archeologico
+  lighting: fredda_obliqua
+  particle_effect: cenere_sospesa

--- a/docs/planning/encounters-draft/enc_tutorial_06_hardcore.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_06_hardcore.yaml
@@ -1,0 +1,87 @@
+# =============================================================================
+# DRAFT (Claude-proposed, pending master-dd ratify + band-verify) -- NOT promoted.
+# Lives in encounters-draft/ (inert: no loader/validator/sim reads this dir).
+# Node: ROVINE_PLANARI (rovine_planari) TERMINAL climax (secondary id in the node
+# encounters[], the boss). graph weight 0.5. Mirrors enc_hardcore_reinf_01 (same
+# biome/diff5/hardcore niche). resolve_parallel_key -> hardcore_06 (HC06 band ~15-25% WR).
+# Threat proposal: diff 5, hardcore class (1.4x + enrage), elimination + reinforcement.
+# Species = proven archetype labels (stats from tier table); master-dd may reskin.
+# =============================================================================
+
+encounter_id: enc_tutorial_06_hardcore
+name: 'Cuore delle Rovine'
+biome_id: rovine_planari
+grid_size: [10, 10]
+difficulty_rating: 5
+estimated_turns: 15
+encounter_class: hardcore
+
+objective:
+  type: elimination
+
+player_spawn:
+  - [0, 4]
+  - [0, 5]
+  - [0, 6]
+  - [1, 5]
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [9, 4]
+      - [9, 5]
+      - [9, 6]
+    units:
+      - species: guardiani_risonanza
+        count: 2
+        tier: elite
+        ai_profile: aggressive
+      - species: custode_basalto
+        count: 1
+        tier: apex
+        ai_profile: flanking
+
+reinforcement_pool:
+  - unit_id: predoni_nomadi
+    weight: 3
+    max_spawns: 4
+    hp: 7
+    mod: 2
+    dc: 12
+    ai_profile: aggressive
+  - unit_id: guardiani_risonanza_elite
+    weight: 1
+    max_spawns: 2
+    hp: 10
+    mod: 3
+    dc: 13
+    ai_profile: flanking
+
+reinforcement_entry_tiles:
+  - [9, 0]
+  - [9, 9]
+  - [0, 0]
+  - [0, 9]
+
+reinforcement_policy:
+  enabled: true
+  min_tier: Alert
+  cooldown_rounds: 3
+  max_total_spawns: 4
+  min_distance_from_pg: 4
+
+conditions: []
+
+tags: [boss]
+
+didactic_focus:
+  - pressure_management
+  - reinforcement_timing
+  - ai_progress_reading
+
+visual_mood:
+  mood_tag: archeologico
+  lighting: fredda_obliqua
+  particle_effect: cenere_sospesa
+  accent_override: '#b8935a'

--- a/docs/planning/encounters-draft/enc_tutorial_07_hardcore_pod_rush.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_07_hardcore_pod_rush.yaml
@@ -1,0 +1,81 @@
+# =============================================================================
+# DRAFT (Claude-proposed, pending master-dd ratify + band-verify) -- NOT promoted.
+# Lives in encounters-draft/ (inert: no loader/validator/sim reads this dir).
+# Node: ATOLLO_OBSIDIANA (atollo_obsidiana), graph weight 0.45 (SP-temperament route).
+# resolve_parallel_key -> hardcore_07 (HC07 band ~30-50% WR). "pod_rush" = swarm:
+# many base pods + reinforcement rush (count is the lever, not per-unit power).
+# Threat proposal: diff 4, hardcore class, elimination + reinforcement.
+# Species = proven archetype labels (stats from tier table); master-dd may reskin.
+# =============================================================================
+
+encounter_id: enc_tutorial_07_hardcore_pod_rush
+name: 'Risacca Obsidiana'
+biome_id: atollo_obsidiana
+grid_size: [10, 10]
+difficulty_rating: 4
+estimated_turns: 14
+encounter_class: hardcore
+
+objective:
+  type: elimination
+
+player_spawn:
+  - [0, 4]
+  - [0, 5]
+  - [0, 6]
+  - [1, 5]
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [9, 3]
+      - [9, 5]
+      - [9, 7]
+    units:
+      - species: bracconieri_echomantici
+        count: 4
+        tier: base
+        ai_profile: aggressive
+      - species: guardiani_risonanza
+        count: 1
+        tier: elite
+        ai_profile: territorial
+
+reinforcement_pool:
+  - unit_id: bracconieri_echomantici
+    weight: 4
+    max_spawns: 6
+    hp: 7
+    mod: 1
+    dc: 11
+    ai_profile: aggressive
+
+reinforcement_entry_tiles:
+  - [9, 0]
+  - [9, 9]
+  - [5, 0]
+  - [5, 9]
+
+reinforcement_policy:
+  enabled: true
+  min_tier: Alert
+  cooldown_rounds: 2
+  max_total_spawns: 6
+  min_distance_from_pg: 3
+
+conditions:
+  - type: fog_of_war
+    fov_radius: 5
+
+tags: [boss, storm]
+
+didactic_focus:
+  - swarm_control
+  - aoe_value
+  - pressure_management
+
+visual_mood:
+  mood_tag: vivacita_acquatica
+  lighting: chiaroscuro_subacqueo
+  particle_effect: bolle_reef

--- a/tests/api/metaNetworkRouteEndpoint.test.js
+++ b/tests/api/metaNetworkRouteEndpoint.test.js
@@ -81,6 +81,25 @@ test('meta-network/next: flag ON -> eligible candidates from the real alpha grap
   );
 });
 
+test('meta-network/next: flag ON -> candidates carry the rich threat telegraph (difficulty + tier)', async (t) => {
+  process.env.META_NETWORK_ROUTING = 'true';
+  t.after(() => {
+    delete process.env.META_NETWORK_ROUTING;
+  });
+  const url = startTestServer(t);
+  const r = await get(`${url}/api/campaign/meta-network/next?from=BADLANDS`);
+  assert.equal(r.status, 200);
+  const byId = Object.fromEntries(r.body.candidates.map((c) => [c.node_id, c]));
+  // DESERTO_CALDO serves enc_savana_01 (live encounters/, difficulty 2)
+  assert.equal(byId.DESERTO_CALDO.encounter_id, 'enc_savana_01');
+  assert.ok(byId.DESERTO_CALDO.threat, 'threat resolved for the destination encounter');
+  assert.equal(byId.DESERTO_CALDO.threat.difficulty_rating, 2);
+  assert.equal(byId.DESERTO_CALDO.threat.encounter_class, 'standard');
+  assert.ok(['base', 'elite', 'apex'].includes(byId.DESERTO_CALDO.threat.max_tier));
+  // FORESTA_TEMPERATA serves enc_caverna_02 (difficulty 3)
+  assert.equal(byId.FORESTA_TEMPERATA.threat.difficulty_rating, 3);
+});
+
 test('meta-network/next: flag ON + cleared filters a visited node', async (t) => {
   process.env.META_NETWORK_ROUTING = 'true';
   t.after(() => {

--- a/tests/worldgen/encounterThreat.test.js
+++ b/tests/worldgen/encounterThreat.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// TKT-WORLDGEN-GAPC preview-threat-resolver (decoupled from live combat).
+// Resolves an encounter's THREAT METADATA (difficulty_rating + encounter_class + peak
+// enemy tier + initial spawn count) for the Into-the-Breach route-choice telegraph, reading
+// the encounter YAML from docs/planning/encounters/ (live) UNION docs/planning/encounters-draft/
+// (node-encounter proposals not promoted to live combat). Read-only metadata: it does NOT make
+// the drafts live combat (combat's encounterLoader stays encounters/-only -> band-safe).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  encounterThreat,
+  enrichCandidatesWithThreat,
+  _resetCache,
+} = require('../../apps/backend/services/worldgen/encounterThreat');
+
+test('encounterThreat: reads a live encounters/ encounter (savana_01)', () => {
+  _resetCache();
+  const t = encounterThreat('enc_savana_01');
+  assert.ok(t, 'resolved');
+  assert.equal(t.difficulty_rating, 2);
+  assert.equal(t.encounter_class, 'standard');
+  assert.equal(t.max_tier, 'elite', 'wave2 custode_basalto is elite = peak tier');
+  assert.equal(t.wave1_count, 2);
+});
+
+test('encounterThreat: reads a draft-dir encounter (boss apex) without promoting it to combat', () => {
+  _resetCache();
+  const t = encounterThreat('enc_tutorial_06_hardcore');
+  assert.ok(t, 'resolved from encounters-draft/');
+  assert.equal(t.difficulty_rating, 5);
+  assert.equal(t.encounter_class, 'hardcore');
+  assert.equal(t.max_tier, 'apex');
+  assert.equal(t.wave1_count, 3);
+});
+
+test('encounterThreat: graceful null on missing id / bad input', () => {
+  _resetCache();
+  assert.equal(encounterThreat('enc_does_not_exist_xyz'), null);
+  assert.equal(encounterThreat(null), null);
+  assert.equal(encounterThreat(''), null);
+});
+
+test('enrichCandidatesWithThreat: adds threat per candidate by encounter_id, null when unknown, additive', () => {
+  _resetCache();
+  const candidates = [
+    { node_id: 'DESERTO_CALDO', encounter_id: 'enc_savana_01', weight: 0.4 },
+    { node_id: 'ROVINE_PLANARI', encounter_id: 'enc_tutorial_06_hardcore', weight: 0.5 },
+    { node_id: 'GHOST', encounter_id: null, weight: 0 },
+  ];
+  const out = enrichCandidatesWithThreat(candidates);
+  assert.equal(out[0].threat.difficulty_rating, 2);
+  assert.equal(out[1].threat.max_tier, 'apex');
+  assert.equal(out[2].threat, null, 'unknown/absent encounter_id -> null threat');
+  // additive: original candidate fields preserved
+  assert.equal(out[0].node_id, 'DESERTO_CALDO');
+  assert.equal(out[0].weight, 0.4);
+});
+
+test('enrichCandidatesWithThreat: non-array input -> returns as-is (back-compat)', () => {
+  assert.deepEqual(enrichCandidatesWithThreat(null), null);
+  assert.deepEqual(enrichCandidatesWithThreat(undefined), undefined);
+});


### PR DESCRIPTION
## What
Two band-safe pieces for the meta-network rich route-choice preview (toward the deferred `META_NETWORK_ROUTING` flip), with **NO live-combat promote**:

1. **5 node-encounter metadata drafts** in inert `docs/planning/encounters-draft/` (the graph node-encounters lacking authored YAML). Schema-valid (ajv 5/5), difficulty-validated (0 err/0 warn), build valid scenario rosters. Claude-proposed comp/curve (diff 3..5) -- reskin/retune freely.
2. **Preview threat resolver** (`apps/backend/services/worldgen/encounterThreat.js`): resolves each route candidate's threat (`difficulty_rating` + `encounter_class` + peak `max_tier` + `wave1_count`) from the encounter YAML (`encounters/` + `encounters-draft/`) -> surfaced on `GET /api/campaign/meta-network/next` + `/advance` `route_choice.candidates`. Builds on #2592's `encounter_id`/`terminal` -> the Godot fase-3 UI now has the full Into-the-Breach telegraph.

## Why decoupled (NOT promoted to live combat)
Promoting the drafts to `encounters/` was attempted + reverted: it crashes completion **0/10** (even faithful, no overlay) -- 2 gating elimination fights become 7, compounding vs the one-attempt-per-mission cap, un-fittable by `calibrationScaling` (see prior comments). The rich preview needs only the THREAT METADATA, not the live fight. So `encounterThreat` reads the draft metadata **read-only**; combat's `encounterLoader` stays `encounters/`-only -> the ratified completion bands (#2576/#2580) are untouched.

## Safety
- Band-safe: worldgen+endpoint **80/80** (6 new), AI **500/500**, sim **113/113**.
- Flag-gated: preview only surfaces under `META_NETWORK_ROUTING=true` (OFF default). Does NOT flip the flag.
- Combat untouched (`encounterLoader` `encounters/`-only). No forbidden paths, no deps.

## Owner-gated
Part of the meta-network arc; the draft comp is Claude-proposed (reskin freely). Say `vai` to merge.
