### PR TITLE
docs(spec-mnop): retro harsh-review fixes (ARCHON) + ratify forks QA1/QA2/QA3

### DIFF
--- a/docs/design/evo-tactics-ermes-runtime-pressure.md
+++ b/docs/design/evo-tactics-ermes-runtime-pressure.md
@@ -48,6 +48,11 @@ riscrive.
 - SPEC-I NON decide i valori-seme delle bande/cap (engine-owned, start-values L-069, lock
   = playtest N=40, sez. 8).
 - SPEC-I NON tocca l'authority device/surface (SPEC-K).
+- SPEC-I NON possiede il write-side del degrado cross-run (**A13** biome-wound): quello e'
+  **SPEC-P** (QA1, ratificato 2026-06-08). SPEC-I copre il read-side della pressione +,
+  in futuro, il segnale **A2** StressWave (telegraph) -- oggi il wire `stresswave->pressure`
+  e' DEAD (`biomeModifiers.js`:188). La riga roadmap 3bis che assegna A2/A13 a SPEC-I va
+  letta con questo split.
 
 Complementarieta' in una riga:
 

--- a/docs/design/evo-tactics-failure-as-lore.md
+++ b/docs/design/evo-tactics-failure-as-lore.md
@@ -24,21 +24,46 @@ B16 + B14, oggi DESIGN-ONLY (0 hit `failureLore`). Pillar P2 (emergente) + P4
 Chiudere il loop run-fail come arco narrativo persistente ma bounded: la
 sconfitta diventa lore, non game-over secco, senza brickare la campagna.
 
+## Non-scopo
+
+- SPEC-P NON ridecide la failure-as-lore per-creatura: i fork **J3** (cicatrice
+  -> tratto/mutazione permanente) e **J5** (lineage automatica + Custode opt-in)
+  sono ratificati in SPEC-J sez. 7. SPEC-P opera al livello RUN (epilogo + degrado
+  meta-network), non al livello creatura.
+- Sequenza ratificata (QA2, 2026-06-08): su wipe/run-fail, **J5 scrive prima** la
+  lineage/Custode per-creatura; **poi** l'epilogo SPEC-P CONSUMA quell'output (narra
+  i caduti + il degrado). J5 = input dell'epilogo, non output.
+- SPEC-P NON definisce lo scoring/threshold di ERMES (engine-owned, SPEC-I).
+
 ## Deve coprire
 
 - Trigger run-fail: vittoria mancata / wipe / ritirata / timeout.
 - Epilogo Skiv/Custode (~60s) che traduce il fallimento in lore.
 - Wiki/Codex progressivo (pattern Hades, B14): aggiornamento alla scoperta/fallimento.
-- Degrado meta-network bounded: biome "ferito" cumulativo cross-run (A13) con cap.
-- StressWave come telegraph diegetico del degrado (A2; condiviso con SPEC-I).
-- Export Custodi porta il frammento di lore (SPEC-F).
+- Degrado meta-network bounded: biome "ferito" cumulativo cross-run (**A13**) con cap.
+  Ownership ratificata (QA1, 2026-06-08): **SPEC-P possiede il write-side di A13**
+  (degrado run-level); SPEC-I resta sul read-side della pressione. Cap concreto = fork
+  aperto (vedi sez. Decisioni).
+- StressWave come telegraph diegetico del degrado (**A2**): SPEC-I fornisce il SEGNALE
+  StressWave (read-side telegraph); SPEC-P lo consuma per il degrado. NB: oggi il wire
+  `stresswave -> pressure/spawn` e' DEAD (`biomeModifiers.js`:188 "separate combat PR,
+  band-verify") -- da attivare prima dell'uso runtime.
+- Export Custodi porta il frammento di lore (SPEC-F): veicolo = `voice_diary_portable`
+  (max 5) salvo nuovo campo `failure_lore_fragment` da aggiungere al contratto export SPEC-F.
 - Device confirmation; public (TV recap) vs private (device).
 - Failure bounded: nessuno stato che renda la campagna ingiocabile.
 
 ## Dipendenze
 
