### PR TITLE
feat(device-input): SPEC-A ledger backend (schema/tier/engine-integration)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -44,6 +44,10 @@ const {
 } = require('../services/traitEffects');
 const { loadFairnessConfig, checkCapPtBudget, consumeCapPt } = require('../services/fairnessCap');
 const { loadTelemetryConfig, buildVcSnapshot } = require('../services/vcScoring');
+// SPEC-A Device Input Ledger: validate + consent-gate device events into the
+// session event log, and tier-filter the TV-mirror channel (public + aggregated).
+const { ingest: ingestDeviceEvent } = require('../services/deviceInput');
+const { filterForTvMirror } = require('../services/deviceInput/tierFilter');
 // TKT-ORPHAN-VCSNAP — Game-side serializer that flattens a vc snapshot to the
 // Godot-parity debrief_payload (sentience_tier + conviction_axis + ennea_archetype).
 const { vcSnapshotToDebriefPayload } = require('../services/coop/vcSnapshotToDebriefPayload');
@@ -4107,6 +4111,63 @@ function createSessionRouter(options = {}) {
   // Le 4 route qui sotto abilitano il nuovo modello round-based
   // (shared-planning → commit → resolve) descritto in
   // ADR-2026-04-16-session-engine-round-migration.md e implementato
+
+  // ────────────────────────────────────────────────────────────────
+  // SPEC-A Device Input Ledger — device-event ingest + TV-mirror view
+  // ────────────────────────────────────────────────────────────────
+  //
+  // POST /api/session/device-event
+  //   body: { session_id, event, profilingConsent? }
+  //   - validates the device event (schema + tier) and consent-gates `signal`
+  //     events (behavioral profiling is opt-in; decision-events always pass);
+  //   - accepted events append to session.events via the canonical appendEvent
+  //     (action_index + persist) so the existing vcScoring / convictionEngine
+  //     pipeline consumes them. Raw events never cross the wire.
+  //   - profilingConsent, when a boolean is provided, persists on the session.
+  //   Spec: docs/design/evo-tactics-device-input-ledger.md
+  router.post('/device-event', async (req, res, next) => {
+    try {
+      const { session_id, event, profilingConsent } = req.body || {};
+      const { error, session } = resolveSession(session_id);
+      if (error) return res.status(error.status).json(error.body);
+      if (typeof profilingConsent === 'boolean') {
+        session.profilingConsent = profilingConsent;
+      }
+      const consent = session.profilingConsent === true;
+      // ingest() is the pure validate + consent-gate facade; run it against a
+      // scratch buffer, then append the accepted event canonically.
+      const scratch = [];
+      const result = ingestDeviceEvent(scratch, event, { profilingConsent: consent });
+      if (result.accepted) {
+        await appendEvent(session, result.event);
+      }
+      return res.json({
+        accepted: result.accepted,
+        reason: result.reason || null,
+        profiling_consent: consent,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // GET /api/session/tv-mirror?session_id=...
+  //   Returns the TV-mirror-safe slice of the event log: only `public` +
+  //   `aggregated` tiered events (fail-closed; untagged events are stripped).
+  //   The cinematic / spectator channel (SPEC-D, Plan 2) consumes this.
+  router.get('/tv-mirror', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.query.session_id);
+      if (error) return res.status(error.status).json(error.body);
+      const events = Array.isArray(session.events) ? session.events : [];
+      return res.json({
+        session_id: session.session_id,
+        events: filterForTvMirror(events),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
 
   // Round endpoints mounted from sessionRoundBridge.js (token optimization).
   roundBridge.mountRoundEndpoints(router);

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -4139,6 +4139,14 @@ function createSessionRouter(options = {}) {
       const scratch = [];
       const result = ingestDeviceEvent(scratch, event, { profilingConsent: consent });
       if (result.accepted) {
+        // Server-side actor attribution: bind the device event to the player's
+        // controlled unit so the conviction / vcScoring pipeline can score it.
+        // Client-supplied actor_id is never trusted (the schema strips it); we
+        // derive it from the trusted session roster (controlled_by === playerId).
+        const owned = Array.isArray(session.units)
+          ? session.units.find((u) => u && u.controlled_by === result.event.playerId)
+          : null;
+        if (owned) result.event.actor_id = owned.id;
         await appendEvent(session, result.event);
       }
       return res.json({

--- a/apps/backend/services/convictionEngine.js
+++ b/apps/backend/services/convictionEngine.js
@@ -111,9 +111,15 @@ function classifyEvent(event) {
   if (event.action_type === 'sacrifice') return { ...DELTA.SACRIFICE };
 
   const flags = event.flags || {};
+
+  // SPEC-A device-input ledger: explicit semantic flags on decision-events,
+  // honored regardless of action_type. Reuse existing bounded DELTA magnitudes.
+  if (flags.refuse_order === true) return { ...DELTA.REFUSE_ORDER };
+  if (flags.sacrifice === true) return { ...DELTA.SACRIFICE };
+  if (flags.mercy === true) return { ...DELTA.KILL_MERCY };
+
   // Kill semantic split.
   if (event.action_type === 'kill' || (event.action_type === 'attack' && event.result === 'kill')) {
-    if (flags.mercy === true) return { ...DELTA.KILL_MERCY };
     // Pragma kill on low HP target (no mercy flag, target was weak).
     if (Number.isFinite(event.target_hp_before) && event.target_hp_before <= 3) {
       return { ...DELTA.KILL_LOW_HP_NO_MERCY };

--- a/apps/backend/services/deviceInput/eventSchema.js
+++ b/apps/backend/services/deviceInput/eventSchema.js
@@ -18,7 +18,16 @@ function validateDeviceEvent(ev) {
     return { ok: false, error: 'playerId required' };
   const tier = ev.tier == null ? DEFAULT_TIER_BY_CLASS[ev.kind] : ev.tier;
   if (!TIERS.has(tier)) return { ok: false, error: `invalid tier: ${tier}` };
-  return { ok: true, event: { ...ev, tier } };
+  // Whitelist-construct the persisted event: never spread the raw client object.
+  // A wholesale spread would let a client forge combat-reserved keys (actor_id,
+  // action_type, damage_dealt, result, first_blood) that the scoring / promotion
+  // pipeline would then count as real play. Only the device-event contract fields
+  // cross the wire; actor attribution is assigned server-side from the roster.
+  const event = { kind: ev.kind, type: ev.type, playerId: ev.playerId, tier };
+  if (ev.payload !== undefined) event.payload = ev.payload;
+  if (ev.value !== undefined) event.value = ev.value;
+  if (ev.flags !== undefined) event.flags = ev.flags;
+  return { ok: true, event };
 }
 
 module.exports = { TIERS, DEFAULT_TIER_BY_CLASS, validateDeviceEvent };

--- a/apps/backend/services/deviceInput/eventSchema.js
+++ b/apps/backend/services/deviceInput/eventSchema.js
@@ -1,0 +1,24 @@
+const TIERS = new Set(['public', 'private', 'aggregated', 'secret']);
+
+// Default tier per event class (override allowed via explicit ev.tier).
+const DEFAULT_TIER_BY_CLASS = {
+  decision: 'public', // group decisions are public by default
+  signal: 'secret', // behavioral signals feed engines, hidden from humans
+};
+
+const VALID_KINDS = new Set(['decision', 'signal']); // 'raw' never crosses the wire
+
+function validateDeviceEvent(ev) {
+  if (!ev || typeof ev !== 'object') return { ok: false, error: 'event must be an object' };
+  if (ev.kind === 'raw')
+    return { ok: false, error: 'raw events must not cross the wire (edge-first)' };
+  if (!VALID_KINDS.has(ev.kind)) return { ok: false, error: `invalid kind: ${ev.kind}` };
+  if (typeof ev.type !== 'string' || !ev.type) return { ok: false, error: 'type required' };
+  if (typeof ev.playerId !== 'string' || !ev.playerId)
+    return { ok: false, error: 'playerId required' };
+  const tier = ev.tier == null ? DEFAULT_TIER_BY_CLASS[ev.kind] : ev.tier;
+  if (!TIERS.has(tier)) return { ok: false, error: `invalid tier: ${tier}` };
+  return { ok: true, event: { ...ev, tier } };
+}
+
+module.exports = { TIERS, DEFAULT_TIER_BY_CLASS, validateDeviceEvent };

--- a/apps/backend/services/deviceInput/index.js
+++ b/apps/backend/services/deviceInput/index.js
@@ -1,0 +1,15 @@
+const { validateDeviceEvent } = require('./eventSchema');
+
+// Thin facade: validate -> consent-gate -> enrich the existing session event log.
+// Engines consume `log` via the existing vcScoring.computeRawMetrics pipeline.
+function ingest(sessionEvents, deviceEvent, { profilingConsent = false } = {}) {
+  const v = validateDeviceEvent(deviceEvent);
+  if (!v.ok) return { accepted: false, reason: `invalid: ${v.error}` };
+  if (v.event.kind === 'signal' && !profilingConsent) {
+    return { accepted: false, reason: 'profiling-opt-out' };
+  }
+  sessionEvents.push(v.event);
+  return { accepted: true, event: v.event };
+}
+
+module.exports = { ingest };

--- a/apps/backend/services/deviceInput/tierFilter.js
+++ b/apps/backend/services/deviceInput/tierFilter.js
@@ -1,0 +1,9 @@
+const TV_VISIBLE_TIERS = new Set(['public', 'aggregated']);
+
+// Fail-closed: anything not explicitly TV-visible is stripped.
+function filterForTvMirror(events) {
+  if (!Array.isArray(events)) return [];
+  return events.filter((e) => e && TV_VISIBLE_TIERS.has(e.tier));
+}
+
+module.exports = { TV_VISIBLE_TIERS, filterForTvMirror };

--- a/apps/backend/services/vcScoring.js
+++ b/apps/backend/services/vcScoring.js
@@ -36,6 +36,13 @@ const DEFAULT_TELEMETRY_PATH = path.resolve(
 
 const SCORING_VERSION = '0.1.0';
 
+// SPEC-A device input ledger: behavioral signal normalization ceilings + J/P fold weight.
+// Deterministic, bounded (anti-noise): avg signal value / ceiling, clamped to [0,1].
+const COMMIT_LATENCY_CEILING_MS = 3000; // avg commit deliberation ms at which signal saturates
+const HESITATION_CEILING = 5; // avg hesitation units (undo + option-switch) saturating
+const PREVIEW_DWELL_CEILING_MS = 4000; // avg preview dwell ms saturating
+const JP_COMMIT_LATENCY_WEIGHT = 0.3; // J/P fold weight: high commit_latency -> Perceiving
+
 // Raw metrics derivabili dai log post-SPRINT_003 fase 0.
 // L'ordine non conta, ma e' la lista autoritativa usata dalla
 // rinormalizzazione dei pesi.
@@ -199,6 +206,13 @@ function computeRawMetrics(events, units, gridSize = 6) {
       prev_action_type: null,
       concrete_action_count: 0,
       abstract_action_count: 0,
+      // SPEC-A device input ledger: behavioral signal accumulators (sum + count).
+      commit_latency_sum: 0,
+      commit_latency_count: 0,
+      hesitation_sum: 0,
+      hesitation_count: 0,
+      preview_dwell_sum: 0,
+      preview_dwell_count: 0,
     };
   }
 
@@ -227,6 +241,28 @@ function computeRawMetrics(events, units, gridSize = 6) {
 
   for (const event of events) {
     if (!event) continue;
+
+    // SPEC-A device input ledger: behavioral signal-events (kind 'signal') carry a
+    // numeric `value`; accumulate per actor (bucket by actor_id, fallback playerId)
+    // and never touch combat counters.
+    if (event.kind === 'signal') {
+      const sigBucket = perActor[event.actor_id] || perActor[event.playerId];
+      const sigValue = Number(event.value);
+      if (sigBucket && Number.isFinite(sigValue)) {
+        if (event.type === 'commit_latency') {
+          sigBucket.commit_latency_sum += sigValue;
+          sigBucket.commit_latency_count += 1;
+        } else if (event.type === 'hesitation_score') {
+          sigBucket.hesitation_sum += sigValue;
+          sigBucket.hesitation_count += 1;
+        } else if (event.type === 'preview_dwell') {
+          sigBucket.preview_dwell_sum += sigValue;
+          sigBucket.preview_dwell_count += 1;
+        }
+      }
+      continue;
+    }
+
     const actorId = event.actor_id;
     // Le azioni IA hanno actor_id="sistema" ma il metrics sono sempre
     // attribuiti allo unit reale. Usiamo ia_controlled_unit quando
@@ -440,6 +476,23 @@ function computeRawMetrics(events, units, gridSize = 6) {
     // <=1 non derivabile (nessuna transizione possibile).
     const actionSwitchRate = iter2Total > 1 ? bucket.action_switches / (iter2Total - 1) : null;
 
+    // SPEC-A device input ledger: normalized behavioral signals (null when absent so
+    // axes fall back to legacy formulas; clamp01 bounds anti-noise).
+    const commitLatencyNorm =
+      bucket.commit_latency_count > 0
+        ? clamp01(
+            bucket.commit_latency_sum / bucket.commit_latency_count / COMMIT_LATENCY_CEILING_MS,
+          )
+        : null;
+    const hesitationRate =
+      bucket.hesitation_count > 0
+        ? clamp01(bucket.hesitation_sum / bucket.hesitation_count / HESITATION_CEILING)
+        : null;
+    const previewDwellNorm =
+      bucket.preview_dwell_count > 0
+        ? clamp01(bucket.preview_dwell_sum / bucket.preview_dwell_count / PREVIEW_DWELL_CEILING_MS)
+        : null;
+
     finalRaw[unitId] = {
       attacks_started: attacksStarted,
       attack_hit_rate: attackHitRate,
@@ -468,6 +521,10 @@ function computeRawMetrics(events, units, gridSize = 6) {
       enemy_target_ratio: enemyTargetRatio,
       concrete_action_ratio: concreteActionRatio,
       action_switch_rate: actionSwitchRate,
+      // SPEC-A device input ledger: behavioral signals (null when no consented signal).
+      commit_latency_norm: commitLatencyNorm,
+      hesitation_rate: hesitationRate,
+      preview_dwell_norm: previewDwellNorm,
     };
   }
 
@@ -573,10 +630,23 @@ function computeMbtiAxes(raw) {
 
   // J_P: Judging vs Perceiving
   const setupProxy = clamp01(raw.setup_ratio);
+  // SPEC-A device input ledger: long commit deliberation -> Perceiving (lower value).
+  // Folded only when present; absent -> identical to the legacy two-term formula.
+  const commitLatencyNorm = clamp01(raw.commit_latency_norm);
   if (setupProxy !== null && timeToCommit !== null) {
-    const totalWeight = 0.6 + 0.2;
-    const normalised = 1 - (0.6 / totalWeight) * setupProxy - (0.2 / totalWeight) * timeToCommit;
-    axes.J_P = { value: clamp01(normalised), coverage: 'partial' };
+    if (commitLatencyNorm !== null) {
+      const totalWeight = 0.6 + 0.2 + JP_COMMIT_LATENCY_WEIGHT;
+      const normalised =
+        1 -
+        (0.6 / totalWeight) * setupProxy -
+        (0.2 / totalWeight) * timeToCommit -
+        (JP_COMMIT_LATENCY_WEIGHT / totalWeight) * commitLatencyNorm;
+      axes.J_P = { value: clamp01(normalised), coverage: 'partial' };
+    } else {
+      const totalWeight = 0.6 + 0.2;
+      const normalised = 1 - (0.6 / totalWeight) * setupProxy - (0.2 / totalWeight) * timeToCommit;
+      axes.J_P = { value: clamp01(normalised), coverage: 'partial' };
+    }
   }
 
   return axes;

--- a/data/core/telemetry.yaml
+++ b/data/core/telemetry.yaml
@@ -51,7 +51,8 @@ mbti_axes:
   # S_N: new_tiles = exploration (N), setup_ratio = methodical (S), evasion_ratio = improvisation (N)
   S_N: {formula: "1 - 0.4*new_tiles + 0.3*setup_ratio - 0.3*evasion_ratio"}
   T_F: {formula: "1 - 0.5*utility_actions + 0.5*support_bias"}
-  J_P: {formula: "1 - 0.6*setup - 0.2*time_to_commit + 0.2*last_second"}
+  # SPEC-A: + commit_latency_norm term (device deliberation -> Perceiving) when present.
+  J_P: {formula: "1 - 0.6*setup - 0.2*time_to_commit + 0.2*last_second - 0.3*commit_latency_norm"}
 ennea_themes:
   # VC Calibration iter1 (2026-04-17): soglie abbassate per indici
   # con weight parziali (cohesion/explore/setup/tilt). Vedi

--- a/docs/architecture/ai-policy-engine.md
+++ b/docs/architecture/ai-policy-engine.md
@@ -321,6 +321,13 @@ position from/to su move    └─ new_tiles ───────┘           
 Vedi `apps/backend/services/vcScoring.js` e `data/core/telemetry.yaml`
 per i pesi dei singoli indici e le condizioni dei themes.
 
+> **SPEC-A device input ledger (2026-06-07)**: i signal behavioral del device
+> (`commit_latency`, `hesitation_score`, `preview_dwell`) confluiscono come raw
+> metrics aggiuntive (`commit_latency_norm`, `hesitation_rate`, `preview_dwell_norm`)
+> in `computeRawMetrics`. `commit_latency_norm` e' foldato nell'asse J_P (lunga
+> deliberazione -> Perceiving) solo quando presente; assente -> formula legacy
+> invariata. Ref: `docs/design/evo-tactics-device-input-ledger.md`.
+
 ## Utility AI gradual rollout (ADR-2026-04-17 Q-001 T3.1)
 
 Architettura Utility AI formalizzata in [ADR-2026-04-16](../adr/ADR-2026-04-16-ai-architecture-utility.md), attivazione gradual via feature flag data-driven formalizzata in [ADR-2026-04-17](../adr/ADR-2026-04-17-utility-ai-default-activation.md) (Opzione C).

--- a/docs/design/evo-tactics-device-input-ledger.md
+++ b/docs/design/evo-tactics-device-input-ledger.md
@@ -78,7 +78,7 @@ hard-gate. I signal sono input morbidi, mai cancelli netti.
    - `decision_events` (canonici). Mai raw. Mai dalla TV.
 4. **`deviceInputLedger` (backend, nuovo, thin).**
    - valida + registra i `decision_events` (campaign / debrief / Custodi);
-   - instrada i `signal_events` agli engine LIVE come input aggiuntivi;
+   - arricchisce `session.events` con decision-events flaggati (`event.flags.*`) + campi behavioral; gli engine LIVE li consumano via la pipeline esistente `vcScoring.computeRawMetrics` -> `computeMbtiAxes` / `evaluateConviction` (il ledger NON instrada a un bus parallelo);
    - applica il tier di visibilita' (sez. 5) e decide cosa la TV puo' mirror-are.
 5. **Consumers (esistenti).** Engine di scoring -> effetti gia' live (recruit,
    mating, Nido, ERMES/ALIENA, Tri-Sorgente, debrief). Alimentati, non sostituiti.
@@ -90,7 +90,8 @@ raw (device, effimero)
   -> derive (device)
   -> [signal_events + decision_events, tier-tagged]
   -> wire
-  -> deviceInputLedger { record decision ; route signal -> engine }
+  -> deviceInputLedger { validate + tier-tag ; enrich session.events }
+  -> vcScoring.computeRawMetrics (pipeline esistente) -> axes/conviction
   -> effetti di campagna esistenti
   -> debrief / Custodi
 ```
@@ -191,6 +192,7 @@ Acceptance: la spec e' implementabile quando i signal v1 hanno schema + derivazi
   `convictionEngine` / `mbti*` / `vcScore` va letta sul codice e confermata
   prima di redigere il piano (Currency Gate). Il mapping in sez. 6 e' proposto,
   non ancora verificato contro l'API.
+  - **RISOLTO 2026-06-07**: engine API = event-log-driven (`vcScoring.computeRawMetrics` + `convictionEngine` `event.flags`). Integrazione via enrichment di `session.events`, non routing-bus.
 - **VERIFY device buffer**: capacita'/lifecycle del buffer raw lato Godot
   (memoria, scarto) da dimensionare con il client.
 - **Full-loop metric**: indicare quali metriche del full-loop runner misureranno

--- a/docs/superpowers/plans/2026-06-07-spec-a-device-input-ledger-backend.md
+++ b/docs/superpowers/plans/2026-06-07-spec-a-device-input-ledger-backend.md
@@ -1,0 +1,395 @@
+# SPEC-A Device Input Ledger -- Backend Integration Implementation Plan (Plan 1/2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the backend half of the Device Input Ledger -- ingest tier-tagged device events, feed the existing identity stack (MBTI/Conviction/VC) via the live event-log pipeline, and enforce TV-mirror visibility.
+
+**Architecture:** The identity stack is already EVENT-LOG-DRIVEN (`vcScoring.computeRawMetrics(events, units)` -> `computeMbtiAxes` + `evaluateConviction`, telemetry-YAML config). SPEC-A therefore does NOT add a parallel signal-bus: it (a) validates device events against a schema + tier taxonomy, (b) enriches `session.events` with flagged decision-events + behavioral fields, (c) extends `computeRawMetrics` + telemetry weights to consume them, (d) filters the TV-mirror channel to public+aggregated only. Engines stay owner of the math.
+
+**Tech Stack:** Node.js (Express backend, `apps/backend`), existing test harness (`tests/`, `node --test` / run-test-api), YAML telemetry config.
+
+**Scope (decomposed):**
+
+- **Plan 1 (this doc)** = backend: schema/tier module, tier-enforcement filter, conviction event-flag extension, `computeRawMetrics` extension, telemetry weights, consent/decision-only path. Self-contained + testable with synthetic events.
+- **Plan 2 (follow-up)** = Godot client (`Game-Godot-v2`): raw capture buffer, on-device derivation, event emission. Depends on Plan 1's wire contract (Task 2 schema).
+
+**Source spec:** `docs/design/evo-tactics-device-input-ledger.md` (MERGED #2616).
+**VERIFY done 2026-06-07:** engine APIs confirmed -- `convictionEngine.classifyEvent(event)` reads `event.flags.*` (extension point); `vcScoring.computeRawMetrics(events, units, gridSize)` is the raw-metric derivation; `mbtiSurface.js` is surface-only (do NOT touch for ingest).
+
+---
+
+## File structure (backend)
+
+- Create: `apps/backend/services/deviceInput/eventSchema.js` -- event schema + tier taxonomy + validation (pure, no deps).
+- Create: `apps/backend/services/deviceInput/tierFilter.js` -- TV-mirror visibility filter (pure).
+- Create: `apps/backend/services/deviceInput/index.js` -- thin `deviceInputLedger` facade (validate -> enrich-event -> hand to existing pipeline).
+- Modify: `apps/backend/services/convictionEngine.js` -- extend `classifyEvent` flag handling (after read).
+- Modify: `apps/backend/services/vcScoring.js` -- extend `computeRawMetrics` to read behavioral fields (after read).
+- Modify: telemetry YAML (path via `vcScoring.DEFAULT_TELEMETRY_PATH`) -- weights for new raw metrics (after read).
+- Modify: `apps/backend/routes/session.js` + `services/network/wsSession.js` -- consent flag + decision-only gate + tier-filter on TV broadcast (after read).
+- Tests: `tests/services/deviceInput/*.test.js` (+ extensions to existing conviction/vcScoring tests).
+
+---
+
+## Task 1: Amend SPEC-A sez.4 to the verified integration mechanism
+
+The spec's sez.4 describes a "signal-bus routes to engines". The VERIFY proved the real mechanism is event-log enrichment + `computeRawMetrics` extension. Align the canon-adjacent doc before code so implementers don't build the wrong thing.
+
+**Files:**
+
+- Modify: `docs/design/evo-tactics-device-input-ledger.md` (sez. 4.1 component 4 + 4.2 data flow)
+
+- [ ] **Step 1: Edit sez.4.1 component 4** -- replace "instrada i `signal_events` agli engine LIVE come input aggiuntivi" with: "arricchisce `session.events` con decision-events flaggati (`event.flags.*`) + campi behavioral; gli engine LIVE li consumano via la pipeline esistente `vcScoring.computeRawMetrics` -> `computeMbtiAxes` / `evaluateConviction`. Il ledger NON instrada a un bus parallelo."
+
+- [ ] **Step 2: Edit sez.4.2 data flow** -- change `deviceInputLedger { record decision ; route signal -> engine }` to `deviceInputLedger { validate + tier-tag ; enrich session.events } -> vcScoring.computeRawMetrics (pipeline esistente) -> axes/conviction`.
+
+- [ ] **Step 3: Add a note** under sez.10 VERIFY: "RISOLTO 2026-06-07: engine API = event-log-driven (vcScoring.computeRawMetrics + convictionEngine event.flags). Integrazione via enrichment, non routing-bus."
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/design/evo-tactics-device-input-ledger.md
+git commit -m "docs(spec-a): amend sez.4 to verified event-log enrichment mechanism
+
+Coding-Agent: <agent-id>
+Trace-Id: <uuidv7>"
+```
+
+---
+
+## Task 2: Event schema + tier taxonomy module
+
+The wire contract. Pure module, fully groundable -- this is also Plan 2's dependency (the Godot client emits to this schema).
+
+**Files:**
+
+- Create: `apps/backend/services/deviceInput/eventSchema.js`
+- Test: `tests/services/deviceInput/eventSchema.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  TIERS,
+  validateDeviceEvent,
+  DEFAULT_TIER_BY_CLASS,
+} = require('../../../apps/backend/services/deviceInput/eventSchema');
+
+test('TIERS has the 4 canonical tiers', () => {
+  assert.deepEqual([...TIERS].sort(), ['aggregated', 'private', 'public', 'secret']);
+});
+
+test('valid decision event passes', () => {
+  const ev = {
+    kind: 'decision',
+    type: 'route_vote',
+    playerId: 'p1',
+    tier: 'public',
+    payload: { route: 'A' },
+  };
+  const r = validateDeviceEvent(ev);
+  assert.equal(r.ok, true);
+});
+
+test('signal event gets default tier when omitted', () => {
+  const ev = { kind: 'signal', type: 'commit_latency', playerId: 'p1', value: 1200 };
+  const r = validateDeviceEvent(ev);
+  assert.equal(r.ok, true);
+  assert.equal(r.event.tier, DEFAULT_TIER_BY_CLASS.signal); // 'secret'
+});
+
+test('raw events are rejected on the wire', () => {
+  const ev = { kind: 'raw', type: 'tap', playerId: 'p1' };
+  const r = validateDeviceEvent(ev);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /raw/i);
+});
+
+test('invalid tier is rejected', () => {
+  const ev = { kind: 'signal', type: 'x', playerId: 'p1', tier: 'banana' };
+  const r = validateDeviceEvent(ev);
+  assert.equal(r.ok, false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/services/deviceInput/eventSchema.test.js`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// apps/backend/services/deviceInput/eventSchema.js
+const TIERS = new Set(['public', 'private', 'aggregated', 'secret']);
+
+// Default tier per event class (override allowed via explicit ev.tier).
+const DEFAULT_TIER_BY_CLASS = {
+  decision: 'public', // group decisions are public by default
+  signal: 'secret', // behavioral signals feed engines, hidden from humans
+};
+
+const VALID_KINDS = new Set(['decision', 'signal']); // 'raw' never crosses the wire
+
+function validateDeviceEvent(ev) {
+  if (!ev || typeof ev !== 'object') return { ok: false, error: 'event must be an object' };
+  if (ev.kind === 'raw')
+    return { ok: false, error: 'raw events must not cross the wire (edge-first)' };
+  if (!VALID_KINDS.has(ev.kind)) return { ok: false, error: `invalid kind: ${ev.kind}` };
+  if (typeof ev.type !== 'string' || !ev.type) return { ok: false, error: 'type required' };
+  if (typeof ev.playerId !== 'string' || !ev.playerId)
+    return { ok: false, error: 'playerId required' };
+  const tier = ev.tier == null ? DEFAULT_TIER_BY_CLASS[ev.kind] : ev.tier;
+  if (!TIERS.has(tier)) return { ok: false, error: `invalid tier: ${tier}` };
+  return { ok: true, event: { ...ev, tier } };
+}
+
+module.exports = { TIERS, DEFAULT_TIER_BY_CLASS, validateDeviceEvent };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/services/deviceInput/eventSchema.test.js`
+Expected: PASS (5/5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/services/deviceInput/eventSchema.js tests/services/deviceInput/eventSchema.test.js
+git commit -m "feat(device-input): event schema + tier taxonomy + validation
+
+Coding-Agent: <agent-id>
+Trace-Id: <uuidv7>"
+```
+
+---
+
+## Task 3: TV-mirror tier-enforcement filter
+
+Pure function: the TV broadcast may only carry `public` + `aggregated`. Fully groundable.
+
+**Files:**
+
+- Create: `apps/backend/services/deviceInput/tierFilter.js`
+- Test: `tests/services/deviceInput/tierFilter.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  filterForTvMirror,
+  TV_VISIBLE_TIERS,
+} = require('../../../apps/backend/services/deviceInput/tierFilter');
+
+test('TV sees only public + aggregated', () => {
+  assert.deepEqual([...TV_VISIBLE_TIERS].sort(), ['aggregated', 'public']);
+});
+
+test('private and secret are stripped from TV payload', () => {
+  const events = [
+    { type: 'a', tier: 'public' },
+    { type: 'b', tier: 'private' },
+    { type: 'c', tier: 'aggregated' },
+    { type: 'd', tier: 'secret' },
+  ];
+  const out = filterForTvMirror(events);
+  assert.deepEqual(
+    out.map((e) => e.type),
+    ['a', 'c'],
+  );
+});
+
+test('missing tier is treated as not-TV-visible (fail-closed)', () => {
+  const out = filterForTvMirror([{ type: 'x' }]);
+  assert.equal(out.length, 0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/services/deviceInput/tierFilter.test.js`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```js
+// apps/backend/services/deviceInput/tierFilter.js
+const TV_VISIBLE_TIERS = new Set(['public', 'aggregated']);
+
+// Fail-closed: anything not explicitly TV-visible is stripped.
+function filterForTvMirror(events) {
+  if (!Array.isArray(events)) return [];
+  return events.filter((e) => e && TV_VISIBLE_TIERS.has(e.tier));
+}
+
+module.exports = { TV_VISIBLE_TIERS, filterForTvMirror };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/services/deviceInput/tierFilter.test.js`
+Expected: PASS (3/3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/services/deviceInput/tierFilter.js tests/services/deviceInput/tierFilter.test.js
+git commit -m "feat(device-input): TV-mirror tier-enforcement filter (fail-closed)
+
+Coding-Agent: <agent-id>
+Trace-Id: <uuidv7>"
+```
+
+---
+
+## Task 4: convictionEngine event-flag extension
+
+`classifyEvent` already has an explicit extension point for `event.flags.mercy/refuse`. Map the relevant decision-events (`risk_posture`, `choice_consistency` semantics) to conviction flags.
+
+**Files:**
+
+- Modify: `apps/backend/services/convictionEngine.js` (`classifyEvent`, ~line 106)
+- Test: extend `tests/services/convictionEngine.test.js` (or the existing conviction test)
+
+- [ ] **Step 1: READ FIRST (no placeholder).** Read `apps/backend/services/convictionEngine.js` lines 106-246 (`classifyEvent` body + `DELTA` table at line 54). Identify how existing events map to {utility, liberty, morality} deltas and the exact shape `classifyEvent` returns (delta object or null). Record the existing flag handling.
+
+- [ ] **Step 2: Write the failing test** -- after the read, write a test asserting that a decision-event carrying `flags.refuse_order` produces a positive `liberty` delta and `flags.sacrifice`/`flags.mercy` produce a `morality` delta, using the SAME return shape observed in Step 1. (Write the concrete assertions against the real `evaluateConviction`/`classifyEvent` signature.)
+
+- [ ] **Step 3: Run test -- expect FAIL** (flags not yet honored).
+
+- [ ] **Step 4: Implement** -- extend `classifyEvent` to read `event.flags.{refuse_order, sacrifice, mercy}` and emit the corresponding bounded delta (reuse the existing `DELTA` magnitudes; do NOT invent new scales). Keep null-return for events without semantics.
+
+- [ ] **Step 5: Run test -- expect PASS** + run the full conviction suite to confirm no regression.
+
+- [ ] **Step 6: Commit** (`feat(conviction): honor explicit event.flags for liberty/morality deltas` + ADR-0011 trailers).
+
+---
+
+## Task 5: computeRawMetrics extension for behavioral signals
+
+Feed `commit_latency` / `hesitation_score` / `preview_dwell` (carried on signal-events in the log) into the raw-metric layer that `computeMbtiAxes` consumes.
+
+**Files:**
+
+- Modify: `apps/backend/services/vcScoring.js` (`computeRawMetrics`, ~line 132; `computeMbtiAxes`, ~line 524)
+- Modify: telemetry YAML (`DEFAULT_TELEMETRY_PATH` near line 86)
+- Test: extend `tests/api/` vcScoring/mbti coverage
+
+- [ ] **Step 1: READ FIRST.** Read `apps/backend/services/vcScoring.js` lines 132-260 (`computeRawMetrics`) + 503-675 (`computeAggregateIndices`, `computeMbtiAxes`, `computeMbtiAxesIter2`). Read the telemetry YAML at `DEFAULT_TELEMETRY_PATH`. Record: the exact `raw` object shape, how weights are keyed, and which axes map J/P + S/N + E/I.
+
+- [ ] **Step 2: Write the failing test** -- assert that an events array containing signal-events with `commit_latency` (high) raises the raw metric used for the J/P axis in the direction documented in SPEC-A (long deliberation -> P). Use the real `computeRawMetrics`/`computeMbtiAxes` signatures from Step 1.
+
+- [ ] **Step 3: Run test -- expect FAIL.**
+
+- [ ] **Step 4: Implement** -- in `computeRawMetrics`, accumulate the behavioral fields from signal-events into new raw keys (e.g. `raw.avgCommitLatency`, `raw.hesitationRate`, `raw.previewDwell`); add their weights to the telemetry YAML so `computeAggregateIndices`/`computeMbtiAxes` fold them. Keep deterministic; bound contributions (anti-noise, mirror existing dead-band logic at line 610).
+
+- [ ] **Step 5: Run test -- expect PASS** + full vcScoring/mbti suite green (no regression on existing axes).
+
+- [ ] **Step 6: Commit** (`feat(vcScoring): fold device behavioral signals into raw metrics + telemetry weights` + trailers).
+
+---
+
+## Task 6: Consent opt-in + decision-only graceful-degrade
+
+`secret` behavioral profiling is opt-in; opt-out runs the ledger in decision-only mode (decision-events still score; behavioral signals dropped) and the game stays playable.
+
+**Files:**
+
+- Create: `apps/backend/services/deviceInput/index.js` (facade: `ingest(sessionEvents, deviceEvent, { profilingConsent })`)
+- Test: `tests/services/deviceInput/ingest.test.js`
+- Modify (after read): `apps/backend/routes/session.js` / `wsSession.js` to call the facade + carry the consent flag.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { ingest } = require('../../../apps/backend/services/deviceInput');
+
+test('decision events are always ingested', () => {
+  const log = [];
+  const r = ingest(
+    log,
+    { kind: 'decision', type: 'route_vote', playerId: 'p1', tier: 'public' },
+    { profilingConsent: false },
+  );
+  assert.equal(r.accepted, true);
+  assert.equal(log.length, 1);
+});
+
+test('signal events dropped when consent is false (decision-only)', () => {
+  const log = [];
+  const r = ingest(
+    log,
+    { kind: 'signal', type: 'commit_latency', playerId: 'p1', value: 900 },
+    { profilingConsent: false },
+  );
+  assert.equal(r.accepted, false);
+  assert.equal(r.reason, 'profiling-opt-out');
+  assert.equal(log.length, 0);
+});
+
+test('signal events ingested when consent is true', () => {
+  const log = [];
+  const r = ingest(
+    log,
+    { kind: 'signal', type: 'commit_latency', playerId: 'p1', value: 900 },
+    { profilingConsent: true },
+  );
+  assert.equal(r.accepted, true);
+  assert.equal(log.length, 1);
+});
+
+test('invalid (raw) event is rejected regardless of consent', () => {
+  const log = [];
+  const r = ingest(log, { kind: 'raw', type: 'tap', playerId: 'p1' }, { profilingConsent: true });
+  assert.equal(r.accepted, false);
+  assert.match(r.reason, /raw|invalid/i);
+});
+```
+
+- [ ] **Step 2: Run test -- expect FAIL** (module not found).
+
+- [ ] **Step 3: Implement**
+
+```js
+// apps/backend/services/deviceInput/index.js
+const { validateDeviceEvent } = require('./eventSchema');
+
+// Thin facade: validate -> consent-gate -> enrich the existing session event log.
+// Engines consume `log` via the existing vcScoring.computeRawMetrics pipeline.
+function ingest(sessionEvents, deviceEvent, { profilingConsent = false } = {}) {
+  const v = validateDeviceEvent(deviceEvent);
+  if (!v.ok) return { accepted: false, reason: `invalid: ${v.error}` };
+  if (v.event.kind === 'signal' && !profilingConsent) {
+    return { accepted: false, reason: 'profiling-opt-out' };
+  }
+  sessionEvents.push(v.event);
+  return { accepted: true, event: v.event };
+}
+
+module.exports = { ingest };
+```
+
+- [ ] **Step 4: Run test -- expect PASS** (4/4).
+
+- [ ] **Step 5: Commit** (`feat(device-input): ingest facade with consent gate + decision-only degrade` + trailers).
+
+- [ ] **Step 6: Wire into routes (after read).** Read the WS drain handlers in `services/network/wsSession.js` + `routes/session.js`, then route incoming device events through `ingest(...)`, apply `filterForTvMirror(...)` on the TV broadcast path, and thread `profilingConsent` from session/onboarding state. Add a route-level integration test mirroring the existing `tests/api/session*Wire.test.js` pattern.
+
+---
+
+## Self-review
+
+- **Spec coverage:** sez.4 architecture -> T1+T2+T6; sez.5 tiers -> T2 (taxonomy) + T3 (TV enforcement); sez.6 signals -> T4 (conviction) + T5 (mbti); sez.7 retention/consent -> T6; sez.8 error-handling -> T2/T6 validation + fail-closed T3; sez.9 testing -> every task is TDD. Raw-retention (sez.7.1) is a Plan 2 (device) concern -- noted.
+- **No placeholders:** T2/T3/T6 carry complete code. T4/T5 + T6.Step6 are deliberately read-first (engine/route bodies unread at plan time -- VERIFY confirmed signatures only); fabricating exact diffs there would be the placeholder. Each read-first step names exact file+line ranges.
+- **Type consistency:** `validateDeviceEvent` returns `{ ok, event|error }`; `ingest` returns `{ accepted, reason|event }`; `filterForTvMirror` takes/returns event arrays. Consistent across tasks.
+
+## Open dependencies
+
+- **Plan 2 (Godot client)** consumes Task 2's schema as the emission contract. Do not finalize Plan 2 until Task 2 lands.
+- **Telemetry YAML weights (T5)** may need a calibration pass (full-loop runner N=40) once signals flow -- out of scope for Plan 1, flagged for SPEC-A full-loop-metric follow-up.

--- a/docs/superpowers/plans/2026-06-07-spec-a-device-input-ledger-backend.md
+++ b/docs/superpowers/plans/2026-06-07-spec-a-device-input-ledger-backend.md
@@ -39,13 +39,13 @@ The spec's sez.4 describes a "signal-bus routes to engines". The VERIFY proved t
 
 - Modify: `docs/design/evo-tactics-device-input-ledger.md` (sez. 4.1 component 4 + 4.2 data flow)
 
-- [ ] **Step 1: Edit sez.4.1 component 4** -- replace "instrada i `signal_events` agli engine LIVE come input aggiuntivi" with: "arricchisce `session.events` con decision-events flaggati (`event.flags.*`) + campi behavioral; gli engine LIVE li consumano via la pipeline esistente `vcScoring.computeRawMetrics` -> `computeMbtiAxes` / `evaluateConviction`. Il ledger NON instrada a un bus parallelo."
+- [x] **Step 1: Edit sez.4.1 component 4** -- replace "instrada i `signal_events` agli engine LIVE come input aggiuntivi" with: "arricchisce `session.events` con decision-events flaggati (`event.flags.*`) + campi behavioral; gli engine LIVE li consumano via la pipeline esistente `vcScoring.computeRawMetrics` -> `computeMbtiAxes` / `evaluateConviction`. Il ledger NON instrada a un bus parallelo."
 
-- [ ] **Step 2: Edit sez.4.2 data flow** -- change `deviceInputLedger { record decision ; route signal -> engine }` to `deviceInputLedger { validate + tier-tag ; enrich session.events } -> vcScoring.computeRawMetrics (pipeline esistente) -> axes/conviction`.
+- [x] **Step 2: Edit sez.4.2 data flow** -- change `deviceInputLedger { record decision ; route signal -> engine }` to `deviceInputLedger { validate + tier-tag ; enrich session.events } -> vcScoring.computeRawMetrics (pipeline esistente) -> axes/conviction`.
 
-- [ ] **Step 3: Add a note** under sez.10 VERIFY: "RISOLTO 2026-06-07: engine API = event-log-driven (vcScoring.computeRawMetrics + convictionEngine event.flags). Integrazione via enrichment, non routing-bus."
+- [x] **Step 3: Add a note** under sez.10 VERIFY: "RISOLTO 2026-06-07: engine API = event-log-driven (vcScoring.computeRawMetrics + convictionEngine event.flags). Integrazione via enrichment, non routing-bus."
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add docs/design/evo-tactics-device-input-ledger.md
@@ -66,7 +66,7 @@ The wire contract. Pure module, fully groundable -- this is also Plan 2's depend
 - Create: `apps/backend/services/deviceInput/eventSchema.js`
 - Test: `tests/services/deviceInput/eventSchema.test.js`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```js
 const { test } = require('node:test');
@@ -114,12 +114,12 @@ test('invalid tier is rejected', () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `node --test tests/services/deviceInput/eventSchema.test.js`
 Expected: FAIL (module not found).
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 ```js
 // apps/backend/services/deviceInput/eventSchema.js
@@ -149,12 +149,12 @@ function validateDeviceEvent(ev) {
 module.exports = { TIERS, DEFAULT_TIER_BY_CLASS, validateDeviceEvent };
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `node --test tests/services/deviceInput/eventSchema.test.js`
 Expected: PASS (5/5).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/backend/services/deviceInput/eventSchema.js tests/services/deviceInput/eventSchema.test.js
@@ -175,7 +175,7 @@ Pure function: the TV broadcast may only carry `public` + `aggregated`. Fully gr
 - Create: `apps/backend/services/deviceInput/tierFilter.js`
 - Test: `tests/services/deviceInput/tierFilter.test.js`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```js
 const { test } = require('node:test');
@@ -209,12 +209,12 @@ test('missing tier is treated as not-TV-visible (fail-closed)', () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `node --test tests/services/deviceInput/tierFilter.test.js`
 Expected: FAIL (module not found).
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 ```js
 // apps/backend/services/deviceInput/tierFilter.js
@@ -229,12 +229,12 @@ function filterForTvMirror(events) {
 module.exports = { TV_VISIBLE_TIERS, filterForTvMirror };
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `node --test tests/services/deviceInput/tierFilter.test.js`
 Expected: PASS (3/3).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add apps/backend/services/deviceInput/tierFilter.js tests/services/deviceInput/tierFilter.test.js
@@ -255,17 +255,17 @@ Trace-Id: <uuidv7>"
 - Modify: `apps/backend/services/convictionEngine.js` (`classifyEvent`, ~line 106)
 - Test: extend `tests/services/convictionEngine.test.js` (or the existing conviction test)
 
-- [ ] **Step 1: READ FIRST (no placeholder).** Read `apps/backend/services/convictionEngine.js` lines 106-246 (`classifyEvent` body + `DELTA` table at line 54). Identify how existing events map to {utility, liberty, morality} deltas and the exact shape `classifyEvent` returns (delta object or null). Record the existing flag handling.
+- [x] **Step 1: READ FIRST (no placeholder).** Read `apps/backend/services/convictionEngine.js` lines 106-246 (`classifyEvent` body + `DELTA` table at line 54). Identify how existing events map to {utility, liberty, morality} deltas and the exact shape `classifyEvent` returns (delta object or null). Record the existing flag handling.
 
-- [ ] **Step 2: Write the failing test** -- after the read, write a test asserting that a decision-event carrying `flags.refuse_order` produces a positive `liberty` delta and `flags.sacrifice`/`flags.mercy` produce a `morality` delta, using the SAME return shape observed in Step 1. (Write the concrete assertions against the real `evaluateConviction`/`classifyEvent` signature.)
+- [x] **Step 2: Write the failing test** -- after the read, write a test asserting that a decision-event carrying `flags.refuse_order` produces a positive `liberty` delta and `flags.sacrifice`/`flags.mercy` produce a `morality` delta, using the SAME return shape observed in Step 1. (Write the concrete assertions against the real `evaluateConviction`/`classifyEvent` signature.)
 
-- [ ] **Step 3: Run test -- expect FAIL** (flags not yet honored).
+- [x] **Step 3: Run test -- expect FAIL** (flags not yet honored).
 
-- [ ] **Step 4: Implement** -- extend `classifyEvent` to read `event.flags.{refuse_order, sacrifice, mercy}` and emit the corresponding bounded delta (reuse the existing `DELTA` magnitudes; do NOT invent new scales). Keep null-return for events without semantics.
+- [x] **Step 4: Implement** -- extend `classifyEvent` to read `event.flags.{refuse_order, sacrifice, mercy}` and emit the corresponding bounded delta (reuse the existing `DELTA` magnitudes; do NOT invent new scales). Keep null-return for events without semantics.
 
-- [ ] **Step 5: Run test -- expect PASS** + run the full conviction suite to confirm no regression.
+- [x] **Step 5: Run test -- expect PASS** + run the full conviction suite to confirm no regression.
 
-- [ ] **Step 6: Commit** (`feat(conviction): honor explicit event.flags for liberty/morality deltas` + ADR-0011 trailers).
+- [x] **Step 6: Commit** (`feat(conviction): honor explicit event.flags for liberty/morality deltas` + ADR-0011 trailers).
 
 ---
 
@@ -279,17 +279,17 @@ Feed `commit_latency` / `hesitation_score` / `preview_dwell` (carried on signal-
 - Modify: telemetry YAML (`DEFAULT_TELEMETRY_PATH` near line 86)
 - Test: extend `tests/api/` vcScoring/mbti coverage
 
-- [ ] **Step 1: READ FIRST.** Read `apps/backend/services/vcScoring.js` lines 132-260 (`computeRawMetrics`) + 503-675 (`computeAggregateIndices`, `computeMbtiAxes`, `computeMbtiAxesIter2`). Read the telemetry YAML at `DEFAULT_TELEMETRY_PATH`. Record: the exact `raw` object shape, how weights are keyed, and which axes map J/P + S/N + E/I.
+- [x] **Step 1: READ FIRST.** Read `apps/backend/services/vcScoring.js` lines 132-260 (`computeRawMetrics`) + 503-675 (`computeAggregateIndices`, `computeMbtiAxes`, `computeMbtiAxesIter2`). Read the telemetry YAML at `DEFAULT_TELEMETRY_PATH`. Record: the exact `raw` object shape, how weights are keyed, and which axes map J/P + S/N + E/I.
 
-- [ ] **Step 2: Write the failing test** -- assert that an events array containing signal-events with `commit_latency` (high) raises the raw metric used for the J/P axis in the direction documented in SPEC-A (long deliberation -> P). Use the real `computeRawMetrics`/`computeMbtiAxes` signatures from Step 1.
+- [x] **Step 2: Write the failing test** -- assert that an events array containing signal-events with `commit_latency` (high) raises the raw metric used for the J/P axis in the direction documented in SPEC-A (long deliberation -> P). Use the real `computeRawMetrics`/`computeMbtiAxes` signatures from Step 1.
 
-- [ ] **Step 3: Run test -- expect FAIL.**
+- [x] **Step 3: Run test -- expect FAIL.**
 
-- [ ] **Step 4: Implement** -- in `computeRawMetrics`, accumulate the behavioral fields from signal-events into new raw keys (e.g. `raw.avgCommitLatency`, `raw.hesitationRate`, `raw.previewDwell`); add their weights to the telemetry YAML so `computeAggregateIndices`/`computeMbtiAxes` fold them. Keep deterministic; bound contributions (anti-noise, mirror existing dead-band logic at line 610).
+- [x] **Step 4: Implement** -- in `computeRawMetrics`, accumulate the behavioral fields from signal-events into new raw keys (e.g. `raw.avgCommitLatency`, `raw.hesitationRate`, `raw.previewDwell`); add their weights to the telemetry YAML so `computeAggregateIndices`/`computeMbtiAxes` fold them. Keep deterministic; bound contributions (anti-noise, mirror existing dead-band logic at line 610).
 
-- [ ] **Step 5: Run test -- expect PASS** + full vcScoring/mbti suite green (no regression on existing axes).
+- [x] **Step 5: Run test -- expect PASS** + full vcScoring/mbti suite green (no regression on existing axes).
 
-- [ ] **Step 6: Commit** (`feat(vcScoring): fold device behavioral signals into raw metrics + telemetry weights` + trailers).
+- [x] **Step 6: Commit** (`feat(vcScoring): fold device behavioral signals into raw metrics + telemetry weights` + trailers).
 
 ---
 
@@ -303,7 +303,7 @@ Feed `commit_latency` / `hesitation_score` / `preview_dwell` (carried on signal-
 - Test: `tests/services/deviceInput/ingest.test.js`
 - Modify (after read): `apps/backend/routes/session.js` / `wsSession.js` to call the facade + carry the consent flag.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```js
 const { test } = require('node:test');
@@ -352,9 +352,9 @@ test('invalid (raw) event is rejected regardless of consent', () => {
 });
 ```
 
-- [ ] **Step 2: Run test -- expect FAIL** (module not found).
+- [x] **Step 2: Run test -- expect FAIL** (module not found).
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```js
 // apps/backend/services/deviceInput/index.js
@@ -375,11 +375,11 @@ function ingest(sessionEvents, deviceEvent, { profilingConsent = false } = {}) {
 module.exports = { ingest };
 ```
 
-- [ ] **Step 4: Run test -- expect PASS** (4/4).
+- [x] **Step 4: Run test -- expect PASS** (4/4).
 
-- [ ] **Step 5: Commit** (`feat(device-input): ingest facade with consent gate + decision-only degrade` + trailers).
+- [x] **Step 5: Commit** (`feat(device-input): ingest facade with consent gate + decision-only degrade` + trailers).
 
-- [ ] **Step 6: Wire into routes (after read).** Read the WS drain handlers in `services/network/wsSession.js` + `routes/session.js`, then route incoming device events through `ingest(...)`, apply `filterForTvMirror(...)` on the TV broadcast path, and thread `profilingConsent` from session/onboarding state. Add a route-level integration test mirroring the existing `tests/api/session*Wire.test.js` pattern.
+- [x] **Step 6: Wire into routes (after read).** Read the WS drain handlers in `services/network/wsSession.js` + `routes/session.js`, then route incoming device events through `ingest(...)`, apply `filterForTvMirror(...)` on the TV broadcast path, and thread `profilingConsent` from session/onboarding state. Add a route-level integration test mirroring the existing `tests/api/session*Wire.test.js` pattern.
 
 ---
 

--- a/tests/api/convictionAxis.test.js
+++ b/tests/api/convictionAxis.test.js
@@ -140,3 +140,48 @@ test('vcScoring: buildVcSnapshot per_actor includes conviction_axis (debrief sur
     `morality after assist >= baseline, got ${snap.per_actor.unit_1.conviction_axis.morality}`,
   );
 });
+
+test('convictionEngine: classifyEvent explicit flags.refuse_order -> liberty+ (SPEC-A)', () => {
+  const delta = classifyEvent({
+    action_type: 'decision',
+    actor_id: 'unit_1',
+    flags: { refuse_order: true },
+  });
+  assert.ok(delta);
+  assert.equal(delta.liberty, 4);
+});
+
+test('convictionEngine: classifyEvent explicit flags.sacrifice -> morality+, utility- (SPEC-A)', () => {
+  const delta = classifyEvent({
+    action_type: 'decision',
+    actor_id: 'unit_1',
+    flags: { sacrifice: true },
+  });
+  assert.ok(delta);
+  assert.equal(delta.morality, 5);
+  assert.equal(delta.utility, -3);
+});
+
+test('convictionEngine: classifyEvent explicit flags.mercy on non-kill decision -> morality+ (SPEC-A)', () => {
+  const delta = classifyEvent({
+    action_type: 'decision',
+    actor_id: 'unit_1',
+    flags: { mercy: true },
+  });
+  assert.ok(delta);
+  assert.equal(delta.morality, 5);
+  assert.equal(delta.utility, -2);
+});
+
+test('convictionEngine: explicit flags accumulate via evaluateConviction (SPEC-A)', () => {
+  const events = [
+    { action_type: 'decision', actor_id: 'unit_1', flags: { refuse_order: true } },
+    { action_type: 'decision', actor_id: 'unit_1', flags: { sacrifice: true } },
+  ];
+  const result = evaluateConviction(events, [{ id: 'unit_1' }]);
+  // refuse_order (lib+4) -> lib=54 ; sacrifice (mor+5, util-3) -> mor=55, util=47
+  assert.equal(result.unit_1.liberty, 54);
+  assert.equal(result.unit_1.morality, 55);
+  assert.equal(result.unit_1.utility, 47);
+  assert.equal(result.unit_1.events_classified, 2);
+});

--- a/tests/api/sessionDeviceEventWire.test.js
+++ b/tests/api/sessionDeviceEventWire.test.js
@@ -1,0 +1,89 @@
+// tests/api/sessionDeviceEventWire.test.js — SPEC-A Device Input Ledger wire.
+//
+// Pins the backend seam: device events POST -> ingest (validate + consent-gate)
+// -> session.events; signal events are gated by profilingConsent (opt-in, with
+// decision-only graceful degrade); the TV-mirror GET exposes only public +
+// aggregated tiers (fail-closed). Raw events never cross the wire.
+// Spec: docs/design/evo-tactics-device-input-ledger.md
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({
+      units: [{ id: 'u1', controlled_by: 'player', hp: 10, max_hp: 10, position: { x: 1, y: 1 } }],
+    });
+  return res.body.session_id;
+}
+
+test('device-event wire: decision ingested, signal consent-gated, tv-mirror filtered', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app);
+
+  // 1. decision event is always ingested (no consent needed).
+  const dec = await request(app)
+    .post('/api/session/device-event')
+    .send({
+      session_id: sid,
+      event: {
+        kind: 'decision',
+        type: 'route_vote',
+        playerId: 'p1',
+        tier: 'public',
+        payload: { route: 'A' },
+      },
+    });
+  assert.equal(dec.status, 200, JSON.stringify(dec.body).slice(0, 200));
+  assert.equal(dec.body.accepted, true);
+
+  // 2. signal event dropped when profiling consent absent (decision-only mode).
+  const sigNo = await request(app)
+    .post('/api/session/device-event')
+    .send({
+      session_id: sid,
+      event: { kind: 'signal', type: 'commit_latency', playerId: 'p1', value: 900 },
+    });
+  assert.equal(sigNo.body.accepted, false);
+  assert.equal(sigNo.body.reason, 'profiling-opt-out');
+
+  // 3. signal event ingested once consent is granted (persists on session).
+  const sigYes = await request(app)
+    .post('/api/session/device-event')
+    .send({
+      session_id: sid,
+      profilingConsent: true,
+      event: { kind: 'signal', type: 'commit_latency', playerId: 'p1', value: 900 },
+    });
+  assert.equal(sigYes.body.accepted, true);
+  assert.equal(sigYes.body.profiling_consent, true);
+
+  // 4. TV-mirror exposes only public/aggregated tiers (secret signal hidden).
+  const tv = await request(app).get('/api/session/tv-mirror').query({ session_id: sid });
+  assert.equal(tv.status, 200);
+  const types = tv.body.events.map((e) => e.type);
+  assert.ok(types.includes('route_vote'), 'public decision visible on TV');
+  assert.ok(!types.includes('commit_latency'), 'secret behavioral signal hidden from TV');
+});
+
+test('device-event wire: raw events are rejected at the route (edge-first)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app);
+  const res = await request(app)
+    .post('/api/session/device-event')
+    .send({ session_id: sid, event: { kind: 'raw', type: 'tap', playerId: 'p1' } });
+  assert.equal(res.body.accepted, false);
+  assert.match(res.body.reason, /raw|invalid/i);
+});

--- a/tests/api/sessionDeviceEventWire.test.js
+++ b/tests/api/sessionDeviceEventWire.test.js
@@ -87,3 +87,73 @@ test('device-event wire: raw events are rejected at the route (edge-first)', asy
   assert.equal(res.body.accepted, false);
   assert.match(res.body.reason, /raw|invalid/i);
 });
+
+test('device-event wire: forged combat keys are stripped (no scoring injection)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app); // unit u1 controlled_by 'player' (not 'p1')
+  await request(app)
+    .post('/api/session/device-event')
+    .send({
+      session_id: sid,
+      event: {
+        kind: 'decision',
+        type: 'forged',
+        playerId: 'p1',
+        tier: 'public',
+        actor_id: 'u1',
+        action_type: 'attack',
+        result: 'hit',
+        damage_dealt: 9999,
+        first_blood: true,
+      },
+    });
+  const replay = await request(app).get(`/api/session/${sid}/replay`);
+  const injected = replay.body.events.find((e) => e.type === 'forged');
+  assert.ok(injected, 'event ingested');
+  assert.equal(injected.action_type, undefined, 'forged action_type stripped');
+  assert.equal(injected.damage_dealt, undefined, 'forged damage_dealt stripped');
+  assert.equal(injected.result, undefined, 'forged result stripped');
+  // client actor_id is not trusted; p1 controls no unit here, so none is bound.
+  assert.equal(injected.actor_id, undefined, 'client actor_id not honored (no roster match)');
+});
+
+test('device-event wire: a consented decision flag reaches conviction (server actor binding)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  // unit controlled_by matches the device playerId -> server binds actor_id.
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({
+      units: [{ id: 'hero', controlled_by: 'p1', hp: 10, max_hp: 10, position: { x: 1, y: 1 } }],
+    });
+  const sid = startRes.body.session_id;
+
+  const dec = await request(app)
+    .post('/api/session/device-event')
+    .send({
+      session_id: sid,
+      event: {
+        kind: 'decision',
+        type: 'moral_choice',
+        playerId: 'p1',
+        tier: 'public',
+        flags: { sacrifice: true },
+      },
+    });
+  assert.equal(dec.body.accepted, true);
+
+  const vc = await request(app).get(`/api/session/${sid}/vc`);
+  assert.equal(vc.status, 200);
+  const axis =
+    vc.body.per_actor && vc.body.per_actor.hero && vc.body.per_actor.hero.conviction_axis;
+  assert.ok(axis, 'hero conviction_axis present');
+  assert.ok(
+    axis.morality > 50,
+    `sacrifice flag lifted morality above baseline (got ${axis.morality})`,
+  );
+});

--- a/tests/services/deviceInput/eventSchema.test.js
+++ b/tests/services/deviceInput/eventSchema.test.js
@@ -1,0 +1,43 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  TIERS,
+  validateDeviceEvent,
+  DEFAULT_TIER_BY_CLASS,
+} = require('../../../apps/backend/services/deviceInput/eventSchema');
+
+test('TIERS has the 4 canonical tiers', () => {
+  assert.deepEqual([...TIERS].sort(), ['aggregated', 'private', 'public', 'secret']);
+});
+
+test('valid decision event passes', () => {
+  const ev = {
+    kind: 'decision',
+    type: 'route_vote',
+    playerId: 'p1',
+    tier: 'public',
+    payload: { route: 'A' },
+  };
+  const r = validateDeviceEvent(ev);
+  assert.equal(r.ok, true);
+});
+
+test('signal event gets default tier when omitted', () => {
+  const ev = { kind: 'signal', type: 'commit_latency', playerId: 'p1', value: 1200 };
+  const r = validateDeviceEvent(ev);
+  assert.equal(r.ok, true);
+  assert.equal(r.event.tier, DEFAULT_TIER_BY_CLASS.signal); // 'secret'
+});
+
+test('raw events are rejected on the wire', () => {
+  const ev = { kind: 'raw', type: 'tap', playerId: 'p1' };
+  const r = validateDeviceEvent(ev);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /raw/i);
+});
+
+test('invalid tier is rejected', () => {
+  const ev = { kind: 'signal', type: 'x', playerId: 'p1', tier: 'banana' };
+  const r = validateDeviceEvent(ev);
+  assert.equal(r.ok, false);
+});

--- a/tests/services/deviceInput/ingest.test.js
+++ b/tests/services/deviceInput/ingest.test.js
@@ -1,0 +1,44 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { ingest } = require('../../../apps/backend/services/deviceInput');
+
+test('decision events are always ingested', () => {
+  const log = [];
+  const r = ingest(
+    log,
+    { kind: 'decision', type: 'route_vote', playerId: 'p1', tier: 'public' },
+    { profilingConsent: false },
+  );
+  assert.equal(r.accepted, true);
+  assert.equal(log.length, 1);
+});
+
+test('signal events dropped when consent is false (decision-only)', () => {
+  const log = [];
+  const r = ingest(
+    log,
+    { kind: 'signal', type: 'commit_latency', playerId: 'p1', value: 900 },
+    { profilingConsent: false },
+  );
+  assert.equal(r.accepted, false);
+  assert.equal(r.reason, 'profiling-opt-out');
+  assert.equal(log.length, 0);
+});
+
+test('signal events ingested when consent is true', () => {
+  const log = [];
+  const r = ingest(
+    log,
+    { kind: 'signal', type: 'commit_latency', playerId: 'p1', value: 900 },
+    { profilingConsent: true },
+  );
+  assert.equal(r.accepted, true);
+  assert.equal(log.length, 1);
+});
+
+test('invalid (raw) event is rejected regardless of consent', () => {
+  const log = [];
+  const r = ingest(log, { kind: 'raw', type: 'tap', playerId: 'p1' }, { profilingConsent: true });
+  assert.equal(r.accepted, false);
+  assert.match(r.reason, /raw|invalid/i);
+});

--- a/tests/services/deviceInput/tierFilter.test.js
+++ b/tests/services/deviceInput/tierFilter.test.js
@@ -1,0 +1,29 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  filterForTvMirror,
+  TV_VISIBLE_TIERS,
+} = require('../../../apps/backend/services/deviceInput/tierFilter');
+
+test('TV sees only public + aggregated', () => {
+  assert.deepEqual([...TV_VISIBLE_TIERS].sort(), ['aggregated', 'public']);
+});
+
+test('private and secret are stripped from TV payload', () => {
+  const events = [
+    { type: 'a', tier: 'public' },
+    { type: 'b', tier: 'private' },
+    { type: 'c', tier: 'aggregated' },
+    { type: 'd', tier: 'secret' },
+  ];
+  const out = filterForTvMirror(events);
+  assert.deepEqual(
+    out.map((e) => e.type),
+    ['a', 'c'],
+  );
+});
+
+test('missing tier is treated as not-TV-visible (fail-closed)', () => {
+  const out = filterForTvMirror([{ type: 'x' }]);
+  assert.equal(out.length, 0);
+});

--- a/tests/services/deviceSignalsMbti.test.js
+++ b/tests/services/deviceSignalsMbti.test.js
@@ -1,0 +1,52 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { computeRawMetrics, computeMbtiAxes } = require('../../apps/backend/services/vcScoring');
+
+const units = [{ id: 'unit_1', controlled_by: 'player', max_hp: 10 }];
+
+test('SPEC-A: commit_latency signal-events accumulate into raw.commit_latency_norm', () => {
+  const events = [
+    { kind: 'signal', type: 'commit_latency', actor_id: 'unit_1', playerId: 'p1', value: 2400 },
+    { kind: 'signal', type: 'commit_latency', actor_id: 'unit_1', playerId: 'p1', value: 2700 },
+  ];
+  const raw = computeRawMetrics(events, units);
+  assert.ok(raw.unit_1, 'unit_1 bucket present');
+  assert.notEqual(raw.unit_1.commit_latency_norm, null);
+  assert.ok(raw.unit_1.commit_latency_norm > 0.5, 'avg 2550/3000 ~ 0.85');
+});
+
+test('SPEC-A: hesitation + preview_dwell signal-events also accumulate', () => {
+  const events = [
+    { kind: 'signal', type: 'hesitation_score', actor_id: 'unit_1', value: 3 },
+    { kind: 'signal', type: 'preview_dwell', actor_id: 'unit_1', value: 2000 },
+  ];
+  const raw = computeRawMetrics(events, units);
+  assert.ok(
+    Number.isFinite(raw.unit_1.hesitation_rate) && raw.unit_1.hesitation_rate > 0,
+    'hesitation_rate finite > 0 (3/5 = 0.6)',
+  );
+  assert.ok(
+    Number.isFinite(raw.unit_1.preview_dwell_norm) && raw.unit_1.preview_dwell_norm > 0,
+    'preview_dwell_norm finite > 0 (2000/4000 = 0.5)',
+  );
+});
+
+test('SPEC-A: high commit_latency pushes J_P toward P (lower value)', () => {
+  const baseAxes = computeMbtiAxes({ setup_ratio: 0.5, time_to_commit: 0.5 });
+  const sigAxes = computeMbtiAxes({
+    setup_ratio: 0.5,
+    time_to_commit: 0.5,
+    commit_latency_norm: 0.9,
+  });
+  assert.ok(baseAxes.J_P && sigAxes.J_P, 'both J_P computed');
+  assert.ok(
+    sigAxes.J_P.value < baseAxes.J_P.value,
+    `signal J_P ${sigAxes.J_P.value} < baseline ${baseAxes.J_P.value} (toward P)`,
+  );
+});
+
+test('SPEC-A: absent commit_latency leaves J_P at legacy two-term value (backward compat)', () => {
+  const axes = computeMbtiAxes({ setup_ratio: 0.5, time_to_commit: 0.5 });
+  // legacy: 1 - 0.75*setup - 0.25*time_to_commit = 1 - 0.375 - 0.125 = 0.5
+  assert.equal(axes.J_P.value, 0.5);
+});


### PR DESCRIPTION
## SPEC-A Device Input Ledger -- Backend (Plan 1/2)

Backend half of the Device Input Ledger per the merged spec (`docs/design/evo-tactics-device-input-ledger.md`, #2616) and the TDD plan (`docs/superpowers/plans/2026-06-07-spec-a-device-input-ledger-backend.md`). Integrates through the **existing** event-log identity stack (`vcScoring.computeRawMetrics` -> MBTI/Conviction); no parallel signal-bus. Plan 2 (Godot client emitter) is a separate follow-up and consumes Task 2's schema as its wire contract.

### Tasks (strict TDD, one commit each)
- **T1** docs: amend spec sez.4 to the verified event-log enrichment mechanism (`d2cd9a4`).
- **T2** `deviceInput/eventSchema.js` -- event schema + 4-tier taxonomy + validation; raw rejected on the wire (`36eefeb`).
- **T3** `deviceInput/tierFilter.js` -- TV-mirror filter, fail-closed to `public`+`aggregated` (`fbc832b`).
- **T4** `convictionEngine.classifyEvent` -- honor explicit `event.flags.{refuse_order,sacrifice,mercy}` reusing existing DELTA magnitudes; dedups the now-redundant kill-branch mercy check (`2afd215`).
- **T5** `vcScoring.computeRawMetrics` -- accumulate device behavioral signals (`commit_latency`/`hesitation_score`/`preview_dwell`) into raw metrics; fold `commit_latency` into the J/P axis (long deliberation -> Perceiving), byte-identical to the legacy formula when absent; telemetry formula + `ai-policy-engine.md` note synced (`6b8369c`).
- **T6** `deviceInput/index.js` ingest facade (validate -> consent-gate -> append) with decision-only graceful degrade (`c2d74ec`); wired into session routes as `POST /api/session/device-event` + `GET /api/session/tv-mirror` (`58ab0cf`).

### Review hardening (`425305b`)
An independent review of the wiring found two real issues, both fixed + regression-tested:
- **[Critical / security]** `eventSchema` spread the raw client object, so a client could forge combat-reserved keys (`actor_id`/`action_type`/`damage_dealt`/`first_blood`) that the scoring + promotion pipeline would count as real play. Now whitelist-constructs the persisted event (only `kind/type/playerId/tier/payload/value/flags`).
- **[Important]** device events carry `playerId`, not `actor_id`, so `evaluateConviction` skipped them and the decision->conviction hook was unreachable (the "Engine LIVE Surface DEAD" failure mode). The route now binds `actor_id` server-side from the trusted roster (`controlled_by === playerId`), which also attributes signals in vcScoring. Added forged-keys-stripped + conviction-reach wire tests.

### Test evidence (0 fail)
- Full services suite: **1423 / 1423**
- API suite (`npm run test:api`): **500 / 500** (incl. `sessionDeviceEventWire`, `convictionAxis`)
- AI suite: **500 / 500** (>= 382 baseline preserved)
- New tests: eventSchema (5), tierFilter (3), conviction flags (4), device-signal MBTI (4), ingest (4), device-event wire (4 -- incl. security + conviction-reach)
- Prettier clean on all 16 changed files. (Repo-wide `format:check` has 114 pre-existing unrelated failures, intentionally not touched.)

### Notes / deviations
- T1 done inline (docs-only, exact edits) rather than via subagent.
- T5: the plan said "add weights to telemetry YAML so computeMbtiAxes folds them"; verified `computeMbtiAxes` is hardcoded (not telemetry-weight-driven), so the J/P fold is a direct, backward-compatible formula edit. `DERIVABLE_RAW_KEYS` left untouched (no aggregate index consumes the new keys yet).
- Secondary axis folds (`hesitation_score` -> J/P, `preview_dwell` -> S/N) are accumulated into raw but not yet folded into axes -- deferred to the N=40 telemetry calibration pass the plan flags as out-of-scope for Plan 1.

**Rollback:** revert the range `d2cd9a4..960ecd3` (all new files + additive, no migrations / no contract-schema changes).

NOT auto-merged -- behavior-critical backend, pending master-dd review. ADR-0011 trailers on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
