### PR TITLE
feat(coop): co-op WS route-vote phase for meta-network route choice (GAP-C fase-3)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -69,6 +69,16 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
         payload: orch.worldTally(allPlayerIds(room), connectedPlayerIds(room)),
       });
     }
+    // GAP-C fase-3 — re-surface an open meta-network route choice (phase-agnostic:
+    // gated on open candidates, not a PHASES value). Keeps phones in sync on any
+    // coop-state rebroadcast while a route vote is in progress.
+    if (Array.isArray(orch.routeCandidates) && orch.routeCandidates.length > 0) {
+      room.broadcast({ type: 'route_choice', payload: { candidates: orch.routeCandidates } });
+      room.broadcast({
+        type: 'route_tally',
+        payload: orch.routeTally(allPlayerIds(room), connectedPlayerIds(room)),
+      });
+    }
     // M19 — debrief ready list if in debrief.
     if (orch.phase === 'debrief') {
       room.broadcast({
@@ -380,6 +390,41 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
       return res.json({ phase: orch.phase, result });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'combat_end_failed' });
+    }
+  });
+
+  // GAP-C fase-3 — host opens a meta-network route choice. The host (TV) has
+  // just called POST /api/campaign/advance and received choice_required +
+  // route_choice.candidates (>1 eligible node). This stores them on the
+  // orchestrator + broadcasts `route_choice` (the render model) and the initial
+  // `route_tally` to phones so they can vote per node_id (route_vote WS intent
+  // -> route_tally). The winning node (tally.leading_node_id; tie-break =
+  // highest candidate.weight, master-dd Q2) feeds the host's POST
+  // /api/campaign/choose { id, node_id }. Flag-gated upstream: when
+  // META_NETWORK_ROUTING is OFF, /advance never returns choice_required, so the
+  // host never calls this (band-safe, zero campaign-flow change).
+  router.post('/coop/route/open', (req, res) => {
+    const { code, host_token: hostToken, candidates } = req.body || {};
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      return res.status(400).json({ error: 'candidates richiesto (array non vuoto)' });
+    }
+    try {
+      const stored = orch.openRouteChoice(candidates);
+      if (stored.length === 0) {
+        return res.status(400).json({ error: 'candidates privi di node_id' });
+      }
+      room.broadcast({ type: 'route_choice', payload: { candidates: stored } });
+      room.broadcast({
+        type: 'route_tally',
+        payload: orch.routeTally(allPlayerIds(room), connectedPlayerIds(room)),
+      });
+      return res.json({ ok: true, candidates: stored });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'route_open_failed' });
     }
   });
 

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -100,6 +100,14 @@ class CoopOrchestrator {
     this.worldVotes = new Map(); // player_id → scenario_id|null
     // S22-B -- per-player mating pair vote { player_id -> { pair_id, ts } }.
     this.matingVotes = new Map();
+    // GAP-C fase-3 -- per-player meta-network route vote { player_id ->
+    // { node_id, ts } } + the open candidate list. Phase-agnostic storage
+    // (mirror formPulses/revealAcks): the route choice is offered at the
+    // debrief->next-encounter transition when POST /api/campaign/advance
+    // returns >1 candidate. Open candidates (set by openRouteChoice) gate
+    // voteRoute, not a strict PHASES enum value.
+    this.routeVotes = new Map();
+    this.routeCandidates = null;
     this.debriefChoices = new Map();
     // 2026-05-06 narrative onboarding port — host single-choice identity
     // for entire branco. Pre-assigned trait propagated to all party
@@ -232,6 +240,8 @@ class CoopOrchestrator {
     this.worldVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();
+    this.routeVotes.clear();
+    this.routeCandidates = null;
     this.debriefChoices.clear();
     this.revealAcks.clear();
     this.formPulses.clear();
@@ -270,6 +280,8 @@ class CoopOrchestrator {
     this.worldVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();
+    this.routeVotes.clear();
+    this.routeCandidates = null;
     this.debriefChoices.clear();
     this.revealAcks.clear();
     this.formPulses.clear();
@@ -693,6 +705,91 @@ class CoopOrchestrator {
   }
 
   /**
+   * GAP-C fase-3 -- open a meta-network route choice. Stores the candidate
+   * list (from POST /api/campaign/advance route_choice.candidates) so phones
+   * can vote per node_id and routeTally can break a tie by candidate.weight
+   * (master-dd Q2). Clears any prior votes. Idempotent re-open replaces the
+   * candidates + resets votes. Candidates without a node_id are dropped.
+   *
+   * @param candidates - array of candidate objects (need node_id; weight used
+   *                     for tie-break, defaults to 0 when absent).
+   * @returns the stored (normalized) candidate array.
+   */
+  openRouteChoice(candidates = []) {
+    const list = Array.isArray(candidates) ? candidates.filter((c) => c && c.node_id != null) : [];
+    this.routeCandidates = list;
+    this.routeVotes.clear();
+    this._emit('route_choice_open', { candidates: list });
+    return list;
+  }
+
+  /**
+   * GAP-C fase-3 -- player votes for a meta-network route node_id. Mirror of
+   * voteWorld / voteMating. Idempotent re-vote (replaces). Requires an open
+   * route choice (openRouteChoice) AND node_id to be one of the open
+   * candidates. Returns the current routeTally.
+   */
+  voteRoute(playerId, nodeId, { allPlayerIds = [], connectedPlayerIds } = {}) {
+    if (!this.routeCandidates || this.routeCandidates.length === 0) {
+      throw new Error('route_choice_not_open');
+    }
+    if (!playerId) throw new Error('player_id_required');
+    if (nodeId == null || nodeId === '') throw new Error('node_id_required');
+    const valid = this.routeCandidates.some((c) => String(c.node_id) === String(nodeId));
+    if (!valid) throw new Error('invalid_route_node');
+    this.routeVotes.set(playerId, { node_id: nodeId, ts: this.now() });
+    this._emit('route_vote', { player_id: playerId, node_id: nodeId });
+    return this.routeTally(allPlayerIds, connectedPlayerIds);
+  }
+
+  /**
+   * GAP-C fase-3 -- tally route votes. Per-node counts + the leading node +
+   * quorum. Mirror of matingTally shape, BUT the tie-break is master-dd Q2:
+   * on equal votes the highest candidate.weight wins (the Godot
+   * RouteChoiceFlow.resolve_tie_break mirrors this client-side); node_id asc
+   * is the deterministic final fallback so equal-weight ties stay stable.
+   */
+  routeTally(allPlayerIds = [], connectedPlayerIds) {
+    const weightOf = (nodeId) => {
+      const c = (this.routeCandidates || []).find((x) => String(x.node_id) === String(nodeId));
+      const w = c ? Number(c.weight) : NaN;
+      return Number.isFinite(w) ? w : 0;
+    };
+    const counts = new Map();
+    const perPlayer = {};
+    for (const [pid, vote] of this.routeVotes.entries()) {
+      perPlayer[pid] = vote;
+      counts.set(vote.node_id, (counts.get(vote.node_id) || 0) + 1);
+    }
+    const tallies = Array.from(counts.entries())
+      .map(([node_id, votes]) => ({ node_id, votes, weight: weightOf(node_id) }))
+      .sort(
+        (x, y) =>
+          y.votes - x.votes || // most votes wins
+          y.weight - x.weight || // master-dd Q2 tie-break: highest weight
+          String(x.node_id).localeCompare(String(y.node_id)), // deterministic fallback
+      );
+    const voted = this.routeVotes.size;
+    const tally = {
+      tallies,
+      leading_node_id: tallies.length ? tallies[0].node_id : null,
+      total: allPlayerIds.length || voted,
+      pending: Math.max((allPlayerIds.length || voted) - voted, 0),
+      per_player: perPlayer,
+      candidates: this.routeCandidates || [],
+    };
+    if (Array.isArray(connectedPlayerIds)) {
+      const connected = connectedPlayerIds.filter(Boolean);
+      const connectedVoted = connected.filter((pid) => this.routeVotes.has(pid)).length;
+      tally.connected_total = connected.length;
+      tally.connected_voted = connectedVoted;
+      tally.connected_pending = Math.max(connected.length - connectedVoted, 0);
+      tally.all_connected_voted = connected.length > 0 && connectedVoted === connected.length;
+    }
+    return tally;
+  }
+
+  /**
    * S22-B Task 8 -- if mating quorum is met and not yet resolved, mark
    * resolved and return the winning pair (parsed ids). Idempotent: null on
    * subsequent calls or before quorum. Connected-only quorum (mirror world).
@@ -940,6 +1037,8 @@ class CoopOrchestrator {
     this.worldVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();
+    this.routeVotes.clear();
+    this.routeCandidates = null;
     this.formPulses.clear();
     this.revealAcks.clear();
     this._setPhase('world_setup');

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -748,6 +748,12 @@ class CoopOrchestrator {
    * on equal votes the highest candidate.weight wins (the Godot
    * RouteChoiceFlow.resolve_tie_break mirrors this client-side); node_id asc
    * is the deterministic final fallback so equal-weight ties stay stable.
+   *
+   * P1-B (PR #2597 review): a disconnected player's vote PERSISTS in routeVotes
+   * (mirrors mating) until the next run-advance clears it. The connected_* fields
+   * self-heal via connectedPlayerIds, but the raw `tallies` still count a departed
+   * voter -- intentional, to survive a brief reconnect. Ratify-or-prune is Eduardo's
+   * call (review question 1); this comment documents the inherited invariant.
    */
   routeTally(allPlayerIds = [], connectedPlayerIds) {
     const weightOf = (nodeId) => {

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1009,6 +1009,17 @@ function sendCoopSnapshotToPlayer(room, orch, playerId) {
   if (orch.phase === 'world_setup' && typeof orch.worldTally === 'function') {
     send({ type: 'world_tally', payload: orch.worldTally(allIds, connectedIds) });
   }
+  // GAP-C fase-3 — a route choice is phase-agnostic (gated on open candidates,
+  // not a PHASES value), so a reconnecting phone must re-receive the candidates
+  // + the live tally to render the vote view. Skipped when no choice is open.
+  if (
+    Array.isArray(orch.routeCandidates) &&
+    orch.routeCandidates.length > 0 &&
+    typeof orch.routeTally === 'function'
+  ) {
+    send({ type: 'route_choice', payload: { candidates: orch.routeCandidates } });
+    send({ type: 'route_tally', payload: orch.routeTally(allIds, connectedIds) });
+  }
   if (orch.phase === 'debrief' && typeof orch.debriefReadyList === 'function') {
     send({
       type: 'debrief_ready_list',
@@ -1054,6 +1065,16 @@ function rebroadcastCoopState(room, orch) {
   }
   if (orch.phase === 'world_setup' && typeof orch.worldTally === 'function') {
     room.broadcast({ type: 'world_tally', payload: orch.worldTally(allIds, connectedIds) });
+  }
+  // GAP-C fase-3 — re-surface an open route choice after host transfer (mirror
+  // the reconnect snapshot above). Phase-agnostic: gated on open candidates.
+  if (
+    Array.isArray(orch.routeCandidates) &&
+    orch.routeCandidates.length > 0 &&
+    typeof orch.routeTally === 'function'
+  ) {
+    room.broadcast({ type: 'route_choice', payload: { candidates: orch.routeCandidates } });
+    room.broadcast({ type: 'route_tally', payload: orch.routeTally(allIds, connectedIds) });
   }
   if (orch.phase === 'debrief' && typeof orch.debriefReadyList === 'function') {
     room.broadcast({
@@ -1634,6 +1655,49 @@ function createWsServer({
                 JSON.stringify({
                   type: 'error',
                   payload: { code: err.message || 'mating_vote_failed' },
+                }),
+              );
+            }
+            return;
+          }
+          // GAP-C fase-3 — drain route_vote intents server-side via
+          // coopOrchestrator.voteRoute (mirror world_vote / mating_vote).
+          // Phone sends { action: 'route_vote', node_id } while a meta-network
+          // route choice is open (host opened it via POST /coop/route/open after
+          // /campaign/advance returned >1 candidate). Broadcasts route_tally +
+          // acks route_vote_accepted. Flag-gated upstream: when
+          // META_NETWORK_ROUTING is OFF the route choice is never opened, so a
+          // stray route_vote just errors `route_choice_not_open` (band-safe).
+          if (action === 'route_vote' && coopStore) {
+            try {
+              const orch = coopStore.get(room.code);
+              if (!orch) {
+                socket.send(
+                  JSON.stringify({ type: 'error', payload: { code: 'run_not_started' } }),
+                );
+                return;
+              }
+              const allPids = Array.from(room.players.values()).map((p) => p.id);
+              const connectedPids = Array.from(room.players.values())
+                .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
+                .map((p) => p.id);
+              const tally = orch.voteRoute(playerId, msg.payload?.node_id, {
+                allPlayerIds: allPids,
+                connectedPlayerIds: connectedPids,
+              });
+              logLobbyEvent('route_vote', {
+                code: room.code,
+                player_id: playerId,
+                node_id: msg.payload?.node_id || null,
+                leading_node_id: tally.leading_node_id,
+              });
+              room.broadcast({ type: 'route_tally', payload: tally });
+              socket.send(JSON.stringify({ type: 'route_vote_accepted', payload: { tally } }));
+            } catch (err) {
+              socket.send(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { code: err.message || 'route_vote_failed' },
                 }),
               );
             }

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -2110,7 +2110,10 @@ function createWsServer({
             const connectedPids = Array.from(room.players.values())
               .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
               .map((p) => p.id);
-            room.broadcast({ type: 'route_tally', payload: orch.routeTally(allPids, connectedPids) });
+            room.broadcast({
+              type: 'route_tally',
+              payload: orch.routeTally(allPids, connectedPids),
+            });
           }
         } catch {
           // swallow -- best-effort re-broadcast.

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1669,6 +1669,16 @@ function createWsServer({
           // META_NETWORK_ROUTING is OFF the route choice is never opened, so a
           // stray route_vote just errors `route_choice_not_open` (band-safe).
           if (action === 'route_vote' && coopStore) {
+            // P2-A (PR #2597 review): host is arbiter-only for route vote, mirroring the
+            // combat `host_cannot_intent` guard (above). A host vote would land in
+            // routeVotes -- skewing the raw `tallies` -- while being excluded from the
+            // `connected_*` quorum, so the two views would disagree. Reject it.
+            if (playerId === room.hostId || room.players.get(playerId)?.role === 'host') {
+              socket.send(
+                JSON.stringify({ type: 'error', payload: { code: 'host_cannot_intent' } }),
+              );
+              return;
+            }
             try {
               const orch = coopStore.get(room.code);
               if (!orch) {
@@ -2088,6 +2098,24 @@ function createWsServer({
         type: 'player_disconnected',
         payload: { player_id: playerId },
       });
+      // P1-A (PR #2597 review): if a route choice is open, this disconnect changed the
+      // connected set -- re-broadcast route_tally so the host's connected_total/pending
+      // drops the departed player. Without it the host UI waits forever for a gone voter
+      // (every other lifecycle event re-surfaces the tally; the disconnect path did not).
+      if (coopStore && typeof coopStore.get === 'function') {
+        try {
+          const orch = coopStore.get(room.code);
+          if (orch && Array.isArray(orch.routeCandidates) && orch.routeCandidates.length > 0) {
+            const allPids = Array.from(room.players.values()).map((p) => p.id);
+            const connectedPids = Array.from(room.players.values())
+              .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
+              .map((p) => p.id);
+            room.broadcast({ type: 'route_tally', payload: orch.routeTally(allPids, connectedPids) });
+          }
+        } catch {
+          // swallow -- best-effort re-broadcast.
+        }
+      }
       // TKT-M11B-05 — if the host's socket dropped, schedule an auto host
       // transfer. If the host reconnects before the grace window, the timer
       // is cleared in the hello/attach path above.

--- a/tests/api/coopRouteChoiceBroadcast.test.js
+++ b/tests/api/coopRouteChoiceBroadcast.test.js
@@ -1,0 +1,122 @@
+// GAP-C fase-3 -- POST /api/coop/route/open: the host (TV), having received
+// choice_required + route_choice.candidates from POST /api/campaign/advance,
+// opens the co-op route choice. The server stores the candidates on the
+// orchestrator + broadcasts `route_choice` (the render model) and an initial
+// `route_tally` to phones, which then vote per node_id (route_vote WS intent).
+//
+// Mirrors coop-recruit-candidates.test.js (host posts data -> broadcast to
+// phones). Flag-gated upstream: when META_NETWORK_ROUTING is OFF, /advance
+// never returns choice_required, so this endpoint is never reached (band-safe).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const broadcasts = [];
+  const origGetRoom = lobby.getRoom.bind(lobby);
+  lobby.getRoom = function (code) {
+    const room = origGetRoom(code);
+    if (room && !room.__broadcastWrapped) {
+      const origBroadcast = room.broadcast.bind(room);
+      room.broadcast = function (msg) {
+        broadcasts.push({ code, msg });
+        return origBroadcast(msg);
+      };
+      room.__broadcastWrapped = true;
+    }
+    return room;
+  };
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app, lobby, coopStore, broadcasts };
+}
+
+const CANDS = [
+  { node_id: 'BADLANDS', biome_id: 'badlands', weight: 0.7, encounter_id: 'enc_a' },
+  { node_id: 'CRYOSTEPPE', biome_id: 'cryosteppe', weight: 0.9, encounter_id: 'enc_b' },
+];
+
+async function setupRun(app) {
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'TV', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  await request(app).post('/api/lobby/join').send({ code, player_name: 'P1' });
+  await request(app)
+    .post('/api/coop/run/start')
+    .send({ code, host_token: hostToken, scenario_stack: ['enc_demo_01'] });
+  return { code, hostToken };
+}
+
+test('POST /coop/route/open: broadcasts route_choice with candidates', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupRun(app);
+  broadcasts.length = 0;
+  const res = await request(app)
+    .post('/api/coop/route/open')
+    .send({ code, host_token: hostToken, candidates: CANDS });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.ok, true);
+  const rc = broadcasts.find((b) => b.msg.type === 'route_choice');
+  assert.ok(rc, 'route_choice must be broadcast');
+  assert.deepEqual(
+    rc.msg.payload.candidates.map((c) => c.node_id),
+    ['BADLANDS', 'CRYOSTEPPE'],
+  );
+});
+
+test('POST /coop/route/open: also broadcasts an initial (empty) route_tally', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupRun(app);
+  broadcasts.length = 0;
+  await request(app)
+    .post('/api/coop/route/open')
+    .send({ code, host_token: hostToken, candidates: CANDS });
+  const rt = broadcasts.find((b) => b.msg.type === 'route_tally');
+  assert.ok(rt, 'route_tally must be broadcast');
+  assert.equal(rt.msg.payload.leading_node_id, null, 'no votes yet -> no leader');
+  assert.equal(rt.msg.payload.tallies.length, 0);
+});
+
+test('POST /coop/route/open: empty candidates -> 400 + no broadcast', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupRun(app);
+  broadcasts.length = 0;
+  const res = await request(app)
+    .post('/api/coop/route/open')
+    .send({ code, host_token: hostToken, candidates: [] });
+  assert.equal(res.status, 400);
+  assert.equal(
+    broadcasts.some((b) => b.msg.type === 'route_choice'),
+    false,
+  );
+});
+
+test('POST /coop/route/open: missing host_token -> 403', async () => {
+  const { app } = buildApp();
+  const { code } = await setupRun(app);
+  const res = await request(app).post('/api/coop/route/open').send({ code, candidates: CANDS });
+  assert.equal(res.status, 403);
+});
+
+test('POST /coop/route/open: run not started -> 409', async () => {
+  const { app } = buildApp();
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'TV', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  const res = await request(app)
+    .post('/api/coop/route/open')
+    .send({ code, host_token: hostToken, candidates: CANDS });
+  assert.equal(res.status, 409);
+});

--- a/tests/services/coopRouteVote.test.js
+++ b/tests/services/coopRouteVote.test.js
@@ -1,0 +1,130 @@
+// GAP-C fase-3 -- co-op meta-network route vote (per-node, mirror voteWorld/
+// voteMating). The route choice is offered at the debrief->next-encounter
+// transition when POST /api/campaign/advance returns >1 candidate. Phones vote
+// per node_id; routeTally counts per node and breaks a tie by candidate.weight
+// (master-dd Q2; the Godot RouteChoiceFlow.resolve_tie_break mirrors this).
+//
+// Storage is phase-agnostic (mirror formPulses/revealAcks): voteRoute is gated
+// on an OPEN route choice (openRouteChoice), not a strict PHASES enum value.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+
+function setupOrch() {
+  const co = new CoopOrchestrator({ roomCode: 'ROUTE', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_demo_01'] });
+  return co;
+}
+
+// node names + weights mirror the real graph candidate shape (node_id + weight).
+const CANDS = [
+  { node_id: 'BADLANDS', biome_id: 'badlands', weight: 0.7, encounter_id: 'enc_a' },
+  { node_id: 'CRYOSTEPPE', biome_id: 'cryosteppe', weight: 0.9, encounter_id: 'enc_b' },
+  { node_id: 'ATOLLO', biome_id: 'atollo', weight: 0.5, encounter_id: 'enc_c' },
+];
+
+test('openRouteChoice: stores candidates, clears prior votes, emits event', () => {
+  const co = setupOrch();
+  const events = [];
+  co.on((evt) => events.push(evt));
+  const stored = co.openRouteChoice(CANDS);
+  assert.equal(stored.length, 3);
+  assert.deepEqual(
+    stored.map((c) => c.node_id),
+    ['BADLANDS', 'CRYOSTEPPE', 'ATOLLO'],
+  );
+  assert.equal(co.routeVotes.size, 0);
+  assert.ok(events.some((e) => e.kind === 'route_choice_open'));
+});
+
+test('openRouteChoice: filters candidates without a node_id', () => {
+  const co = setupOrch();
+  const stored = co.openRouteChoice([...CANDS, { biome_id: 'no_node', weight: 1 }, null]);
+  assert.equal(stored.length, 3);
+});
+
+test('voteRoute: throws when no route choice is open', () => {
+  const co = setupOrch();
+  assert.throws(() => co.voteRoute('p1', 'BADLANDS'), /route_choice_not_open/);
+});
+
+test('voteRoute: throws on missing player_id / node_id', () => {
+  const co = setupOrch();
+  co.openRouteChoice(CANDS);
+  assert.throws(() => co.voteRoute(null, 'BADLANDS'), /player_id_required/);
+  assert.throws(() => co.voteRoute('p1', null), /node_id_required/);
+});
+
+test('voteRoute: throws when node_id is not an open candidate', () => {
+  const co = setupOrch();
+  co.openRouteChoice(CANDS);
+  assert.throws(() => co.voteRoute('p1', 'NOT_A_NODE'), /invalid_route_node/);
+});
+
+test('voteRoute: records vote + returns tally; leading is the most-voted node', () => {
+  const co = setupOrch();
+  co.openRouteChoice(CANDS);
+  co.voteRoute('p1', 'BADLANDS', { allPlayerIds: ['p1', 'p2'] });
+  const tally = co.voteRoute('p2', 'BADLANDS', { allPlayerIds: ['p1', 'p2'] });
+  assert.equal(tally.leading_node_id, 'BADLANDS');
+  assert.equal(tally.pending, 0);
+  assert.equal(tally.total, 2);
+  const badlands = tally.tallies.find((t) => t.node_id === 'BADLANDS');
+  assert.equal(badlands.votes, 2);
+});
+
+test('voteRoute: idempotent re-vote replaces the player previous node', () => {
+  const co = setupOrch();
+  co.openRouteChoice(CANDS);
+  co.voteRoute('p1', 'BADLANDS');
+  const tally = co.voteRoute('p1', 'ATOLLO');
+  assert.equal(co.routeVotes.size, 1);
+  assert.equal(tally.per_player.p1.node_id, 'ATOLLO');
+  assert.equal(tally.leading_node_id, 'ATOLLO');
+});
+
+test('routeTally tie-break (master-dd Q2): equal votes -> highest candidate.weight wins', () => {
+  const co = setupOrch();
+  co.openRouteChoice(CANDS);
+  // 1 vote each for BADLANDS (w=0.7) and CRYOSTEPPE (w=0.9): a genuine 1-1 tie.
+  co.voteRoute('p1', 'BADLANDS', { allPlayerIds: ['p1', 'p2'] });
+  const tally = co.voteRoute('p2', 'CRYOSTEPPE', { allPlayerIds: ['p1', 'p2'] });
+  assert.equal(tally.tallies[0].votes, tally.tallies[1].votes, 'a real tie on votes');
+  assert.equal(tally.leading_node_id, 'CRYOSTEPPE', 'highest weight breaks the tie');
+});
+
+test('routeTally tie-break fallback: equal votes + equal weight -> node_id asc (deterministic)', () => {
+  const co = setupOrch();
+  co.openRouteChoice([
+    { node_id: 'ZED', weight: 0.5 },
+    { node_id: 'ABE', weight: 0.5 },
+  ]);
+  co.voteRoute('p1', 'ZED', { allPlayerIds: ['p1', 'p2'] });
+  const tally = co.voteRoute('p2', 'ABE', { allPlayerIds: ['p1', 'p2'] });
+  assert.equal(tally.leading_node_id, 'ABE', 'lexicographic node_id asc is the stable fallback');
+});
+
+test('routeTally: connected-only quorum fields (mirror worldTally / matingTally)', () => {
+  const co = setupOrch();
+  co.openRouteChoice(CANDS);
+  co.voteRoute('p1', 'BADLANDS', { allPlayerIds: ['p1', 'p2'], connectedPlayerIds: ['p1'] });
+  const tally = co.routeTally(['p1', 'p2'], ['p1']);
+  assert.equal(tally.connected_total, 1);
+  assert.equal(tally.connected_voted, 1);
+  assert.equal(tally.connected_pending, 0);
+  assert.equal(tally.all_connected_voted, true);
+});
+
+test('startRun resets routeVotes + routeCandidates (mirror worldVotes/matingVotes)', () => {
+  // Fresh orch (phase=lobby): seed stale route state from a hypothetical prior
+  // run, then startRun must clear it via the reset block.
+  const co = new CoopOrchestrator({ roomCode: 'ROUTE', hostId: 'p_h' });
+  co.routeCandidates = [{ node_id: 'BADLANDS', weight: 0.7 }];
+  co.routeVotes.set('p1', { node_id: 'BADLANDS', ts: 1 });
+  co.startRun({ scenarioStack: ['enc_demo_01'] });
+  assert.equal(co.routeVotes.size, 0);
+  assert.equal(co.routeCandidates, null);
+});

--- a/tests/services/network/wsSession-routeVote.test.js
+++ b/tests/services/network/wsSession-routeVote.test.js
@@ -220,3 +220,133 @@ test('co-op smoke: 2 phones vote route node_ids -> host resolves leader to /choo
     delete process.env.META_NETWORK_ROUTING;
   }
 });
+
+// Shared boot for the route-vote edge tests (PR #2597 review fixes P2-A + P1-A):
+// campaign -> multi-candidate choice, room + N phones joined, run started, route opened.
+async function bootRouteVote(phoneNames) {
+  process.env.META_NETWORK_ROUTING = 'true';
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const wsPort = wsHandle.wss.address().port;
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter());
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  const httpServer = app.listen(0);
+  const baseUrl = `http://127.0.0.1:${httpServer.address().port}`;
+
+  const started = await post(baseUrl, '/api/campaign/start', { player_id: 'route_edge_boot' });
+  const campaignId = started.body.campaign.id;
+  const adv = await post(baseUrl, '/api/campaign/advance', { id: campaignId, outcome: 'victory' });
+  const candidates = adv.body.route_choice.candidates;
+  assert.ok(candidates.length > 1, 'a genuine multi-candidate choice');
+
+  const created = lobby.createRoom({ hostName: 'TV' });
+  const code = created.code;
+  const hostToken = created.host_token;
+  const hostId = created.host_id;
+  const phones = phoneNames.map((name) => ({ name, ...lobby.joinRoom({ code, playerName: name }) }));
+  await post(baseUrl, '/api/coop/run/start', {
+    code,
+    host_token: hostToken,
+    scenario_stack: ['enc_demo_01'],
+  });
+  await post(baseUrl, '/api/coop/route/open', { code, host_token: hostToken, candidates });
+
+  async function cleanup() {
+    await new Promise((r) => httpServer.close(r));
+    await wsHandle.close();
+    delete process.env.META_NETWORK_ROUTING;
+  }
+  return { wsPort, code, hostToken, hostId, candidates, phones, cleanup };
+}
+
+// P2-A (review #2597): host is arbiter-only for route vote -- a host route_vote
+// must be rejected (host_cannot_intent) and must NOT land in the tally.
+test('route-vote P2-A: host cannot cast a route vote (arbiter-only)', async () => {
+  const ctx = await bootRouteVote(['Ann']);
+  const hostWs = openWs(ctx.wsPort, { code: ctx.code, player_id: ctx.hostId, token: ctx.hostToken });
+  const annWs = openWs(ctx.wsPort, {
+    code: ctx.code,
+    player_id: ctx.phones[0].player_id,
+    token: ctx.phones[0].player_token,
+  });
+  try {
+    await waitOpen(hostWs);
+    await waitOpen(annWs);
+    await waitForMessage(hostWs, (m) => m.type === 'hello');
+    await waitForMessage(annWs, (m) => m.type === 'hello');
+
+    // Host attempts a route vote -> must be rejected, not accepted.
+    hostWs.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id } }),
+    );
+    const err = await waitForMessage(hostWs, (m) => m.type === 'error', 2000);
+    assert.equal(err.payload.code, 'host_cannot_intent', 'host route_vote rejected');
+
+    // A real phone votes -> its route_vote_accepted tally counts exactly 1 (the host
+    // vote was rejected, so it never landed in routeVotes; otherwise total would be 2).
+    annWs.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: ctx.candidates[1].node_id } }),
+    );
+    const acc = await waitForMessage(annWs, (m) => m.type === 'route_vote_accepted', 2000);
+    const totalVotes = (acc.payload.tally.tallies || []).reduce((s, t) => s + t.votes, 0);
+    assert.equal(totalVotes, 1, 'only the phone vote counted; host vote rejected, not in tally');
+  } finally {
+    hostWs.close();
+    annWs.close();
+    await ctx.cleanup();
+  }
+});
+
+// P1-A (review #2597): a non-voter disconnect during an open route choice must
+// re-broadcast route_tally with the departed player dropped from connected_total
+// (otherwise the host waits forever for a gone voter).
+test('route-vote P1-A: non-voter disconnect re-broadcasts route_tally with reduced connected_total', async () => {
+  const ctx = await bootRouteVote(['Ann', 'Bob', 'Cara']);
+  const [ann, bob, cara] = ctx.phones;
+  const annWs = openWs(ctx.wsPort, { code: ctx.code, player_id: ann.player_id, token: ann.player_token });
+  const bobWs = openWs(ctx.wsPort, { code: ctx.code, player_id: bob.player_id, token: bob.player_token });
+  const caraWs = openWs(ctx.wsPort, { code: ctx.code, player_id: cara.player_id, token: cara.player_token });
+  try {
+    await waitOpen(annWs);
+    await waitOpen(bobWs);
+    await waitOpen(caraWs);
+    await waitForMessage(annWs, (m) => m.type === 'hello');
+    await waitForMessage(bobWs, (m) => m.type === 'hello');
+    await waitForMessage(caraWs, (m) => m.type === 'hello');
+
+    // Ann + Bob vote; Cara (3rd connected) does NOT vote -> total 3, voted 2, pending 1.
+    annWs.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id } }),
+    );
+    bobWs.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id } }),
+    );
+    await waitForMessage(
+      annWs,
+      (m) => m.type === 'route_tally' && m.payload.connected_total === 3 && m.payload.connected_voted === 2,
+      2000,
+    );
+
+    // Cara disconnects without voting -> P1-A must re-broadcast a tally with connected_total = 2.
+    caraWs.close();
+    const reTally = await waitForMessage(
+      annWs,
+      (m) => m.type === 'route_tally' && m.payload.connected_total === 2,
+      3000,
+    );
+    assert.equal(reTally.payload.connected_voted, 2, 'the remaining 2 connected both voted');
+    assert.equal(reTally.payload.all_connected_voted, true, 'quorum reached once the non-voter left');
+  } finally {
+    annWs.close();
+    bobWs.close();
+    caraWs.close();
+    await ctx.cleanup();
+  }
+});

