### PR TITLE
feat(missions): SPEC-O sabotage + escape templates (6/6 objective coverage)

### DIFF
--- a/docs/design/evo-tactics-mission-template-library.md
+++ b/docs/design/evo-tactics-mission-template-library.md
@@ -46,13 +46,23 @@ TV Cinematic Director ed ERMES abbiano una grammatica di missione condivisa.
 
 ## Stato runtime (git-verify 2026-06-08)
 
-DESIGN/PARTIAL: 6 tipi documentati (`15-LEVEL_DESIGN`); `schemas/evo/encounter.schema.json`
-esiste con i 6 tipi nell'enum `objective.type`. `data/core/missions/skydock_siege.yaml` e'
-un TUNE-LOG (source_logs + adjustments per tier), NON un encounter-template schema-valido --
-i 6 template da costruire devono conformarsi a encounter.schema.json. Costruire i template =
-content production (gate kill-60 = playtest N>=10 per template; 50-righe = PR fuori
-apps/backend/ <50 LOC o approval). I 3 output (template / estensione Director+ERMES /
-calibrazione) possono viaggiare in PR separati.
+COPERTURA 6/6 (aggiornata via ground-truth 2026-06-08; NON "1 solo encounter"): l'engine
+objective e' LIVE -- `objectiveEvaluator.js` (ADR-2026-04-20) registra TUTTI e 6 i tipi
+(elimination/capture_point/escort/sabotage/survival/escape); `encounterLoader.js` carica gli
+encounter schema-validi da `docs/planning/encounters/`. Stato reale:
+
+- **10 encounter schema-validi gia' presenti** in `docs/planning/encounters/` -- coprivano
+  4/6 tipi (elimination, capture_point, escort, survival).
+- **+2 questo lavoro (SPEC-O)**: `enc_sabotage_01.yaml` + `enc_escape_01.yaml` -> **6/6 tipi
+  coperti**. Schema-validi (`tests/scripts/encounterSchema.test.js` 15/15), caricati da
+  encounterLoader, valutabili da objectiveEvaluator.
+- `data/core/missions/skydock_siege.yaml` resta un TUNE-LOG (formato `groups`/`party_vc`
+  diverso, non schema-encounter) -- distinto dai template.
+- **NON ancora calibrati (DRAFT)**: il gate `completion_rate` 0.40-0.70 per template richiede
+  un `full-loop-runner` mission-type-aware (oggi scenario fisso) -- prerequisito di tooling,
+  non costruito. I roster/wave dei 2 nuovi sono provvisori (mirror degli esistenti).
+- Restano le estensioni SPEC-D/I (hook `mission_type`) come delta da proporre (vedi Deve
+  coprire).
 
 ## Output consigliato
 

--- a/docs/planning/encounters/enc_escape_01.yaml
+++ b/docs/planning/encounters/enc_escape_01.yaml
@@ -1,0 +1,60 @@
+# =============================================================================
+# Encounter: "Fuga dalla Faglia" -- Escape
+# Difficulty: 3/5 - Grid: 12x10 - Bioma: rovine_planari
+# Objective: portare TUTTI i PG nella zona di estrazione [10,8,11,9] entro il
+#            time_limit; gli inseguitori spawnano alle spalle della party.
+# Pilastro coverage: 1 (tattica leggibile) -- obiettivo non-elimination
+# Schema: schemas/evo/encounter.schema.json
+# ADR: ADR-2026-04-20 (objective evaluator escape)
+# SPEC-O: completa la copertura dei 6 tipi-obiettivo (escape era mancante).
+# NB DRAFT: roster/wave NON ancora calibrati -- il gate completion_rate
+#           0.40-0.70 richiede un full-loop-runner mission-type-aware (vedi SPEC-O).
+# =============================================================================
+
+encounter_id: enc_escape_01
+name: 'Fuga dalla Faglia'
+biome_id: rovine_planari
+grid_size: [12, 10]
+difficulty_rating: 3
+estimated_turns: 10
+encounter_class: standard
+
+objective:
+  type: escape
+  target_zone: [10, 8, 11, 9]
+  time_limit: 10
+  loss_conditions:
+    time_limit: 10
+    player_wipe: true
+
+player_spawn:
+  - [0, 0]
+  - [0, 1]
+  - [1, 0]
+  - [1, 1]
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [0, 9]
+      - [2, 9]
+    units:
+      - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
+        count: 2
+        tier: base
+        ai_profile: aggressive
+  - wave_id: 2
+    turn_trigger: 3
+    spawn_points:
+      - [0, 5]
+      - [5, 9]
+    units:
+      - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
+        count: 1
+        tier: base
+        ai_profile: aggressive
+
+tags: [standard, timed]

