### PR TITLE
feat(encounters): canonical species_id on GAP-C route encounters (#418 Game side)

### DIFF
--- a/apps/backend/services/combat/reinforcementSpawner.js
+++ b/apps/backend/services/combat/reinforcementSpawner.js
@@ -267,6 +267,11 @@ function tick(session, encounter, opts = {}) {
     const newUnit = {
       id: unitId,
       species: entry.unit_id,
+      // GAP-C #418: carry the canonical species_id when the pool entry authors
+      // one (empty otherwise -> the no-canonical-species path, same contract as
+      // the initial-wave units). Lets a recruit/species consumer resolve the
+      // real creature instead of the archetype label.
+      species_id: entry.species_id || '',
       controlled_by: 'sistema',
       position: tile,
       hp: Number(entry.hp) || 8,

--- a/docs/planning/encounters-draft/enc_tutorial_03.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_03.yaml
@@ -32,10 +32,12 @@ waves:
       - [9, 6]
     units:
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 2
         tier: base
         ai_profile: aggressive
       - species: custode_basalto
+        species_id: terracetus_ambulator
         count: 1
         tier: elite
         ai_profile: territorial
@@ -46,6 +48,7 @@ waves:
       - [8, 8]
     units:
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 2
         tier: base
         ai_profile: flanking

--- a/docs/planning/encounters-draft/enc_tutorial_04.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_04.yaml
@@ -31,10 +31,12 @@ waves:
       - [9, 5]
     units:
       - species: cartografi_subsonici
+        species_id: rupicapra_sensoria
         count: 2
         tier: base
         ai_profile: support
       - species: guardiani_risonanza
+        species_id: leviatano_risonante
         count: 1
         tier: elite
         ai_profile: territorial
@@ -45,10 +47,12 @@ waves:
       - [8, 8]
     units:
       - species: guardiani_risonanza
+        species_id: leviatano_risonante
         count: 1
         tier: elite
         ai_profile: aggressive
       - species: cartografi_subsonici
+        species_id: rupicapra_sensoria
         count: 1
         tier: base
         ai_profile: cautious

--- a/docs/planning/encounters-draft/enc_tutorial_05.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_05.yaml
@@ -32,10 +32,12 @@ waves:
       - [9, 6]
     units:
       - species: guardiani_risonanza
+        species_id: leviatano_risonante
         count: 2
         tier: elite
         ai_profile: territorial
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 1
         tier: base
         ai_profile: flanking
@@ -46,10 +48,12 @@ waves:
       - [5, 0]
     units:
       - species: custode_basalto
+        species_id: terracetus_ambulator
         count: 1
         tier: apex
         ai_profile: aggressive
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 1
         tier: elite
         ai_profile: flanking

--- a/docs/planning/encounters-draft/enc_tutorial_06_hardcore.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_06_hardcore.yaml
@@ -46,6 +46,7 @@ waves:
 
 reinforcement_pool:
   - unit_id: predoni_nomadi
+    species_id: gulogluteus_scutiger
     weight: 3
     max_spawns: 4
     hp: 7
@@ -53,6 +54,7 @@ reinforcement_pool:
     dc: 12
     ai_profile: aggressive
   - unit_id: guardiani_risonanza_elite
+    species_id: leviatano_risonante
     weight: 1
     max_spawns: 2
     hp: 10

--- a/docs/planning/encounters-draft/enc_tutorial_06_hardcore.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_06_hardcore.yaml
@@ -34,10 +34,12 @@ waves:
       - [9, 6]
     units:
       - species: guardiani_risonanza
+        species_id: leviatano_risonante
         count: 2
         tier: elite
         ai_profile: aggressive
       - species: custode_basalto
+        species_id: terracetus_ambulator
         count: 1
         tier: apex
         ai_profile: flanking

--- a/docs/planning/encounters-draft/enc_tutorial_07_hardcore_pod_rush.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_07_hardcore_pod_rush.yaml
@@ -34,10 +34,12 @@ waves:
       - [9, 7]
     units:
       - species: bracconieri_echomantici
+        species_id: anguis_magnetica
         count: 4
         tier: base
         ai_profile: aggressive
       - species: guardiani_risonanza
+        species_id: leviatano_risonante
         count: 1
         tier: elite
         ai_profile: territorial

--- a/docs/planning/encounters-draft/enc_tutorial_07_hardcore_pod_rush.yaml
+++ b/docs/planning/encounters-draft/enc_tutorial_07_hardcore_pod_rush.yaml
@@ -46,6 +46,7 @@ waves:
 
 reinforcement_pool:
   - unit_id: bracconieri_echomantici
+    species_id: anguis_magnetica
     weight: 4
     max_spawns: 6
     hp: 7

--- a/docs/planning/encounters/enc_capture_01.yaml
+++ b/docs/planning/encounters/enc_capture_01.yaml
@@ -40,10 +40,12 @@ waves:
       - [0, 9]
     units:
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 2
         tier: base
         ai_profile: aggressive
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 1
         tier: elite
         ai_profile: flanking
@@ -55,6 +57,7 @@ waves:
       - [9, 5]
     units:
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 2
         tier: base
         ai_profile: balanced

--- a/docs/planning/encounters/enc_caverna_02.yaml
+++ b/docs/planning/encounters/enc_caverna_02.yaml
@@ -33,10 +33,12 @@ waves:
       - [8, 3]
     units:
       - species: bracconieri_echomantici
+        species_id: anguis_magnetica
         count: 2
         tier: base
         ai_profile: aggressive
       - species: cartografi_subsonici
+        species_id: rupicapra_sensoria
         count: 1
         tier: base
         ai_profile: support
@@ -48,6 +50,7 @@ waves:
       - [4, 9]
     units:
       - species: guardiani_risonanza
+        species_id: leviatano_risonante
         count: 2
         tier: elite
         affixes: [eco]

--- a/docs/planning/encounters/enc_savana_01.yaml
+++ b/docs/planning/encounters/enc_savana_01.yaml
@@ -32,6 +32,7 @@ waves:
       - [9, 6]
     units:
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 2
         tier: base
         ai_profile: balanced
@@ -42,10 +43,12 @@ waves:
       - [8, 8]
     units:
       - species: custode_basalto
+        species_id: terracetus_ambulator
         count: 1
         tier: elite
         ai_profile: aggressive
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 1
         tier: base
         ai_profile: cautious

--- a/docs/planning/encounters/enc_tutorial_01.yaml
+++ b/docs/planning/encounters/enc_tutorial_01.yaml
@@ -29,6 +29,7 @@ waves:
       - [7, 5]
     units:
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 2
         tier: base
         ai_profile: defensive

--- a/docs/planning/encounters/enc_tutorial_02.yaml
+++ b/docs/planning/encounters/enc_tutorial_02.yaml
@@ -32,6 +32,7 @@ waves:
       - [7, 7]
     units:
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 2
         tier: base
         ai_profile: aggressive
@@ -42,6 +43,7 @@ waves:
       - [0, 7]
     units:
       - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
         count: 2
         tier: base
         ai_profile: balanced

--- a/schemas/evo/encounter.schema.json
+++ b/schemas/evo/encounter.schema.json
@@ -136,6 +136,7 @@
               "additionalProperties": false,
               "properties": {
                 "species": { "type": "string", "minLength": 1 },
+                "species_id": { "type": "string" },
                 "count": { "type": "integer", "minimum": 1 },
                 "tier": {
                   "type": "string",

--- a/tests/services/reinforcementSpawner.test.js
+++ b/tests/services/reinforcementSpawner.test.js
@@ -71,6 +71,44 @@ test('tick spawns 1 unit at Alert tier (budget 1)', () => {
   assert.deepEqual(spawn.spawn_tile, [9, 9]);
 });
 
+test('tick carries canonical species_id from pool entry to spawned unit (#418)', () => {
+  const session = mockSession({ pressure: 30 });
+  const enc = mockEncounter({
+    reinforcement_pool: [
+      {
+        unit_id: 'guardiani_risonanza_elite',
+        species_id: 'leviatano_risonante',
+        weight: 1.0,
+        max_spawns: 5,
+        hp: 10,
+        mod: 3,
+      },
+    ],
+  });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.spawned.length, 1);
+  const spawned = session.units.find((u) => u.reinforcement === true);
+  assert.equal(spawned.species, 'guardiani_risonanza_elite', 'species keeps the archetype label');
+  assert.equal(
+    spawned.species_id,
+    'leviatano_risonante',
+    'canonical species_id propagated so a recruit consumer resolves the real creature',
+  );
+});
+
+test('tick leaves species_id empty when the pool entry authors none (back-compat)', () => {
+  const session = mockSession({ pressure: 30 });
+  const enc = mockEncounter(); // minion_01, no species_id
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.spawned.length, 1);
+  const spawned = session.units.find((u) => u.reinforcement === true);
+  assert.equal(
+    spawned.species_id,
+    '',
+    'unauthored pool entry -> empty species_id (no label fallback)',
+  );
+});
+
 test('tick spawns 4 units at Apex tier (budget 4)', () => {
   const session = mockSession({ pressure: 95 }); // Apex → budget 4
   const enc = mockEncounter({


### PR DESCRIPTION
## GAP-C #418 (Game side) — canonical `species_id` on campaign-route encounters

Authors a ratified canonical `species_id` per wave unit on every encounter the meta-network graph routes, plus the schema field that makes it valid. With `META_NETWORK_ROUTING` ON, the Godot routed roster forwards a real species to `RecruitCandidatesBuilder` instead of the empty-string drop (codex P2 #417 no-label-fallback contract).

### What changed
- **Schema** `schemas/evo/encounter.schema.json`: add optional `species_id` (string) to the wave-unit object. It had `additionalProperties: false`, so the field was previously rejected.
- **Live encounters** `docs/planning/encounters/`: `enc_tutorial_01`, `enc_tutorial_02`, `enc_savana_01`, `enc_caverna_02`, `enc_capture_01`.
- **Draft encounters** `docs/planning/encounters-draft/`: `enc_tutorial_03..05`, `enc_tutorial_06_hardcore`, `enc_tutorial_07_hardcore_pod_rush`.

### Ratified foodweb mapping (5 archetype labels → 5 canonical creatures)
| archetype label | canonical species_id |
|---|---|
| predoni_nomadi | gulogluteus_scutiger |
| custode_basalto | terracetus_ambulator |
| guardiani_risonanza | leviatano_risonante |
| cartografi_subsonici | rupicapra_sensoria |
| bracconieri_echomantici | anguis_magnetica |

Mapping picked from the complete per-biome foodweb (trophic role + biome theme): only `gulogluteus_scutiger` + `anguis_magnetica` matched biome-faithfully; the other three mapped by trophic-role + theme onto the 15-species Godot tutorial catalog. Ratified by the owner.

### Verification
- `ajv` (draft 2020-12) PASS on all 10 edited encounters.
- Pre-commit `lint-staged` (prettier) clean.

### Scope notes (deferred, owner decision)
- `enc_escort_01`, `enc_survival_01`, `enc_hardcore_reinf_01` also use mapped archetypes but are **off the GAP-C campaign route** — left untouched to keep this PR to the route surface. A later content-consistency pass can fold them in.
- `enc_frattura_03`, `enc_savana_skiv_solo_vs_pack` use species **outside** the ratified 5-key mapping (araldi_fotofase, cori_voidsong, pulverator_gregarius, …) — these need their own canonical mapping decision.

### Paired PR
Godot side (consumes this via the additive `encounters.json`): MasterDD-L34D/Game-Godot-v2 `claude/gapc-418-godot-species`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
