### PR TITLE
feat(sim): option-C graph-combat band-verify + Phase 3 re-tune (cm3/hp2; Phase 2 dropped)

### DIFF
--- a/docs/planning/2026-06-04-option-c-handoff.md
+++ b/docs/planning/2026-06-04-option-c-handoff.md
@@ -37,12 +37,15 @@ the AUTHORED overlay completion = 10/10 (the climax is winnable). See the band-v
 
 ### Phase 3 -- re-tune ✅ DONE (2026-06-04, `77021ca8`); re-ratify = the only gate left
 
-Re-tuned the graph-mode `calibrationScaling` overlay `countMult 5 + hpAdd 4 -> 3 + 2` (the stale
-default was tuned for the weak fallback enemies; `5x` an authored hardcore roster gave the 0/10).
-N=40: greedy 0.75 / ESFP 0.775 / INTJ 0.775, all inside the #2589-ratified wider band (0.4-0.85).
-Static `cave_path` default (cm5/hp3) unchanged -> no static re-ratify. **Owner re-ratify
-(master-dd):** ratify the ~0.77 centre (within 0.4-0.85), OR ask for a tighter ~0.6 (a harder
-overlay e.g. `cm3 + hpAdd 3` lowers it); also update the aggregator `PROVISIONAL_BANDS`. Then: the flip.
+Re-tuned the graph-mode `calibrationScaling` overlay `countMult 5 + hpAdd 4 -> countMult 3 + hpAdd 2
+
+- dcAdd 1`(the stale default was tuned for the weak fallback enemies;`5x`an authored hardcore
+roster gave the 0/10). master-dd picked the TIGHTER centre:`dcAdd 1`(the fine knob; hpAdd alone is
+razor-steep, 2->3 jumps 0.77->0.2). N=40: greedy 0.675 / ESFP 0.70 / INTJ 0.60 -- all inside the
+tight 0.4-0.7 band (~0.66 centre). Static`cave_path`default unchanged -> no static re-ratify.
+**Owner re-ratify (master-dd):** ratify ~0.66 + update the aggregator`PROVISIONAL_BANDS`. Then:
+merge; the Godot `graph_mode`consumer (🔴 Godot combat is LOCAL via`round_orchestrator`, NOT backend
+`/session/start` -> routed draft encounters need Godot-side loading, scope separately); the flip.
 
 ### Disambiguation insight (do this FIRST in the dedicated session)
 

--- a/docs/planning/2026-06-04-option-c-handoff.md
+++ b/docs/planning/2026-06-04-option-c-handoff.md
@@ -29,13 +29,20 @@ review_cycle_days: 30
 
 ## Remaining to the flip (dedicated session)
 
-### Phase 2 -- retry-allowance + soft-ramp (RATIFIED, unbuilt)
+### Phase 2 -- retry-allowance + soft-ramp -- ❌ DROPPED (2026-06-04)
 
-Spec section 9.1. Retry-allowance = graph mode permits re-attempt / reroute on a lost node (meta-loop run-structure). Where it lives: the campaign `/advance` defeat path (`apps/backend/routes/campaign.js`) today does "retry same" -- extend for a graph reroute / bounded re-attempt. Soft-ramp = mostly already in the data (`prior_node_cleared` edge gates). Needs its own brainstorm -> spec -> TDD. The measurement shows the terminal climax is the dominant killer -> retry-allowance directly addresses it.
+The N=10 0/10 that "motivated" retry-allowance was a **CALIBRATION ARTIFACT, not a climax gate**: at
+the AUTHORED overlay completion = 10/10 (the climax is winnable). See the band-verify
+`docs/playtest/2026-06-04-optionc-phase3-retune-band-verify.md`. **No retry mechanic is needed.**
 
-### Phase 3 -- band-verify + re-ratify (mandatory before flip-with-real-fights)
+### Phase 3 -- re-tune ✅ DONE (2026-06-04, `77021ca8`); re-ratify = the only gate left
 
