### PR TITLE
feat(combat): /declare-reaction route (orchestrator surface wire)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -2184,6 +2184,63 @@ function createRoundBridge(deps) {
       }
     });
 
+    // SPEC-C reaction wiring: expose the existing orchestrator declareReaction
+    // (engine was LIVE, route was DEAD). Mirrors /declare-intent; the engine
+    // validates phase + trigger event + payload type + predicates + cooldown.
+    router.post('/declare-reaction', (req, res, next) => {
+      try {
+        const {
+          session_id: sessionId,
+          actor_id: actorId,
+          reaction_trigger: reactionTrigger,
+          reaction_payload: reactionPayload,
+        } = req.body || {};
+        const { error, session } = resolveSession(sessionId);
+        if (error) return res.status(error.status).json(error.body);
+        if (!actorId || typeof actorId !== 'string') {
+          return res.status(400).json({ error: 'actor_id richiesto (string)' });
+        }
+        if (!reactionTrigger || typeof reactionTrigger !== 'object') {
+          return res
+            .status(400)
+            .json({ error: "reaction_trigger richiesto (object con campo 'event')" });
+        }
+        if (!reactionPayload || typeof reactionPayload !== 'object') {
+          return res
+            .status(400)
+            .json({ error: "reaction_payload richiesto (object con campo 'type')" });
+        }
+
+        const state = ensureRoundState(session);
+        let current = state;
+        if (current.round_phase !== PHASE_PLANNING) {
+          current = roundOrchestrator.beginRound(current).nextState;
+          session.roundState = current;
+          startPlanningTimer(session);
+        }
+        const { nextState } = roundOrchestrator.declareReaction(
+          current,
+          actorId,
+          reactionPayload,
+          reactionTrigger,
+        );
+        session.roundState = nextState;
+        res.json({
+          session_id: session.session_id,
+          round_phase: nextState.round_phase,
+          pending_intents: nextState.pending_intents,
+        });
+      } catch (err) {
+        if (
+          err &&
+          /round_phase|unit_id|reaction|predicate|cooldown_rounds/.test(String(err.message || ''))
+        ) {
+          return res.status(400).json({ error: err.message });
+        }
+        next(err);
+      }
+    });
+
     router.post('/clear-intent/:actorId', (req, res, next) => {
       try {
         const sessionId = (req.body && req.body.session_id) || req.query.session_id;

--- a/tests/api/declareReactionWire.test.js
+++ b/tests/api/declareReactionWire.test.js
@@ -1,0 +1,111 @@
+// tests/api/declareReactionWire.test.js — SPEC-C reaction wiring.
+//
+// Pins the missing surface for the existing engine fn
+// roundOrchestrator.declareReaction: POST /api/session/declare-reaction lets a
+// device register a conditional reaction intent during the planning phase
+// (Gate-5: engine was LIVE, route was DEAD). Thin wire, mirrors /declare-intent.
+// Spec: docs/design/evo-tactics-phone-wego-composer.md (SPEC-C, declareReaction).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({
+      units: [
+        { id: 'hero', controlled_by: 'player', hp: 10, max_hp: 10, position: { x: 1, y: 1 } },
+        { id: 'foe', controlled_by: 'sistema', hp: 10, max_hp: 10, position: { x: 2, y: 1 } },
+      ],
+    });
+  return res.body.session_id;
+}
+
+const VALID = {
+  reaction_trigger: { event: 'attacked', source_any_of: null, cooldown_rounds: 0 },
+  reaction_payload: { type: 'parry', parry_bonus: 2 },
+};
+
+test('declare-reaction wire: valid reaction registered in pending_intents', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app);
+
+  const res = await request(app)
+    .post('/api/session/declare-reaction')
+    .send({ session_id: sid, actor_id: 'hero', ...VALID });
+
+  assert.equal(res.status, 200, JSON.stringify(res.body).slice(0, 200));
+  assert.ok(res.body.round_phase, 'round_phase present (planning auto-entered)');
+  const reaction = (res.body.pending_intents || []).find(
+    (i) => i.unit_id === 'hero' && i.reaction_trigger,
+  );
+  assert.ok(reaction, 'reaction intent present in pending_intents');
+  assert.equal(reaction.reaction_trigger.event, 'attacked');
+  assert.equal(reaction.reaction_payload.type, 'parry');
+});
+
+test('declare-reaction wire: unsupported trigger event -> 400', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app);
+  const res = await request(app)
+    .post('/api/session/declare-reaction')
+    .send({
+      session_id: sid,
+      actor_id: 'hero',
+      reaction_trigger: { event: 'unknown_event' },
+      reaction_payload: { type: 'parry', parry_bonus: 1 },
+    });
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /non supportato|event/i);
+});
+
+test('declare-reaction wire: unsupported payload type -> 400', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app);
+  const res = await request(app)
+    .post('/api/session/declare-reaction')
+    .send({
+      session_id: sid,
+      actor_id: 'hero',
+      reaction_trigger: { event: 'attacked' },
+      reaction_payload: { type: 'nuke' },
+    });
+  assert.equal(res.status, 400);
+  assert.match(res.body.error, /non supportato|type/i);
+});
+
+test('declare-reaction wire: missing reaction_payload -> 400', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app);
+  const res = await request(app)
+    .post('/api/session/declare-reaction')
+    .send({ session_id: sid, actor_id: 'hero', reaction_trigger: { event: 'attacked' } });
+  assert.equal(res.status, 400);
+});
+
+test('declare-reaction wire: missing session -> 404', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app)
+    .post('/api/session/declare-reaction')
+    .send({ session_id: 'does_not_exist', actor_id: 'hero', ...VALID });
+  assert.equal(res.status, 404);
+});


### PR DESCRIPTION
## /declare-reaction route -- closes the SPEC-C reaction wiring gap (Gate-5)

SPEC-C (#2619) flagged it: `roundOrchestrator.declareReaction` exists (engine LIVE) but no route exposes it (surface DEAD). This adds `POST /api/session/declare-reaction`, a thin wire mirroring the existing `/declare-intent`.

**What it does:** during the planning phase, a device registers a conditional reaction intent (event + payload + predicates + cooldown) for a unit. The route resolves the session, validates inputs are objects, auto-enters planning (like /declare-intent), calls `roundOrchestrator.declareReaction(state, actor_id, reaction_payload, reaction_trigger)`, persists, and returns `{session_id, round_phase, pending_intents}`. The engine owns all validation (phase / trigger event / payload type / predicates / cooldown); engine errors surface as 400.

**No engine change** -- declareReaction was already implemented + tested (32/32 in roundOrchestrator.test.js). This is purely the missing surface.

**TDD (5 wire tests):** valid -> reaction in pending_intents; unsupported trigger event -> 400; unsupported payload type -> 400; missing reaction_payload -> 400; missing session -> 404.

**Test evidence:** new 5/5 green; round engine 32/32; full API suite 316/316 + 500/500, zero regression. Prettier clean. No forbidden paths.

**Observation for reviewer (existing engine behavior, NOT changed here):** `declareReaction` filters out any existing intent for the same unit before pushing the reaction (`roundOrchestrator.js:517-519`), so declaring a reaction replaces that unit's pending main intent. SPEC-C frames reactions as a *separate* economy from AP/main intents (main intents APPEND, multi per round). If that one-slot-per-unit replace is unintended, it's an engine concern for a follow-up -- out of scope for this route wire.

NOT auto-merged -- behavior-critical combat round, master-dd review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
