### PR TITLE
fix(combat): sabotage objective honors min_units_in_zone

### DIFF
--- a/apps/backend/services/combat/objectiveEvaluator.js
+++ b/apps/backend/services/combat/objectiveEvaluator.js
@@ -199,6 +199,7 @@ register('sabotage', (session, enc, obj) => {
   const state = ensureObjectiveState(session, 'sabotage');
   const zone = obj.target_zone;
   const required = Number(obj.sabotage_turns_required) || Number(obj.hold_turns) || 2;
+  const minUnits = Number(obj.min_units_in_zone) || 1;
   const turn = Number(session.turn) || 0;
 
   if (timeLimitExceeded(session, obj.time_limit || obj.loss_conditions?.time_limit)) {
@@ -225,7 +226,7 @@ register('sabotage', (session, enc, obj) => {
   const inZone = playersInZone(session, zone).length;
   if (turn > state.last_tick_turn) {
     state.progress.sabotage_progress =
-      inZone >= 1
+      inZone >= minUnits
         ? (state.progress.sabotage_progress || 0) + 1
         : state.progress.sabotage_progress || 0;
     state.last_tick_turn = turn;

--- a/docs/design/evo-tactics-mission-template-library.md
+++ b/docs/design/evo-tactics-mission-template-library.md
@@ -66,14 +66,14 @@ Invarianti ereditate:
 
 Ogni tipo ha un evaluator LIVE (`objectiveEvaluator.js`) + campi `objective.*` nello schema:
 
-| Tipo            | Campi `objective`                                      | Win / evaluator                                                                                                                |
-| --------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `elimination`   | (default; nessun campo extra)                          | SIS HP=0 (fallback)                                                                                                            |
-| `capture_point` | `target_zone`, `hold_turns`, `min_units_in_zone`       | PG in zona per N turni consecutivi                                                                                             |
-| `escort`        | `escort_target`, `target_zone` (extract)               | escort_target vivo + in extract_zone                                                                                           |
-| `sabotage`      | `target_zone`, `sabotage_turns_required`, `time_limit` | PG in zona N turni CUMULATIVI entro il time_limit (NB: evaluator hardcoda inZone>=1, IGNORA `min_units_in_zone` -- engine gap) |
-| `survival`      | `survive_turns`                                        | player vivo AND turn >= survive_turns                                                                                          |
-| `escape`        | `target_zone`, `time_limit`                            | TUTTI i PG in target_zone entro il time_limit                                                                                  |
+| Tipo            | Campi `objective`                                                           | Win / evaluator                                                                       |
+| --------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `elimination`   | (default; nessun campo extra)                                               | SIS HP=0 (fallback)                                                                   |
+| `capture_point` | `target_zone`, `hold_turns`, `min_units_in_zone`                            | PG in zona per N turni consecutivi                                                    |
+| `escort`        | `escort_target`, `target_zone` (extract)                                    | escort_target vivo + in extract_zone                                                  |
+| `sabotage`      | `target_zone`, `sabotage_turns_required`, `time_limit`, `min_units_in_zone` | PG (>= `min_units_in_zone`, default 1) in zona N turni CUMULATIVI entro il time_limit |
+| `survival`      | `survive_turns`                                                             | player vivo AND turn >= survive_turns                                                 |
+| `escape`        | `target_zone`, `time_limit`                                                 | TUTTI i PG in target_zone entro il time_limit                                         |
 
 - `loss_conditions` (ADR-2026-04-20) decouplano la sconfitta: `time_limit` + `player_wipe`.
 - Il fallimento di un obiettivo emette outcome (`objective_failed`/`wipe`/`timeout`) = trigger

--- a/docs/planning/encounters/enc_sabotage_01.yaml
+++ b/docs/planning/encounters/enc_sabotage_01.yaml
@@ -23,8 +23,8 @@ objective:
   type: sabotage
   target_zone: [4, 4, 6, 6]
   sabotage_turns_required: 3
-  # NB: il sabotage evaluator hardcoda inZone >= 1 (ignora min_units_in_zone -- engine gap,
-  # vedi SPEC-O sez. 3); non si imposta per non dare un contratto fantasma.
+  # NB: il sabotage evaluator ora onora min_units_in_zone (default 1) -- fix consistency con
+  # hold_zone; lasciato unset (= 1) per non alterare la difficolta' del template draft.
   time_limit: 12
   loss_conditions:
     time_limit: 12

--- a/tests/services/objectiveEvaluator.test.js
+++ b/tests/services/objectiveEvaluator.test.js
@@ -185,6 +185,55 @@ test('sabotage: fails on timeout', () => {
   assert.equal(r.outcome, 'timeout');
 });
 
+test('sabotage: does NOT progress when fewer than min_units_in_zone', () => {
+  const session = mkSession({
+    turn: 1,
+    units: [
+      { id: 'p1', controlled_by: 'player', position: [4, 4], hp: 10 },
+      { id: 's1', controlled_by: 'sistema', position: [9, 9], hp: 5 },
+    ],
+  });
+  const enc = {
+    objective: {
+      type: 'sabotage',
+      target_zone: [3, 3, 5, 5],
+      sabotage_turns_required: 2,
+      min_units_in_zone: 2,
+      time_limit: 10,
+    },
+  };
+  const r1 = evaluateObjective(session, enc);
+  assert.equal(r1.progress.sabotage_progress, 0); // 1 PG in zone, need 2 -> no progress
+  session.turn = 2;
+  const r2 = evaluateObjective(session, enc);
+  assert.equal(r2.progress.sabotage_progress, 0);
+  assert.equal(r2.completed, false);
+});
+
+test('sabotage: progresses when min_units_in_zone met', () => {
+  const session = mkSession({
+    turn: 1,
+    units: [
+      { id: 'p1', controlled_by: 'player', position: [4, 4], hp: 10 },
+      { id: 'p2', controlled_by: 'player', position: [5, 5], hp: 10 },
+      { id: 's1', controlled_by: 'sistema', position: [9, 9], hp: 5 },
+    ],
+  });
+  const enc = {
+    objective: {
+      type: 'sabotage',
+      target_zone: [3, 3, 5, 5],
+      sabotage_turns_required: 2,
+      min_units_in_zone: 2,
+      time_limit: 10,
+    },
+  };
+  evaluateObjective(session, enc);
+  session.turn = 2;
+  const r = evaluateObjective(session, enc);
+  assert.equal(r.completed, true); // 2 PGs in zone -> progresses -> completes
+});
+
 // ── survival ──
 
 test('survival: completes when turn >= survive_turns AND player alive', () => {


### PR DESCRIPTION
## Cosa
SPEC-O residual (code). The `sabotage` objective evaluator hardcoded `inZone >= 1`, ignoring `min_units_in_zone` -- while `hold_zone`/`capture_point` already honor it. Now consistent: reads `min_units_in_zone` (default 1, backward-compat).

## TDD
- RED: `sabotage: does NOT progress when fewer than min_units_in_zone` (1 PG, min=2 -> progress stayed 1 on old code, expected 0) -> failed correctly.
- GREEN: added `const minUnits = Number(obj.min_units_in_zone) || 1;` + `inZone >= minUnits`. 2-line change, mirrors hold_zone.
- objectiveEvaluator 22/22, sessionEncounterWiring 6/6, encounterSchema 15/15, prettier clean.

## Follow-through (stale-note hygiene)
- SPEC-O sez.3 table: removed "engine gap" note, added `min_units_in_zone` to sabotage params.
- `enc_sabotage_01.yaml`: comment updated (evaluator now honors it; left unset=1 to keep draft difficulty).

NB combat.md unchanged (doesn't document objective-eval; SPEC-O does). No forbidden paths, no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)