### PR TITLE
docs(adr): i18n unify on data/i18n (QA3) + SPEC-N re-fix

### DIFF
--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -20,7 +20,7 @@
 ## Index per data (cronologico)
 
 <!-- gen:adr-index -->
-_Generato da `tools/generate_decisions_log.py` (70 ADR). NON editare a mano: editi gli ADR in `docs/adr/`._
+_Generato da `tools/generate_decisions_log.py` (71 ADR). NON editare a mano: editi gli ADR in `docs/adr/`._
 
 | Data | ADR | Titolo | Status |
 | --- | --- | --- | --- |
@@ -94,6 +94,7 @@ _Generato da `tools/generate_decisions_log.py` (70 ADR). NON editare a mano: edi
 | 2026-05-30 | [ADR-2026-05-30-coop-server-authoritative-combat](docs/adr/ADR-2026-05-30-coop-server-authoritative-combat.md) | ADR 2026-05-30 -- Co-op server-authoritative combat (vcSnapshot reconstruction) | Accepted |
 | 2026-05-31 | [ADR-2026-05-31-meta-network-arc-conditions-schema](docs/adr/ADR-2026-05-31-meta-network-arc-conditions-schema.md) | ADR-2026-05-31 — Meta-network edge arc-conditions schema (2.0 → 2.1) | Accepted |
 | 2026-06-07 | [ADR-2026-06-07-device-authority-tv-mirror-canon](docs/adr/ADR-2026-06-07-device-authority-tv-mirror-canon.md) | ADR 2026-06-07 -- Device-authority / TV-mirror canon + reconstruction-suite ratification | Accepted |
+| 2026-06-08 | [ADR-2026-06-08-i18n-unify-data-i18n](docs/adr/ADR-2026-06-08-i18n-unify-data-i18n.md) | ADR 2026-06-08 -- i18n: unificare su data/i18n come sorgente unica (QA3) | Accepted |
 <!-- /gen:adr-index -->
 
 ## Index per tag

