### PR TITLE
docs(spec-o): mission template library spec piena + ratify OA1-OA3

### DIFF
--- a/docs/design/evo-tactics-mission-template-library.md
+++ b/docs/design/evo-tactics-mission-template-library.md
@@ -66,14 +66,14 @@ Invarianti ereditate:
 
 Ogni tipo ha un evaluator LIVE (`objectiveEvaluator.js`) + campi `objective.*` nello schema:
 
-| Tipo            | Campi `objective`                                      | Win / evaluator                               |
-| --------------- | ------------------------------------------------------ | --------------------------------------------- |
-| `elimination`   | (default; nessun campo extra)                          | SIS HP=0 (fallback)                           |
-| `capture_point` | `target_zone`, `hold_turns`, `min_units_in_zone`       | PG in zona per N turni consecutivi            |
-| `escort`        | `escort_target`, `target_zone` (extract)               | escort_target vivo + in extract_zone          |
-| `sabotage`      | `target_zone`, `sabotage_turns_required`, `time_limit` | PG in zona N turni entro il time_limit        |
-| `survival`      | `survive_turns`                                        | player vivo AND turn >= survive_turns         |
-| `escape`        | `target_zone`, `time_limit`                            | TUTTI i PG in target_zone entro il time_limit |
+| Tipo            | Campi `objective`                                      | Win / evaluator                                                                                                                |
+| --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `elimination`   | (default; nessun campo extra)                          | SIS HP=0 (fallback)                                                                                                            |
+| `capture_point` | `target_zone`, `hold_turns`, `min_units_in_zone`       | PG in zona per N turni consecutivi                                                                                             |
+| `escort`        | `escort_target`, `target_zone` (extract)               | escort_target vivo + in extract_zone                                                                                           |
+| `sabotage`      | `target_zone`, `sabotage_turns_required`, `time_limit` | PG in zona N turni CUMULATIVI entro il time_limit (NB: evaluator hardcoda inZone>=1, IGNORA `min_units_in_zone` -- engine gap) |
+| `survival`      | `survive_turns`                                        | player vivo AND turn >= survive_turns                                                                                          |
+| `escape`        | `target_zone`, `time_limit`                            | TUTTI i PG in target_zone entro il time_limit                                                                                  |
 
 - `loss_conditions` (ADR-2026-04-20) decouplano la sconfitta: `time_limit` + `player_wipe`.
 - Il fallimento di un obiettivo emette outcome (`objective_failed`/`wipe`/`timeout`) = trigger
@@ -96,17 +96,18 @@ Contratto template (`schemas/evo/encounter.schema.json`):
 
 Dopo SPEC-O, `docs/planning/encounters/` copre tutti i 6 tipi (12 template schema-validi):
 
-| Tipo          | Template (esempi)                                            | Stato                      |
-| ------------- | ------------------------------------------------------------ | -------------------------- |
-| elimination   | `enc_tutorial_01/02`, `enc_savana_01`, `enc_caverna_02`, ... | pre-esistenti              |
-| capture_point | `enc_capture_01` (+1)                                        | pre-esistenti              |
-| escort        | `enc_escort_01`                                              | pre-esistente              |
-| survival      | `enc_survival_01` (+ altri)                                  | pre-esistenti              |
-| **sabotage**  | `enc_sabotage_01` (Detonazione nel Cuore)                    | **+ SPEC-O #2640 (DRAFT)** |
-| **escape**    | `enc_escape_01` (Fuga dalla Faglia)                          | **+ SPEC-O #2640 (DRAFT)** |
+| Tipo          | Template (esempi)                                                                       | Stato                      |
+| ------------- | --------------------------------------------------------------------------------------- | -------------------------- |
+| elimination   | `enc_tutorial_01/02`, `enc_savana_01`, `enc_caverna_02`, ...                            | pre-esistenti              |
+| capture_point | `enc_capture_01`, `enc_caverna_02`                                                      | pre-esistenti              |
+| escort        | `enc_escort_01`                                                                         | pre-esistente              |
+| survival      | `enc_survival_01`, `enc_frattura_03`, `enc_tutorial_02`, `enc_savana_skiv_solo_vs_pack` | pre-esistenti              |
+| **sabotage**  | `enc_sabotage_01` (Detonazione nel Cuore)                                               | **+ SPEC-O #2640 (DRAFT)** |
+| **escape**    | `enc_escape_01` (Fuga dalla Faglia)                                                     | **+ SPEC-O #2640 (DRAFT)** |
 
 - I 2 nuovi sono schema-validi (15/15 test) ma **NON calibrati** (roster/wave provvisori,
-  mirror degli esistenti). Calibrazione = sez. 9.
+  mirror degli esistenti); NB l'AI-profile `aggressive` va rivisto in calibrazione (es.
+  escape: il nemico dovrebbe INSEGUIRE, non presidiare). Calibrazione = sez. 9.
 
 ## 6. Integrazione SPEC-D (mission_type -> scene grammar) [PROPOSTA]
 
