### PR TITLE
docs(memory-plugin): add JSDoc to auth and container-tag

### DIFF
--- a/tools/memory-plugin/src/lib/auth.js
+++ b/tools/memory-plugin/src/lib/auth.js
@@ -20,6 +20,11 @@ function ensureDir() {
   }
 }
 
+/**
+ * Loads credentials from the credentials file.
+ *
+ * @returns {Object|null} The parsed credentials object containing the apiKey if successful, or null if loading fails or apiKey is absent.
+ */
 function loadCredentials() {
   try {
     if (fs.existsSync(CREDENTIALS_FILE)) {
@@ -30,6 +35,12 @@ function loadCredentials() {
   return null;
 }
 
+/**
+ * Saves the provided API key to the credentials file.
+ *
+ * @param {string} apiKey - The API key to be saved.
+ * @returns {void}
+ */
 function saveCredentials(apiKey) {
   ensureDir();
   const data = {
@@ -39,6 +50,11 @@ function saveCredentials(apiKey) {
   fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(data, null, 2));
 }
 
+/**
+ * Clears the credentials by deleting the credentials file.
+ *
+ * @returns {void}
+ */
 function clearCredentials() {
   try {
     if (fs.existsSync(CREDENTIALS_FILE)) {
@@ -60,6 +76,11 @@ function openBrowser(url) {
   }
 }
 
+/**
+ * Starts the authentication flow by launching a local HTTP server and opening the browser.
+ *
+ * @returns {Promise<string>} A promise that resolves with the obtained API key, or rejects with an error if the flow fails or times out.
+ */
 function startAuthFlow() {
   return new Promise((resolve, reject) => {
     let resolved = false;

--- a/tools/memory-plugin/src/lib/container-tag.js
+++ b/tools/memory-plugin/src/lib/container-tag.js
@@ -3,10 +3,20 @@ const crypto = require('node:crypto');
 const { loadProjectConfig } = require('./project-config');
 const { getGitRoot } = require('./git-utils');
 
+/**
+ * Hashes the input string using SHA-256 and returns the first 16 hex characters.
+ * @param {string} input
+ * @returns {string}
+ */
 function sha256(input) {
   return crypto.createHash('sha256').update(input).digest('hex').slice(0, 16);
 }
 
+/**
+ * Gets the git repository name from the origin remote URL.
+ * @param {string} cwd
+ * @returns {string|null}
+ */
 function getGitRepoName(cwd) {
   try {
     const remoteUrl = execSync('git remote get-url origin', {
@@ -21,6 +31,11 @@ function getGitRepoName(cwd) {
   }
 }
 
+/**
+ * Gets a personal container tag based on project config or a hash of the base path.
+ * @param {string} cwd
+ * @returns {string}
+ */
 function getContainerTag(cwd) {
   const projectConfig = loadProjectConfig(cwd);
   if (projectConfig?.personalContainerTag) {
@@ -39,6 +54,11 @@ function sanitizeRepoName(name) {
     .replace(/^_|_$/g, '');
 }
 
+/**
+ * Gets a repository-specific container tag based on project config or repo name.
+ * @param {string} cwd
+ * @returns {string}
+ */
 function getRepoContainerTag(cwd) {
   const projectConfig = loadProjectConfig(cwd);
   if (projectConfig?.repoContainerTag) {
@@ -53,6 +73,11 @@ function getRepoContainerTag(cwd) {
   return `repo_${sanitizeRepoName(repoName)}`;
 }
 
+/**
+ * Gets the project name from the git repository name or base path.
+ * @param {string} cwd
+ * @returns {string}
+ */
 function getProjectName(cwd) {
   const gitRoot = getGitRoot(cwd);
   const basePath = gitRoot || cwd;


### PR DESCRIPTION
## What
JSDoc on the exported functions of 2 `tools/memory-plugin/src/lib` modules (auth, container-tag). Comment-only, behavior-identical (46 insertions, **zero deletions**), infra tooling.

## Ground-truth REJECTED 2 of 4 (the gate working)
This batch dispatched 4 (auth, container-tag, settings, validate). Ground-truth **rejected 2** before they could ship:
- `settings.js` -- 86-line **rewrite** (scope violation, not JSDoc-only)
- `validate.js` -- **`node --check` parse FAIL** (broken JS)

Cause: the generic "each exported function" prompt let Jules over-reach. Precise function-list prompts (prior batches) stayed 100% clean. Only the 2 verified-clean files are in this PR.

## Provenance
- Authored by Jules (sessions `2499849743189260573` / `14707580089426192573`) via `jules-dispatch.ps1`
- Ground-truthed by Claude: additions-only, `node --check` OK, ASCII, no trailing ws

External-repo -> merge is yours (ADR-0035).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