--- a/docs/adr/ADR-2026-06-08-i18n-unify-data-i18n.md
+++ b/docs/adr/ADR-2026-06-08-i18n-unify-data-i18n.md
@@ -1,0 +1,78 @@
+---
+title: 'ADR 2026-06-08 -- i18n: unificare su data/i18n come sorgente unica (QA3)'
+doc_status: active
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: '2026-06-08'
+source_of_truth: false
+language: it
+review_cycle_days: 30
+related:
+  - 'docs/design/evo-tactics-localization-i18n.md'
+  - 'docs/architecture/i18n-strategy.md'
+  - 'docs/planning/2026-06-05-evo-tactics-open-points-resolution-roadmap.md'
+---
+
+# ADR-2026-06-08 -- i18n: unificare su data/i18n come sorgente unica (QA3)
+
+**Stato**: ACCEPTED (Eduardo 2026-06-08, fork QA3 della retro harsh-review SPEC-N #2636).
+**Trigger**: la retro harsh-review di SPEC-N (Localization) ha scoperto DUE sistemi i18n
+paralleli; serviva una decisione di livello ADR su quale sia la sorgente unica.
+**Scopo**: dare backing di record alla scelta "data/i18n e' la SSOT i18n" e fissare la
+direzione di migrazione, senza che ogni nuova surface duplichi un proprio key-space.
+
+## Contesto (git-verified 2026-06-08)
+
+Esistono due sistemi di localizzazione:
+
+1. **`data/i18n/`** -- layer game-data. `data/i18n/{it,en}/common.json` esistono dal
+   PR #1463 (2026-04-17): 10 namespace dentro `common` (ui/menu/combat/status/objective/
+   result/settings/errors/difficulty/accessibility), `_meta.completion_percent: 5`.
+   Validazione parity LIVE: `npm run i18n:check` -> `tools/py/validate_i18n_parity.py`
+   (i18n-strategy "PR-2 of 6": key-parity + no-placeholder + mustache + completion).
+   **Nessun consumer runtime**: nulla legge `data/i18n/` a runtime oggi.
+2. **`apps/mission-console/src/locales/`** -- runtime vue-i18n COMPLETO (createI18n,
+   `DEFAULT_LOCALE='it'`, `FALLBACK_LOCALE='en'`), con locali PROPRI co-locati, che NON
+   consumano `data/i18n/`.
+
+Il rischio (emerso in SPEC-N retro-review): ogni nuova surface device/TV (SPEC-C/D/E/G/M)
+sceglie un sistema e i due key-space divergono. La roadmap `docs/architecture/i18n-strategy.md`
+prevede gia' loader (PR-3) + migration (PR-4) + namespace split (PR-5).
+
+## Decisione
+
+1. **`data/i18n/` e' la SSOT i18n** (game-data + tutte le surface player-facing).
+2. **`mission-console` migra** a consumare `data/i18n/` (non piu' i locali co-locati).
+3. **Le nuove surface** (SPEC-C/D/E/G/M, Godot phone/TV) consumano `data/i18n/` via il
+   loader (PR-3), MAI literali hardcoded.
+4. **Fallback** dal punto di vista del consumer: `locale=en` con key mancante -> `it`
+   (en -> it; default it). Mirror del comportamento mission-console attuale.
+5. **Gate "no hardcoded strings"** = forward-only: vincola le surface create DOPO questo
+   ADR; il debito esistente (es. `apps/play/biomeChip.js` BIOME_LABELS IT-hardcoded) e'
+   migrazione PR-4, non bloccante per le nuove surface.
+
+## Conseguenze
+
+- **Sblocca** la sequenza i18n-strategy: PR-3 (loader runtime + `t()` helper) -> PR-4
+  (migration mission-console + debito esistente) -> PR-5 (split namespace combat/tutorial/
+  narrative in file separati). PR-2 (parity validator) e' GIA' fatto.
+- **Ticket di migrazione** (PR-4) da aprire: mission-console -> data/i18n. Effort L.
+- Lo schema JSON formale (`data/i18n/_schema/i18n.schema.json` + AJV) resta OPZIONALE:
+  la parity check copre gia' il grosso della validazione; aggiungerlo solo se serve un
+  contratto strict oltre la parity.
+- Nessun loader i18n nel backend Game finche' una surface backend non lo richiede
+  (oggi la localizzazione e' lato frontend/Godot; evitare engine-ahead-of-surface).
+
+## Alternative scartate
+
+- **Tenere i due sistemi separati** (data/i18n per game-data, mission-console per la sua
+  UI): meno churn ora, ma i key-space divergono a ogni nuova surface (la ragione per cui
+  QA3 e' stato sollevato). Scartata.
+- **Unificare su mission-console locales**: legherebbe la SSOT a un'app specifica;
+  `data/i18n/` e' neutro rispetto alla surface. Scartata.
+
+## Riferimenti
+
+- Fork QA3 ratificato nella retro harsh-review SPEC-N (PR #2636).
+- `docs/design/evo-tactics-localization-i18n.md` (SPEC-N).
+- `docs/architecture/i18n-strategy.md` (roadmap PR-1..PR-6).

--- a/docs/design/evo-tactics-localization-i18n.md
+++ b/docs/design/evo-tactics-localization-i18n.md
@@ -30,8 +30,8 @@ hardcoded.
 
 - Struttura namespace: `common` / `combat` / `tutorial` / `narrative` (oggi tutte dentro
   `common.json`; split in file separati = PR-5).
-- Formato: `data/i18n/{it,en}/<namespace>.json` + `_schema/i18n.schema.json` + AJV
-  (schema + AJV = PR-2, da costruire).
+- Formato: `data/i18n/{it,en}/<namespace>.json`. Validazione parity GIA' LIVE (PR-2,
+  `validate_i18n_parity.py`); schema JSON formale (`_schema/`) opzionale oltre la parity.
 - Convenzione key + fallback: dal punto di vista del consumer, `locale=en` con key mancante
   -> fallback a `it` (en -> it; default it -- mirror mission-console DEFAULT_LOCALE=it /
   FALLBACK_LOCALE=en).
@@ -41,7 +41,8 @@ hardcoded.
   debito esistente (es. `apps/play/biomeChip.js` BIOME_LABELS IT-hardcoded) = PR-4
   migration, non bloccante qui.
 - **QA3 ratificato (2026-06-08)**: `data/i18n/` = sorgente unica; mission-console + le
-  nuove surface migrano a consumarlo (loader PR-3). Richiede ADR + ticket migrazione.
+  nuove surface migrano a consumarlo (loader PR-3). Backing: `ADR-2026-06-08-i18n-unify-data-i18n`;
+  ticket migrazione = PR-4.
 
 ## Dipendenze
 
@@ -55,9 +56,12 @@ PARTIAL (NON design-only -- correzione retro-review):
   (2026-04-17), 10 namespace popolati dentro `common` (ui/menu/combat/status/objective/
   result/settings/errors/difficulty/accessibility) + `_meta.completion_percent: 5`. NON
   sono stub vuoti.
-- **Manca**: `_schema/i18n.schema.json` + AJV (PR-2); loader runtime + `t()` backend
-  (PR-3); split namespace combat/tutorial/narrative in file separati (oggi sezioni dentro
-  `common.json`; PR-5).
+- **Validazione LIVE**: `npm run i18n:check` -> `tools/py/validate_i18n_parity.py`
+  (i18n-strategy "PR-2 of 6": key-parity + no-placeholder + mustache + completion_percent).
+  Gia' fatto -- NON un deliverable aperto.
+- **Manca**: loader runtime + `t()` (PR-3); migration mission-console -> data/i18n (PR-4);
+  split namespace combat/tutorial/narrative in file separati (oggi sezioni dentro
+  `common.json`; PR-5). Schema JSON formale = opzionale (la parity check copre il grosso).
 - **Backend**: nessun loader i18n reale (il prefisso `i18n:traits.*` e' solo convenzione
   di naming, non runtime).
 - **mission-console** ha gia' un runtime vue-i18n COMPLETO ma con locali PROPRI
@@ -65,6 +69,7 @@ PARTIAL (NON design-only -- correzione retro-review):
 
 ## Output consigliato
 
-NON ricreare lo scaffold (esiste). Sequenza: (1) `_schema/i18n.schema.json` + AJV (PR-2);
-(2) loader runtime + `t()` (PR-3); (3) ADR unificazione `data/i18n` vs mission-console
-(QA3) + ticket migrazione (PR-4); (4) split namespace combat/tutorial/narrative (PR-5).
+NON ricreare lo scaffold (esiste) ne' la validazione (PR-2 `validate_i18n_parity.py` LIVE).
+QA3 unify ratificato -> `ADR-2026-06-08-i18n-unify-data-i18n`. Sequenza residua: (1) loader
+runtime + `t()` (PR-3); (2) migration mission-console -> data/i18n + debito esistente (PR-4);
+(3) split namespace combat/tutorial/narrative (PR-5).


### PR DESCRIPTION
## Cosa
Implementative follow-up of the SPEC-N retro harsh-review (QA3 fork). Docs-only.

- **ADR-2026-06-08-i18n-unify-data-i18n** (ACCEPTED): formalizes QA3 -- `data/i18n/` = single i18n source; mission-console + new surfaces (SPEC-C/D/E/G/M) migrate to consume it via loader; en->it fallback; forward-only no-hardcoded gate. Records Eduardo's 2026-06-08 ratification.
- **DECISIONS_LOG** row added.
- **SPEC-N re-fix**: 3rd-layer ground-truth -- `validate_i18n_parity.py` IS i18n-strategy "PR-2 of 6" (already LIVE via `npm run i18n:check`). My #2636 fix still listed "schema+AJV = PR-2 to build" -- corrected. Residual = PR-3 loader, PR-4 migration, PR-5 split.

## Why ADR-only (not full implementation)
The other implementative follow-ups need design/model-first and are NOT safe to blast autonomously (surfaced separately): SPEC-M onboarding per-player model = a design fork (current model is host-submits-one-choice); SPEC-O = 6 mission templates (invented content) + objective-logic runner; SPEC-P = spec-piena. The i18n loader (PR-3) is the next code step but a backend loader is premature (no backend surface needs it; localization is frontend/Godot).

governance errors=0; ADR needs no registry entry (matches recent ADR precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)