@@ -132,20 +133,23 @@ Dopo SPEC-O, `docs/planning/encounters/` copre tutti i 6 tipi (12 template schem
 ## 9. Calibrazione full-loop
 
 - Metrica: `completion_rate` target **0.40-0.70** per template (mirror band full-loop).
-- **Prerequisito (verificato):** `tools/sim/full-loop-runner.js` NON e' mission-type-aware
-  (scenario fisso); per calibrare i 6 tipi serve estenderlo con `mission_type`/scenari
-  per-template. Approccio = fork OA2.
+- **Prerequisito (verificato) -- la calibrazione dei tipi non-elimination e' OGGI IMPOSSIBILE:**
+  `tools/sim/scenario-enemies.js` ha `SUPPORTED_OBJECTIVES = {elimination}` (`:52`) -> per
+  qualsiasi altro tipo `buildScenarioEnemies` ritorna null -> il runner cade sul nemico-fisso
+  DEBOLE -> `completion_rate` degenera (~1.0, non misurabile). Serve (OA2): (a) estendere
+  `SUPPORTED_OBJECTIVES`, (b) un DRIVER che guidi le meccaniche objective non-elim nel loop sim
+  (hold zone / escape race / escort survival), (c) `mission_type`-awareness del runner.
 - Gate di promozione: un template passa da DRAFT a "ratificato" solo con `completion_rate`
   in banda su N=40 (mirror SPEC-I/ERMES gate), senza regressione fuori banda.
 
 ## 10. Visibilita' (eredita SPEC-B)
 
-| Dato mission                              | Tier     | Razionale                                                          |
-| ----------------------------------------- | -------- | ------------------------------------------------------------------ |
-| Tipo-obiettivo + obiettivo della missione | `public` | il tavolo sa cosa fa la missione (TV); coperto SPEC-B route/world. |
-| Wave / roster nemico (pre-spawn)          | `secret` | non si rivela il roster futuro (sorpresa tattica); engine-side.    |
-| Stato obiettivo (progress, hold count)    | `public` | parte del combat condiviso (TV), via event-log.                    |
-| `difficulty_rating` del template          | `public` | leggibilita' (stelle 1-5).                                         |
+| Dato mission                              | Tier     | Razionale                                                                                                                                                         |
+| ----------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tipo-obiettivo + obiettivo della missione | `public` | il tavolo sa cosa fa la missione (TV). NB: SPEC-B non ha riga esplicita per objective-type/difficulty -> SPEC-O la PROPONE (addendum SPEC-B, come SPEC-I sez. 9). |
+| Wave / roster nemico (pre-spawn)          | `secret` | non si rivela il roster futuro (sorpresa tattica); engine-side.                                                                                                   |
+| Stato obiettivo (progress, hold count)    | `public` | parte del combat condiviso (TV), via event-log.                                                                                                                   |
+| `difficulty_rating` del template          | `public` | leggibilita' (stelle 1-5).                                                                                                                                        |
 
 ## 11. Relazione con altre spec
 
@@ -182,8 +186,10 @@ tipo). Chi possiede il contratto?
 Per calibrare `completion_rate` per tipo serve estendere il runner.
 
 - **Opzione A -- parametro `mission_type` sul runner (raccomandata).** Un solo runner che