--- a/tests/services/network/wsSession-routeVote.test.js
+++ b/tests/services/network/wsSession-routeVote.test.js
@@ -1,0 +1,222 @@
+// GAP-C fase-3 -- co-op route-vote smoke (2 sockets). Mirror of
+// wsSession-matingVote.test.js, extended end-to-end through the campaign:
+//
+//   1. campaign /advance returns choice_required + route_choice.candidates (>1)
+//   2. host POST /api/coop/route/open broadcasts route_choice to phones
+//   3. two phone WS sockets each send a route_vote {node_id} intent
+//   4. server drains -> coopOrchestrator.voteRoute -> broadcasts route_tally
+//   5. host reads route_tally.leading_node_id (tie-break = highest weight,
+//      master-dd Q2) and resolves it via POST /api/campaign/choose {id, node_id}
+//
+// Flag-gated: META_NETWORK_ROUTING=true so /advance returns choice_required.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const express = require('express');
+const WebSocket = require('ws');
+
+const {
+  LobbyService,
+  createWsServer,
+} = require('../../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+const { createCoopRouter } = require('../../../apps/backend/routes/coop');
+const { createCampaignRouter } = require('../../../apps/backend/routes/campaign');
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+function post(baseUrl, path, body) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(baseUrl + path);
+    const payload = JSON.stringify(body);
+    const r = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () =>
+          resolve({ status: res.statusCode, body: data ? JSON.parse(data) : null }),
+        );
+      },
+    );
+    r.on('error', reject);
+    r.end(payload);
+  });
+}
+
+test('co-op smoke: 2 phones vote route node_ids -> host resolves leader to /choose', async () => {
+  process.env.META_NETWORK_ROUTING = 'true';
+
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const wsPort = wsHandle.wss.address().port;
+
+  // REST app (campaign + coop) sharing the same lobby + coopStore as the WS server.
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter());
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  const httpServer = app.listen(0);
+  const baseUrl = `http://127.0.0.1:${httpServer.address().port}`;
+
+  let p1Ws;
+  let p2Ws;
+  try {
+    // 1. Campaign reaches a multi-candidate route choice.
+    const started = await post(baseUrl, '/api/campaign/start', { player_id: 'coop_route_smoke' });
+    const campaignId = started.body.campaign.id;
+    const adv = await post(baseUrl, '/api/campaign/advance', {
+      id: campaignId,
+      outcome: 'victory',
+    });
+    assert.equal(adv.body.choice_required, true, 'graph mode returns a route choice');
+    const candidates = adv.body.route_choice.candidates;
+    assert.ok(candidates.length > 1, 'a genuine multi-candidate choice');
+
+    // 2. Co-op room + 2 players + a started run.
+    const created = lobby.createRoom({ hostName: 'TV' });
+    const code = created.code;
+    const hostToken = created.host_token;
+    const p1 = lobby.joinRoom({ code, playerName: 'Ann' });
+    const p2 = lobby.joinRoom({ code, playerName: 'Bob' });
+    await post(baseUrl, '/api/coop/run/start', {
+      code,
+      host_token: hostToken,
+      scenario_stack: ['enc_demo_01'],
+    });
+
+    // 3. Host opens the route choice -> route_choice broadcast to phones.
+    const opened = await post(baseUrl, '/api/coop/route/open', {
+      code,
+      host_token: hostToken,
+      candidates,
+    });
+    assert.equal(opened.status, 200);
+
+    // 4. Two phone sockets connect + each votes a (different) node -> a 1-1 tie.
+    p1Ws = openWs(wsPort, { code, player_id: p1.player_id, token: p1.player_token });
+    p2Ws = openWs(wsPort, { code, player_id: p2.player_id, token: p2.player_token });
+    await waitOpen(p1Ws);
+    await waitOpen(p2Ws);
+    await waitForMessage(p1Ws, (m) => m.type === 'hello');
+    await waitForMessage(p2Ws, (m) => m.type === 'hello');
+    // Both phones should have received the route_choice candidates broadcast.
+    const rcMsg = await waitForMessage(p1Ws, (m) => m.type === 'route_choice', 2000);
+    assert.equal(rcMsg.payload.candidates.length, candidates.length);
+
+    const nodeA = candidates[0].node_id;
+    const nodeB = candidates[1].node_id;
+    p1Ws.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: nodeA } }),
+    );
+    p2Ws.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: nodeB } }),
+    );
+
+    // 5. A route_tally broadcast carrying both votes (2 distinct nodes, 1 each).
+    const tallyMsg = await waitForMessage(
+      p1Ws,
+      (m) =>
+        m.type === 'route_tally' &&
+        (m.payload?.tallies || []).reduce((s, t) => s + t.votes, 0) === 2,
+      3000,
+    );
+    const tally = tallyMsg.payload;
+    assert.equal(tally.connected_voted, 2, 'both connected phones voted');
+
+    // master-dd Q2 tie-break: 1-1 vote tie -> highest candidate.weight wins,
+    // node_id asc as the deterministic final fallback.
+    const expectedLeader = [candidates[0], candidates[1]]
+      .slice()
+      .sort(
+        (a, b) =>
+          Number(b.weight || 0) - Number(a.weight || 0) ||
+          String(a.node_id).localeCompare(String(b.node_id)),
+      )[0].node_id;
+    assert.equal(tally.leading_node_id, expectedLeader, 'tie broken by weight then node_id');
+
+    // 6. Host resolves the winner to the campaign /choose -> it advances.
+    const chosen = await post(baseUrl, '/api/campaign/choose', {
+      id: campaignId,
+      node_id: tally.leading_node_id,
+    });
+    assert.equal(chosen.status, 200, 'choose accepted');
+    assert.equal(
+      chosen.body.campaign.currentNode,
+      tally.leading_node_id,
+      'campaign routed to winner',
+    );
+    assert.ok(chosen.body.next_encounter_id, 'the chosen node serves its encounter');
+  } finally {
+    if (p1Ws) p1Ws.close();
+    if (p2Ws) p2Ws.close();
+    await new Promise((r) => httpServer.close(r));
+    await wsHandle.close();
+    delete process.env.META_NETWORK_ROUTING;
+  }
+});

