### PR TITLE
feat(combat): declareReaction main-intent fix + /preview-round v2 (SPEC-C)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -2494,6 +2494,44 @@ function createRoundBridge(deps) {
         next(err);
       }
     });
+
+    // SPEC-C G5: expose previewRound as the v2 server preview (engine was LIVE,
+    // route DEAD). Non-canonical estimate via a NEUTRAL rng (expected outcome,
+    // never the round's real combatRng per G5) and NON-MUTATING -- the engine
+    // clones internally and the route never persists session.roundState.
+    router.post('/preview-round', (req, res, next) => {
+      try {
+        const sessionId = req.body && req.body.session_id;
+        const { error, session } = resolveSession(sessionId);
+        if (error) return res.status(error.status).json(error.body);
+        if (!session.roundState) {
+          return res
+            .status(400)
+            .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
+        }
+        const result = roundOrchestrator.previewRound(
+          session.roundState,
+          null,
+          () => 0.5,
+          placeholderResolveAction,
+        );
+        res.json({
+          session_id: session.session_id,
+          preview: true,
+          round_phase: result.nextState.round_phase,
+          turn_log_entries: result.turnLogEntries,
+          resolution_queue: result.resolutionQueue,
+          reactions_triggered: result.reactionsTriggered,
+          skipped: result.skipped,
+          units: result.nextState.units,
+        });
+      } catch (err) {
+        if (err && /round_phase/.test(String(err.message || ''))) {
+          return res.status(400).json({ error: err.message });
+        }
+        next(err);
+      }
+    });
   }
 
   return {

--- a/apps/backend/services/roundOrchestrator.js
+++ b/apps/backend/services/roundOrchestrator.js
@@ -514,8 +514,10 @@ function declareReaction(state, unitId, reactionPayload, trigger) {
   }
 
   const nextState = _deepClone(state || {});
+  // Separate economy (SPEC-C): a reaction replaces only the unit's PRIOR reaction,
+  // never its main intents (declareIntent APPENDs those). Keep mains, drop old reaction.
   const pending = (nextState.pending_intents || []).filter(
-    (i) => String(i.unit_id || '') !== String(unitId),
+    (i) => !(String(i.unit_id || '') === String(unitId) && i.reaction_trigger),
   );
   const sourceFilter = trigger && trigger.source_any_of;
   const normalisedTrigger = {

--- a/tests/api/previewRoundWire.test.js
+++ b/tests/api/previewRoundWire.test.js
@@ -1,0 +1,83 @@
+// tests/api/previewRoundWire.test.js — SPEC-C G5 preview v2 surface.
+//
+// Exposes the existing engine fn roundOrchestrator.previewRound (server LIVE,
+// route DEAD). POST /api/session/preview-round returns a non-canonical round
+// estimate (neutral rng = expected outcome, never the round's real rng per G5)
+// WITHOUT mutating the real session state. Spec: SPEC-C G5
+// (docs/design/evo-tactics-phone-wego-composer.md).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startSession(app) {
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({
+      units: [
+        { id: 'hero', controlled_by: 'player', hp: 10, max_hp: 10, position: { x: 1, y: 1 } },
+        { id: 'foe', controlled_by: 'sistema', hp: 10, max_hp: 10, position: { x: 2, y: 1 } },
+      ],
+    });
+  return res.body.session_id;
+}
+
+async function beginPlanning(app, sid) {
+  return request(app).post('/api/session/round/begin-planning').send({ session_id: sid });
+}
+
+test('preview-round wire: returns a non-canonical preview during planning', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app);
+  await beginPlanning(app, sid);
+
+  const res = await request(app).post('/api/session/preview-round').send({ session_id: sid });
+
+  assert.equal(res.status, 200, JSON.stringify(res.body).slice(0, 200));
+  assert.equal(res.body.preview, true, 'flagged as a preview, not the real resolve');
+  assert.ok(res.body.round_phase, 'preview carries a round_phase');
+  assert.ok(Array.isArray(res.body.units), 'preview carries the resolved units snapshot');
+});
+
+test('preview-round wire: is non-mutating (idempotent — real round not consumed)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app);
+  await beginPlanning(app, sid);
+
+  const first = await request(app).post('/api/session/preview-round').send({ session_id: sid });
+  const second = await request(app).post('/api/session/preview-round').send({ session_id: sid });
+
+  assert.equal(first.status, 200);
+  assert.equal(second.status, 200, 'second preview still works -> real state was not mutated');
+  assert.equal(first.body.round_phase, second.body.round_phase, 'deterministic, stable');
+});
+
+test('preview-round wire: 400 when roundState not initialized', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app); // no begin-planning -> no roundState
+  const res = await request(app).post('/api/session/preview-round').send({ session_id: sid });
+  assert.equal(res.status, 400);
+});
+
+test('preview-round wire: 404 missing session', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app)
+    .post('/api/session/preview-round')
+    .send({ session_id: 'does_not_exist' });
+  assert.equal(res.status, 404);
+});