-  carica il template (encounterLoader) + applica l'objective evaluator del tipo. Tradeoff:
-  riusa l'engine objective LIVE; un solo harness.
+  carica il template (encounterLoader) + applica l'objective evaluator del tipo. **Scope reale
+  (verificato):** include (1) estendere `SUPPORTED_OBJECTIVES` in `scenario-enemies.js` (oggi
+  solo elimination), (2) un driver objective non-elim nel loop sim (hold/escape/escort
+  survival), oltre al param. Tradeoff: riusa l'engine objective LIVE; un solo harness.
 - **Opzione B -- scenari per-template dedicati.** Uno scenario sim per ogni tipo. Tradeoff:
   piu' controllo per-tipo, ma 6 harness da mantenere.
 - **Raccomandazione:** A (carica il template reale, niente duplicazione).
@@ -203,8 +209,9 @@ SPEC-O e' implementabile/chiudibile quando:
 
 1. i 6 tipi-obiettivo (sez. 3) hanno ciascuno >=1 template schema-valido in
    `docs/planning/encounters/` (FATTO: 6/6, `encounterSchema.test.js` verde);
-2. i 2 nuovi template (sabotage/escape) sono CALIBRATI (`completion_rate` 0.40-0.70 su N=40),
-   il che richiede il runner mission-type-aware (OA2) -- oggi DRAFT;
+2. OA2 e' risolto+implementato (`SUPPORTED_OBJECTIVES` esteso in scenario-enemies.js + driver
+   objective non-elim nel runner) E i 2 nuovi template (sabotage/escape) sono CALIBRATI
+   (`completion_rate` 0.40-0.70 su N=40 col ROSTER REALE, non il nemico-fisso) -- oggi DRAFT;
 3. l'integrazione `mission_type` con SPEC-D (scene grammar) + SPEC-I (pressione per tipo) e'
    contrattualizzata secondo l'ownership OA1 (addendum D/I);
 4. il difficulty profile (OA3) e' deciso (field+mult vs DifficultyCalculator);

--- a/docs/design/evo-tactics-mission-template-library.md
+++ b/docs/design/evo-tactics-mission-template-library.md
@@ -1,69 +1,213 @@
 ---
-title: 'Evo-Tactics SPEC-O Mission Template Library'
+title: 'Evo-Tactics SPEC-O Mission Template Library (spec piena)'
 date: 2026-06-08
 type: design-spec
 doc_status: review_needed
 doc_owner: master-dd
 workstream: flow
 last_verified: '2026-06-08'
+review_cycle_days: 30
 source_of_truth: false
 language: it
-review_cycle_days: 30
-tags: [evo-tactics, spec-o, level-design, missions]
-related: docs/planning/2026-06-05-evo-tactics-open-points-resolution-roadmap.md
+tags: [evo-tactics, spec-o, level-design, missions, objective-types, encounter, calibration]
+related: ADR-2026-06-07-device-authority-tv-mirror-canon
 ---
 
-# SPEC-O: Mission Template Library
+# Evo-Tactics SPEC-O Mission Template Library (spec piena)
 
-Origine: harvest 2026-06-08 (cluster Spec-M nuove). Recupera
-`15-LEVEL_DESIGN` (6 tipi obiettivo documentati), oggi PARTIAL (solo 1 encounter
-tunato, Skydock Siege).
+Contratto Wave-4 (gap-harvest). Spec piena dello scope-doc omonimo: definisce la libreria
+canonica dei 6 tipi-obiettivo come template encounter schema-validi, cosi' che il combat,
+il TV Cinematic Director (SPEC-D) ed ERMES (SPEC-I) condividano una grammatica di missione.
+Recupera `15-LEVEL_DESIGN` (A-canon). Engine objective gia' LIVE (ADR-2026-04-20).
 
-## Obiettivo
+## 1. Scopo e non-scopo
 
-Definire la libreria canonica dei 6 tipi-obiettivo come template YAML, cosi' che
-TV Cinematic Director ed ERMES abbiano una grammatica di missione condivisa.
+**Scopo.** Definire i 6 tipi-obiettivo + lo schema encounter/wave riusabile + la copertura
+template (6/6) + le estensioni PROPOSTE a SPEC-D (mission_type -> scene grammar) e SPEC-I
+(pressione per tipo) + il difficulty profile + il gate di calibrazione full-loop. SPEC-O
+ALIMENTA gli engine LIVE (objectiveEvaluator, encounterLoader), non li riscrive.
 
-## Deve coprire
+**Non-scopo (esplicito).**
 