--- a/tests/services/network/wsSession-routeVote.test.js
+++ b/tests/services/network/wsSession-routeVote.test.js
@@ -250,7 +250,10 @@ async function bootRouteVote(phoneNames) {
   const code = created.code;
   const hostToken = created.host_token;
   const hostId = created.host_id;
-  const phones = phoneNames.map((name) => ({ name, ...lobby.joinRoom({ code, playerName: name }) }));
+  const phones = phoneNames.map((name) => ({
+    name,
+    ...lobby.joinRoom({ code, playerName: name }),
+  }));
   await post(baseUrl, '/api/coop/run/start', {
     code,
     host_token: hostToken,
@@ -270,7 +273,11 @@ async function bootRouteVote(phoneNames) {
 // must be rejected (host_cannot_intent) and must NOT land in the tally.
 test('route-vote P2-A: host cannot cast a route vote (arbiter-only)', async () => {
   const ctx = await bootRouteVote(['Ann']);
-  const hostWs = openWs(ctx.wsPort, { code: ctx.code, player_id: ctx.hostId, token: ctx.hostToken });
+  const hostWs = openWs(ctx.wsPort, {
+    code: ctx.code,
+    player_id: ctx.hostId,
+    token: ctx.hostToken,
+  });
   const annWs = openWs(ctx.wsPort, {
     code: ctx.code,
     player_id: ctx.phones[0].player_id,
@@ -284,7 +291,10 @@ test('route-vote P2-A: host cannot cast a route vote (arbiter-only)', async () =
 
     // Host attempts a route vote -> must be rejected, not accepted.
     hostWs.send(
-      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id } }),
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id },
+      }),
     );
     const err = await waitForMessage(hostWs, (m) => m.type === 'error', 2000);
     assert.equal(err.payload.code, 'host_cannot_intent', 'host route_vote rejected');
@@ -292,7 +302,10 @@ test('route-vote P2-A: host cannot cast a route vote (arbiter-only)', async () =
     // A real phone votes -> its route_vote_accepted tally counts exactly 1 (the host
     // vote was rejected, so it never landed in routeVotes; otherwise total would be 2).
     annWs.send(
-      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: ctx.candidates[1].node_id } }),
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'route_vote', node_id: ctx.candidates[1].node_id },
+      }),
     );
     const acc = await waitForMessage(annWs, (m) => m.type === 'route_vote_accepted', 2000);
     const totalVotes = (acc.payload.tally.tallies || []).reduce((s, t) => s + t.votes, 0);
