### PR TITLE
chore(gitignore): ignore playtest parallel-hardcore run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,8 @@ apps/backend/public/phone/
 
 # 2026-05-21 staging-writer fix (issue #2356) -- ephemeral calibration candidate
 data/core/balance/damage_curves.staging.yaml
+
+# Playtest parallel-hardcore run artifacts (raw shards/streams/logs).
+# Historical runs already committed stay tracked; this stops NEW runs from
+# cluttering git status. To intentionally keep a run: git add -f.
+docs/playtest/parallel-hardcore_*


### PR DESCRIPTION
38 uncommitted `parallel-hardcore` sim outputs (2 runs: 2026-05-26-002805 + 2026-05-28-015205, shards/streams/logs) were cluttering `git status` on the Ryzen Game tree.

Adds `docs/playtest/parallel-hardcore_*` to .gitignore.

**Note (reviewed):** 82 sibling `parallel-hardcore_*` files are ALREADY tracked (historical runs committed intentionally). gitignore does NOT untrack them -- they stay. The rule only stops NEW runs from cluttering; to intentionally keep a future run, `git add -f`. Verified: post-rule `git status docs/playtest/` = clean, `git ls-files` parallel-hardcore = still 82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)