-Spec section 6. 1) graph-mode N=40 via `tools/sim/full-loop-batch.js --runs 40` (`META_NETWORK_ROUTING=true`, greedy + MBTI sample). 2) **re-tune `calibrationScaling` graph-mode knobs on the REAL rosters** -- the current `hpAdd4` (#2589) was tuned for the fallback enemies and is now over-hard (even savana times out); sim-only, reversible via `FL_ENEMY_*`. 3) re-ratify the #2589 graph-mode bands with the new substrate (master-dd decision-handoff). 4) static `cave_path` N=40 unchanged regression.
+Re-tuned the graph-mode `calibrationScaling` overlay `countMult 5 + hpAdd 4 -> 3 + 2` (the stale
+default was tuned for the weak fallback enemies; `5x` an authored hardcore roster gave the 0/10).
+N=40: greedy 0.75 / ESFP 0.775 / INTJ 0.775, all inside the #2589-ratified wider band (0.4-0.85).
+Static `cave_path` default (cm5/hp3) unchanged -> no static re-ratify. **Owner re-ratify
+(master-dd):** ratify the ~0.77 centre (within 0.4-0.85), OR ask for a tighter ~0.6 (a harder
+overlay e.g. `cm3 + hpAdd 3` lowers it); also update the aggregator `PROVISIONAL_BANDS`. Then: the flip.
 
 ### Disambiguation insight (do this FIRST in the dedicated session)
 

--- a/docs/planning/2026-06-04-option-c-handoff.md
+++ b/docs/planning/2026-06-04-option-c-handoff.md
@@ -1,0 +1,54 @@
+---
+title: 'Option-C handoff -- meta-network graph-combat (C1 shipped, Phase 2+3 to flip)'
+date: 2026-06-04
+doc_status: active
+doc_owner: master-dd
+workstream: worldgen
+last_verified: '2026-06-04'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Option-C handoff -- 2026-06-04
+
+## TL;DR
+
+- **C1 SHIPPED** ([Game #2601](https://github.com/MasterDD-L34D/Game/pull/2601) squash `3ab6aca7`): graph-mode combat resolves the REAL telegraphed encounter for all 6 meta-network nodes (was 2/6; terminal climax was degraded). `loadEncounter(id,{graphMode})` unions `encounters-draft/`; static path byte-stable. Flag `META_NETWORK_ROUTING` OFF in prod.
+- **Band-verify FIDELITY wired** ([Game #2603](https://github.com/MasterDD-L34D/Game/pull/2603), OPEN owner-gated): the sim now fights the REAL draft rosters in graph mode (`buildScenarioEnemies(...,{graphMode})`). Pre-this the 4 draft nodes fought weak-fixed fallback enemies -> the #2589 ratified bands measured FALLBACK combat, not real difficulty.
+- **MEASURED (the reason we paused)**: N=10 greedy graph-mode = **completion 0/10** (band 0.4-0.7). Blocker = terminal climax `enc_tutorial_05` timeout (6/10, after winning the 2 live fights) + occasional `enc_savana_01` timeout (4/10). REAL difficulty (4 chained gating fights), not a bug.
+- **FLIP stays gated** on Phase 2 + Phase 3 below + master-dd go. Spec (ratified): `docs/superpowers/specs/2026-06-03-worldgen-gapc-option-c-graph-combat-decouple-design.md`.
+
+## Done this session
+
+| Item                                | Ref              | State              |
+| ----------------------------------- | ---------------- | ------------------ |
+| C1 mode-aware loadEncounter         | #2601 `3ab6aca7` | MERGED             |
+| Sim band-verify fights real rosters | #2603            | OPEN (owner-gated) |
+| N=10 greedy graph-mode probe        | this doc         | 0/10 measured      |
+
+## Remaining to the flip (dedicated session)
+
+### Phase 2 -- retry-allowance + soft-ramp (RATIFIED, unbuilt)
+
+Spec section 9.1. Retry-allowance = graph mode permits re-attempt / reroute on a lost node (meta-loop run-structure). Where it lives: the campaign `/advance` defeat path (`apps/backend/routes/campaign.js`) today does "retry same" -- extend for a graph reroute / bounded re-attempt. Soft-ramp = mostly already in the data (`prior_node_cleared` edge gates). Needs its own brainstorm -> spec -> TDD. The measurement shows the terminal climax is the dominant killer -> retry-allowance directly addresses it.
+
+### Phase 3 -- band-verify + re-ratify (mandatory before flip-with-real-fights)
+
+Spec section 6. 1) graph-mode N=40 via `tools/sim/full-loop-batch.js --runs 40` (`META_NETWORK_ROUTING=true`, greedy + MBTI sample). 2) **re-tune `calibrationScaling` graph-mode knobs on the REAL rosters** -- the current `hpAdd4` (#2589) was tuned for the fallback enemies and is now over-hard (even savana times out); sim-only, reversible via `FL_ENEMY_*`. 3) re-ratify the #2589 graph-mode bands with the new substrate (master-dd decision-handoff). 4) static `cave_path` N=40 unchanged regression.
+
+### Disambiguation insight (do this FIRST in the dedicated session)
+
+The 0/10 CONFOUNDS two causes: the terminal-climax gate AND the stale fallback-tuned scaling. **Re-tune the graph-mode `calibrationScaling` on real rosters first** (Phase 3 step 2) until the live fights (savana/caverna) win reliably -> THEN the residual failure isolates the climax-gate -> size Phase 2 (retry-allowance) from clean data. This avoids over/under-building retry.
+
+### Then: the flip + the consumer
+
+- Flip (owner, reversible): FF the lenovo-host worktree to main + `export META_NETWORK_ROUTING=true` in `~/.config/api-keys/keys.env` + restart the `EvoTacticsBackend` scheduled task (self-heal launcher frees ports). Verify `evo-tactics.com/api/campaign/meta-network/next` -> `enabled:true` + a `/start->/advance->/choose` smoke.
+- Consumer (Gate-5): the Godot route-choice UI (`#401` single + `#404` coop merged) must send `graph_mode:true` on `/session/start` for routed fights (cross-repo Game-Godot-v2).
+
+## Cross-refs
+
+- Spec (ratified, on main): `docs/superpowers/specs/2026-06-03-worldgen-gapc-option-c-graph-combat-decouple-design.md`.
+- C1 plan + evidence: `docs/superpowers/plans/2026-06-04-gapc-optionc-c1-mode-aware-loadencounter.md`, `docs/playtest/2026-06-04-gapc-optionc-c1-real-fight-smoke.md`.
+- Memory: `project_meta_network_live_routing.md` (C1 + flip-gate corrected).
+- Reproduce the probe: `GIT_COMMIT=$(git rev-parse HEAD) META_NETWORK_ROUTING=true node tools/sim/full-loop-batch.js --runs 10 --policy greedy --out <dir>` (needs #2603 wiring).

--- a/docs/playtest/2026-06-04-optionc-phase3-retune-band-verify.md
+++ b/docs/playtest/2026-06-04-optionc-phase3-retune-band-verify.md
@@ -1,0 +1,69 @@
+---
+title: 'Option-C Phase 3 -- graph-mode re-tune band-verify (real rosters)'
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-04'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Option-C Phase 3 -- graph-mode re-tune band-verify (2026-06-04)
+
+## The disambiguation (why the 0/10 happened)
+
+The earlier graph-mode probe (N=10 greedy) returned **completion 0/10** with the real draft rosters
+(#2603 wiring). This doc disambiguates: was it the terminal-climax gate (-> needs Phase 2
+retry-allowance) or a stale calibration overlay?
+
+`calibrationScaling()` applied **countMult 5 + hpAdd 4** -- a graph-mode default tuned for the
+WEAK-FIXED fallback enemies (#2589, pre-#2603). Applied to the REAL authored rosters that #2603 now
+loads, that is `5x` an authored hardcore roster -> brutal -> 0/10.
+
+**Neutralising the overlay isolates the cause:**
+
+| overlay (graph-mode, greedy)     | completion | reading                                                |
+| -------------------------------- | ---------- | ------------------------------------------------------ |
+| countMult 1 + hpAdd 0 (authored) | **10/10**  | the real rosters incl the terminal climax are WINNABLE |
+| countMult 3 + hpAdd 2            | ~0.6-0.75  | band-landing                                           |
+| countMult 4 + hpAdd 0            | 0.1        | too hard                                               |
+| countMult 5 + hpAdd 4 (stale)    | **0**      | the artifact                                           |
+
+→ **The 0/10 was a CALIBRATION ARTIFACT, not an inherent climax gate.** The terminal climax is
+winnable (10/10 at authored). **Therefore retry-allowance (option-C Phase 2) is NOT needed and is
+dropped.** The fix is a single knob: the graph-mode overlay drops to `countMult 3 + hpAdd 2`.
+
+## N=40 ratify (countMult 3 + hpAdd 2, `--isolate`)
+
+| policy | completion        | vs #2589 ratified band (0.4-0.85) |
+| ------ | ----------------- | :-------------------------------: |
+| greedy | 30/40 = **0.75**  |                ✅                 |
+| ESFP   | 31/40 = **0.775** |                ✅                 |
+| INTJ   | 31/40 = **0.775** |                ✅                 |
+
+Consistent ~0.77 across policies (the policy spread is tight at N=40, unlike the N=12 probe). This
+sits inside the **#2589-ratified wider band (0.4-0.85)** but **above the 0.4-0.7 PROVISIONAL** still
+shown by `meta-band-aggregator` (the aggregator's provisional was never widened to the ratified
+number). The razor-steep HP curve (a documented #2589 property) keeps integer knobs from pinning a
+tighter centre.
+
+## What shipped + what is owner-gated
+
+- **Shipped (this PR):** `calibrationScaling()` graph-mode default `countMult 5 + hpAdd 4 -> 3 + 2`
+  (`tools/sim/full-loop-batch.js`); static default (`countMult 5 + hpAdd 3`) unchanged -> ratified
+  static `cave_path` bands hold (graph-only change, test-locked 25/25). Phase 2 dropped.
+- **Owner re-ratify (master-dd decision-handoff):** the graph-mode completion centre is ~0.77.
+  Ratify it as the band (it is within the already-ratified 0.4-0.85), OR ask for a tighter centre
+  (~0.6) -- a slightly harder overlay (e.g. `countMult 3 + hpAdd 3`) would lower it, at the cost of
+  the razor-steep variance. Also: update the aggregator's PROVISIONAL_BANDS to the ratified number.
+- **Then:** the flip (the only remaining option-C step) + the Godot `graph_mode:true` consumer wire.
+
+## Reproduce
+
+```
+META_NETWORK_ROUTING=true FL_ENEMY_COUNT_MULT=3 FL_ENEMY_HP_ADD=2 \
+  node tools/sim/full-loop-batch.js --runs 40 --policy greedy --isolate --out <dir>
+```
+
+(needs the #2603 real-roster wiring; without `FL_ENEMY_*` the new graph-mode default is the same cm3/hp2.)

--- a/docs/playtest/2026-06-04-optionc-phase3-retune-band-verify.md
+++ b/docs/playtest/2026-06-04-optionc-phase3-retune-band-verify.md
@@ -34,30 +34,34 @@ loads, that is `5x` an authored hardcore roster -> brutal -> 0/10.
 winnable (10/10 at authored). **Therefore retry-allowance (option-C Phase 2) is NOT needed and is
 dropped.** The fix is a single knob: the graph-mode overlay drops to `countMult 3 + hpAdd 2`.
 
-## N=40 ratify (countMult 3 + hpAdd 2, `--isolate`)
+## N=40 ratify (countMult 3 + hpAdd 2 + dcAdd 1, `--isolate`)
 
-| policy | completion        | vs #2589 ratified band (0.4-0.85) |
-| ------ | ----------------- | :-------------------------------: |
-| greedy | 30/40 = **0.75**  |                ✅                 |
-| ESFP   | 31/40 = **0.775** |                ✅                 |
-| INTJ   | 31/40 = **0.775** |                ✅                 |
+master-dd chose the TIGHTER ~0.6 centre over the easy ~0.77. The razor-steep HP curve cannot pin a
+tight centre (`hpAdd 2 -> 3` jumps ~0.77 -> ~0.2), so the fine knob is **`dcAdd`** (enemy defense;
+sim-only -- does NOT change the encounter telegraph or the actual game combat):
 
-Consistent ~0.77 across policies (the policy spread is tight at N=40, unlike the N=12 probe). This
-sits inside the **#2589-ratified wider band (0.4-0.85)** but **above the 0.4-0.7 PROVISIONAL** still
-shown by `meta-band-aggregator` (the aggregator's provisional was never widened to the ratified
-number). The razor-steep HP curve (a documented #2589 property) keeps integer knobs from pinning a
-tighter centre.
+| overlay (cm3 + hp2 +) | greedy    | ESFP     | INTJ     | centre            |
+| --------------------- | --------- | -------- | -------- | ----------------- |
+| dcAdd 0               | 0.75      | 0.775    | 0.775    | ~0.77 (easy)      |
+| **dcAdd 1 (ADOPTED)** | **0.675** | **0.70** | **0.60** | **~0.66 (tight)** |
+| dcAdd 2               | 0.375     | 0.575    | 0.45     | ~0.47 (hard)      |
+
+**Adopted `dcAdd 1`:** N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60 -- all inside the tight **0.4-0.7**
+band, INTJ right at the ~0.6 target. (`0.6` exactly is not pinnable; the integer-knob distribution
+is the QD-healthy reality the #2589 razor-steep property predicts.)
 
 ## What shipped + what is owner-gated
 
-- **Shipped (this PR):** `calibrationScaling()` graph-mode default `countMult 5 + hpAdd 4 -> 3 + 2`
-  (`tools/sim/full-loop-batch.js`); static default (`countMult 5 + hpAdd 3`) unchanged -> ratified
-  static `cave_path` bands hold (graph-only change, test-locked 25/25). Phase 2 dropped.
-- **Owner re-ratify (master-dd decision-handoff):** the graph-mode completion centre is ~0.77.
-  Ratify it as the band (it is within the already-ratified 0.4-0.85), OR ask for a tighter centre
-  (~0.6) -- a slightly harder overlay (e.g. `countMult 3 + hpAdd 3`) would lower it, at the cost of
-  the razor-steep variance. Also: update the aggregator's PROVISIONAL_BANDS to the ratified number.
-- **Then:** the flip (the only remaining option-C step) + the Godot `graph_mode:true` consumer wire.
+- **Shipped (this PR):** `calibrationScaling()` graph-mode default `countMult 5 + hpAdd 4 -> countMult
+3 + hpAdd 2 + dcAdd 1` (`tools/sim/full-loop-batch.js`); static default (`countMult 5 + hpAdd 3 +
+dcAdd 0`) unchanged -> ratified static `cave_path` bands hold (graph-only, test-locked 25/25).
+  option-C Phase 2 (retry-allowance) dropped.
+- **Owner re-ratify (master-dd):** completion centre ~0.66, inside the tight 0.4-0.7 band (the chosen
+  target). Update the `meta-band-aggregator` PROVISIONAL_BANDS to ratify it.
+- **Then:** merge; the Godot `graph_mode` consumer -- 🔴 the Godot game runs combat LOCALLY
+  (`round_orchestrator` + D20Resolver), NOT via the backend `/session/start`, so the routed draft
+  encounters need Godot-side loading (a GDScript C1 equivalent) -- NOT a one-line body flag, scope
+  separately before the flip; then the flip.
 
 ## Reproduce
 

--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -176,12 +176,18 @@ test('calibrationScaling: graph-mode (META_NETWORK_ROUTING) re-calibrates to cou
     delete process.env.META_NETWORK_ROUTING;
     assert.equal(calibrationScaling().hpAdd, 3, 'static-chain hpAdd default unchanged');
     assert.equal(calibrationScaling().countMult, 5, 'static-chain countMult default unchanged');
+    assert.equal(calibrationScaling().dcAdd, 0, 'static-chain dcAdd default unchanged');
     process.env.META_NETWORK_ROUTING = 'true';
     assert.equal(calibrationScaling().hpAdd, 2, 'graph-mode re-calibrated hpAdd (real rosters)');
     assert.equal(
       calibrationScaling().countMult,
       3,
       'graph-mode re-calibrated countMult (real rosters)',
+    );
+    assert.equal(
+      calibrationScaling().dcAdd,
+      1,
+      'graph-mode re-calibrated dcAdd (fine knob, real rosters)',
     );
     // env override still wins over the graph-mode default.
     process.env.FL_ENEMY_HP_ADD = '9';

--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -165,17 +165,24 @@ test('calibrationScaling: FL_ENEMY_* env overrides each knob (robust to baked de
   }
 });
 
-// Graph-mode re-calibration: shorter graph routes leave completion too high at the static hpAdd 3,
-// so META_NETWORK_ROUTING=true bumps the baked hpAdd to 4 (band centre); the static default stays 3.
-test('calibrationScaling: graph-mode (META_NETWORK_ROUTING) bumps baked hpAdd 3 -> 4', () => {
+// Graph-mode re-calibration (REAL draft rosters, option-C #2603): the draft nodes now fight their
+// REAL rosters, so the static overlay countMult 5 + hpAdd 4 is brutal (5x a hardcore roster -> 0/10).
+// META_NETWORK_ROUTING=true drops the baked overlay to countMult 3 + hpAdd 2 (N=40 greedy/ESFP/INTJ
+// land in the ratified wider band 0.4-0.85); the static default stays countMult 5 + hpAdd 3.
+test('calibrationScaling: graph-mode (META_NETWORK_ROUTING) re-calibrates to countMult 3 + hpAdd 2', () => {
   for (const k of ['FL_ENEMY_HP_ADD', 'FL_ENEMY_COUNT_MULT']) delete process.env[k];
   const prev = process.env.META_NETWORK_ROUTING;
   try {
     delete process.env.META_NETWORK_ROUTING;
-    assert.equal(calibrationScaling().hpAdd, 3, 'static-chain default unchanged');
+    assert.equal(calibrationScaling().hpAdd, 3, 'static-chain hpAdd default unchanged');
+    assert.equal(calibrationScaling().countMult, 5, 'static-chain countMult default unchanged');
     process.env.META_NETWORK_ROUTING = 'true';
-    assert.equal(calibrationScaling().hpAdd, 4, 'graph-mode re-calibrated default');
-    assert.equal(calibrationScaling().countMult, 5, 'countMult unchanged in graph mode');
+    assert.equal(calibrationScaling().hpAdd, 2, 'graph-mode re-calibrated hpAdd (real rosters)');
+    assert.equal(
+      calibrationScaling().countMult,
+      3,
+      'graph-mode re-calibrated countMult (real rosters)',
+    );
     // env override still wins over the graph-mode default.
     process.env.FL_ENEMY_HP_ADD = '9';
     assert.equal(calibrationScaling().hpAdd, 9, 'env override beats the graph-mode default');

--- a/tests/sim/scenarioEnemiesGraphMode.test.js
+++ b/tests/sim/scenarioEnemiesGraphMode.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// GAP-C option-C band-verify wiring: the sim must fight the REAL draft node-encounter
+// rosters in graph mode (mirror combat C1). Without graphMode, draft ids stay null ->
+// runner falls back to the weak-fixed enemy (the pre-C1 sim behavior, static-band-safe).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildScenarioEnemies } = require('../../tools/sim/scenario-enemies');
+
+test('buildScenarioEnemies: draft id -> null without graphMode (encounters/-only)', () => {
+  assert.equal(buildScenarioEnemies('enc_tutorial_03'), null);
+});
+
+test('buildScenarioEnemies: draft id -> real roster with graphMode (unions encounters-draft/)', () => {
+  const enemies = buildScenarioEnemies('enc_tutorial_03', {}, { graphMode: true });
+  assert.ok(Array.isArray(enemies) && enemies.length > 0, 'draft roster built in graph mode');
+  assert.ok(enemies[0].hp > 0, 'enemy has hp');
+  assert.equal(enemies[0].controlled_by, 'sistema');
+});
+
+test('buildScenarioEnemies: live id builds in both modes (static unchanged)', () => {
+  assert.ok(buildScenarioEnemies('enc_savana_01'), 'live encounter in static mode');
+  assert.ok(buildScenarioEnemies('enc_savana_01', {}, { graphMode: true }), 'live in graph mode');
+});

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -248,18 +248,21 @@ function calibrationScaling() {
   // completion_rate lands in the provisional 0.4-0.7 band. Each FL_ENEMY_* env var overrides
   // one knob for re-calibration. (hpAdd not hpMult: integer per-unit HP is the natural dial.)
   //
-  // Graph-mode re-calibration (META_NETWORK_ROUTING=true): the graph routes are SHORTER than the
-  // static cave_path (greedy 3 nodes, ESFP 5) so the static hpAdd 3 leaves completion too high
-  // (greedy 0.9 / ESFP 0.825, OOB). hpAdd 4 (graph-mode default) re-centres it (greedy ~0.65 in
-  // band; ESFP ~0.75 -- its recruit-snowball over the longer route keeps it marginally above 0.7,
-  // a known route-length effect). The HP curve is razor-steep (hpAdd 3->0.9, 4->0.65, 5->0.2),
-  // so 4 is the band centre. The static default (3) is unchanged -> the ratified static bands hold.
+  // Graph-mode re-calibration (META_NETWORK_ROUTING=true, REAL draft rosters via option-C #2603):
+  // once the draft node-encounters fight their REAL authored rosters (not the weak-fixed fallback),
+  // the static overlay countMult 5 + hpAdd 4 is brutal (5x an authored hardcore roster -> 0/10).
+  // The real rosters are already substantial, so the graph overlay drops to countMult 3 + hpAdd 2:
+  // N=40 lands greedy + ESFP inside the 0.4-0.7 band (INTJ snowballs marginally above = a documented
+  // route/policy spread, QD-healthy). KEY: the original 0/10 was a CALIBRATION ARTIFACT of the stale
+  // fallback-tuned overlay, NOT an inherent climax gate -- the terminal climax is winnable, so NO
+  // retry-allowance mechanic is needed (option-C Phase 2 dropped). The static default (countMult 5,
+  // hpAdd 3) is unchanged -> the ratified static cave_path bands hold.
   const graphMode = process.env.META_NETWORK_ROUTING === 'true';
   return {
-    countMult: num('FL_ENEMY_COUNT_MULT', 5),
+    countMult: num('FL_ENEMY_COUNT_MULT', graphMode ? 3 : 5),
     countAdd: num('FL_ENEMY_COUNT_ADD', 0),
     hpMult: num('FL_ENEMY_HP_MULT', 1),
-    hpAdd: num('FL_ENEMY_HP_ADD', graphMode ? 4 : 3),
+    hpAdd: num('FL_ENEMY_HP_ADD', graphMode ? 2 : 3),
     modAdd: num('FL_ENEMY_MOD_ADD', 0),
     dcAdd: num('FL_ENEMY_DC_ADD', 0),
   };

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -251,9 +251,10 @@ function calibrationScaling() {
   // Graph-mode re-calibration (META_NETWORK_ROUTING=true, REAL draft rosters via option-C #2603):
   // once the draft node-encounters fight their REAL authored rosters (not the weak-fixed fallback),
   // the static overlay countMult 5 + hpAdd 4 is brutal (5x an authored hardcore roster -> 0/10).
-  // The real rosters are already substantial, so the graph overlay drops to countMult 3 + hpAdd 2:
-  // N=40 lands greedy + ESFP inside the 0.4-0.7 band (INTJ snowballs marginally above = a documented
-  // route/policy spread, QD-healthy). KEY: the original 0/10 was a CALIBRATION ARTIFACT of the stale
+  // The real rosters are already substantial, so the graph overlay drops to countMult 3 + hpAdd 2 +
+  // dcAdd 1 (dcAdd = the fine knob; the razor-steep HP curve cannot pin a tight centre on its own --
+  // hpAdd 2->3 jumps ~0.77->~0.2). N=40 lands all three policies in the tight 0.4-0.7 band (greedy
+  // 0.675 / ESFP 0.70 / INTJ 0.60). KEY: the original 0/10 was a CALIBRATION ARTIFACT of the stale
   // fallback-tuned overlay, NOT an inherent climax gate -- the terminal climax is winnable, so NO
   // retry-allowance mechanic is needed (option-C Phase 2 dropped). The static default (countMult 5,
   // hpAdd 3) is unchanged -> the ratified static cave_path bands hold.
@@ -264,7 +265,7 @@ function calibrationScaling() {
     hpMult: num('FL_ENEMY_HP_MULT', 1),
     hpAdd: num('FL_ENEMY_HP_ADD', graphMode ? 2 : 3),
     modAdd: num('FL_ENEMY_MOD_ADD', 0),
-    dcAdd: num('FL_ENEMY_DC_ADD', 0),
+    dcAdd: num('FL_ENEMY_DC_ADD', graphMode ? 1 : 0),
   };
 }
 

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -274,7 +274,9 @@ async function runFullLoop(http, opts = {}) {
     // fase-2a scaled enemies: load the chapter's real encounter roster from YAML; fall
     // back to the weak-fixed enemy when the encounter has no YAML (cave_path: tutorial_03/
     // 04/05 + tutorial_06_hardcore) or an unsupported objective, so the loop still runs.
-    const scaledEnemies = buildScenarioEnemies(enc, enemyScaling);
+    // GAP-C option-C: in graph mode union encounters-draft/ (mirror combat C1) so the draft
+    // route nodes fight their REAL rosters -> the meta band-verify measures real difficulty.
+    const scaledEnemies = buildScenarioEnemies(enc, enemyScaling, { graphMode });
     const enemies = scaledEnemies && scaledEnemies.length ? scaledEnemies : enemiesForChapter(step);
     const enemiesSource = scaledEnemies && scaledEnemies.length ? 'scenario' : 'fallback';
 

--- a/tools/sim/scenario-enemies.js
+++ b/tools/sim/scenario-enemies.js
@@ -21,6 +21,14 @@ const path = require('node:path');
 const yaml = require('js-yaml');
 
 const ENCOUNTER_DIR = path.resolve(__dirname, '..', '..', 'docs', 'planning', 'encounters');
+const ENCOUNTER_DRAFT_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'docs',
+  'planning',
+  'encounters-draft',
+);
 
 // Tier -> base combat stats (mirrors ai-driven-sim buildEnemiesFromYaml hp/mod table;
 // dc scales with tier so higher tiers are also harder to hit). These are the FAITHFUL
@@ -48,7 +56,7 @@ const SUPPORTED_OBJECTIVES = new Set(['elimination']);
 // decisive lever: damage is ~1-3/hit, so 2 units can never out-race a 60-HP party -- more
 // units can); hpMult/hpAdd + modAdd/dcAdd tune the per-unit knife-edge. Pure DI (no env
 // global) so it stays unit-testable + the batch records the values in provenance.
-function buildScenarioEnemies(scenarioId, scaling = {}) {
+function buildScenarioEnemies(scenarioId, scaling = {}, opts = {}) {
   const s = scaling || {};
   const num = (v, d) => (Number.isFinite(Number(v)) ? Number(v) : d);
   const countMult = num(s.countMult, 1);
@@ -58,7 +66,13 @@ function buildScenarioEnemies(scenarioId, scaling = {}) {
   const modAdd = num(s.modAdd, 0);
   const dcAdd = num(s.dcAdd, 0);
 
-  const yamlPath = path.join(ENCOUNTER_DIR, `${scenarioId}.yaml`);
+  // GAP-C option-C band-verify: graph-mode runs union encounters-draft/ (mirror combat C1)
+  // so the 4 draft node-encounters fight their REAL rosters; static runs stay encounters/-only
+  // (the weak-fixed fallback) -> ratified static cave_path bands untouched.
+  let yamlPath = path.join(ENCOUNTER_DIR, `${scenarioId}.yaml`);
+  if (!fs.existsSync(yamlPath) && opts.graphMode) {
+    yamlPath = path.join(ENCOUNTER_DRAFT_DIR, `${scenarioId}.yaml`);
+  }
   if (!fs.existsSync(yamlPath)) return null;
 
   let parsed;


### PR DESCRIPTION
## Cosa

Option-C **Phase-3 prep** (band-verify fidelity): the meta-network graph-mode sim now fights the REAL draft node-encounter rosters. Before this, `buildScenarioEnemies` read `encounters/` only -> the 4 draft nodes (enc_tutorial_03/04/05/07) fell back to weak-fixed enemies -> the graph-mode meta band-verify (including the #2589 ratified bands) measured FALLBACK combat, not the real route difficulty.

## Come (additivo, sim-only, mirror combat C1 #2601)

- `tools/sim/scenario-enemies.js`: `buildScenarioEnemies(id, scaling, { graphMode })` unions `encounters-draft/` when graphMode; static runs stay `encounters/`-only (weak-fixed fallback) -> ratified static cave_path bands untouched.
- `tools/sim/full-loop-runner.js`: passes `{ graphMode }` (already in scope from `META_NETWORK_ROUTING`).

## Measurement (the reason this matters)

With this wiring, an N=10 greedy graph-mode probe (`META_NETWORK_ROUTING=true node tools/sim/full-loop-batch.js --runs 10 --policy greedy`) measured **completion 0/10** (band 0.4-0.7). Dominant blocker = the **terminal climax `enc_tutorial_05`** timeout (6/10, after winning the 2 live fights) + occasional `enc_savana_01` timeout (4/10). The 0/10 is REAL difficulty (a graph descent chains up to 4 real gating fights) -- NOT a bug. It CONFOUNDS two causes:

1. the terminal-climax gate -> **Phase 2 retry-allowance** (ratified, unbuilt);
2. a stale `calibrationScaling` (hpAdd4, tuned for the fallback enemies, now over-hard on real rosters -> even savana times out) -> **Phase 3 re-tune**.

## Test

- New `tests/sim/scenarioEnemiesGraphMode.test.js` (3): draft -> null static / real roster with graphMode / live both modes.
- Regression: `scenarioEnemies` 7/7, full-loop suite 41/41.

## Scope / gate

Band-verify FIDELITY only. Does NOT change the game (flag OFF in prod; sim-only difficulty). **THE FLIP stays gated on Phase 2 + Phase 3 (re-tune `calibrationScaling` on real rosters + re-ratify #2589) + master-dd go.** See the option-C handoff `docs/planning/2026-06-04-option-c-handoff.md`.

## Rollback (03A)

Revert the commit -- additive, sim-only, no schema/contract change.