@@ -310,9 +323,21 @@ test('route-vote P2-A: host cannot cast a route vote (arbiter-only)', async () =
 test('route-vote P1-A: non-voter disconnect re-broadcasts route_tally with reduced connected_total', async () => {
   const ctx = await bootRouteVote(['Ann', 'Bob', 'Cara']);
   const [ann, bob, cara] = ctx.phones;
-  const annWs = openWs(ctx.wsPort, { code: ctx.code, player_id: ann.player_id, token: ann.player_token });
-  const bobWs = openWs(ctx.wsPort, { code: ctx.code, player_id: bob.player_id, token: bob.player_token });
-  const caraWs = openWs(ctx.wsPort, { code: ctx.code, player_id: cara.player_id, token: cara.player_token });
+  const annWs = openWs(ctx.wsPort, {
+    code: ctx.code,
+    player_id: ann.player_id,
+    token: ann.player_token,
+  });
+  const bobWs = openWs(ctx.wsPort, {
+    code: ctx.code,
+    player_id: bob.player_id,
+    token: bob.player_token,
+  });
+  const caraWs = openWs(ctx.wsPort, {
+    code: ctx.code,
+    player_id: cara.player_id,
+    token: cara.player_token,
+  });
   try {
     await waitOpen(annWs);
     await waitOpen(bobWs);
@@ -323,14 +348,23 @@ test('route-vote P1-A: non-voter disconnect re-broadcasts route_tally with reduc
 
     // Ann + Bob vote; Cara (3rd connected) does NOT vote -> total 3, voted 2, pending 1.
     annWs.send(
-      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id } }),
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id },
+      }),
     );
     bobWs.send(
-      JSON.stringify({ type: 'intent', payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id } }),
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'route_vote', node_id: ctx.candidates[0].node_id },
+      }),
     );
     await waitForMessage(
       annWs,
-      (m) => m.type === 'route_tally' && m.payload.connected_total === 3 && m.payload.connected_voted === 2,
+      (m) =>
+        m.type === 'route_tally' &&
+        m.payload.connected_total === 3 &&
+        m.payload.connected_voted === 2,
       2000,
     );
 