--- a/tests/services/roundOrchestrator.test.js
+++ b/tests/services/roundOrchestrator.test.js
@@ -359,6 +359,34 @@ test('declareReaction rejects unsupported event', () => {
   );
 });
 
+test('declareReaction keeps the unit main intent (separate economy, no wipe)', () => {
+  let state = makeState({ round_phase: PHASE_PLANNING });
+  state = declareIntent(state, 'alpha', attackAction('alpha', 'bravo')).nextState;
+  state = declareReaction(
+    state,
+    'alpha',
+    { type: 'parry', parry_bonus: 1 },
+    { event: 'attacked' },
+  ).nextState;
+  const mainIntents = state.pending_intents.filter((i) => i.unit_id === 'alpha' && i.action);
+  const reactions = state.pending_intents.filter(
+    (i) => i.unit_id === 'alpha' && i.reaction_trigger,
+  );
+  assert.equal(mainIntents.length, 1, 'main intent survives the reaction');
+  assert.equal(reactions.length, 1, 'reaction registered alongside');
+});
+
+test('declareReaction replaces only the prior reaction of the same unit', () => {
+  let state = makeState({ round_phase: PHASE_PLANNING });
+  state = declareReaction(state, 'alpha', { type: 'parry' }, { event: 'attacked' }).nextState;
+  state = declareReaction(state, 'alpha', { type: 'counter' }, { event: 'damaged' }).nextState;
+  const reactions = state.pending_intents.filter(
+    (i) => i.unit_id === 'alpha' && i.reaction_trigger,
+  );
+  assert.equal(reactions.length, 1, 'one reaction per unit (prior replaced)');
+  assert.equal(reactions[0].reaction_payload.type, 'counter', 'latest reaction kept');
+});
+
 test('declareReaction rejects unsupported payload type', () => {
   const state = makeState({ round_phase: PHASE_PLANNING });
   assert.throws(


### PR DESCRIPTION
## Round model -- two SPEC-C follow-ups (1 fix + 1 surface)

### fix(combat): declareReaction keeps unit main intents (`d8d77a1`)
SPEC-C frames reactions as a *separate* economy from AP/main intents (declareIntent APPENDs, multi per round). But `declareReaction` filtered out ALL of a unit's pending intents before pushing the reaction (`roundOrchestrator.js:517`), wiping the unit's main intent. Fix: filter only the unit's PRIOR reaction -- keep mains, replace the previous reaction (one-reaction-per-unit preserved). `clearIntent` (which intentionally clears all of a unit's intents) is unchanged.
- TDD: 2 engine tests (reaction keeps main intent; reaction replaces only prior reaction).

### feat(combat): /preview-round route (`929f307`)
SPEC-C G5 ratified the preview as client-side v1 with `/preview-round` as the open v2 door. `previewRound` existed server-side (engine LIVE) but the bridge never exposed it (surface DEAD). Adds `POST /api/session/preview-round`: a non-canonical round estimate via a NEUTRAL rng (`() => 0.5` = expected outcome, never the round's real combatRng per G5), NON-MUTATING (engine clones internally; route never persists `session.roundState`). Thin wire, mirrors `/resolve-round`.
- TDD: 4 wire tests (preview during planning; idempotent/non-mutating; 400 no roundState; 404 no session).

### Test evidence (0 fail)
Services suite **1425/1425** · API suite **316/316 + 500/500**. Engine 34/34, the two new wire suites 5/5 + 4/4. Prettier clean, no forbidden paths.

### Notes
- The declareReaction fix changes combat-round semantics (reactions no longer wipe main intents) -- behavior-critical, master-dd review. The just-merged `/declare-reaction` route (#2622) is unaffected (tests stay 5/5).
- `/preview-round` returns only the "expected" estimate; the G5 "atteso + range" (min/max via rng 0/0.99) is left as a follow-up if needed.

NOT auto-merged -- behavior-critical combat round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