-- SPEC-J (rituali ferite/morte per-creatura), SPEC-I (ERMES/StressWave),
-  SPEC-F (Custodi portano lore), SPEC-D (epilogo cinematic), event-log deterministico.
+- SPEC-J (rituali ferite/morte per-creatura; J3/J5 = livello creatura, vedi Non-scopo).
+- SPEC-I (read-side StressWave/pressione ecologica; A2 = segnale).
+- SPEC-F (Custodi portano il frammento di lore; veicolo `voice_diary_portable`).
+- SPEC-H (Codex/wiki progressivo, B14: l'epilogo emette eventi che il consumer Codex di
+  SPEC-H raccoglie).
+- SPEC-D (regia round-level): l'epilogo run-end NON e' un round-beat -> e' una surface
+  separata; SPEC-P possiede il contratto epilogo (trigger + payload + tier public/private)
+  oppure richiede un addendum run-end a SPEC-D.
+- event-log deterministico.
 
 ## Stato runtime (git-verify 2026-06-08)
 
@@ -47,5 +72,18 @@ DESIGN-ONLY: 0 hit `failureLore`/epilogo-lore; meta-network arc-conditions live
 
 ## Output consigliato
 
-Spec piena del loop + emitter event-log -> wiki/Codex -> meta-network degrade ->
-Custode lore-fragment.
+Spec piena del loop + emitter event-log -> wiki/Codex (SPEC-H) -> meta-network degrade
+(A13 write-side) -> Custode lore-fragment (SPEC-F).
+
+## Decisioni ratificate (Eduardo 2026-06-08)
+
+- **QA1** -- A2/A13 ownership: SPEC-I = read-side A2 StressWave (segnale/telegraph);
+  SPEC-P = write-side A13 degrado biome cross-run (run-level). Fence speculare in SPEC-I.
+- **QA2** -- J5 vs SPEC-P: layered + sequenced (J5 per-creatura scrive prima; epilogo
+  SPEC-P consuma dopo; vedi Non-scopo).
+
+## Decisioni aperte (per Eduardo)
+
+- Cap concreto del degrado A13 (es. max N biomi degradati simultanei + recupero dopo M
+  run): da fissare nella spec piena.
+- Surface epilogo run-end: contratto inline in SPEC-P vs addendum run-end a SPEC-D.

--- a/docs/design/evo-tactics-localization-i18n.md
+++ b/docs/design/evo-tactics-localization-i18n.md
@@ -15,10 +15,10 @@ related: docs/planning/2026-06-05-evo-tactics-open-points-resolution-roadmap.md
 
 # SPEC-N: Localization i18n Scaffold
 
-Origine: harvest 2026-06-08 (cluster Spec-M nuove). Recupera
-`architecture/i18n-strategy.md` (vault), oggi DESIGN-ONLY (struttura specificata,
-0 stringhe). Launch-blocker per il pubblico EN; basso costo, alto valore
-orizzontale (ogni spec UI futura usa le key).
+Origine: harvest 2026-06-08 (cluster Spec-M nuove). Recupera la roadmap di consegna in
+`docs/architecture/i18n-strategy.md` (LOCAL, `doc_status: active` -- NON vault; PR-1..PR-6).
+Launch-blocker per il pubblico EN; basso costo, alto valore orizzontale (ogni spec UI
+futura usa le key).
 
 ## Obiettivo
 
@@ -28,11 +28,20 @@ hardcoded.
 
 ## Deve coprire
 