@@ -342,7 +376,11 @@ test('route-vote P1-A: non-voter disconnect re-broadcasts route_tally with reduc
       3000,
     );
     assert.equal(reTally.payload.connected_voted, 2, 'the remaining 2 connected both voted');
-    assert.equal(reTally.payload.all_connected_voted, true, 'quorum reached once the non-voter left');
+    assert.equal(
+      reTally.payload.all_connected_voted,
+      true,
+      'quorum reached once the non-voter left',
+    );
   } finally {
     annWs.close();
     bobWs.close();


### PR DESCRIPTION
## Cosa

GAP-C fase-3 (DoD-3): aggiunge la **co-op WS route-vote phase** -- i giocatori votano per-nodo la rotta meta-network, come il voto `world_setup`. Prima esisteva solo il TV-pick host-driven (#2582 `world_vote -> /choose` era REST-test-only); il layer WS co-op non aveva voto per-nodo.

Consuma il contratto gia shipped (`/advance` graph-mode -> `choice_required` + `route_choice.candidates`; `/choose {id, node_id}`) -- nessuna modifica al campaign router.

## Come (tutto additivo + flag-gated)

- **coopOrchestrator**: `openRouteChoice(candidates)` salva la lista candidati aperta (phase-agnostic, mirror `formPulses`/`revealAcks`); `voteRoute(playerId, nodeId)` + `routeTally()` mirror di `voteMating`/`matingTally`. **Tie-break = `candidate.weight` piu alto (master-dd Q2)**, `node_id` asc come fallback deterministico. `routeVotes`/`routeCandidates` resettati insieme a `worldVotes`/`matingVotes`.
- **wsSession**: drena intent `route_vote {node_id}` -> `routeTally` -> broadcast `route_tally` + ack `route_vote_accepted` (mirror `world_vote`/`mating_vote`). Choice aperta ri-emessa su reconnect snapshot + host-transfer rebroadcast (reconnect survival).
- **coop route**: `POST /coop/route/open` (host) salva i candidati + broadcast `route_choice` + `route_tally` iniziale ai phone; `broadcastCoopState` ri-emette una choice aperta. L'host risolve `tally.leading_node_id` via `POST /api/campaign/choose`.

Messaggi WS nuovi: `route_choice` (broadcast candidati), `route_vote` (intent phone), `route_tally` (broadcast), `route_vote_accepted` (ack).

## Flag / band-safety

`META_NETWORK_ROUTING` OFF (prod default) -> `/advance` non ritorna mai `choice_required` -> la phase non viene mai aperta. **Zero impatto campaign-flow / combat bands** finche il flag non viene flippato (owner verdict separato). Solo routing campaign UI.

## Test (nuovi)

- `tests/services/coopRouteVote.test.js` (13): openRouteChoice/voteRoute/routeTally, tie-break peso + fallback node_id equal-weight, quorum connected-only, reset.
- `tests/api/coopRouteChoiceBroadcast.test.js` (5): `/coop/route/open` broadcast + guard auth/empty/run-not-started.
- `tests/services/network/wsSession-routeVote.test.js` (1): **co-op smoke 2 socket** -- entrambi votano node_id, `route_tally` tie-break, host risolve a `/campaign/choose`.

Evidenze: 17 nuovi pass; regressione coop/ws/campaign 84/84; AI 500/500; Prettier clean. Nessun file in forbidden-path.

## Rollback (03A)

Revert del commit (tutto additivo). In prod il flag `META_NETWORK_ROUTING` resta OFF -> la feature e dormiente a prescindere; nessuna migrazione, nessun cambio schema/contracts.

## Spec

`docs/superpowers/specs/2026-06-03-worldgen-gapc-fase3-godot-route-choice-ui-design.md` (§4.3 co-op + §9 Q2).

## Follow-up appaiato (repo Game-Godot-v2)

Wire `RouteChoiceView` (gia phone-capable, emette `route_chosen(node_id)`) in `scripts/phone/phone_composer_view.gd` come nuovo MODE che renderizza i candidati dal broadcast `route_choice` e invia l'intent `route_vote` (mirror MODE_WORLD_VOTE). Host (TV) consuma `route_tally` + chiama `CampaignApi.choose` via `MainRouteChoice`.

## Note merge

NON auto-merge L3: i file test (~370 LOC) sono fuori `apps/backend/` (gate 6). Richiede review Codex + verdetto master-dd.
