### PR TITLE
docs(memory-plugin): add JSDoc to lib utils

### DIFF
--- a/tools/memory-plugin/src/lib/git-utils.js
+++ b/tools/memory-plugin/src/lib/git-utils.js
@@ -1,6 +1,11 @@
 const { execSync } = require('node:child_process');
 const path = require('node:path');
 
+/**
+ * Gets the git root directory for the given working directory.
+ * @param {string} cwd The current working directory.
+ * @returns {string|null} The path to the git root directory, or null if not in a git repository.
+ */
 function getGitRoot(cwd) {
   const isolateWorktrees = process.env.SUPERMEMORY_ISOLATE_WORKTREES === 'true';
 

--- a/tools/memory-plugin/src/lib/project-config.js
+++ b/tools/memory-plugin/src/lib/project-config.js
@@ -5,12 +5,22 @@ const { getGitRoot } = require('./git-utils');
 const CONFIG_DIR = path.join('.claude', '.supermemory-claude');
 const CONFIG_FILE = 'config.json';
 
+/**
+ * Gets the path to the configuration file for the project.
+ * @param {string} cwd - The current working directory.
+ * @returns {string} The resolved path to the config file.
+ */
 function getConfigPath(cwd) {
   const gitRoot = getGitRoot(cwd);
   const basePath = gitRoot || cwd;
   return path.join(basePath, CONFIG_DIR, CONFIG_FILE);
 }
 
+/**
+ * Loads the project configuration if it exists.
+ * @param {string} cwd - The current working directory.
+ * @returns {Object|null} The parsed configuration object, or null if it cannot be loaded.
+ */
 function loadProjectConfig(cwd) {
   try {
     const configPath = getConfigPath(cwd);
@@ -21,6 +31,12 @@ function loadProjectConfig(cwd) {
   return null;
 }
 
+/**
+ * Saves the given configuration to the project config file.
+ * @param {string} cwd - The current working directory.
+ * @param {Object} config - The configuration data to save.
+ * @returns {string} The path where the configuration was saved.
+ */
 function saveProjectConfig(cwd, config) {
   const gitRoot = getGitRoot(cwd);
   const basePath = gitRoot || cwd;

--- a/tools/memory-plugin/src/lib/stdin.js
+++ b/tools/memory-plugin/src/lib/stdin.js
@@ -1,3 +1,8 @@
+/**
+ * Reads data from stdin and parses it as JSON.
+ *
+ * @returns {Promise<Object>} A promise that resolves to the parsed JSON object or an empty object.
+ */
 async function readStdin() {
   return new Promise((resolve, reject) => {
     let data = '';
@@ -17,10 +22,22 @@ async function readStdin() {
   });
 }
 
+/**
+ * Writes data to stdout as a JSON string.
+ *
+ * @param {Object} data The data object to be written.
+ * @returns {void}
+ */
 function writeOutput(data) {
   console.log(JSON.stringify(data));
 }
 
+/**
+ * Outputs a success message to stdout, optionally with additional context.
+ *
+ * @param {Object|null} [additionalContext=null] Optional additional context for the success message.
+ * @returns {void}
+ */
 function outputSuccess(additionalContext = null) {
   if (additionalContext) {
     writeOutput({
@@ -31,6 +48,12 @@ function outputSuccess(additionalContext = null) {
   }
 }
 
+/**
+ * Outputs an error message to stderr and a continuation message to stdout.
+ *
+ * @param {string} message The error message to log.
+ * @returns {void}
+ */
 function outputError(message) {
   console.error(`Supermemory: ${message}`);
   writeOutput({ continue: true, suppressOutput: true });


### PR DESCRIPTION
## What
JSDoc on the exported functions of 3 `tools/memory-plugin/src/lib` modules (git-utils, project-config, stdin). Comment-only, behavior-identical (44 insertions, **zero deletions**), infra tooling -- no game-logic, outside all freeze paths.

## Provenance (Jules loop via wrapper, batched)
- Authored by Jules (3 S3 gitPatches: `13411912630146404483` / `13003832912684084050` / `17372770475174240329`)
- Dispatched via `jules-dispatch.ps1` fail-closed wrapper (dedup verified distinct targets live)
- Ground-truthed by Claude: additions-only, `module.exports` unchanged, `node --check` OK on all 3, ASCII-clean, no trailing whitespace

External-repo -> **merge is yours** (ADR-0035). One PR for the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