-- Struttura namespace: `common` / `combat` / `tutorial` / `narrative`.
-- Formato: `data/i18n/{it,en}/<namespace>.json` + `_schema/i18n.schema.json` + AJV.
-- Convenzione key + fallback it -> en.
-- Integrazione con SPEC-B/C/D: le surface device/TV consumano key, non literali.
-- Policy: nessuna stringa hardcoded nelle nuove surface (gate review).
+- Struttura namespace: `common` / `combat` / `tutorial` / `narrative` (oggi tutte dentro
+  `common.json`; split in file separati = PR-5).
+- Formato: `data/i18n/{it,en}/<namespace>.json` + `_schema/i18n.schema.json` + AJV
+  (schema + AJV = PR-2, da costruire).
+- Convenzione key + fallback: dal punto di vista del consumer, `locale=en` con key mancante
+  -> fallback a `it` (en -> it; default it -- mirror mission-console DEFAULT_LOCALE=it /
+  FALLBACK_LOCALE=en).
+- Integrazione con SPEC-B/C/D/E/G/M: le surface device/TV consumano key -- MA serve prima
+  il loader (PR-3); finche' manca, il gate e' forward-only (sotto).
+- Policy: nessuna stringa hardcoded nelle NUOVE surface (gate review forward-only); il
+  debito esistente (es. `apps/play/biomeChip.js` BIOME_LABELS IT-hardcoded) = PR-4
+  migration, non bloccante qui.
+- **QA3 ratificato (2026-06-08)**: `data/i18n/` = sorgente unica; mission-console + le
+  nuove surface migrano a consumarlo (loader PR-3). Richiede ADR + ticket migrazione.
 
 ## Dipendenze
 
@@ -40,9 +49,22 @@ hardcoded.
 
 ## Stato runtime (git-verify 2026-06-08)
 
-DESIGN-ONLY: nessun runtime i18n nel backend Game; struttura solo specificata.
+PARTIAL (NON design-only -- correzione retro-review):
+
+- **Scaffold GIA' presente**: `data/i18n/{it,en}/common.json` esistono dal PR #1463
+  (2026-04-17), 10 namespace popolati dentro `common` (ui/menu/combat/status/objective/
+  result/settings/errors/difficulty/accessibility) + `_meta.completion_percent: 5`. NON
+  sono stub vuoti.
+- **Manca**: `_schema/i18n.schema.json` + AJV (PR-2); loader runtime + `t()` backend
+  (PR-3); split namespace combat/tutorial/narrative in file separati (oggi sezioni dentro
+  `common.json`; PR-5).
+- **Backend**: nessun loader i18n reale (il prefisso `i18n:traits.*` e' solo convenzione
+  di naming, non runtime).
+- **mission-console** ha gia' un runtime vue-i18n COMPLETO ma con locali PROPRI
+  (`apps/mission-console/src/locales/`), NON consuma `data/i18n/` (vedi QA3).
 
 ## Output consigliato
 
-Scaffold `data/i18n/` (stub vuoti) + schema + registrazione AJV -> spec piena se
-serve estensione oltre it/en.
+NON ricreare lo scaffold (esiste). Sequenza: (1) `_schema/i18n.schema.json` + AJV (PR-2);
+(2) loader runtime + `t()` (PR-3); (3) ADR unificazione `data/i18n` vs mission-console
+(QA3) + ticket migrazione (PR-4); (4) split namespace combat/tutorial/narrative (PR-5).

--- a/docs/design/evo-tactics-mission-template-library.md
+++ b/docs/design/evo-tactics-mission-template-library.md
@@ -28,10 +28,17 @@ TV Cinematic Director ed ERMES abbiano una grammatica di missione condivisa.
 
 - 6 tipi: Eliminazione, Cattura punto, Escort, Sabotaggio, Sopravvivenza, Fuga.
 - Schema encounter + wave config riusabile.
