### PR TITLE
feat(coop): SPEC-M per-player onboarding model (map + readiness-gate)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -113,6 +113,9 @@ class CoopOrchestrator {
     // for entire branco. Pre-assigned trait propagated to all party
     // members on character_creation transition.
     this.onboardingChoice = null; // { option_key, trait_id, label, narrative, auto_selected, ts }
+    // SPEC-M (ADR-2026-06-07 device-authority) — per-player onboarding choices.
+    // player_id -> normalized choice. Readiness-gated advance (mirror characters).
+    this.onboardingChoices = new Map();
     // 2026-05-06 phone smoke W8b — track per-player reveal acknowledgment
     // for the UI-only `world_seed_reveal` transient phase. When all
     // expected players ack, auto-advance world_seed_reveal → world_setup.
@@ -246,6 +249,7 @@ class CoopOrchestrator {
     this.revealAcks.clear();
     this.formPulses.clear();
     this.onboardingChoice = null;
+    this.onboardingChoices.clear();
     this._setPhase('character_creation');
     this._emit('run_started', { run_id: this.run.id });
     return this.run;
@@ -286,28 +290,41 @@ class CoopOrchestrator {
     this.revealAcks.clear();
     this.formPulses.clear();
     this.onboardingChoice = null;
+    this.onboardingChoices.clear();
     this._setPhase('onboarding');
     this._emit('run_started', { run_id: this.run.id, with_onboarding: true });
     return this.run;
   }
 
   /**
-   * 2026-05-06 narrative onboarding port — host submits identity choice
-   * for entire branco. Auto-advances onboarding → character_creation on
-   * success. Host-only enforcement: only `hostId` may submit. Choice
-   * object pre-resolved by caller from campaign onboarding YAML.
+   * Onboarding identity choice. Two modes (SPEC-M, ADR-2026-06-07 device-authority):
+   *  - **per-player** (`allPlayerIds` provided): each device player submits its OWN
+   *    choice; stored in `onboardingChoices` Map; auto-advances onboarding ->
+   *    character_creation ONLY when ALL expected players have submitted (readiness gate).
+   *    No host gate -- each player owns its identity input.
+   *  - **legacy single-choice** (no `allPlayerIds`): host submits one choice for the
+   *    branco and it advances immediately; host-only enforced. Backward-compatible with
+   *    the 2026-05-06 narrative onboarding port (current wsSession caller) until the Godot
+   *    client is updated to send per-player onboarding_choice.
+   * `onboardingChoice` (singular) mirrors the last submitter for legacy consumers.
    *
-   * @param playerId — submitting player (must equal hostId)
+   * @param playerId — submitting player
    * @param choice — { option_key, trait_id, label, narrative, auto_selected }
-   * @param hostId — current host player id (host-only gate)
+   * @param opts.allPlayerIds — expected device players (enables per-player readiness)
+   * @param opts.hostId — host player id (legacy host-only gate when no allPlayerIds)
    */
-  submitOnboardingChoice(playerId, choice, { hostId } = {}) {
+  submitOnboardingChoice(playerId, choice, { allPlayerIds = [], hostId } = {}) {
     if (this.phase !== 'onboarding') throw new Error('not_in_onboarding');
     if (!playerId) throw new Error('player_id_required');
-    if (hostId && playerId !== hostId) throw new Error('host_only');
+    const expected = new Set((Array.isArray(allPlayerIds) ? allPlayerIds : []).filter(Boolean));
+    const perPlayer = expected.size > 0;
+    // Legacy single-choice mode: host-only gate. Per-player mode: any expected player.
+    if (!perPlayer && hostId && playerId !== hostId) throw new Error('host_only');
     if (!choice || !choice.option_key || !choice.trait_id) {
       throw new Error('choice_invalid');
     }
+    // Per-player mode: reject a ghost client not in the current roster.
+    if (perPlayer && !expected.has(playerId)) throw new Error('player_not_in_room');
     const normalized = {
       option_key: String(choice.option_key),
       trait_id: String(choice.trait_id),
@@ -317,10 +334,33 @@ class CoopOrchestrator {
       submitted_by: playerId,
       submitted_at: this.now(),
     };
-    this.onboardingChoice = normalized;
+    this.onboardingChoices.set(playerId, normalized);
+    this.onboardingChoice = normalized; // legacy mirror (last submitter)
     this._emit('onboarding_chosen', normalized);
-    this._setPhase('character_creation');
+    if (perPlayer) {
+      const allReady = Array.from(expected).every((pid) => this.onboardingChoices.has(pid));
+      if (allReady) this._setPhase('character_creation');
+    } else {
+      // Legacy: a single choice for the branco advances immediately.
+      this._setPhase('character_creation');
+    }
     return normalized;
+  }
+
+  /**
+   * Per-player onboarding ready-state snapshot for broadcast (SPEC-M).
+   * Mirrors characterReadyList: one entry per expected device player.
+   */
+  onboardingReadyList(allPlayerIds = []) {
+    return (Array.isArray(allPlayerIds) ? allPlayerIds : []).map((pid) => {
+      const ch = this.onboardingChoices.get(pid);
+      return {
+        player_id: pid,
+        option_key: ch?.option_key || null,
+        trait_id: ch?.trait_id || null,
+        ready: Boolean(ch),
+      };
+    });
   }
 
   /**

--- a/docs/design/evo-tactics-onboarding-identity-flow.md
+++ b/docs/design/evo-tactics-onboarding-identity-flow.md
@@ -62,11 +62,20 @@ DESIGN/PARTIAL (NON design-only -- correzione retro-review):
   `zampe_a_molla`/`pelle_elastomera`/`denti_seghettati`) + `default_campaign_mvp.yaml`
   (sezione `onboarding:`).
 - **VC axes + MBTI/Conviction scoring: LIVE** (`vcScoring.js`, `convictionEngine.js`).
-- **DEBT host-only**: `coopOrchestrator.submitOnboardingChoice` ha guard `host_only`
-  residuo (L25 + enforcement) -- da estendere a tutti i device prima della surface
-  device-driven SPEC-K.
+- **Per-player onboarding model: backend LIVE** (SPEC-M, 2026-06-08) --
+  `coopOrchestrator.submitOnboardingChoice(playerId, choice, { allPlayerIds })` ora
+  dual-mode: con `allPlayerIds` ogni device player submette la PROPRIA scelta
+  (`onboardingChoices` Map) + readiness-gate (advance a character_creation solo quando
+  TUTTI hanno submesso) + `onboardingReadyList()` per broadcast (mirror characterReadyList).
+  Senza `allPlayerIds` resta la modalita' legacy host-only single-choice (backward-compat,
+  niente regressione del flusso Godot attuale). TDD: 8/8 `coopOrchestrator.test.js`.
+- **Follow-up wiring (Gate-5, cross-repo)**: `wsSession.js` onboarding handler resta in
+  modalita' legacy (passa `{ hostId }`); va aggiornato a passare `allPlayerIds` +
+  broadcast `onboarding_ready_list` + advance gate su all-ready QUANDO il client Godot
+  invia `onboarding_choice` per-player (oggi invia host-only). Finche' Godot non e'
+  aggiornato, il gate per-player resta opt-in lato backend.
 - DESIGN-ONLY resta solo: la UX device (swipe micro-scenari + social/clan ritual) + il
-  Godot char-creation device-driven (sostituzione slider).
+  Godot char-creation device-driven (sostituzione slider) + il wiring wsSession sopra.
 
 ## Output consigliato
 

--- a/tests/api/coopOrchestrator.test.js
+++ b/tests/api/coopOrchestrator.test.js
@@ -178,7 +178,7 @@ test('startOnboarding transitions lobby → onboarding', () => {
   assert.ok(run.id.startsWith('run_'));
 });
 
-test('submitOnboardingChoice host-only + auto-advance to character_creation', () => {
+test('submitOnboardingChoice legacy host-only + auto-advance (no roster)', () => {
   const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
   co.startOnboarding();
   const choice = {
@@ -188,14 +188,50 @@ test('submitOnboardingChoice host-only + auto-advance to character_creation', ()
     narrative: 'Non saremo mai abbastanza forti.',
     auto_selected: false,
   };
-  // Non-host rejected with host_only.
+  // Legacy mode (no allPlayerIds): non-host rejected with host_only.
   assert.throws(() => co.submitOnboardingChoice('p_other', choice, { hostId: 'p_h' }), /host_only/);
-  // Host accepted, auto-advance to character_creation.
+  // Host accepted, auto-advance to character_creation (single-choice for branco).
   const result = co.submitOnboardingChoice('p_h', choice, { hostId: 'p_h' });
   assert.equal(co.phase, 'character_creation');
   assert.equal(result.option_key, 'option_a');
   assert.equal(result.trait_id, 'zampe_a_molla');
   assert.equal(co.onboardingChoice.trait_id, 'zampe_a_molla');
+});
+
+test('submitOnboardingChoice per-player map + readiness-gate (SPEC-M)', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startOnboarding();
+  const ids = ['p1', 'p2'];
+  const mk = (k, t) => ({ option_key: k, trait_id: t });
+  // p1 submits own choice (per-player mode) — NOT all ready, phase stays onboarding.
+  // No host_only gate in per-player mode (p1 is not the host, accepted).
+  co.submitOnboardingChoice('p1', mk('option_a', 'zampe_a_molla'), { allPlayerIds: ids });
+  assert.equal(co.phase, 'onboarding');
+  assert.equal(co.onboardingChoices.size, 1);
+  let ready = co.onboardingReadyList(ids);
+  assert.equal(ready.find((r) => r.player_id === 'p1').ready, true);
+  assert.equal(ready.find((r) => r.player_id === 'p2').ready, false);
+  // p2 submits — all expected submitted, auto-advance to character_creation.
+  co.submitOnboardingChoice('p2', mk('option_b', 'pelle_elastomera'), { allPlayerIds: ids });
+  assert.equal(co.phase, 'character_creation');
+  assert.equal(co.onboardingChoices.size, 2);
+  assert.equal(co.onboardingChoices.get('p2').trait_id, 'pelle_elastomera');
+  ready = co.onboardingReadyList(ids);
+  assert.ok(ready.every((r) => r.ready));
+});
+
+test('submitOnboardingChoice per-player rejects ghost not in roster', () => {
+  const co = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'p_h' });
+  co.startOnboarding();
+  assert.throws(
+    () =>
+      co.submitOnboardingChoice(
+        'ghost',
+        { option_key: 'a', trait_id: 't' },
+        { allPlayerIds: ['p1', 'p2'] },
+      ),
+    /player_not_in_room/,
+  );
 });
 
 test('submitOnboardingChoice rejects invalid choice + wrong phase', () => {


### PR DESCRIPTION
## Cosa
SPEC-M implementative follow-up (Eduardo greenlit per-player model). Backend per-player onboarding in `coopOrchestrator`.

`submitOnboardingChoice(playerId, choice, { allPlayerIds })` is now **dual-mode**:
- **per-player** (allPlayerIds given): each device player submits its OWN choice -> `onboardingChoices` Map + **readiness-gate** (advance onboarding -> character_creation only when ALL expected players submit) + `onboardingReadyList()` snapshot (mirror `characterReadyList`). No host gate.
- **legacy** (no allPlayerIds): host-only single-choice, advances immediately. **Backward-compat -> zero regression** to the current wsSession/Godot flow (which still passes `{ hostId }`).

## Why backend-only (Gate-5 follow-up flagged)
Rewiring the live wsSession gate to all-ready would HANG the current Godot client (host-only-single). So the per-player gate is opt-in backend now; the wsSession + Godot per-player wiring is a cross-repo follow-up (documented in the SPEC-M doc). Matches the suite's backend-first pattern.

## Verify (TDD)
- New tests: per-player map + readiness-gate + ghost-rejection + legacy host-only. `coopOrchestrator.test.js` **57/57**.
- AI suite **500/500** (DoD >=382). coop-api regression (disconnect/host-transfer) **7/7**. format:check green.

SPEC-M doc updated (Stato runtime: per-player model now backend-LIVE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)