### PR TITLE
chore(sim): record graph-mode band re-ratify (0.4-0.7, dcAdd1)

### DIFF
--- a/docs/planning/2026-06-04-session-handoff-optionc-flip.md
+++ b/docs/planning/2026-06-04-session-handoff-optionc-flip.md
@@ -1,0 +1,71 @@
+---
+title: 'Session handoff 2026-06-04 -- option-C to the flip + Godot step-8'
+date: 2026-06-04
+doc_status: active
+doc_owner: master-dd
+workstream: worldgen
+last_verified: '2026-06-04'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Session handoff 2026-06-04 -- option-C route-choice to the flip
+
+## TL;DR
+
+This session took GAP-C fase-3 (meta-network route choice) from "flip-ready?" to **backend-complete +
+calibrated**, and discovered the **real** remaining work (a Godot-side change, NOT a flag flip). The
+flip is now gated on ONE substantial sub-task -> handed to a fresh chip.
+
+## What was DONE this session (all merged unless noted)
+
+| #   | Item                                                 | Ref                                                                        | Note                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| --- | ---------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Flip-readiness re-verified                           | --                                                                         | The handoff brief was STALE (anti-pattern #19): the prereq (start_node + candidate enrichment) was ALREADY shipped (#2582/#2592/#2593). Proved via isolated-worktree flag-on HTTP smoke 6/6.                                                                                                                                                                                                                                                                                                                         |
+| 2   | The REAL gap found (via master-dd "controlla #2597") | #2599                                                                      | Flag-on delivered route choice for all 6 nodes but a REAL fight for only **2/6** -- the 4 draft nodes (incl the terminal climax) degraded to a fallback.                                                                                                                                                                                                                                                                                                                                                             |
+| 3   | **C1 -- mode-aware loadEncounter**                   | [#2601](https://github.com/MasterDD-L34D/Game/pull/2601) `3ab6aca7` MERGED | `loadEncounter(id,{graphMode})` unions `encounters-draft/` -> 7/7 real fights. Static byte-stable.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| 4   | **#406 mating facade** evaluated + merged            | GGv2 #406 `4ddfceb8` MERGED                                                | Ground-truthed: code = handoff exactly (compose-only, backend-canonical, additive). Dead-by-design (no live caller).                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 5   | **12h PR audit**                                     | --                                                                         | Mating loop ALREADY lit (live consumers recruit #399 / mating #400 / route-vote #404) -> the facade Gate-5 is LOW value. Route-choice (option-C) is the high-leverage DARK built work. Orphan: Game **#2512** (drift-audit draft: 74 stale branches + 60 ADR-no-status, owner housekeeping).                                                                                                                                                                                                                         |
+| 6   | **option-C Phase 3 re-tune** (autonomous)            | [#2603](https://github.com/MasterDD-L34D/Game/pull/2603) `7ab8550f` MERGED | 🔑 the N=10 **0/10 was a CALIBRATION ARTIFACT, not a climax gate** (at the AUTHORED overlay completion = 10/10). The stale `countMult 5 + hpAdd 4` (tuned for the weak FALLBACK enemies) was 5x an authored hardcore roster. **-> Phase 2 (retry-allowance) DROPPED.** Re-tuned graph-mode overlay -> `cm3/hp2/dcAdd1` (master-dd chose the tighter ~0.6): N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60 = tight 0.4-0.7 band. Also wired the sim to fight real draft rosters (`buildScenarioEnemies(...,{graphMode})`). |
+| 7   | Band re-ratify                                       | [#2604](https://github.com/MasterDD-L34D/Game/pull/2604) (merging)         | aggregator PROVISIONAL_BANDS note records the 2026-06-04 graph-mode re-ratify (band 0.4-0.7 holds).                                                                                                                                                                                                                                                                                                                                                                                                                  |
+
+**option-C BACKEND is now fully on main** (#2599 spec + #2601 C1 + #2603 sim/re-tune + #2604 re-ratify). Phase 2 eliminated.
+
+## 🔴 The REAL remaining work (for the chip) -- Godot step-8
+
+`META_NETWORK_ROUTING` flips the BACKEND graph routing. But the route-choice UI (`#401` single + `#404`
+co-op, both MERGED on GGv2) leads into combat that the Godot game runs **LOCALLY**:
+`main_route_choice.gd` stamps `next_encounter_id` -> re-entry -> `main.gd:188`
+`round_orchestrator.start_session(unit_specs, D20Resolver)`. The Godot game does NOT appear to delegate
+combat to the backend `/session/start` -- so the backend C1 graph_mode is consumed by the SIM only, NOT
+the game. **Therefore the routed draft encounters (enc_tutorial_03/04/05/07) need GODOT-side loading**
+(a GDScript C1 equivalent / encounter catalog) before the flip delivers real routed fights.
+
+**Chip tasks (in order):**
+
+1. 🔴 VERIFY the "round_orchestrator is local, no backend /session/start" claim with a FULL read (it was
+   concluded from a grep -- anti-pattern #19; `round_orchestrator.gd` was in the `/session/start` caller
+   list). Confirm where the Godot game gets the routed encounter roster.
+2. If local: brainstorm -> spec -> build a GDScript path so the Godot game can load + fight the draft
+   node-encounters in graph mode (GUT-tested; **godot v4.6.2 IS available locally** at
+   `C:/dev/tools/godot/Godot_v4.6.2-stable_win64_console.exe`; GUT headless =
+   `--headless -s addons/gut/gut_cmdln.gd -gdir=res://tests/unit -gexit`). Cross-repo Game-Godot-v2.
+3. THEN the flip (master-dd authorized "accetto"): FF the lenovo-host worktree (`C:/dev/_gamewt-lenovo-host`)
+   to main + `export META_NETWORK_ROUTING=true` in `~/.config/api-keys/keys.env` + restart the
+   `EvoTacticsBackend` scheduled task (self-heal launcher frees ports 3334/3341). Verify
+   `evo-tactics.com/api/campaign/meta-network/next` -> `enabled:true` + a `/start->/advance->/choose` smoke.
+   Reversible (unset env + restart). DO NOT flip before step 2 (route UI works but routed fights break).
+
+## Lower-priority parallel items (NOT blocking the flip)
+
+- Game **#2512** orphan: batch-delete 74 stale branches (mostly `codex/*` Oct-Nov 2025) + backfill 60 ADR `status:` fields. Owner housekeeping.
+- Canvas-D **active** mating UI (consumes #406 facade): LOW marginal value (the mating loop already has live consumers); a fresh feature, not a quick win.
+
+## Key references
+
+- option-C spec (ratified): `docs/superpowers/specs/2026-06-03-worldgen-gapc-option-c-graph-combat-decouple-design.md`
+- option-C handoff (Phase tracking): `docs/planning/2026-06-04-option-c-handoff.md`
+- Band-verify: `docs/playtest/2026-06-04-optionc-phase3-retune-band-verify.md`
+- Memory: `project_meta_network_live_routing.md` (full arc + flip mechanics + godot-available correction)
+- The flip mechanics + prod topology: memory `project_meta_network_live_routing.md` (lenovo-host always-on, cloudflared -> evo-tactics.com).

--- a/tools/sim/meta-band-aggregator.js
+++ b/tools/sim/meta-band-aggregator.js
@@ -36,7 +36,10 @@ const PROVISIONAL_BANDS = {
   note:
     'RATIFIED 2026-06-03 by master-dd (L-069): the working bands. Reversible (two-way door) -- ' +
     'revise when evidence warrants. Keep the design space healthy (Quality-Diversity); do not ' +
-    'optimize to a single best run.',
+    'optimize to a single best run. GRAPH-MODE RE-RATIFIED 2026-06-04 by master-dd (#2603): with ' +
+    'the real draft rosters + the cm3/hp2/dcAdd1 overlay, graph-mode completion lands ~0.66 ' +
+    '(N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60), inside this 0.4-0.7 band -- the fallback-era ' +
+    'wider 0.4-0.85 is superseded; completion_rate [0.4, 0.7] holds for both static and graph mode.',
 };
 
 function mean(arr) {


### PR DESCRIPTION
## Cosa

Records master-dd's **graph-mode completion band re-ratify** (2026-06-04, post #2603) in the `meta-band-aggregator` PROVISIONAL_BANDS note. With the real draft rosters (#2603) + the `cm3/hp2/dcAdd1` overlay, graph-mode completion lands **~0.66** (N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60), inside the **0.4-0.7** band. The fallback-era wider 0.4-0.85 is superseded.

**Band number `[0.4, 0.7]` unchanged** (already correct) -> annotation only. Static bands untouched. No code-path change.

Band-verify: `docs/playtest/2026-06-04-optionc-phase3-retune-band-verify.md`.