-- Integrazione SPEC-D: tipo missione -> grammatica scene/camera beats.
-- Integrazione SPEC-I: pressione ERMES scala col tipo obiettivo.
-- Difficulty profile per template (engine difficulty gia' live/pervasivo).
-- Metrica full-loop: `completion_rate` entro 0.40-0.70 per template.
+- Estensione SPEC-D (NON contratto esistente): proporre `mission_type` come context del
+  Director -> grammatica scene/camera beats. SPEC-D oggi e' round-scoped, niente
+  mission_type -> soggetto a review SPEC-D.
+- Estensione SPEC-I (NON contratto esistente): proporre che la pressione ERMES scali col
+  tipo obiettivo. SPEC-I oggi e' per-bioma, niente hook objective_type -> delta da proporre.
+- Difficulty profile per template: oggi esistono `difficulty_rating` (field schema) +
+  moltiplicatore per classe (tutorial/hardcore), NON un modulo DifficultyCalculator (da
+  creare, vedi `difficulty-integration.md`). "pervasivo" e' eccessivo.
+- Metrica full-loop: `completion_rate` target 0.40-0.70 per template -- **prerequisito**:
+  `tools/sim/full-loop-runner.js` oggi NON e' mission-type-aware (scenario fisso); va esteso
+  con parametro `mission_type` o scenari per-template prima di poter calibrare.
 
 ## Dipendenze
 
@@ -39,8 +46,13 @@ TV Cinematic Director ed ERMES abbiano una grammatica di missione condivisa.
 
 ## Stato runtime (git-verify 2026-06-08)
 
-DESIGN/PARTIAL: 6 tipi documentati; schema encounter esiste; 1 solo encounter
-tunato. Costruire i 5 template restanti = content production (gate kill-60 + 50-righe).
+DESIGN/PARTIAL: 6 tipi documentati (`15-LEVEL_DESIGN`); `schemas/evo/encounter.schema.json`
+esiste con i 6 tipi nell'enum `objective.type`. `data/core/missions/skydock_siege.yaml` e'
+un TUNE-LOG (source_logs + adjustments per tier), NON un encounter-template schema-valido --
+i 6 template da costruire devono conformarsi a encounter.schema.json. Costruire i template =
+content production (gate kill-60 = playtest N>=10 per template; 50-righe = PR fuori
+apps/backend/ <50 LOC o approval). I 3 output (template / estensione Director+ERMES /
+calibrazione) possono viaggiare in PR separati.
 
 ## Output consigliato
 

--- a/docs/design/evo-tactics-onboarding-identity-flow.md
+++ b/docs/design/evo-tactics-onboarding-identity-flow.md
@@ -17,8 +17,9 @@ related: docs/planning/2026-06-05-evo-tactics-open-points-resolution-roadmap.md
 
 Origine: harvest 2026-06-08 (`docs/planning/2026-06-08-spec-a-l-gap-harvest.md`,
 cluster "Onboarding & identita'"). Recupera idee dal flow V3 (B1/B4/B5) +
-`51-ONBOARDING-60S` + ADR-2026-04-21b, oggi DESIGN-ONLY (0 hit `formPulse`,
-slider = MVP/debug per roadmap sez. 2).
+`51-ONBOARDING-60S` + ADR-2026-04-21b. Stato reale = DESIGN/PARTIAL (backend
+form_pulse + initial_trait_choice LIVE; manca la UX device + Godot char-creation; vedi
+Stato runtime).
 
 ## Obiettivo
 
@@ -30,14 +31,17 @@ MVP/debug con un onboarding diegetico.
 
 - 3 scelte identitarie pre-Act-0 (ADR-2026-04-21b): 3 opzioni + timer + auto-select A.
 - Form Pulse: 5 micro-scenari swipe (~15s) -> assi creature-themed (NON test
-  psicologico; sposta i pesi VC, non li fissa).
+  psicologico; sposta i pesi VC, non li fissa). Authority/visibilita' = SPEC-B sez. 3.2
+  (tier) + F1 (TV = radar aggregato di default; per-player opt-in, mai imposto). SPEC-M
+  esegue, non ridecide.
 - Biome-form affinity landing (V3 B4): atterri nel bioma piu' affine alla Forma;
   specie iniziale = istanza role_template del bioma.
 - Social/clan ritual test (V3 B5): prima interazione ecologica (help/hinder/ignore),
   3 esiti che spostano la Forma del party.
 - Mapping verso VC / MBTI / Ennea / Conviction (riusa il device ledger SPEC-A).
 - Device authority: nessun input da TV; TV = splash/mirror dell'identita' emergente.