-- 6 tipi: Eliminazione, Cattura punto, Escort, Sabotaggio, Sopravvivenza, Fuga.
-- Schema encounter + wave config riusabile.
-- Estensione SPEC-D (NON contratto esistente): proporre `mission_type` come context del
-  Director -> grammatica scene/camera beats. SPEC-D oggi e' round-scoped, niente
-  mission_type -> soggetto a review SPEC-D.
-- Estensione SPEC-I (NON contratto esistente): proporre che la pressione ERMES scali col
-  tipo obiettivo. SPEC-I oggi e' per-bioma, niente hook objective_type -> delta da proporre.
-- Difficulty profile per template: oggi esistono `difficulty_rating` (field schema) +
-  moltiplicatore per classe (tutorial/hardcore), NON un modulo DifficultyCalculator (da
-  creare, vedi `difficulty-integration.md`). "pervasivo" e' eccessivo.
-- Metrica full-loop: `completion_rate` target 0.40-0.70 per template -- **prerequisito**:
-  `tools/sim/full-loop-runner.js` oggi NON e' mission-type-aware (scenario fisso); va esteso
-  con parametro `mission_type` o scenari per-template prima di poter calibrare.
+- SPEC-O NON reimplementa l'objective engine: `objectiveEvaluator.js` (ADR-2026-04-20) +
+  `encounterLoader.js` sono LIVE. Qui si forniscono i template + si propone l'estensione.
+- SPEC-O NON ridefinisce lo schema encounter: `schemas/evo/encounter.schema.json` esiste
+  (6 tipi nell'enum); i template vi si conformano.
+- SPEC-O NON e' un re-design hand-crafted-vs-procedurale: `15-LEVEL_DESIGN` ha gia' deciso
+  hand-crafted dentro i biomi (derivato, non fork); i template sono seed-dati, non output di
+  un generatore.
+- SPEC-O NON possiede l'authority di SPEC-D/I: propone l'estensione `mission_type`, non la
+  ratifica al posto loro (OA1).
 
-## Dipendenze
+## 2. Baseline LIVE (verificato 2026-06-08, non ricostruire)
 
-- SPEC-D (director), SPEC-I (ERMES), `tools/sim/full-loop-runner.js` per calibrazione.
+| Engine / artefatto                                        | Ruolo / stato                                                                                                                |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `services/combat/objectiveEvaluator.js` (ADR-2026-04-20)  | Registry LIVE di TUTTI e 6 i tipi (elimination/capture_point/escort/sabotage/survival/escape) -> {completed,failed,outcome}. |
+| `services/combat/encounterLoader.js`                      | Carica encounter schema-validi da `docs/planning/encounters/` (+ `encounters-draft/` in graphMode).                          |
+| `schemas/evo/encounter.schema.json`                       | Schema encounter: `objective.type` enum (6 tipi), `waves`, `player_spawn`, `grid_size`, `difficulty_rating`, `tags` (enum).  |
+| `tools/py/author_encounter.py`                            | Authoring + validazione struttura vs schema; `tests/scripts/encounterSchema.test.js` valida tutti i template (AJV).          |
+| `docs/planning/encounters/*.yaml`                         | **12 template schema-validi** (post-SPEC-O): 6/6 tipi coperti (vedi sez. 5).                                                 |
+| `data/core/missions/skydock_siege.yaml`                   | TUNE-LOG (formato `groups`/`party_vc`, NON schema-encounter) -- distinto dai template.                                       |
+| `tools/sim/full-loop-runner.js`                           | Runner full-loop; usa `completion_rate`. NB: NON e' mission-type-aware (scenario fisso) -- vedi sez. 9 / OA2.                |
+| difficulty: `difficulty_rating` (schema 1-5) + class mult | `hardcoreScenario`/`tutorialScenario` moltiplicatore per classe. NESSUN modulo DifficultyCalculator (OA3).                   |
 
-## Stato runtime (git-verify 2026-06-08)
+Invarianti ereditate:
 
-COPERTURA 6/6 (aggiornata via ground-truth 2026-06-08; NON "1 solo encounter"): l'engine
-objective e' LIVE -- `objectiveEvaluator.js` (ADR-2026-04-20) registra TUTTI e 6 i tipi
-(elimination/capture_point/escort/sabotage/survival/escape); `encounterLoader.js` carica gli
-encounter schema-validi da `docs/planning/encounters/`. Stato reale:
+- **ADR-2026-04-20 (objective parametrizzato + damage curves):** difficolta' come FEATURE,
+  non tuning; objective evaluator pluggable; loss_conditions decouplate dalle win conditions.
+- **15-LEVEL_DESIGN (A-canon):** 6 tipi-obiettivo; encounter hand-crafted dentro i biomi.
+- **Tags enum (schema):** `tutorial/standard/boss/survival/escort/puzzle/timed/night/storm`
+  -- NIENTE tag custom (verificato: il test rifiuta tag fuori enum).
+- **Gate-5 / 50-righe / kill-60:** i template sono DATA (`docs/planning/encounters/`, fuori
+  apps/backend/); il content-production e' autorizzato esplicitamente (Eduardo 2026-06-08).
 
-- **10 encounter schema-validi gia' presenti** in `docs/planning/encounters/` -- coprivano
-  4/6 tipi (elimination, capture_point, escort, survival).
-- **+2 questo lavoro (SPEC-O)**: `enc_sabotage_01.yaml` + `enc_escape_01.yaml` -> **6/6 tipi
-  coperti**. Schema-validi (`tests/scripts/encounterSchema.test.js` 15/15), caricati da
-  encounterLoader, valutabili da objectiveEvaluator.
-- `data/core/missions/skydock_siege.yaml` resta un TUNE-LOG (formato `groups`/`party_vc`
-  diverso, non schema-encounter) -- distinto dai template.
-- **NON ancora calibrati (DRAFT)**: il gate `completion_rate` 0.40-0.70 per template richiede
-  un `full-loop-runner` mission-type-aware (oggi scenario fisso) -- prerequisito di tooling,
-  non costruito. I roster/wave dei 2 nuovi sono provvisori (mirror degli esistenti).
-- Restano le estensioni SPEC-D/I (hook `mission_type`) come delta da proporre (vedi Deve
-  coprire).
+## 3. I 6 tipi-obiettivo
 
-## Output consigliato
+Ogni tipo ha un evaluator LIVE (`objectiveEvaluator.js`) + campi `objective.*` nello schema:
 
-6 template YAML + integrazione Director + calibrazione full-loop.
+| Tipo            | Campi `objective`                                      | Win / evaluator                               |
+| --------------- | ------------------------------------------------------ | --------------------------------------------- |
+| `elimination`   | (default; nessun campo extra)                          | SIS HP=0 (fallback)                           |
+| `capture_point` | `target_zone`, `hold_turns`, `min_units_in_zone`       | PG in zona per N turni consecutivi            |
+| `escort`        | `escort_target`, `target_zone` (extract)               | escort_target vivo + in extract_zone          |
+| `sabotage`      | `target_zone`, `sabotage_turns_required`, `time_limit` | PG in zona N turni entro il time_limit        |
+| `survival`      | `survive_turns`                                        | player vivo AND turn >= survive_turns         |
+| `escape`        | `target_zone`, `time_limit`                            | TUTTI i PG in target_zone entro il time_limit |
+
+- `loss_conditions` (ADR-2026-04-20) decouplano la sconfitta: `time_limit` + `player_wipe`.
+- Il fallimento di un obiettivo emette outcome (`objective_failed`/`wipe`/`timeout`) = trigger
+  run-fail per SPEC-P sez. 3.
+
+## 4. Schema encounter + wave config
+
+Contratto template (`schemas/evo/encounter.schema.json`):
+
+- Required: `encounter_id` (`^enc_[a-z0-9_]+$`), `name`, `biome_id`, `grid_size`,
+  `objective`, `player_spawn`, `waves`, `difficulty_rating` (1-5).
+- `waves[]`: `wave_id`, `turn_trigger`, `spawn_points`, `units[]` (`species`, `count`,
+  `tier` base/elite/apex, `ai_profile`, `affixes`).
+- `conditions[]` opzionali: fog_of_war / stress_wave / terrain_collapse /
+  allied_reinforcement / environmental_mutation.
+- `tags`: solo enum (sez. 2). `encounter_class`: standard/hardcore/tutorial (moltiplicatore).
+- Validazione: `author_encounter.py` + `encounterSchema.test.js` (AJV, fail-on-invalid).
+
+## 5. Copertura template 6/6
+
+Dopo SPEC-O, `docs/planning/encounters/` copre tutti i 6 tipi (12 template schema-validi):
+
+| Tipo          | Template (esempi)                                            | Stato                      |
+| ------------- | ------------------------------------------------------------ | -------------------------- |
+| elimination   | `enc_tutorial_01/02`, `enc_savana_01`, `enc_caverna_02`, ... | pre-esistenti              |
+| capture_point | `enc_capture_01` (+1)                                        | pre-esistenti              |
+| escort        | `enc_escort_01`                                              | pre-esistente              |
+| survival      | `enc_survival_01` (+ altri)                                  | pre-esistenti              |
+| **sabotage**  | `enc_sabotage_01` (Detonazione nel Cuore)                    | **+ SPEC-O #2640 (DRAFT)** |
+| **escape**    | `enc_escape_01` (Fuga dalla Faglia)                          | **+ SPEC-O #2640 (DRAFT)** |
+
+- I 2 nuovi sono schema-validi (15/15 test) ma **NON calibrati** (roster/wave provvisori,
+  mirror degli esistenti). Calibrazione = sez. 9.
+
+## 6. Integrazione SPEC-D (mission_type -> scene grammar) [PROPOSTA]
+
+- INTENTO: `mission_type` come context del Director -> grammatica scene/camera beats (es. un
+  escape ha beats diversi da un'eliminazione).
+- **Stato reale (verificato):** SPEC-D e' round-scoped; NON ha hook `mission_type`. Questa e'
+  una ESTENSIONE DA PROPORRE, non un contratto esistente. Ownership = OA1.
+
+## 7. Integrazione SPEC-I (pressione per tipo) [PROPOSTA]
+
+- INTENTO: la pressione ERMES scala col tipo-obiettivo (es. survival alza la pressione nel
+  tempo).
+- **Stato reale (verificato):** SPEC-I e' per-bioma (low/med/high band); NON ha hook
+  `objective_type`. ESTENSIONE DA PROPORRE entro il cap ER2. Ownership = OA1.
+
+## 8. Difficulty profile
+
+- LIVE: `difficulty_rating` (schema 1-5) + moltiplicatore per `encounter_class`
+  (tutorial 1.0x / hardcore 1.4x+enrage). Difficolta'-come-feature (ADR-2026-04-20).
+- NON esiste un modulo `DifficultyCalculator` (vedi `difficulty-integration.md`: "da
+  creare"). Se costruirlo (profilo difficolta' per template) = fork OA3.
+
+## 9. Calibrazione full-loop
+
+- Metrica: `completion_rate` target **0.40-0.70** per template (mirror band full-loop).
+- **Prerequisito (verificato):** `tools/sim/full-loop-runner.js` NON e' mission-type-aware
+  (scenario fisso); per calibrare i 6 tipi serve estenderlo con `mission_type`/scenari
+  per-template. Approccio = fork OA2.
+- Gate di promozione: un template passa da DRAFT a "ratificato" solo con `completion_rate`
+  in banda su N=40 (mirror SPEC-I/ERMES gate), senza regressione fuori banda.
+
+## 10. Visibilita' (eredita SPEC-B)
+
+| Dato mission                              | Tier     | Razionale                                                          |
+| ----------------------------------------- | -------- | ------------------------------------------------------------------ |
+| Tipo-obiettivo + obiettivo della missione | `public` | il tavolo sa cosa fa la missione (TV); coperto SPEC-B route/world. |
+| Wave / roster nemico (pre-spawn)          | `secret` | non si rivela il roster futuro (sorpresa tattica); engine-side.    |
+| Stato obiettivo (progress, hold count)    | `public` | parte del combat condiviso (TV), via event-log.                    |
+| `difficulty_rating` del template          | `public` | leggibilita' (stelle 1-5).                                         |
+
+## 11. Relazione con altre spec
+
+- **SPEC-D** (TV director): consuma l'event-log; l'estensione `mission_type` (sez. 6) e'
+  proposta, soggetta a review SPEC-D (OA1).
+- **SPEC-I** (ERMES): l'estensione pressione-per-tipo (sez. 7) e' proposta, entro il cap ER2
+  (OA1).
+- **SPEC-P** (failure-as-lore): i fallimenti obiettivo (timeout/wipe/objective_failed) sono
+  trigger run-fail (SPEC-P sez. 3).
+- **SPEC-B/A**: visibilita' (sez. 10) + tier.
+- **SPEC-L**: traccia lo stato (engine 6/6 LIVE; template 6/6 schema-validi; calibrazione +
+  integrazioni D/I = pending).
+
+## 12. Decisioni aperte (per Eduardo)
+
+Fork etichetta `OA#` (anti-clash con F/G/H/E/FC/TS/J/HA/ER/QA/PA/MA).
+
+### OA1 -- Ownership dell'integrazione mission_type (SPEC-D + SPEC-I)
+
+SPEC-O propone `mission_type` come hook per Director (scene grammar) + ERMES (pressione per
+tipo). Chi possiede il contratto?
+
+- **Opzione A -- SPEC-O definisce il campo, SPEC-D/I lo consumano (raccomandata).** SPEC-O
+  dichiara `mission_type` sul template (gia' = `objective.type`); SPEC-D/SPEC-I aprono un
+  addendum per consumarlo (review loro). Tradeoff: SPEC-O non si blocca; D/I decidono il
+  proprio uso. Mirror del pattern MA2 -> SPEC-K.
+- **Opzione B -- SPEC-D/I ownano tutto.** SPEC-O fornisce solo i template; le integrazioni
+  sono interamente in SPEC-D/I. Tradeoff: confine pulito, ma SPEC-O perde la "grammatica
+  condivisa" dichiarata nell'obiettivo.
+- **Raccomandazione:** A (il campo esiste gia' come `objective.type`; D/I aprono addendum).
+
+### OA2 -- Come rendere il full-loop-runner mission-type-aware
+
+Per calibrare `completion_rate` per tipo serve estendere il runner.
+
+- **Opzione A -- parametro `mission_type` sul runner (raccomandata).** Un solo runner che
+  carica il template (encounterLoader) + applica l'objective evaluator del tipo. Tradeoff:
+  riusa l'engine objective LIVE; un solo harness.
+- **Opzione B -- scenari per-template dedicati.** Uno scenario sim per ogni tipo. Tradeoff:
+  piu' controllo per-tipo, ma 6 harness da mantenere.
+- **Raccomandazione:** A (carica il template reale, niente duplicazione).
+
+### OA3 -- DifficultyCalculator: costruirlo o restare su field + class-mult?
+
+- **Opzione A -- restare su field + class-mult (raccomandata MVP).** `difficulty_rating` +
+  moltiplicatore per classe bastano per i template draft. Tradeoff: zero nuovo modulo;
+  difficolta' meno granulare.
+- **Opzione B -- costruire DifficultyCalculator** (profilo per template). Tradeoff: piu'
+  granularita', ma nuovo modulo + tuning (difficulty-integration.md).
+- **Raccomandazione:** A ora; B se la calibrazione (sez. 9) lo richiede.
+
+## 13. Acceptance
+
+SPEC-O e' implementabile/chiudibile quando:
+
+1. i 6 tipi-obiettivo (sez. 3) hanno ciascuno >=1 template schema-valido in
+   `docs/planning/encounters/` (FATTO: 6/6, `encounterSchema.test.js` verde);
+2. i 2 nuovi template (sabotage/escape) sono CALIBRATI (`completion_rate` 0.40-0.70 su N=40),
+   il che richiede il runner mission-type-aware (OA2) -- oggi DRAFT;
+3. l'integrazione `mission_type` con SPEC-D (scene grammar) + SPEC-I (pressione per tipo) e'
+   contrattualizzata secondo l'ownership OA1 (addendum D/I);
+4. il difficulty profile (OA3) e' deciso (field+mult vs DifficultyCalculator);
+5. la visibilita' (sez. 10) e' coerente con SPEC-B (tipo/obiettivo `public`, roster `secret`);
+6. OA1-OA3 sono ratificati da Eduardo; il flip `review_needed` -> `accepted` al merge resta a
+   lui (`source_of_truth:false`).

--- a/docs/design/evo-tactics-mission-template-library.md
+++ b/docs/design/evo-tactics-mission-template-library.md
@@ -98,7 +98,7 @@ Dopo SPEC-O, `docs/planning/encounters/` copre tutti i 6 tipi (12 template schem
 
 | Tipo          | Template (esempi)                                                                       | Stato                      |
 | ------------- | --------------------------------------------------------------------------------------- | -------------------------- |
-| elimination   | `enc_tutorial_01/02`, `enc_savana_01`, `enc_caverna_02`, ...                            | pre-esistenti              |
+| elimination   | `enc_tutorial_01`, `enc_savana_01`, `enc_hardcore_reinf_01`                             | pre-esistenti              |
 | capture_point | `enc_capture_01`, `enc_caverna_02`                                                      | pre-esistenti              |
 | escort        | `enc_escort_01`                                                                         | pre-esistente              |
 | survival      | `enc_survival_01`, `enc_frattura_03`, `enc_tutorial_02`, `enc_savana_skiv_solo_vs_pack` | pre-esistenti              |
@@ -163,9 +163,19 @@ Dopo SPEC-O, `docs/planning/encounters/` copre tutti i 6 tipi (12 template schem
 - **SPEC-L**: traccia lo stato (engine 6/6 LIVE; template 6/6 schema-validi; calibrazione +
   integrazioni D/I = pending).
 
-## 12. Decisioni aperte (per Eduardo)
+## 12. Decisioni
 
 Fork etichetta `OA#` (anti-clash con F/G/H/E/FC/TS/J/HA/ER/QA/PA/MA).
+
+**Ratificate (Eduardo 2026-06-08):**
+
+| Fork | Esito ratificato (2026-06-08)                                                           |
+| ---- | --------------------------------------------------------------------------------------- |
+| OA1  | SPEC-O dichiara `mission_type` (= objective.type); SPEC-D/SPEC-I aprono addendum loro   |
+| OA2  | Un solo runner + param `mission_type` (estende SUPPORTED_OBJECTIVES + driver objective) |
+| OA3  | Resta `difficulty_rating` + moltiplicatore classe (MVP); DifficultyCalculator deferito  |
+
+Sotto: opzioni/rationale originali di ogni fork (storia della decisione).
 
 ### OA1 -- Ownership dell'integrazione mission_type (SPEC-D + SPEC-I)
 

--- a/docs/planning/encounters/enc_sabotage_01.yaml
+++ b/docs/planning/encounters/enc_sabotage_01.yaml
@@ -23,7 +23,8 @@ objective:
   type: sabotage
   target_zone: [4, 4, 6, 6]
   sabotage_turns_required: 3
-  min_units_in_zone: 1
+  # NB: il sabotage evaluator hardcoda inZone >= 1 (ignora min_units_in_zone -- engine gap,
+  # vedi SPEC-O sez. 3); non si imposta per non dare un contratto fantasma.
   time_limit: 12
   loss_conditions:
     time_limit: 12


### PR DESCRIPTION
## Cosa
SPEC-O spec-piena (Eduardo: "spec piena ... O ... come per P"). Scope-doc -> full contract. Docs-only.

**Contract**: 6 objective types + evaluators - encounter schema + waves - 6/6 template coverage (12 templates) - SPEC-D/I integration as PROPOSED extensions - difficulty profile - full-loop calibration gate - visibility - OA1-OA3 - acceptance.

## Harsh-review (ARCHON, ground-truthed) -- 3 REDs fixed
- **P1**: scenario-enemies.js `SUPPORTED_OBJECTIVES={elimination}` -> non-elim calibration uses the weak-fixed enemy -> completion_rate degenerate (~1.0). OA2 scope expanded (SUPPORTED_OBJECTIVES + objective-driver); sez.9 flags it.
- **P2**: sabotage evaluator hardcodes inZone>=1, IGNORES min_units_in_zone -> removed the phantom field from enc_sabotage_01 + noted the engine gap.
- **P3**: sez.10 visibility EXTENDS SPEC-B (no existing row for objective-type/difficulty), not "coperto".
- Plus: acceptance #2 non-circular, sez.5 completeness (caverna_02 + survival names + elimination row fix), escape AI-profile note.
- Critic GREEN-verified: 6 evaluators wired, encounterLoader path, schema enum, full-loop-runner not mission-type-aware, no DifficultyCalculator, SPEC-D/I no mission_type hook, species/biome IDs real.

## Forks ratified (Eduardo 2026-06-08)
OA1 SPEC-O declares mission_type (D/I addenda) - OA2 one runner + mission_type param - OA3 keep field+class-mult (MVP).

encounterSchema.test 15/15, governance errors=0. review_needed + source_of_truth:false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)