### PR TITLE
docs(spec-p): back-ref SPEC-P -> SPEC-Q M-7 chronicle

### DIFF
--- a/docs/design/evo-tactics-failure-as-lore.md
+++ b/docs/design/evo-tactics-failure-as-lore.md
@@ -185,6 +185,11 @@ Invariante P1: **nessuno stato rende la campagna ingiocabile.**
   (SPEC-O non ha epilogo run-end).
 - **SPEC-B/A**: visibilita' (sez. 9) + tier enforcement.
 - **SPEC-L**: traccia lo stato (0-built oggi) del loop failure-as-lore.
+- **SPEC-Q** (DF-levels narrative depth, in arrivo #2639): l'epilogo run-end + il degrado
+  cross-run (A13) + i frammenti di lore persistono nel **Chronicle/EventLog cross-session
+  (M-7)** + Memory-mode viewer -- SPEC-P possiede il write-side, SPEC-Q M-7 lo store + la
+  resa storica (gli heirloom/named-mutation L3 M-1/M-3 possono comparire nell'epilogo).
+  SPEC-Q gia' dichiara la dipendenza inversa ("failure usa chronicle").
 
 ## 11. Decisioni
 


### PR DESCRIPTION
## Cosa

Aggiunge il **back-ref mancante SPEC-P -> SPEC-Q**. SPEC-P spec-piena (#2641) e' stata scritta mentre SPEC-Q era unmerged (#2639), quindi non lo citava. Il link inverso (SPEC-Q -> SPEC-P "failure usa chronicle") gia' esiste; questo chiude il loop.

## Change (docs-only, +5)

SPEC-P sez. 10 "Relazione con altre spec": l'epilogo run-end + degrado cross-run (A13) + frammenti di lore persistono nel **Chronicle/EventLog cross-session (SPEC-Q M-7)** + Memory-mode viewer -- SPEC-P = write-side, SPEC-Q M-7 = store + resa storica.

## Nota

Forward-ref a SPEC-Q (in arrivo #2639). `check_docs_governance --strict` errors=0; ASCII-clean.

## Rollback

Docs-only. `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