-- Public/private: cosa appare su TV (recap identita') vs cosa resta sul device.
+- Public/private: ratificato in SPEC-B F6 (3 scelte identitarie = `private` + opt-in,
+  specchio F1). SPEC-M esegue, non ridecide.
 
 ## Dipendenze
 
@@ -47,9 +51,22 @@ MVP/debug con un onboarding diegetico.
 
 ## Stato runtime (git-verify 2026-06-08)
 
-DESIGN-ONLY: 0 hit per `formPulse`/`form_pulse`; VC axes engine + MBTI scoring
-live ma la UX micro-scenario non esiste. Le 3 trait-choice esistono gia' in
-`active_effects.yaml`.
+DESIGN/PARTIAL (NON design-only -- correzione retro-review):
+
+- **form_pulse: backend LIVE** -- `coopOrchestrator.js` ha `formPulses` Map +
+  `submitFormPulse` (axes per-player, store, broadcast `form_pulse_list`, ready-gate;
+  phone smoke W4/W7). Manca solo la UX micro-scenario swipe in Godot.
+- **initial_trait_choice: backend LIVE** -- `POST /api/campaign/start` accetta
+  `initial_trait_choice` (option_a/b/c) e applica `acquiredTraits[]` al branco
+  (`routes/campaign.js`:150). Le 3 trait sono in `active_effects.yaml` (definizioni
+  `zampe_a_molla`/`pelle_elastomera`/`denti_seghettati`) + `default_campaign_mvp.yaml`
+  (sezione `onboarding:`).
+- **VC axes + MBTI/Conviction scoring: LIVE** (`vcScoring.js`, `convictionEngine.js`).
+- **DEBT host-only**: `coopOrchestrator.submitOnboardingChoice` ha guard `host_only`
+  residuo (L25 + enforcement) -- da estendere a tutti i device prima della surface
+  device-driven SPEC-K.
+- DESIGN-ONLY resta solo: la UX device (swipe micro-scenari + social/clan ritual) + il
+  Godot char-creation device-driven (sostituzione slider).
 
 ## Output consigliato
 


### PR DESCRIPTION
## Cosa
SPEC-M/N/O/P were merged via #2633 WITHOUT the harsh-review the rest of the suite got. This is the retro QA pass: 4x ARCHON critic-redteam (sonnet, 4-pass), every engine claim ground-truthed. Docs-only, +126/-32, 5 files.

## Fixes per spec (factual corrections of API-fidelity / runtime-state)
- **SPEC-M**: "0-hit form_pulse" was FALSE -> backend LIVE (coopOrchestrator submitFormPulse + form_pulse_list); `POST /api/campaign/start {initial_trait_choice}` LIVE; flagged host-only debt; Form Pulse + public/private now defer to SPEC-B 3.2/F1/F6 (authority, don't re-decide).
- **SPEC-N**: scaffold `data/i18n/{it,en}/common.json` ALREADY EXISTS (10 namespaces, since #1463) -> "create stub" was wrong; i18n-strategy.md is LOCAL docs/architecture (not "vault"); no loader yet (PR-3); mission-console has its own vue-i18n.
- **SPEC-O**: SPEC-D/I "integration" reframed as PROPOSED extensions (no mission_type hook exists in either); completion_rate needs a mission-type-aware full-loop-runner (today it isn't); skydock_siege = tune-log not schema-template; difficulty "pervasivo" downgraded to field+multiplier.
- **SPEC-P**: Non-scopo fence vs SPEC-J J3/J5 (per-creature failure-as-lore, ratified); added SPEC-H Codex dep; SPEC-D is round-scoped (run-end epilogue surface = P owns or D-addendum).

## Forks ratified (Eduardo 2026-06-08)
- **QA1** A2/A13 ownership: SPEC-I = read-side A2 StressWave signal; **SPEC-P = write-side A13** cross-run degrade. Speculative fence added to SPEC-I too.
- **QA2** J5 vs SPEC-P: layered + sequenced (J5 per-creature writes first; P epilogue consumes).
- **QA3** i18n: unify on `data/i18n/` (ADR + migration); mission-console migrates.

## Gate
governance errors=0; scope = 5 existing docs (no registry change, no new files). All stay review_needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)