### PR TITLE
fix(combat): parity GAP-1/2/3 -- on_hit_status + sbilanciato wire, retire on_hit_stress_delta

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -112,7 +112,7 @@ const STATUS_DURATION_CAPS = {
   slowed: 3,
   burning: 3,
   chilled: 2,
-  disoriented: 1,
+  disorient: 1,
 };
 // M7-#2 Phase B: damage scaling curves runtime (ADR-2026-04-20).
 const {
@@ -557,10 +557,13 @@ function createSessionRouter(options = {}) {
     if (chilledPenalty > 0) {
       actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) - chilledPenalty;
     }
-    // Disoriented: -2 attack_mod_bonus (confusione sensoriale, dura 1 turno). Per-attack, revert post.
-    const disorientedPenalty = Number(actor.status?.disoriented) > 0 ? 2 : 0;
-    if (disorientedPenalty > 0) {
-      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) - disorientedPenalty;
+    // Disorient: -2 attack_mod_bonus (confusione sensoriale, dura 1 turno). Per-attack, revert post.
+    // Canonical key `disorient` (parity PART C 2026-06-07): aligns with the YAML/schema
+    // enum + roundOrchestrator + computeIntentPriority so the on_hit_status producer
+    // (PART A) actually triggers this malus.
+    const disorientPenalty = Number(actor.status?.disorient) > 0 ? 2 : 0;
+    if (disorientPenalty > 0) {
+      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) - disorientPenalty;
     }
 
     // TKT-M14-A 2026-05-11 — Triangle Strategy elevation + terrain hit modifier.
@@ -646,9 +649,9 @@ function createSessionRouter(options = {}) {
     if (chilledPenalty > 0) {
       actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) + chilledPenalty;
     }
