### PR TITLE
docs(governance): ratified decisions -- coop-server ADR + supersede 4 + tool skip-retired

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -54,6 +54,7 @@ Trigger: `docs/combat/README.md` SoT-flip review -- il README era `source_of_tru
 - **Task**: audit parita' def-by-def (~70 def Python da `d0c86c60~1:services/rules/*` vs Node `apps/backend/services/combat/*`). Delegabile (read+grep meccanico, Jules/LLM-locale + verifica). Home = SPEC-L (`runtime-feature-inventory-reconcile`).
 - **Priorita'**: P2, NON urgente (Node gira/funziona/testato). Dopo SPEC-K.
 - **DONE 2026-06-07** (sub-agent grep-verified, ~70 def vs Node): migrazione SOSTANZIALMENTE completa (resolver/round_orchestrator/hydration/grid/trait_effects portati; worker/demo obsoleti; damage-model divergenza intenzionale). **4 GAP** in stress/mental + PT-maneuver -> ticket sotto.
+- Related decisions 2026-06-07: ADR pincer/plan-reveal/networking-colyseus/networking-co-op = SUPERSEDED; new ADR-2026-05-30-coop-server-authoritative-combat written.
 
 ### 🔴 OPEN — Stress / on-hit-status mental layer: port-to-Node O retire orphaned yaml (da parity-sweep 2026-06-07)
 
@@ -62,8 +63,8 @@ Bug funzionale: effetti-trait progettati silenziosamente INERTI su Node + dati `
 - **GAP-1 (HIGH)**: `on_hit_status` + `trigger_dc` (SV d20+tier -> disorient/panic on hit) = LIVE yaml (multi-trait), ZERO consumer Node (`grep on_hit_status apps/` = 0).
 - **GAP-2 (HIGH)**: `on_hit_stress_delta` + breakpoint stress (rage@0.5 / panic@0.75) = LIVE yaml, nessuna logica Node -> loop "attacchi -> stress -> auto rage/panic" assente.
 - **GAP-3 (MEDIUM)**: `spinta` -> `sbilanciato` -> defense-malus: status scritto (shield_bash) ma mai LETTO come malus nel resolver.
-- **GAP-4 (LOW)**: swarm HP-scaling attacks -> NEEDS-HUMAN-CHECK (prob dead-on-arrival anche in Python).
-- **Decisione (Eduardo)**: portare il mental-state layer in `performAttack`, O ritirare i campi yaml orfani. Ref: `resolver.py` (d0c86c60~1) STEP3 vs `apps/backend/routes/session.js` performAttack + `traitEffects.js`.
+- **GAP-4 (DROP 2026-06-07)**: swarm `scaling_attacks` -- morto ovunque, mai dato live, esisteva solo nel Python rimosso; `multi_attack` copre lo spazio. No-action.
+- **Decisione (Eduardo)**: portare il mental-state layer in `performAttack`, O ritirare i campi yaml orfani. Ref: `resolver.py` (d0c86c60~1) STEP3 vs `apps/backend/routes/session.js` performAttack + `traitEffects.js`. DECISO 2026-06-07: D1 = HYBRID (PORT `on_hit_status` 13 trait in performAttack + RETIRE `on_hit_stress_delta` 2 trait); GAP-3 `sbilanciato` = WIRE-IT (statusModifiers read-path). -> code-batch pending.
 
 ### 🟢 P2 DONE 2026-06-07 — Sprint Impronta (aa01/cap-\*) = SUPERSEDE (design non-canonico)
 

--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -20,7 +20,7 @@
 ## Index per data (cronologico)
 
 <!-- gen:adr-index -->
-_Generato da `tools/generate_decisions_log.py` (69 ADR). NON editare a mano: editi gli ADR in `docs/adr/`._
+_Generato da `tools/generate_decisions_log.py` (70 ADR). NON editare a mano: editi gli ADR in `docs/adr/`._
 
 | Data | ADR | Titolo | Status |
 | --- | --- | --- | --- |
@@ -33,15 +33,15 @@ _Generato da `tools/generate_decisions_log.py` (69 ADR). NON editare a mano: edi
 | 2026-04-15 | [ADR-2026-04-15-round-based-combat-model](docs/adr/ADR-2026-04-15-round-based-combat-model.md) | ADR-2026-04-15: Round-based combat model (shared planning → commit → ordered resolution) | Accepted |
 | 2026-04-16 | [ADR-2026-04-16-ai-architecture-utility](docs/adr/ADR-2026-04-16-ai-architecture-utility.md) | ADR-2026-04-16: AI Sistema — Utility AI Architecture | Accepted |
 | 2026-04-16 | [ADR-2026-04-16-grid-type-hex-axial](docs/adr/ADR-2026-04-16-grid-type-hex-axial.md) | ADR-2026-04-16: Grid Type — Hex con coordinate axial | Accepted |
-| 2026-04-16 | [ADR-2026-04-16-networking-co-op](docs/adr/ADR-2026-04-16-networking-co-op.md) | ADR-2026-04-16: Networking architecture for co-op multiplayer | Proposed |
-| 2026-04-16 | [ADR-2026-04-16-networking-colyseus](docs/adr/ADR-2026-04-16-networking-colyseus.md) | ADR-2026-04-16: Networking Co-op — Colyseus | Accepted |
+| 2026-04-16 | [ADR-2026-04-16-networking-co-op](docs/adr/ADR-2026-04-16-networking-co-op.md) | ADR-2026-04-16: Networking architecture for co-op multiplayer | Superseded |
+| 2026-04-16 | [ADR-2026-04-16-networking-colyseus](docs/adr/ADR-2026-04-16-networking-colyseus.md) | ADR-2026-04-16: Networking Co-op — Colyseus | Superseded |
 | 2026-04-16 | [ADR-2026-04-16-session-engine-round-migration](docs/adr/ADR-2026-04-16-session-engine-round-migration.md) | ADR-2026-04-16: Migrazione Node session engine al round-based combat model | Accepted |
 | 2026-04-17 | [ADR-2026-04-17-coop-scaling-4to8](docs/adr/ADR-2026-04-17-coop-scaling-4to8.md) | ADR 2026-04-17 — Co-op scaling: 4 → 8 giocatori | Accepted |
 | 2026-04-17 | [ADR-2026-04-17-utility-ai-default-activation](docs/adr/ADR-2026-04-17-utility-ai-default-activation.md) | ADR 2026-04-17 — Utility AI: Default Activation Decision | Accepted |
 | 2026-04-17 | [ADR-2026-04-17-xp-cipher-official-park](docs/adr/ADR-2026-04-17-xp-cipher-official-park.md) | ADR 2026-04-17 — XP Cipher: Official Park | Accepted |
 | 2026-04-18 | [ADR-2026-04-18-art-direction-placeholder](docs/adr/ADR-2026-04-18-art-direction-placeholder.md) | ADR 2026-04-18 — Art Direction canonical (naturalistic stylized) | Accepted |
 | 2026-04-18 | [ADR-2026-04-18-audio-direction-placeholder](docs/adr/ADR-2026-04-18-audio-direction-placeholder.md) | ADR 2026-04-18 — Audio Direction canonical (ambient organic + percussive) | Accepted |
-| 2026-04-18 | [ADR-2026-04-18-plan-reveal-round](docs/adr/ADR-2026-04-18-plan-reveal-round.md) | ADR 2026-04-18 — Plan & Reveal round model (contemporary hybrid) | Proposed |
+| 2026-04-18 | [ADR-2026-04-18-plan-reveal-round](docs/adr/ADR-2026-04-18-plan-reveal-round.md) | ADR 2026-04-18 — Plan & Reveal round model (contemporary hybrid) | Superseded |
 | 2026-04-18 | [ADR-2026-04-18-zero-cost-asset-policy](docs/adr/ADR-2026-04-18-zero-cost-asset-policy.md) | ADR 2026-04-18 — Zero-cost asset policy + AI-generated legal framework | Accepted |
 | 2026-04-19 | [ADR-2026-04-19-kill-python-rules-engine](docs/adr/ADR-2026-04-19-kill-python-rules-engine.md) | ADR 2026-04-19 — Kill Python rules engine (services/rules/) | Accepted |
 | 2026-04-19 | [ADR-2026-04-19-reinforcement-spawn-engine](docs/adr/ADR-2026-04-19-reinforcement-spawn-engine.md) | ADR 2026-04-19 — Reinforcement spawn engine (Option B) | Accepted |
@@ -62,7 +62,7 @@ _Generato da `tools/generate_decisions_log.py` (69 ADR). NON editare a mano: edi
 | 2026-04-26 | [ADR-2026-04-26-m15-coop-ui-redesign](docs/adr/ADR-2026-04-26-m15-coop-ui-redesign.md) | ADR 2026-04-26 — M15 co-op UI redesign (Jackbox pattern phone+TV) | Accepted |
 | 2026-04-26 | [ADR-2026-04-26-multi-stage-encounter-schema](docs/adr/ADR-2026-04-26-multi-stage-encounter-schema.md) | ADR-2026-04-26 — Multi-stage encounter schema (HP threshold + form switch) | Proposed |
 | 2026-04-26 | [ADR-2026-04-26-parley-outcome-enum](docs/adr/ADR-2026-04-26-parley-outcome-enum.md) | ADR-2026-04-26 — Parley/accordo outcome enum extension | Proposed |
-| 2026-04-26 | [ADR-2026-04-26-pincer-followup-queue](docs/adr/ADR-2026-04-26-pincer-followup-queue.md) | ADR 2026-04-26 — Pincer follow-up intent queue (Triangle Strategy Mechanic 3B) | Proposed |
+| 2026-04-26 | [ADR-2026-04-26-pincer-followup-queue](docs/adr/ADR-2026-04-26-pincer-followup-queue.md) | ADR 2026-04-26 — Pincer follow-up intent queue (Triangle Strategy Mechanic 3B) | Superseded |
 | 2026-04-26 | [ADR-2026-04-26-sg-earn-mixed](docs/adr/ADR-2026-04-26-sg-earn-mixed.md) | ADR-2026-04-26 — SG (Surge Gauge) earn formula — Opzione C mixed | Accepted |
 | 2026-04-26 | [ADR-2026-04-26-spore-part-pack-slots](docs/adr/ADR-2026-04-26-spore-part-pack-slots.md) | ADR-2026-04-26 — Spore part-pack slots — schema lock + Moderate scope | Accepted |
 | 2026-04-27 | [ADR-2026-04-27-ability-r3-r4-tier](docs/adr/ADR-2026-04-27-ability-r3-r4-tier.md) | ADR-2026-04-27: Ability r3/r4 tier progressive — Sprint 8 final closure Tier S #6 | Accepted |
@@ -91,6 +91,7 @@ _Generato da `tools/generate_decisions_log.py` (69 ADR). NON editare a mano: edi
 | 2026-05-18 | [ADR-2026-05-18-df-levels-integration-direction](docs/adr/ADR-2026-05-18-df-levels-integration-direction.md) | ADR-2026-05-18 — DF-Levels integration: direzione confermata + decision-matrix governata | Accepted |
 | 2026-05-18 | [ADR-2026-05-18-sistema-persistent-state-learning](docs/adr/ADR-2026-05-18-sistema-persistent-state-learning.md) | ADR-2026-05-18 — Sistema persistent cross-session state (learning AI, P5) | Accepted |
 | 2026-05-26 | [ADR-2026-05-26-deep-genetics-phase1-supersede-freeze](docs/adr/ADR-2026-05-26-deep-genetics-phase1-supersede-freeze.md) | ADR-2026-05-26 — Deep genetics Fase-1: scoped supersede of FINAL-DESIGN-FREEZE §21.3 | Accepted |
+| 2026-05-30 | [ADR-2026-05-30-coop-server-authoritative-combat](docs/adr/ADR-2026-05-30-coop-server-authoritative-combat.md) | ADR 2026-05-30 -- Co-op server-authoritative combat (vcSnapshot reconstruction) | Accepted |
 | 2026-05-31 | [ADR-2026-05-31-meta-network-arc-conditions-schema](docs/adr/ADR-2026-05-31-meta-network-arc-conditions-schema.md) | ADR-2026-05-31 — Meta-network edge arc-conditions schema (2.0 → 2.1) | Accepted |
 | 2026-06-07 | [ADR-2026-06-07-device-authority-tv-mirror-canon](docs/adr/ADR-2026-06-07-device-authority-tv-mirror-canon.md) | ADR 2026-06-07 -- Device-authority / TV-mirror canon + reconstruction-suite ratification | Accepted |
 <!-- /gen:adr-index -->

--- a/docs/adr/ADR-2026-04-16-networking-co-op.md
+++ b/docs/adr/ADR-2026-04-16-networking-co-op.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR-2026-04-16: Networking architecture for co-op multiplayer'
-doc_status: draft
+doc_status: superseded
 doc_owner: combat-team
 workstream: combat
 last_verified: 2026-04-16
@@ -10,6 +10,8 @@ review_cycle_days: 14
 ---
 
 # ADR-2026-04-16: Networking architecture for co-op multiplayer
+
+> Superseded 2026-06-07 by ADR-2026-05-30-coop-server-authoritative-combat (ratifies Express WS server-authoritative).
 
 - **Data**: 2026-04-16
 - **Stato**: Proposed (draft)

--- a/docs/adr/ADR-2026-04-16-networking-colyseus.md
+++ b/docs/adr/ADR-2026-04-16-networking-colyseus.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR-2026-04-16: Networking Co-op — Colyseus'
-doc_status: active
+doc_status: superseded
 doc_owner: platform-docs
 workstream: cross-cutting
 last_verified: 2026-04-16
@@ -10,6 +10,8 @@ review_cycle_days: 30
 ---
 
 # ADR-2026-04-16: Networking Co-op — Colyseus
+
+> Superseded 2026-06-07 by ADR-2026-05-30-coop-server-authoritative-combat: Express WS server-authoritative chosen, NOT Colyseus.
 
 - **Data**: 2026-04-16
 - **Stato**: Proposto

--- a/docs/adr/ADR-2026-04-18-plan-reveal-round.md
+++ b/docs/adr/ADR-2026-04-18-plan-reveal-round.md
@@ -1,6 +1,7 @@
 ---
 title: 'ADR 2026-04-18 — Plan & Reveal round model (contemporary hybrid)'
-doc_status: draft
+doc_status: superseded
+superseded_by: ADR-2026-06-07-device-authority-tv-mirror-canon
 doc_owner: master-dd
 workstream: combat
 last_verified: 2026-04-18
@@ -15,6 +16,8 @@ related:
 ---
 
 # ADR-2026-04-18 · Plan & Reveal round model
+
+> Superseded 2026-06-07 by ADR-2026-06-07: the plan->commit->event-log->reveal model is now ratified canon + live (`docs/combat/round-loop.md`). Unabsorbed = threat-preview UI overlay + `fog_of_intent` toggle = device-surface, deferred to a device/UI SPEC.
 
 **Stato**: 🟡 DRAFT — proposta design post-research M4, awaiting playtest validation before ACCEPTED
 **Trigger**: user feedback #1600 playtest + research `docs/core/44-HUD-LAYOUT-REFERENCES.md`

--- a/docs/adr/ADR-2026-04-26-pincer-followup-queue.md
+++ b/docs/adr/ADR-2026-04-26-pincer-followup-queue.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR 2026-04-26 — Pincer follow-up intent queue (Triangle Strategy Mechanic 3B)'
-doc_status: draft
+doc_status: superseded
 doc_owner: claude-code
 workstream: combat
 last_verified: '2026-04-26'
@@ -15,6 +15,8 @@ related:
 ---
 
 # ADR-2026-04-26 · Pincer follow-up intent queue
+
+> Superseded 2026-06-07: design goal absorbed by shipped flank/rear/elevation positional system (`sessionHelpers.computePositionalDamage`); hex `detectPincer` orphaned vs live {x,y} runtime; chain-actions = combat-canon §6 non-scope. `pushFollowup` NOT built.
 
 **Stato**: 🟡 **DRAFT** — scope-in per next session (M14-D). Nessuna implementazione
 in PR corrente (#1740 P1).

--- a/docs/adr/ADR-2026-05-30-coop-server-authoritative-combat.md
+++ b/docs/adr/ADR-2026-05-30-coop-server-authoritative-combat.md
@@ -1,0 +1,67 @@
+---
+title: 'ADR 2026-05-30 -- Co-op server-authoritative combat (vcSnapshot reconstruction)'
+doc_status: active
+doc_owner: master-dd
+workstream: backend
+last_verified: '2026-06-07'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+related:
+  - 'docs/core/00-SOURCE-OF-TRUTH.md'
+  - 'docs/core/00D-ENGINES_AS_GAME_FEATURES.md'
+  - 'docs/adr/ADR-2026-04-16-networking-co-op.md'
+  - 'docs/adr/ADR-2026-04-16-networking-colyseus.md'
+  - 'docs/adr/ADR-2026-06-07-device-authority-tv-mirror-canon.md'
+---
+
+# ADR-2026-05-30 - Co-op server-authoritative combat (vcSnapshot reconstruction)
+
+**Stato**: ACCEPTED (decisione 2026-05-30; **formalizzata 2026-06-07** -- era gia'
+citata come decision-of-record in SoT §24.1 / `00D §16.4` ma il file non esisteva).
+**Supersedes**: `ADR-2026-04-16-networking-colyseus.md` (opzione rifiutata) +
+`ADR-2026-04-16-networking-co-op.md` (draft incrementale).
+
+## Contesto
+
+Il co-op (4-8 player, TV + device) richiede (a) una architettura di rete e (b) una
+decisione su DOVE risiede l'autorita' del combat. Tre opzioni di transport valutate
+(SoT, sezione networking):
+
+- **A. Express + Socket.io** -- minimo overhead, state-sync manuale.
+- **B. Colyseus** -- state-sync delta automatico, rooms, matchmaking, ma nuova
+  dipendenza pesante (stima 2-3 settimane di refactor `session.js` -> Colyseus Schema).
+- **C. Custom WebSocket sul session engine** -- controllo totale, server source-of-truth.
+
+In parallelo: il combat single-player e' client-side (SoT §24.1). In co-op serve che lo
+scoring/evoluzione (vcSnapshot) NON sia cittadino-di-seconda-classe.
+
+## Decisione
+
+1. **Transport = Express WebSocket server-authoritative** (opzione C, **NON Colyseus**).
+   Layer WS (`ws`) sopra le route session esistenti; server = source-of-truth per
+   stato/fase/lobby/room/host-transfer/reconnect. Godot HTML5 usa un custom
+   `WebSocketClient` verso il server Express (NO Godot MultiplayerAPI). Nessuna
+   dipendenza Colyseus.
+2. **Il combat resta client-side; il server RICOSTRUISCE `vcSnapshot` dal
+   ledger/event-log** (D3 Opzione 2). Il server non risolve il combat: riceve
+   l'event-log deterministico e ne ricostruisce lo scoring VC, cosi' il
+   debrief/evoluzione co-op e' allineato al single-player senza violare SoT §24.1.
+3. Coerente col canon device-authority (ADR-2026-06-07): TV = mirror; input/commit dai
+   device; il server e' authoritative per lo STATO condiviso, non per l'input di gameplay.
+
+## Conseguenze
+
+- Scoring/evoluzione co-op = first-class (ricostruito server-side dal ledger).
+- Nessuna dipendenza Colyseus; la rete resta Express WS (gia' in uso).
+- `ADR-2026-04-16-networking-colyseus` (opzione B) e `ADR-2026-04-16-networking-co-op`
+  (draft incrementale) sono **SUPERSEDED** da questo ADR.
+- I riferimenti preesistenti (SoT §24.1, `00D §16.4`) ora risolvono a un
+  decision-of-record reale.
+
+## Evidenze
+
+- `docs/core/00-SOURCE-OF-TRUTH.md` (opzioni networking A/B/C + §24.1 combat client-side).
+- `docs/core/00D-ENGINES_AS_GAME_FEATURES.md` §16.4 (vcSnapshot ricostruito dal ledger).
+- `docs/planning/2026-04-29-master-execution-plan-v3.md` ("keep Express WS server
+  authoritative, NO Godot MultiplayerAPI").

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -286,7 +286,7 @@
     {
       "path": "docs/adr/ADR-2026-04-16-networking-colyseus.md",
       "title": "ADR-2026-04-16: Networking Co-op — Colyseus",
-      "doc_status": "active",
+      "doc_status": "superseded",
       "doc_owner": "platform-docs",
       "workstream": "cross-cutting",
       "last_verified": "2026-04-16",
@@ -338,7 +338,7 @@
     {
       "path": "docs/adr/ADR-2026-04-18-plan-reveal-round.md",
       "title": "ADR-2026-04-18: Plan & Reveal round model (contemporary hybrid)",
-      "doc_status": "draft",
+      "doc_status": "superseded",
       "doc_owner": "master-dd",
       "workstream": "combat",
       "last_verified": "2026-04-18",
@@ -464,13 +464,27 @@
     {
       "path": "docs/adr/ADR-2026-04-26-pincer-followup-queue.md",
       "title": "ADR 2026-04-26 — Pincer follow-up intent queue (Triangle Strategy Mechanic 3B)",
-      "doc_status": "draft",
+      "doc_status": "superseded",
       "doc_owner": "claude-code",
       "workstream": "combat",
       "last_verified": "2026-04-26",
       "source_of_truth": false,
       "language": "it",
       "review_cycle_days": 30
+    },
+    {
+      "path": "docs/adr/ADR-2026-05-30-coop-server-authoritative-combat.md",
+      "title": "Co-op server-authoritative combat (vcSnapshot reconstruction)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "backend",
+      "last_verified": "2026-06-07",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "tags": ["adr", "networking", "coop", "combat"],
+      "primary": false,
+      "track": "new"
     },
     {
       "path": "docs/adr/ADR-2026-04-26-sg-earn-mixed.md",

--- a/tools/check_docs_governance.py
+++ b/tools/check_docs_governance.py
@@ -220,7 +220,8 @@ def validate_registry(repo_root: Path, registry: dict[str, Any]) -> list[Issue]:
                 issues.append(Issue("error", "invalid_review_cycle", rel_path, f"review_cycle_days invalido: {cycle}"))
             else:
                 due = lv_date + timedelta(days=cycle)
-                if due < today:
+                _retired_statuses = {"superseded", "deprecated", "archived"}
+                if due < today and entry.get("doc_status") not in _retired_statuses:
                     issues.append(Issue("warning", "stale_document", rel_path, f"Documento stale: revisione scaduta il {due.isoformat()}"))
 
         if not abs_path.exists():


### PR DESCRIPTION
Executes the Eduardo-ratified evidence-based decisions (DOC/tool subset; code decisions D1/D8a = separate TDD batch).

- **D2+D5** NEW `ADR-2026-05-30-coop-server-authoritative-combat` -- formalizes the decision-of-record already cited by SoT §24.1 / 00D §16.4 (Express WS server-authoritative, vcSnapshot reconstructed from ledger, combat client-side). Supersedes the `networking-colyseus` + `networking-co-op` drafts.
- **D3** `pincer-followup-queue` -> superseded (goal shipped via flank/rear/elevation `sessionHelpers.computePositionalDamage`; `pushFollowup` never built; chain-actions = combat-canon §6 non-scope).
- **D4** `plan-reveal-round` -> superseded by ADR-2026-06-07 (3-phase model now ratified canon + live in round-loop.md).
- **D7** `check_docs_governance.py` skips stale-warning for `superseded`/`deprecated`/`archived` doc_status (structural -- stops retired docs re-flagging).
- **D8b** GAP-4 swarm -> DROP; BACKLOG records D1=HYBRID + GAP-3=WIRE-IT (code-batch pending).

Governance: **250 -> 246 warnings, 0 errors** (new ADR registered; superseded skipped). Registry JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)