--- a/docs/planning/encounters/enc_sabotage_01.yaml
+++ b/docs/planning/encounters/enc_sabotage_01.yaml
@@ -1,0 +1,63 @@
+# =============================================================================
+# Encounter: "Detonazione nel Cuore" -- Sabotage
+# Difficulty: 3/5 - Grid: 10x10 - Bioma: badlands
+# Objective: restare nella zona centrale [4,4,6,6] per 3 turni (cumulativi) di
+#            sabotaggio entro il time_limit; i difensori provano a sloggiarti.
+# Pilastro coverage: 1 (tattica leggibile) -- obiettivo non-elimination
+# Schema: schemas/evo/encounter.schema.json
+# ADR: ADR-2026-04-20 (objective evaluator sabotage)
+# SPEC-O: completa la copertura dei 6 tipi-obiettivo (sabotage era mancante).
+# NB DRAFT: roster/wave NON ancora calibrati -- il gate completion_rate
+#           0.40-0.70 richiede un full-loop-runner mission-type-aware (vedi SPEC-O).
+# =============================================================================
+
+encounter_id: enc_sabotage_01
+name: 'Detonazione nel Cuore'
+biome_id: badlands
+grid_size: [10, 10]
+difficulty_rating: 3
+estimated_turns: 12
+encounter_class: standard
+
+objective:
+  type: sabotage
+  target_zone: [4, 4, 6, 6]
+  sabotage_turns_required: 3
+  min_units_in_zone: 1
+  time_limit: 12
+  loss_conditions:
+    time_limit: 12
+    player_wipe: true
+
+player_spawn:
+  - [0, 0]
+  - [0, 1]
+  - [1, 0]
+  - [1, 1]
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [9, 9]
+      - [9, 5]
+      - [5, 9]
+    units:
+      - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
+        count: 2
+        tier: base
+        ai_profile: aggressive
+  - wave_id: 2
+    turn_trigger: 4
+    spawn_points:
+      - [9, 4]
+      - [4, 9]
+    units:
+      - species: predoni_nomadi
+        species_id: gulogluteus_scutiger
+        count: 1
+        tier: elite
+        ai_profile: aggressive
+
+tags: [standard, timed]


### PR DESCRIPTION
## Cosa
SPEC-O implementative follow-up (Eduardo greenlit drafting templates). Completes objective-type coverage.

**Ground-truth corrected the spec premise**: `objectiveEvaluator.js` (ADR-2026-04-20) already wires ALL 6 objective types; `encounterLoader.js` serves `docs/planning/encounters/`; **10 schema-valid templates already existed** covering 4/6 types (elimination/capture_point/escort/survival). The real gap = **sabotage + escape** (2, not 6).

Adds the 2 missing:
- `enc_sabotage_01.yaml` (Detonazione nel Cuore) -- sabotage, target_zone + sabotage_turns_required + time_limit.
- `enc_escape_01.yaml` (Fuga dalla Faglia) -- escape, target_zone + time_limit.

-> **6/6 objective types covered.**

## Verify
- `tests/scripts/encounterSchema.test.js` **15/15** (schema-valid).
- `encounterLoader.loadEncounter` loads both (objective=sabotage/escape).
- objectiveEvaluator already has both evaluators wired.

## DRAFT caveat
Roster/wave are provisional (mirror existing templates), **NOT balance-calibrated**: the `completion_rate` 0.40-0.70 gate needs a mission-type-aware full-loop-runner (today scenario-fixed) -- a tooling prerequisite, flagged in SPEC-O. SPEC-D/I `mission_type` hook = proposed extensions (not yet contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)