-    // Revert disoriented attack penalty (per-attack, non-persistente).
-    if (disorientedPenalty > 0) {
-      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) + disorientedPenalty;
+    // Revert disorient attack penalty (per-attack, non-persistente).
+    if (disorientPenalty > 0) {
+      actor.attack_mod_bonus = Number(actor.attack_mod_bonus || 0) + disorientPenalty;
     }
     // TKT-M14-A — Revert elevation + terrain modifier deltas (per-attack, non-persistent).
     if (positionMod.attackBonus !== 0) {
@@ -673,6 +676,7 @@ function createSessionRouter(options = {}) {
     let symbiontPoolResult = null;
     let symbiontDeathGraceResult = null;
     let terrainReactionResult = null;
+    let onHitStatusResult = null;
     // M14-A residuo close (TKT-09 2026-04-26): surface positional info
     // (elevation_delta + multiplier) on performAttack return so callers can
     // emit `elevation_multiplier` field for log/telemetry consumers.
@@ -1073,6 +1077,22 @@ function createSessionRouter(options = {}) {
         }
       }
 
+      // Combat parity GAP-1 (2026-06-07): on_hit_status producer hook. Ports
+      // STEP 3 of the removed Python resolver — for each ATTACKER trait that
+      // carries an `on_hit_status` block in trait_mechanics.yaml, the target
+      // rolls a save (d20 + tier vs trigger_dc); on a failed save the status is
+      // applied to target.status[status_id] (integer duration, decayed 1/round
+      // by sessionRoundBridge, read by statusModifiers/session status consumers
+      // e.g. the disorient attack malus). Fires only on a successful hit (this
+      // block is gated by `if (result.hit)`), uses the seeded `rng` for
+      // deterministic calibration, and is best-effort (never blocks the hit).
+      try {
+        const { applyOnHitStatuses } = require('../services/combat/onHitStatus');
+        onHitStatusResult = applyOnHitStatuses(actor, target, { rng });
+      } catch {
+        /* on_hit_status optional; never block the hit */
+      }
+
       // M14-A: terrain reaction post damage step (additive, non-blocking).
       // action.channel ("fuoco"/"ghiaccio"/...) maps to terrainReactions element.
       // Only fires for mapped channels; tile state mutated in session.tile_state_map.
@@ -1280,6 +1300,7 @@ function createSessionRouter(options = {}) {
       intercept: interceptResult,
       bond_reaction: bondReactionResult,
       terrain_reaction: terrainReactionResult,
+      on_hit_status: onHitStatusResult,
       positional: positionalInfo,
       biome_affinity: {
         actor: biomeAffActor.affinity,

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -218,13 +218,13 @@ function createDeclareSistemaIntents(deps) {
     // Helper inline: ripicka target escludendo IDs gia' presi.
     // Mantenuto inline per non allargare l'API pubblica di pickLowestHpEnemy.
     // Phase A status-awareness: a parità di HP (±2 PT), preferisce target debuffati
-    // (slowed/disoriented/chilled/marked riducono efficacia del target).
+    // (slowed/disorient/chilled/marked riducono efficacia del target).
     function hasDebuffStatus(unit) {
       const s = unit?.status;
       if (!s) return false;
       return (
         Number(s.slowed) > 0 ||
-        Number(s.disoriented) > 0 ||
+        Number(s.disorient) > 0 ||
         Number(s.chilled) > 0 ||
         Number(s.marked) > 0
       );

--- a/apps/backend/services/ai/policy.js
+++ b/apps/backend/services/ai/policy.js
@@ -252,7 +252,7 @@ const DEFAULT_OBJECTIVES = {
     weight: 0.4,
   },
   // Phase A status-awareness (Sprint_020): prefer debuffed targets.
-  // slowed/disoriented/chilled reduce target effectiveness; marked amplifies next hit.
+  // slowed/disorient/chilled reduce target effectiveness; marked amplifies next hit.
   // Weight 0.5 = soft preference, does not override HP or range considerations.
   attack_debuffed_target: {
     checker: (_actor, target) => {
@@ -260,7 +260,7 @@ const DEFAULT_OBJECTIVES = {
       if (!s) return false;
       return (
         Number(s.slowed) > 0 ||
-        Number(s.disoriented) > 0 ||
+        Number(s.disorient) > 0 ||
         Number(s.chilled) > 0 ||
         Number(s.marked) > 0
       );

--- a/apps/backend/services/combat/onHitStatus.js
+++ b/apps/backend/services/combat/onHitStatus.js
@@ -1,0 +1,172 @@
+// Combat parity GAP-1 (2026-06-07) — on_hit_status producer hook.
+//
+// Ports STEP 3 `on_hit_status` from the removed Python resolver
+// (services/rules/resolver.py @ commit d0c86c60~1, lines ~840-870) into the
+// live Node attack resolver. The Python engine was deprecated (kill-python-
+// rules-engine ADR) but this auto-status-on-hit trigger was never re-wired:
+// the data lived in trait_mechanics.yaml and the decay/consumer side already
+// existed (sessionRoundBridge.js integer-key decay + statusModifiers.js /
+// session.js status readers), but no producer applied the status on hit.
+//
+// Behaviour (faithful to the Python STEP 3):
+//   On a SUCCESSFUL hit, for each ATTACKER trait that carries an
+//   `on_hit_status` block { status_id, trigger_dc, duration, intensity },
+//   the TARGET rolls a saving throw d20 + target.tier vs trigger_dc.
+//   If the save FAILS (roll + tier < trigger_dc) the status is applied to
+//   the target: target.status[status_id] = max(existing, duration).
+//
+// The d20 helper mirrors session.js performAttack (Math.floor(rng() * 20) + 1)
+// and uses the seedable pseudoRng provider so calibration runs stay
+// deterministic; production (unseeded) delegates to Math.random.
+//
+// Pure module: no I/O in applyOnHitStatuses (the mechanics registry is passed
+// in). loadTraitMechanicsRegistry() is the cached YAML loader used by the
+// production caller; it mirrors traitEffects.loadActiveTraitRegistry.
+//
+// API:
+//   applyOnHitStatuses(actor, target, { rng?, mechanicsRegistry })
+//     -> { applied: [{ status_id, duration, intensity, trigger_dc,
+//                       save_roll, save_total, trait_id }] }
+//   loadTraitMechanicsRegistry(yamlPath?, logger?) -> { traitId: mechanics }
+//   DEFAULT_TRAIT_MECHANICS_PATH
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const { defaultRng } = require('./pseudoRng');
+
+// Canonical location of trait_mechanics.yaml (the SOT for on_hit_status).
+// Mirrors resistanceEngine.DEFAULT_SPECIES_RESISTANCES_PATH (process.cwd()
+// + packs/evo_tactics_pack/data/balance/...).
+const DEFAULT_TRAIT_MECHANICS_PATH = path.join(
+  process.cwd(),
+  'packs',
+  'evo_tactics_pack',
+  'data',
+  'balance',
+  'trait_mechanics.yaml',
+);
+
+let _registryCache = null;
+
+/**
+ * Load trait_mechanics.yaml -> map { traitId: mechanicsEntry }. Cached after
+ * first read (the file is static at runtime). Soft-fail: a missing/broken file
+ * yields {} so the resolver degrades to no-op (no status applied), never
+ * throwing on the hit path. Mirrors traitEffects.loadActiveTraitRegistry.
+ *
+ * @param {string} [yamlPath]
+ * @param {{log: Function, warn: Function}} [logger]
+ * @returns {Object} traits map
+ */
+function loadTraitMechanicsRegistry(yamlPath = DEFAULT_TRAIT_MECHANICS_PATH, logger = console) {
+  if (_registryCache !== null && yamlPath === DEFAULT_TRAIT_MECHANICS_PATH) {
+    return _registryCache;
+  }
+  let traits = {};
+  try {
+    const text = fs.readFileSync(yamlPath, 'utf8');
+    const parsed = yaml.load(text);
+    traits = parsed && typeof parsed === 'object' ? parsed.traits || {} : {};
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      logger.warn(`[on-hit-status] ${yamlPath} non trovato, on_hit_status in modalita' no-op`);
+    } else {
+      logger.warn(`[on-hit-status] errore caricamento ${yamlPath}:`, (err && err.message) || err);
+    }
+    traits = {};
+  }
+  if (yamlPath === DEFAULT_TRAIT_MECHANICS_PATH) {
+    _registryCache = traits;
+  }
+  return traits;
+}
+
+/** Test/boot hook: drop the cached registry so a reload re-reads the file. */
+function _resetCache() {
+  _registryCache = null;
+}
+
+/**
+ * Roll a d20 using the same convention as session.js performAttack:
+ * Math.floor(rng() * 20) + 1 -> integer in [1, 20].
+ */
+function rollD20(rng) {
+  return Math.floor(rng() * 20) + 1;
+}
+
+/**
+ * Apply on_hit_status triggers for a successful hit. Caller MUST gate this on
+ * `result.hit` (only fires on a successful hit, matching the Python STEP 3).
+ *
+ * For each id in actor.traits, look up its on_hit_status block in
+ * mechanicsRegistry. Roll the target's save (d20 + target.tier) vs trigger_dc;
+ * on FAIL (total < trigger_dc) set target.status[status_id] = max(existing,
+ * duration). Statuses decay 1/round via sessionRoundBridge.
+ *
+ * Pure aside from the in-place mutation of target.status (the documented
+ * effect). Never throws; degrades to no-op on malformed input.
+ *
+ * @param {object} actor  attacker (reads actor.traits)
+ * @param {object} target defender (reads target.tier, mutates target.status)
+ * @param {{ rng?: Function, mechanicsRegistry: Object }} opts
+ * @returns {{ applied: Array<object> }}
+ */
+function applyOnHitStatuses(actor, target, opts = {}) {
+  const applied = [];
+  if (!actor || !target) return { applied };
+
+  const rng = typeof opts.rng === 'function' ? opts.rng : defaultRng;
+  const registry =
+    opts.mechanicsRegistry && typeof opts.mechanicsRegistry === 'object'
+      ? opts.mechanicsRegistry
+      : loadTraitMechanicsRegistry();
+
+  const traitIds = Array.isArray(actor.traits) ? actor.traits : [];
+  if (traitIds.length === 0) return { applied };
+
+  const tier = Number.isFinite(Number(target.tier)) ? Number(target.tier) : 1;
+
+  for (const traitId of traitIds) {
+    const entry = registry[traitId];
+    if (!entry || typeof entry !== 'object') continue;
+    const onHit = entry.on_hit_status;
+    if (!onHit || typeof onHit !== 'object') continue;
+
+    const statusId = String(onHit.status_id || '').trim();
+    if (!statusId) continue;
+    const triggerDc = Number.isFinite(Number(onHit.trigger_dc)) ? Number(onHit.trigger_dc) : 10;
+    const duration = Number.isFinite(Number(onHit.duration)) ? Number(onHit.duration) : 1;
+
+    // Target saving throw: d20 + tier vs trigger_dc. Fail (total < DC) -> apply.
+    const saveRoll = rollD20(rng);
+    const saveTotal = saveRoll + tier;
+    if (saveTotal >= triggerDc) continue; // save succeeds -> no status
+
+    if (!target.status || typeof target.status !== 'object') target.status = {};
+    const current = Number(target.status[statusId]) || 0;
+    target.status[statusId] = Math.max(current, duration);
+
+    applied.push({
+      trait_id: traitId,
+      status_id: statusId,
+      duration,
+      intensity: Number.isFinite(Number(onHit.intensity)) ? Number(onHit.intensity) : 1,
+      trigger_dc: triggerDc,
+      save_roll: saveRoll,
+      save_total: saveTotal,
+    });
+  }
+
+  return { applied };
+}
+
+module.exports = {
+  applyOnHitStatuses,
+  loadTraitMechanicsRegistry,
+  DEFAULT_TRAIT_MECHANICS_PATH,
+  _resetCache,
+};

--- a/apps/backend/services/combat/statusModifiers.js
+++ b/apps/backend/services/combat/statusModifiers.js
@@ -192,6 +192,14 @@ function computeStatusModifiers(actor, target, units = []) {
     defenseDelta -= 1;
     log.push({ status: 'frenzy', side: 'target', effect: '-1 defense_mod (rage exposure)' });
   }
+  if (isPositive(targetStatus.sbilanciato)) {
+    // GAP-3 (parity-sweep 2026-06-07) — spinta/shield_bash unbalances the target:
+    // lowered guard, -1 defense_mod (attacker gets an easier hit). Canonical
+    // intensity 1 (combat.schema.json). Writer = shield_bash (jobs.yaml); this is
+    // the missing read-path (Python resolver had it, dropped in Node migration).
+    defenseDelta -= 1;
+    log.push({ status: 'sbilanciato', side: 'target', effect: '-1 defense_mod (spinta exposure)' });
+  }
 
   // ─── Action 5a — wounded_perma severity → actor attack_mod penalty ────
   const wpActor = computeWoundedPermaAttackPenalty(actor);

--- a/packages/contracts/schemas/traitMechanics.schema.json
+++ b/packages/contracts/schemas/traitMechanics.schema.json
@@ -141,12 +141,6 @@
           }
         },
         "on_hit_status": { "$ref": "#/$defs/on_hit_status" },
-        "on_hit_stress_delta": {
-          "type": "number",
-          "minimum": -1,
-          "maximum": 1,
-          "description": "Delta di stress (float [-1, 1]) applicato al target su attack success. Coerente con Frattura draft ('stress 0.05 on hit' delle larve). Il Balancer popola solo trait psi/sensoriali dove la description lo giustifica."
-        },
         "notes": { "type": "string" }
       },
       "additionalProperties": false

--- a/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+++ b/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
@@ -255,8 +255,7 @@ traits:
       duration: 2
       intensity: 1
       trigger_dc: 12
-    on_hit_stress_delta: 0.05
-    notes: "classe offensive via desc 'spore psioniche che sedano e confondono' (no tag breaker). on_hit_status e on_hit_stress_delta giustificati dalla desc_it ('sedano e confondono'). Balance audit 2026-04-25: cost_ap 3→2 (zero damage step, era over-priced vs altri status-only trait). Sprint 6: umbral_spore dark ability + resist dark+10."
+    notes: "classe offensive via desc 'spore psioniche che sedano e confondono' (no tag breaker). on_hit_status giustificato dalla desc_it ('sedano e confondono'); on_hit_stress_delta RITIRATO (parity GAP-2, 2026-06-07: superseded da morale.js event-driven). Balance audit 2026-04-25: cost_ap 3→2 (zero damage step, era over-priced vs altri status-only trait). Sprint 6: umbral_spore dark ability + resist dark+10."
   nucleo_ovomotore_rotante:
     attack_mod: 0
     defense_mod: 0
@@ -628,8 +627,7 @@ traits:
       trigger_dc: 15
       duration: 2
       intensity: 1
-    on_hit_stress_delta: 0.05
-    notes: "offensive (TRT-02): cannone sonico con disorientamento e stress delta. Sprint 6: pressure_wave wind ability (sonic = pressure waveform)."
+    notes: "offensive (TRT-02): cannone sonico con disorientamento. on_hit_stress_delta RITIRATO (parity GAP-2, 2026-06-07: superseded da morale.js event-driven). Sprint 6: pressure_wave wind ability (sonic = pressure waveform)."
 
   # === Wave 5-7 backfill 2026-05-11 (TKT-P6-TRAIT-MECHANICS-SYNC) ===
   # 59 traits added: mirror data/core/traits/active_effects.yaml semantics.

--- a/tests/ai/statusEffectsPhaseA.test.js
+++ b/tests/ai/statusEffectsPhaseA.test.js
@@ -1,5 +1,5 @@
 // tests/ai/statusEffectsPhaseA.test.js
-// Unit tests for Status Effects v2 Phase A: chilled (PR-4) + disoriented (PR-5).
+// Unit tests for Status Effects v2 Phase A: chilled (PR-4) + disorient (PR-5).
 // Pattern: spec-reimplementation — logic mirrored locally, no server needed.
 
 import { describe, it } from 'node:test';
@@ -75,49 +75,49 @@ describe('chilled: attack penalty', () => {
   });
 });
 
-// ── disoriented attack penalty spec ───────────────────────────────────────────
+// ── disorient attack penalty spec ───────────────────────────────────────────
 
 function computeDisorientedPenaltySpec(actor) {
-  return Number(actor?.status?.disoriented) > 0 ? 2 : 0;
+  return Number(actor?.status?.disorient) > 0 ? 2 : 0;
 }
 
-describe('disoriented: attack penalty', () => {
-  it("disoriented active: penalita' -2 al tiro attacco", () => {
-    const actor = { status: { disoriented: 1 }, attack_mod_bonus: 0 };
+describe('disorient: attack penalty', () => {
+  it("disorient active: penalita' -2 al tiro attacco", () => {
+    const actor = { status: { disorient: 1 }, attack_mod_bonus: 0 };
     const penalty = computeDisorientedPenaltySpec(actor);
     assert.equal(penalty, 2);
   });
 
-  it("disoriented a 0 turns: nessuna penalita'", () => {
-    const actor = { status: { disoriented: 0 } };
+  it("disorient a 0 turns: nessuna penalita'", () => {
+    const actor = { status: { disorient: 0 } };
     const penalty = computeDisorientedPenaltySpec(actor);
     assert.equal(penalty, 0);
   });
 
-  it("disoriented assente: nessuna penalita'", () => {
+  it("disorient assente: nessuna penalita'", () => {
     const actor = { status: {} };
     const penalty = computeDisorientedPenaltySpec(actor);
     assert.equal(penalty, 0);
   });
 
   it('pre/revert: attack_mod_bonus ripristinato dopo attacco', () => {
-    const actor = { status: { disoriented: 1 }, attack_mod_bonus: 3 };
+    const actor = { status: { disorient: 1 }, attack_mod_bonus: 3 };
     const penalty = computeDisorientedPenaltySpec(actor);
     actor.attack_mod_bonus = Number(actor.attack_mod_bonus) - penalty;
     actor.attack_mod_bonus = Number(actor.attack_mod_bonus) + penalty;
     assert.equal(actor.attack_mod_bonus, 3);
   });
 
-  it("penalita' maggiore di chilled (-2 vs -1): disoriented piu' severo", () => {
-    const actorDis = { status: { disoriented: 1 } };
+  it("penalita' maggiore di chilled (-2 vs -1): disorient piu' severo", () => {
+    const actorDis = { status: { disorient: 1 } };
     const actorChi = { status: { chilled: 1 } };
     const penDis = computeDisorientedPenaltySpec(actorDis);
     const penChi = Number(actorChi.status?.chilled) > 0 ? 1 : 0;
-    assert.ok(penDis > penChi, `disoriented ${penDis} should be > chilled ${penChi}`);
+    assert.ok(penDis > penChi, `disorient ${penDis} should be > chilled ${penChi}`);
   });
 });
 
-// ── STATUS_DURATION_CAPS spec (chilled + disoriented) ─────────────────────────
+// ── STATUS_DURATION_CAPS spec (chilled + disorient) ─────────────────────────
 
 function applyStatusWithCapSpec(unit, stato, turns, caps) {
   if (!unit || !unit.status) return;
@@ -143,25 +143,25 @@ describe('chilled duration cap', () => {
   });
 });
 
-describe('disoriented duration cap', () => {
-  const CAPS = { disoriented: 1 };
+describe('disorient duration cap', () => {
+  const CAPS = { disorient: 1 };
 
-  it('disoriented cap a 1 turno massimo', () => {
-    const unit = { status: { disoriented: 0 } };
-    applyStatusWithCapSpec(unit, 'disoriented', 3, CAPS);
-    assert.equal(unit.status.disoriented, 1);
+  it('disorient cap a 1 turno massimo', () => {
+    const unit = { status: { disorient: 0 } };
+    applyStatusWithCapSpec(unit, 'disorient', 3, CAPS);
+    assert.equal(unit.status.disorient, 1);
   });
 
-  it("disoriented rimane a 1 se gia' applicato", () => {
-    const unit = { status: { disoriented: 1 } };
-    applyStatusWithCapSpec(unit, 'disoriented', 1, CAPS);
-    assert.equal(unit.status.disoriented, 1);
+  it("disorient rimane a 1 se gia' applicato", () => {
+    const unit = { status: { disorient: 1 } };
+    applyStatusWithCapSpec(unit, 'disorient', 1, CAPS);
+    assert.equal(unit.status.disorient, 1);
   });
 
-  it('disoriented applicato correttamente a 1T', () => {
-    const unit = { status: { disoriented: 0 } };
-    applyStatusWithCapSpec(unit, 'disoriented', 1, CAPS);
-    assert.equal(unit.status.disoriented, 1);
+  it('disorient applicato correttamente a 1T', () => {
+    const unit = { status: { disorient: 0 } };
+    applyStatusWithCapSpec(unit, 'disorient', 1, CAPS);
+    assert.equal(unit.status.disorient, 1);
   });
 });
 
@@ -171,10 +171,7 @@ function hasDebuffStatusSpec(unit) {
   const s = unit?.status;
   if (!s) return false;
   return (
-    Number(s.slowed) > 0 ||
-    Number(s.disoriented) > 0 ||
-    Number(s.chilled) > 0 ||
-    Number(s.marked) > 0
+    Number(s.slowed) > 0 || Number(s.disorient) > 0 || Number(s.chilled) > 0 || Number(s.marked) > 0
   );
 }
 
@@ -182,8 +179,8 @@ describe('hasDebuffStatus: debuff detection', () => {
   it('slowed > 0 → debuffed', () => {
     assert.equal(hasDebuffStatusSpec({ status: { slowed: 2 } }), true);
   });
-  it('disoriented > 0 → debuffed', () => {
-    assert.equal(hasDebuffStatusSpec({ status: { disoriented: 1 } }), true);
+  it('disorient > 0 → debuffed', () => {
+    assert.equal(hasDebuffStatusSpec({ status: { disorient: 1 } }), true);
   });
   it('chilled > 0 → debuffed', () => {
     assert.equal(hasDebuffStatusSpec({ status: { chilled: 2 } }), true);

--- a/tests/api/contracts-trait-mechanics.test.js
+++ b/tests/api/contracts-trait-mechanics.test.js
@@ -178,13 +178,15 @@ test('trait_mechanics.yaml rispetta cost_ap derivato da fattore_mantenimento_ene
   assert.equal(t.criostasi_adattiva.cost_ap, 3, 'Alto -> 3');
 });
 
-test('Fase 8: spore_psichiche_silenziate ha on_hit_status e on_hit_stress_delta popolati', () => {
+test('parity GAP-2: spore_psichiche_silenziate ha on_hit_status; on_hit_stress_delta RETIRED', () => {
   const catalog = loadCatalog();
   const spore = catalog.traits.spore_psichiche_silenziate;
   assert.ok(spore, 'spore_psichiche_silenziate presente');
-  assert.ok(spore.on_hit_status, 'on_hit_status presente');
+  assert.ok(spore.on_hit_status, 'on_hit_status presente (ported in PART A)');
   assert.equal(spore.on_hit_status.status_id, 'disorient');
-  assert.ok(typeof spore.on_hit_stress_delta === 'number' && spore.on_hit_stress_delta > 0);
+  // on_hit_stress_delta retired (HYBRID decision 2026-06-07): superseded by the
+  // event-driven morale.js stress path. The field must no longer be present.
+  assert.equal(spore.on_hit_stress_delta, undefined, 'on_hit_stress_delta retired');
 });
 
 test('traitMechanics schema rifiuta on_hit_status con status_id non canonico', () => {
@@ -214,7 +216,10 @@ test('traitMechanics schema rifiuta on_hit_status con status_id non canonico', (
   );
 });
 
-test('traitMechanics schema rifiuta on_hit_stress_delta fuori range [-1, 1]', () => {
+test('parity GAP-2: traitMechanics schema rifiuta on_hit_stress_delta (campo ritirato)', () => {
+  // on_hit_stress_delta retired (HYBRID decision 2026-06-07). The schema no
+  // longer defines it, so with additionalProperties:false any trait carrying it
+  // must be rejected as an unknown property.
   const validator = buildValidator();
   const broken = {
     schema_version: '0.2.0',
@@ -226,7 +231,7 @@ test('traitMechanics schema rifiuta on_hit_stress_delta fuori range [-1, 1]', ()
         cost_ap: 1,
         resistances: [],
         active_effects: [],
-        on_hit_stress_delta: 1.5,
+        on_hit_stress_delta: 0.05,
       },
     },
   };

--- a/tests/services/combat/onHitStatus.test.js
+++ b/tests/services/combat/onHitStatus.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+// Combat parity GAP-1 — port of the removed Python resolver STEP 3
+// `on_hit_status` (services/rules/resolver.py @ d0c86c60~1, lines ~840-870)
+// into the live Node attack resolver.
+//
+// Behaviour ported: on a SUCCESSFUL hit, for each ATTACKER trait carrying an
+// `on_hit_status` block { status_id, trigger_dc, duration, intensity }, the
+// TARGET rolls a save d20 + target.tier vs trigger_dc. If the save FAILS
+// (roll + tier < trigger_dc) the status is applied to the target
+// (target.status[status_id] = max(existing, duration)). The integer key then
+// decays 1/round via the universal loop in sessionRoundBridge.js and is read
+// by the existing consumers in statusModifiers.js / session.js.
+//
+// The d20 helper mirrors session.js performAttack: Math.floor(rng() * 20) + 1
+// (seeded via pseudoRng for determinism — never Math.random).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { applyOnHitStatuses } = require('../../../apps/backend/services/combat/onHitStatus');
+
+// A fixed-value rng: floor(value * 20) + 1 = the d20 roll.
+//   value 0.45 -> floor(9.0)+1 = roll 10
+//   value 0.95 -> floor(19.0)+1 = roll 20
+function fixedRng(value) {
+  return () => value;
+}
+
+// Minimal mechanics registry shaped like trait_mechanics.yaml `traits` map.
+const MECHANICS = {
+  spore_psichiche_silenziate: {
+    on_hit_status: { status_id: 'disorient', duration: 2, intensity: 1, trigger_dc: 12 },
+  },
+  cannone_sonico_a_raggio: {
+    on_hit_status: { status_id: 'disorient', duration: 2, intensity: 1, trigger_dc: 15 },
+  },
+  inert_trait: {
+    // no on_hit_status -> never contributes
+    attack_mod: 1,
+  },
+};
+
+test('on_hit_status: failing save (roll+tier < trigger_dc) applies the status to the target', () => {
+  const actor = { id: 'a1', traits: ['spore_psichiche_silenziate'] };
+  const target = { id: 't1', tier: 1, status: {} };
+  // roll 10 + tier 1 = 11 < 12 -> save FAILS -> apply.
+  const result = applyOnHitStatuses(actor, target, {
+    rng: fixedRng(0.45),
+    mechanicsRegistry: MECHANICS,
+  });
+  assert.equal(target.status.disorient, 2, 'status applied with its duration on failed save');
+  assert.equal(result.applied.length, 1, 'one status reported applied');
+  assert.equal(result.applied[0].status_id, 'disorient');
+});
+
+test('on_hit_status: passing save (roll+tier >= trigger_dc) does NOT apply the status', () => {
+  const actor = { id: 'a1', traits: ['spore_psichiche_silenziate'] };
+  const target = { id: 't1', tier: 1, status: {} };
+  // roll 20 + tier 1 = 21 >= 12 -> save PASSES -> no apply.
+  const result = applyOnHitStatuses(actor, target, {
+    rng: fixedRng(0.95),
+    mechanicsRegistry: MECHANICS,
+  });
+  assert.equal(target.status.disorient, undefined, 'status NOT applied on passed save');
+  assert.equal(result.applied.length, 0, 'no status reported applied');
+});
+
+test('on_hit_status: target.tier raises the save total (tier can turn a fail into a pass)', () => {
+  // roll 10, trigger_dc 12. tier 1 -> total 11 (fail). tier 2 -> total 12 (>= -> pass).
+  const actor = { id: 'a1', traits: ['spore_psichiche_silenziate'] };
+  const lowTier = { id: 't1', tier: 1, status: {} };
+  const highTier = { id: 't2', tier: 2, status: {} };
+  applyOnHitStatuses(actor, lowTier, { rng: fixedRng(0.45), mechanicsRegistry: MECHANICS });
+  applyOnHitStatuses(actor, highTier, { rng: fixedRng(0.45), mechanicsRegistry: MECHANICS });
+  assert.equal(lowTier.status.disorient, 2, 'tier 1: save fails -> applied');
+  assert.equal(highTier.status.disorient, undefined, 'tier 2: save total meets DC -> not applied');
+});
+
+test('on_hit_status: traits without an on_hit_status block contribute nothing', () => {
+  const actor = { id: 'a1', traits: ['inert_trait'] };
+  const target = { id: 't1', tier: 1, status: {} };
+  const result = applyOnHitStatuses(actor, target, {
+    rng: fixedRng(0.0),
+    mechanicsRegistry: MECHANICS,
+  });
+  assert.equal(result.applied.length, 0, 'inert trait applies no status');
+  assert.deepEqual(target.status, {}, 'target status untouched');
+});
+
+test('on_hit_status: default tier is 1 when target.tier is absent', () => {
+  const actor = { id: 'a1', traits: ['spore_psichiche_silenziate'] };
+  const target = { id: 't1', status: {} }; // no tier
+  // roll 10 + default tier 1 = 11 < 12 -> fail -> apply.
+  applyOnHitStatuses(actor, target, { rng: fixedRng(0.45), mechanicsRegistry: MECHANICS });
+  assert.equal(target.status.disorient, 2, 'missing tier defaults to 1 -> save fails -> applied');
+});
+
+test('on_hit_status: existing duration is kept via max-merge (never shortened)', () => {
+  const actor = { id: 'a1', traits: ['spore_psichiche_silenziate'] };
+  const target = { id: 't1', tier: 1, status: { disorient: 5 } };
+  // failing save would set duration 2, but existing 5 must win (max-merge).
+  applyOnHitStatuses(actor, target, { rng: fixedRng(0.45), mechanicsRegistry: MECHANICS });
+  assert.equal(target.status.disorient, 5, 'max(existing 5, new 2) = 5');
+});
+
+test('on_hit_status: multiple attacker traits each roll an independent save', () => {
+  // spore trigger_dc 12, cannone trigger_dc 15. roll 13 + tier 1 = 14.
+  //   spore: 14 >= 12 -> pass (no apply)
+  //   cannone: 14 < 15 -> fail (apply)
+  // value 0.6 -> floor(12.0)+1 = roll 13.
+  const actor = { id: 'a1', traits: ['spore_psichiche_silenziate', 'cannone_sonico_a_raggio'] };
+  const target = { id: 't1', tier: 1, status: {} };
+  const result = applyOnHitStatuses(actor, target, {
+    rng: fixedRng(0.6),
+    mechanicsRegistry: MECHANICS,
+  });
+  assert.equal(target.status.disorient, 2, 'cannone (DC15) failed save -> disorient applied');
+  assert.equal(result.applied.length, 1, 'only the cannone save failed');
+});

--- a/tests/services/combat/onHitStatusDisorientParity.test.js
+++ b/tests/services/combat/onHitStatusDisorientParity.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+// Combat parity PART C — `disorient` naming reconcile.
+//
+// The trait_mechanics.yaml / schema enum + roundOrchestrator + ctBar +
+// session.js computeIntentPriority all use the canonical status key
+// `disorient`. The session.js performAttack attack-malus path historically
+// read the divergent key `disoriented` (and STATUS_DURATION_CAPS / the AI
+// debuff-preference readers used `disoriented` too), so a `disorient` status
+// applied by the on_hit_status producer (PART A) would NOT trigger the -2
+// attack malus. This suite pins the canonical key end to end:
+//   1. the on_hit_status helper writes target.status.disorient (canonical);
+//   2. session.js production source reads that same canonical key for the
+//      attack malus + duration cap (regression guard against re-divergence);
+//   3. the AI debuff-preference readers recognize the canonical key.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { applyOnHitStatuses } = require('../../../apps/backend/services/combat/onHitStatus');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SESSION_SRC = fs.readFileSync(
+  path.join(REPO_ROOT, 'apps', 'backend', 'routes', 'session.js'),
+  'utf8',
+);
+const POLICY_SRC = fs.readFileSync(
+  path.join(REPO_ROOT, 'apps', 'backend', 'services', 'ai', 'policy.js'),
+  'utf8',
+);
+const DECLARE_SRC = fs.readFileSync(
+  path.join(REPO_ROOT, 'apps', 'backend', 'services', 'ai', 'declareSistemaIntents.js'),
+  'utf8',
+);
+
+const MECHANICS = {
+  spore_psichiche_silenziate: {
+    on_hit_status: { status_id: 'disorient', duration: 2, intensity: 1, trigger_dc: 12 },
+  },
+};
+
+test('on_hit_status applies the CANONICAL `disorient` key (not `disoriented`)', () => {
+  const actor = { id: 'a1', traits: ['spore_psichiche_silenziate'] };
+  const target = { id: 't1', tier: 1, status: {} };
+  // value 0.45 -> roll 10 + tier 1 = 11 < 12 -> save fails -> apply.
+  applyOnHitStatuses(actor, target, { rng: () => 0.45, mechanicsRegistry: MECHANICS });
+  assert.equal(target.status.disorient, 2, 'canonical disorient key set');
+  assert.equal(target.status.disoriented, undefined, 'divergent disoriented key NOT set');
+});
+
+test('the applied `disorient` status triggers the -2 attack malus (canonical key read)', () => {
+  // Replicate the session.js performAttack attack-malus read using the CANONICAL
+  // key, fed by the real producer. If session.js read `disoriented` the applied
+  // status would be inert; this asserts the keys agree.
+  const actor = { id: 'a1', traits: ['spore_psichiche_silenziate'] };
+  const target = { id: 't1', tier: 1, status: {} };
+  applyOnHitStatuses(actor, target, { rng: () => 0.45, mechanicsRegistry: MECHANICS });
+  const disorientPenalty = Number(target.status?.disorient) > 0 ? 2 : 0;
+  assert.equal(disorientPenalty, 2, 'disorient active -> -2 attack malus');
+});
+
+test('session.js performAttack reads canonical `disorient` for the attack malus', () => {
+  // Regression guard: the malus must read actor.status.disorient, never the
+  // divergent actor.status.disoriented.
+  assert.match(
+    SESSION_SRC,
+    /actor\.status\?\.disorient\b(?!ed)/,
+    'attack malus reads actor.status.disorient',
+  );
+  assert.doesNotMatch(
+    SESSION_SRC,
+    /\bdisoriented\b/,
+    'no `disoriented` reference remains in session.js',
+  );
+});
+
+test('STATUS_DURATION_CAPS keys the canonical `disorient`', () => {
+  // The duration cap entry must be keyed `disorient` so on_hit_status statuses
+  // are capped under the same key they are written/read with.
+  assert.match(SESSION_SRC, /\bdisorient:\s*1\b/, 'STATUS_DURATION_CAPS has disorient: 1');
+});
+
+test('AI debuff-preference readers recognize the canonical `disorient` key', () => {
+  assert.doesNotMatch(POLICY_SRC, /\bdisoriented\b/, 'policy.js uses canonical disorient');
+  assert.doesNotMatch(
+    DECLARE_SRC,
+    /\bdisoriented\b/,
+    'declareSistemaIntents.js uses canonical disorient',
+  );
+  assert.match(POLICY_SRC, /s\.disorient\b(?!ed)/, 'policy.js reads s.disorient');
+  assert.match(DECLARE_SRC, /s\.disorient\b(?!ed)/, 'declareSistemaIntents.js reads s.disorient');
+});

--- a/tests/services/coop/worldEnricher.test.js
+++ b/tests/services/coop/worldEnricher.test.js
@@ -4,6 +4,19 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { enrichWorld } = require('../../../apps/backend/services/coop/worldEnricher');
+const ermesExporter = require('../../../apps/backend/services/coop/ermesExporter');
+const path = require('node:path');
+
+// Hermetic ERMES seam: force getErmesForBiome onto a nonexistent report path so
+// assertions exercise the deterministic STATIC_FALLBACKS, independent of whether a
+// local gitignored prototype report
+// (prototypes/ermes_lab/outputs/latest_eco_pressure_report.json) happens to be on
+// disk. Real static-fallback code path still runs; computeRoleGap preserved.
+const NO_ERMES_REPORT = path.join(__dirname, '__no_ermes_report__.json');
+const staticErmes = {
+  ...ermesExporter,
+  getErmesForBiome: (b) => ermesExporter.getErmesForBiome(b, { reportPath: NO_ERMES_REPORT }),
+};
 
 test('enrichWorld empty biomeId returns empty payload', () => {
   const r = enrichWorld({ biomeId: '' });
@@ -14,7 +27,7 @@ test('enrichWorld empty biomeId returns empty payload', () => {
 });
 
 test('enrichWorld savana returns full W5 schema', () => {
-  const r = enrichWorld({ biomeId: 'savana', runSeed: 42 });
+  const r = enrichWorld({ biomeId: 'savana', runSeed: 42 }, { ermesExporter: staticErmes });
   // world
   assert.equal(r.world.biome_id, 'savana');
   assert.ok(typeof r.world.biome_label_it === 'string' && r.world.biome_label_it.length > 0);

--- a/tests/services/statusModifiers.test.js
+++ b/tests/services/statusModifiers.test.js
@@ -74,6 +74,17 @@ test('computeStatusModifiers: target attuned → +1 def', () => {
   assert.equal(r.defenseDelta, 1);
 });
 
+// GAP-3 (parity-sweep 2026-06-07) — sbilanciato defense-malus: shield_bash (jobs.yaml)
+// writes target.status.sbilanciato but the resolver never read it (Python->Node
+// regression; schema combat.schema.json: "sbilanciato -1 defense_mod, 1 turno").
+test('computeStatusModifiers: target sbilanciato → -1 def (spinta/shield_bash exposure)', () => {
+  const actor = { id: 'a', status: {} };
+  const target = { id: 'b', status: { sbilanciato: 1 } };
+  const r = computeStatusModifiers(actor, target, []);
+  assert.equal(r.defenseDelta, -1);
+  assert.ok(r.log.some((e) => e.status === 'sbilanciato' && e.side === 'target'));
+});
+
 test('computeStatusModifiers: telepatic_link → reveal log only, no stat', () => {
   const actor = { id: 'a', status: { telepatic_link: 3 } };
   const target = { id: 'b', status: {} };


### PR DESCRIPTION
Combat parity fixes from the parity-sweep audit (Eduardo-ratified decisions, evidence-based, 2026-06-07). **Behavior-critical -- left for review (no self-merge).** Full TDD.

## Changes
- **GAP-3 (D8a) WIRE `sbilanciato`** -- `shield_bash` (jobs.yaml) wrote `target.status.sbilanciato` but `computeStatusModifiers` never read it (Python->Node regression; schema: -1 defense_mod). Now applies `defenseDelta -= 1`.
- **GAP-1 (D1) PORT `on_hit_status` producer** -- new `onHitStatus.js` `applyOnHitStatuses()` wired into `performAttack` post-hit (gated `if result.hit`, seeded rng, best-effort try/catch). Per attacker trait with `on_hit_status`: target saves `d20+tier` vs `trigger_dc`; fail -> applies status. 13 traits (disorient/bleed/panic-on-hit) were data-live but inert (no producer); consumers already existed.
- **GAP-2 (D1) RETIRE `on_hit_stress_delta`** -- removed from 2 traits + schema + contract test. Superseded by event-driven `morale.js` (avoid a 2nd parallel stress driver).
- **PART-C** reconcile `disorient`/`disoriented` naming (session.js / policy.js / declareSistemaIntents.js + test) so the producer's `disorient` actually fires the -2 attack malus + AI debuff-preference.
- **+ pre-existing flake-fix** (`worldEnricher.test.js`, separate commit `ad190a8d6`): savana W5 test was non-deterministic vs a gitignored ERMES report; injected `staticErmes` to force deterministic STATIC_FALLBACKS. Test-only; needed for green CI (this was the spawn-task'd bug).

## Verification (TDD, RED->GREEN)
- `onHitStatus.test.js` 7/7, `onHitStatusDisorientParity.test.js` 5/5, `contracts-trait-mechanics.test.js` 15/15, `statusModifiers.test.js` 34/34.
- Full backend suite (`npm run test:api`): **3749 pass, 0 fail** (re-verified by lead).

## Review note
`onHitStatusDisorientParity.test.js` includes 3 source-regex guard assertions (regression guards vs `disoriented` re-divergence) -- drop/relocate if you prefer behavior-only tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)