### PR TITLE
feat(chronicle): SPEC-Q M-7 per-branco chronicle service + API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,8 @@ logs/telemetry_*.jsonl
 .pytest_cache/
 # Skiv ticket #7 — unit diary persistence (runtime, not committed)
 data/derived/unit_diaries/
+# SPEC-Q M-7 — per-branco chronicle (runtime, not committed)
+data/derived/chronicles/
 
 # Repo-local tools (ngrok official ZIP, etc) - installed per-PC, NOT committed
 .tools/

--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -34,6 +34,8 @@ const { createCombatRouter } = require('./routes/combat');
 const { createCompanionRouter } = require('./routes/companion');
 // Skiv ticket #7 — unit diary persistence (cross-session memoria)
 const { createDiaryRouter } = require('./routes/diary');
+// SPEC-Q M-7 — per-branco cross-session chronicle (narrative depth L4)
+const { createChronicleRouter } = require('./routes/chronicle');
 // Skiv-as-Monitor — git-event-driven creature feed (2026-04-25)
 const { createSkivRouter } = require('./routes/skiv');
 // Sprint 3 §II (2026-04-27) — AncientBeast wiki cross-link slug bridge.
@@ -824,6 +826,9 @@ function createApp(options = {}) {
 
   // Skiv ticket #7 — unit diary persistence MVP (backend-only, JSONL append).
   app.use('/api', createDiaryRouter(options.diary || {}));
+
+  // SPEC-Q M-7 — per-branco chronicle (cross-session narrative event-store).
+  app.use('/api', createChronicleRouter(options.chronicle || {}));
 
   // Skiv-as-Monitor — git-event-driven creature feed (2026-04-25).
   // Reads data/derived/skiv_monitor/{state.json, feed.jsonl} produced by

--- a/apps/backend/routes/chronicle.js
+++ b/apps/backend/routes/chronicle.js
@@ -1,0 +1,74 @@
+// =============================================================================
+// Chronicle routes -- SPEC-Q M-7 (per-branco cross-session narrative).
+//
+// GET  /api/chronicle/:run_id            tail (default 50, max 500); ?type= ?actor_id= ?limit= ?reverse=
+// GET  /api/chronicle/:run_id/summary    aggregate counts per type + per tier
+// POST /api/chronicle/:run_id            append a chronicle_event (server-side emitters wire here)
+//
+// Store: services/chronicle/chronicleStore.js (JSONL append-only, per run_id).
+// =============================================================================
+
+'use strict';
+
+const express = require('express');
+const {
+  appendEvent,
+  tailChronicle,
+  summary,
+  ALLOWED_EVENT_TYPES,
+  ALLOWED_TIERS,
+} = require('../services/chronicle/chronicleStore');
+
+function createChronicleRouter(opts = {}) {
+  const router = express.Router();
+  const baseDir = opts.baseDir; // optional override (tests)
+
+  router.get('/chronicle/:run_id', (req, res, next) => {
+    try {
+      const runId = req.params.run_id;
+      const limit = Number.parseInt(req.query.limit, 10);
+      const reverse = req.query.reverse === 'true' || req.query.reverse === '1';
+      const events = tailChronicle(runId, {
+        limit: Number.isFinite(limit) ? limit : 50,
+        reverse,
+        type: typeof req.query.type === 'string' ? req.query.type : undefined,
+        actor_id: typeof req.query.actor_id === 'string' ? req.query.actor_id : undefined,
+        baseDir,
+      });
+      res.json({ run_id: runId, count: events.length, events });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/chronicle/:run_id/summary', (req, res, next) => {
+    try {
+      res.json(summary(req.params.run_id, { baseDir }));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/chronicle/:run_id', (req, res, next) => {
+    try {
+      const runId = req.params.run_id;
+      const outcome = appendEvent(runId, req.body || {}, { baseDir });
+      if (!outcome.ok) {
+        const status = outcome.error === 'invalid_run_id' ? 400 : 409;
+        return res.status(status).json({
+          error: outcome.error,
+          detail: outcome.detail || null,
+          allowed_event_types: Array.from(ALLOWED_EVENT_TYPES),
+          allowed_tiers: Array.from(ALLOWED_TIERS),
+        });
+      }
+      res.status(201).json({ ok: true, run_id: runId, event: outcome.event });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createChronicleRouter };

--- a/apps/backend/services/chronicle/chronicleStore.js
+++ b/apps/backend/services/chronicle/chronicleStore.js
@@ -1,0 +1,188 @@
+// =============================================================================
+// Chronicle Store -- SPEC-Q M-7 (DF-levels L4, narrative depth).
+//
+// Per-BRANCO cross-session narrative event-store, SOPRA il combat event-log
+// (sessionRoundBridge = per-round; diaryStore = per-unit). Distinto da entrambi
+// per SCOPE: la cronaca e' la storia condivisa del tavolo/branco (Memory-mode).
+// JSONL append-only per run_id -- cheap rotation + grep-friendly, no DB dep.
+//
+// Schema event (SPEC-Q sez.4):
+//   { ts, type, actor_id, run_id, tier, payload }
+//
+// type whitelist: eventi narrativi salienti (M-1..M-7 + A3/A13 keystone).
+// tier: public/private/secret (eredita SPEC-B sez.10).
+//
+// Storage: `data/derived/chronicles/<sanitised_run_id>.jsonl` (gitignored).
+// QF1-A ratificato (2026-06-08): nuovo servizio per-branco (diaryStore resta
+// per-unit; no double-store). No LLM -- gli emitter passano payload gia' pronti.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_BASE_DIR = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'derived',
+  'chronicles',
+);
+
+const ALLOWED_EVENT_TYPES = new Set([
+  'creature_named', // M-2 identity-earned (name emergence)
+  'creature_death',
+  'mutation_acquired',
+  'scar_earned', // SPEC-J wound -> narrative layer
+  'legacy_formed', // M-2 legacy figure
+  'run_failed', // A3 failure-as-lore (SPEC-P)
+  'biome_wound', // A13 biome-wound cross-run (SPEC-P)
+  'heirloom_created', // M-1 named heirloom (FFT)
+  'mutation_lineage', // M-3 named-mutation lineage (Wildermyth/Godot)
+]);
+
+const ALLOWED_TIERS = new Set(['public', 'private', 'secret']);
+
+const RUN_ID_PATTERN = /^[A-Za-z0-9_\-]+$/;
+
+function sanitiseRunId(runId) {
+  if (typeof runId !== 'string') return null;
+  if (!RUN_ID_PATTERN.test(runId)) return null;
+  if (runId.length === 0 || runId.length > 96) return null;
+  return runId;
+}
+
+function chroniclePath(runId, baseDir = DEFAULT_BASE_DIR) {
+  const safe = sanitiseRunId(runId);
+  if (!safe) return null;
+  return path.join(baseDir, `${safe}.jsonl`);
+}
+
+function ensureBaseDir(baseDir = DEFAULT_BASE_DIR) {
+  fs.mkdirSync(baseDir, { recursive: true });
+}
+
+/**
+ * Append a chronicle event. Validates run_id + type (whitelist) + tier.
+ * Returns { ok, event?, error?, detail? }. Never throws on bad input.
+ */
+function appendEvent(runId, event, opts = {}) {
+  const baseDir = opts.baseDir || DEFAULT_BASE_DIR;
+  const safe = sanitiseRunId(runId);
+  if (!safe) return { ok: false, error: 'invalid_run_id' };
+  if (!event || typeof event !== 'object') return { ok: false, error: 'invalid_event' };
+  const type = event.type;
+  if (!ALLOWED_EVENT_TYPES.has(type)) {
+    return { ok: false, error: 'invalid_event_type', detail: { type } };
+  }
+  const tier = event.tier == null ? 'public' : event.tier;
+  if (!ALLOWED_TIERS.has(tier)) {
+    return { ok: false, error: 'invalid_tier', detail: { tier } };
+  }
+  const stamped = {
+    ts: typeof event.ts === 'string' ? event.ts : new Date().toISOString(),
+    type,
+    actor_id: typeof event.actor_id === 'string' ? event.actor_id : null,
+    run_id: safe,
+    tier,
+    payload: event.payload && typeof event.payload === 'object' ? event.payload : {},
+  };
+  ensureBaseDir(baseDir);
+  const filepath = path.join(baseDir, `${safe}.jsonl`);
+  fs.appendFileSync(filepath, JSON.stringify(stamped) + '\n', 'utf8');
+  return { ok: true, event: stamped };
+}
+
+/**
+ * Read chronicle for a run (chronological). opts.actor_id / opts.type filter.
+ * Returns [] if no file. Malformed lines silently skipped.
+ */
+function getChronicle(runId, opts = {}) {
+  const baseDir = opts.baseDir || DEFAULT_BASE_DIR;
+  const safe = sanitiseRunId(runId);
+  if (!safe) return [];
+  const filepath = path.join(baseDir, `${safe}.jsonl`);
+  if (!fs.existsSync(filepath)) return [];
+  const raw = fs.readFileSync(filepath, 'utf8');
+  const lines = raw.split('\n').filter(Boolean);
+  const out = [];
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+      if (!parsed || typeof parsed !== 'object') continue;
+      if (opts.actor_id && parsed.actor_id !== opts.actor_id) continue;
+      if (opts.type && parsed.type !== opts.type) continue;
+      out.push(parsed);
+    } catch {
+      /* skip malformed line */
+    }
+  }
+  return out;
+}
+
+/**
+ * Tail N events (default 50). reverse=true => most-recent first.
+ * Used by the Memory-mode viewer / debrief (SPEC-K/D consumer).
+ */
+function tailChronicle(runId, opts = {}) {
+  const limit = Number.isFinite(Number(opts.limit))
+    ? Math.max(1, Math.min(500, Number(opts.limit)))
+    : 50;
+  const reverse = Boolean(opts.reverse);
+  const all = getChronicle(runId, opts);
+  const tail = all.slice(-limit);
+  return reverse ? tail.slice().reverse() : tail;
+}
+
+/**
+ * Aggregate: total + counts per type + counts per tier + first/last ts.
+ */
+function summary(runId, opts = {}) {
+  const all = getChronicle(runId, { baseDir: opts.baseDir });
+  if (all.length === 0) {
+    return { run_id: runId, total: 0, by_type: {}, by_tier: {}, first_seen: null, last_seen: null };
+  }
+  const byType = {};
+  const byTier = {};
+  for (const ev of all) {
+    byType[ev.type] = (byType[ev.type] || 0) + 1;
+    if (ev.tier) byTier[ev.tier] = (byTier[ev.tier] || 0) + 1;
+  }
+  return {
+    run_id: runId,
+    total: all.length,
+    by_type: byType,
+    by_tier: byTier,
+    first_seen: all[0].ts || null,
+    last_seen: all[all.length - 1].ts || null,
+  };
+}
+
+/**
+ * Test helper -- wipe the chronicle file for a run. NOT exposed via route.
+ */
+function _resetChronicleForTest(runId, opts = {}) {
+  const baseDir = opts.baseDir || DEFAULT_BASE_DIR;
+  const safe = sanitiseRunId(runId);
+  if (!safe) return;
+  const filepath = path.join(baseDir, `${safe}.jsonl`);
+  if (fs.existsSync(filepath)) fs.unlinkSync(filepath);
+}
+
+module.exports = {
+  ALLOWED_EVENT_TYPES,
+  ALLOWED_TIERS,
+  DEFAULT_BASE_DIR,
+  sanitiseRunId,
+  chroniclePath,
+  ensureBaseDir,
+  appendEvent,
+  getChronicle,
+  tailChronicle,
+  summary,
+  _resetChronicleForTest,
+};

--- a/docs/design/evo-tactics-df-levels-narrative-depth.md
+++ b/docs/design/evo-tactics-df-levels-narrative-depth.md
@@ -74,13 +74,13 @@ Invarianti ereditate:
 
 ## 3. DF-levels coperti
 
-| Livello | Cosa                                           | SPEC-Q gap     | Stato                  |
-| ------- | ---------------------------------------------- | -------------- | ---------------------- |
-| L1      | Identita' guadagnata (name/portrait/storia)    | M-2            | greenfield             |
-| L2/P5   | Sistema leggibile (abilita' nascoste reveal)   | M-4            | 0 design               |
-| L3      | Eredita' tangibile (heirloom + named-mutation) | M-1, M-3       | M-1 0; M-3 Godot-draft |
-| L4      | Cronaca cross-session                          | M-7 (keystone) | chronicle 404          |
-| P3/P2   | Job-identity constraint / visual-swap verify   | M-5, M-6       | design/verify          |
+| Livello | Cosa                                           | SPEC-Q gap     | Stato                       |
+| ------- | ---------------------------------------------- | -------------- | --------------------------- |
+| L1      | Identita' guadagnata (name/portrait/storia)    | M-2            | greenfield                  |
+| L2/P5   | Sistema leggibile (abilita' nascoste reveal)   | M-4            | 0 design                    |
+| L3      | Eredita' tangibile (heirloom + named-mutation) | M-1, M-3       | M-1 0; M-3 Godot-draft      |
+| L4      | Cronaca cross-session                          | M-7 (keystone) | store+API LIVE; viewer TODO |
+| P3/P2   | Job-identity constraint / visual-swap verify   | M-5, M-6       | design/verify               |
 
 L0 (needs/biome-rules) e L5 = POST-MVP gated (non-scopo).
 

--- a/docs/design/evo-tactics-df-levels-narrative-depth.md
+++ b/docs/design/evo-tactics-df-levels-narrative-depth.md
@@ -42,18 +42,18 @@ non lo rimpiazza).
 
 ## 2. Baseline LIVE (verificato 2026-06-08, non ricostruire)
 
-| Engine / artefatto                                         | Ruolo / stato                                                                                                         |
-| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `routes/sessionRoundBridge.js`                             | Combat event-log per-round LIVE. La cronaca (M-7) ci sta SOPRA, non lo rimpiazza.                                     |
-| `services/combat/woundedPerma.js` + `woundSystem.js`       | Scar-as-stat (SPEC-J). M-2 identity riusa lo scar come layer narrativo.                                               |
-| `services/generation/lineagePropagator.js`                 | Mating/lineage Game-side LIVE. M-3 named-mutation lineage vi si aggancia.                                             |
-| `data/core/mutations/mutation_catalog.yaml`                | 36 mutazioni; **24 con `derived_ability_id` null** -> M-6 visual-swap likely 0-runtime (verify).                      |
-| `services/narrative/qbnEngine.js` + `tools/py/skiv_qbn.py` | QBN non-LLM LIVE (+ inkjs). M-7 chronicle usa template parametrici QBN, non LLM.                                      |
-| `services/ai/declareSistemaIntents.js`                     | Intents Sistema. M-4 hidden-ability reveal vi aggiunge la regola soglia + addendum SPEC-H.                            |
-| `sentience_tier` (skiv_archetype_pool / mutagen_events)    | Dato sentience LIVE (#1808) -- input per M-2 identity tier.                                                           |
-| museum `creature-wildermyth-battle-scar-portrait.md`       | Reuse-path M-2: portrait overlay da evento formativo.                                                                 |
-| `/api/v1/session/:id/*` route pattern                      | Pattern endpoint esistente (`/:id/objective`, `/:id/aliena-telemetry`...) -> dove vivra' `/:id/chronicle*`.           |
-| **404 greenfield**                                         | `services/{identity,eventlog,chronicle}`; endpoint chronicle; named heirloom/artifact (0 hit); hidden-ability design. |
+| Engine / artefatto                                         | Ruolo / stato                                                                                                                        |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `routes/sessionRoundBridge.js`                             | Combat event-log per-round LIVE. La cronaca (M-7) ci sta SOPRA, non lo rimpiazza.                                                    |
+| `services/combat/woundedPerma.js` + `woundSystem.js`       | Scar-as-stat (SPEC-J). M-2 identity riusa lo scar come layer narrativo.                                                              |
+| `services/generation/lineagePropagator.js`                 | Mating/lineage Game-side LIVE. M-3 named-mutation lineage vi si aggancia.                                                            |
+| `data/core/mutations/mutation_catalog.yaml`                | 36 mutazioni; **24 con `derived_ability_id` null** -> M-6 visual-swap likely 0-runtime (verify).                                     |
+| `services/narrative/qbnEngine.js` + `tools/py/skiv_qbn.py` | QBN non-LLM LIVE (+ inkjs). M-7 chronicle usa template parametrici QBN, non LLM.                                                     |
+| `services/ai/declareSistemaIntents.js`                     | Intents Sistema. M-4 hidden-ability reveal vi aggiunge la regola soglia + addendum SPEC-H.                                           |
+| `sentience_tier` (skiv_archetype_pool / mutagen_events)    | Dato sentience LIVE (#1808) -- input per M-2 identity tier.                                                                          |
+| museum `creature-wildermyth-battle-scar-portrait.md`       | Reuse-path M-2: portrait overlay da evento formativo.                                                                                |
+| `/api/v1/session/:id/*` route pattern                      | Pattern endpoint esistente (`/:id/objective`, `/:id/aliena-telemetry`...) -> dove vivra' `/:id/chronicle*`.                          |
+| **404 greenfield**                                         | `services/{identity,eventlog}` (chronicle store+API ora LIVE -- vedi sez.4); named heirloom/artifact (0 hit); hidden-ability design. |
 
 **NB diaryStore (verificato, reuse-first P1):** `services/diary/diaryStore.js` + `routes/diary.js`
 sono LIVE = diary PER-UNIT cross-session (Pillar 5; JSONL append-only,
@@ -91,8 +91,10 @@ Event-store narrativo cross-session SOPRA il combat event-log.
 - **Sorgente:** eventi narrativi salienti (nascita/morte/mutazione/scar/legacy/failure)
   emessi dagli altri sistemi (SPEC-J wound, SPEC-P failure, M-2 identity, M-3 lineage) come
   `chronicle_event { type, actor_id, run_id, ts, payload, tier }`.
-- **Contratto API (nuovo, pattern `/api/v1/session/:id/*`):** `POST /:id/chronicle-event`
-  (append) + `GET /:id/chronicle` (read, filtrabile per actor/tipo/run). Store = QF1.
+- **Contratto API (LIVE, QF1-A):** `services/chronicle/chronicleStore.js` (JSONL per-branco) +
+  `POST /api/chronicle/:run_id` (append) + `GET /api/chronicle/:run_id` (read, filtrabile
+  `?type=` / `?actor_id=`) + `/summary`. 9 event-type whitelist + tier public/private/secret.
+  Emitter (A3 `run_failed`, M-2 `creature_named`, M-3 `mutation_lineage`...) + viewer = follow-up.
 - **Viewer + Memory-mode home:** Loop Hero visual-emergence, Slay-the-Princess branching-state
   memory, DF template parametrici (QBN/inkjs LIVE, non LLM). Surface Godot = SPEC-K/D consumer.
 - **Keystone:** SPEC-P (A3 failure-as-lore emette chronicle_event; A13 biome-wound cross-run

--- a/tests/api/chronicleRoute.test.js
+++ b/tests/api/chronicleRoute.test.js
@@ -1,0 +1,93 @@
+// Chronicle route integration -- SPEC-Q M-7 (per-branco narrative event-store).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+function tmpBaseDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'chronicle-route-test-'));
+}
+
+function mkApp(t, baseDir) {
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  return app;
+}
+
+test('GET /api/chronicle/:run_id -- empty returns 200 zero events', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  const r = await request(app).get('/api/chronicle/run1');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.run_id, 'run1');
+  assert.equal(r.body.count, 0);
+  assert.deepEqual(r.body.events, []);
+});
+
+test('POST /api/chronicle/:run_id -- happy path appends + 201 (tier defaults public)', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  const r = await request(app)
+    .post('/api/chronicle/run1')
+    .send({ type: 'creature_named', actor_id: 'skiv', payload: { name: 'Vega' } });
+  assert.equal(r.status, 201);
+  assert.equal(r.body.ok, true);
+  assert.equal(r.body.event.type, 'creature_named');
+  assert.equal(r.body.event.tier, 'public');
+  assert.equal(r.body.event.run_id, 'run1');
+});
+
+test('POST /api/chronicle/:run_id -- invalid type -> 409 + allowed list', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  const r = await request(app).post('/api/chronicle/run1').send({ type: 'spurious' });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'invalid_event_type');
+  assert.ok(Array.isArray(r.body.allowed_event_types));
+  assert.ok(r.body.allowed_event_types.includes('creature_named'));
+});
+
+test('POST /api/chronicle/:run_id -- invalid tier -> 409', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  const r = await request(app)
+    .post('/api/chronicle/run1')
+    .send({ type: 'creature_named', tier: 'cosmic' });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'invalid_tier');
+});
+
+test('POST /api/chronicle/:run_id -- invalid run_id -> 400', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  const r = await request(app).post('/api/chronicle/..%2Fbad').send({ type: 'creature_named' });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'invalid_run_id');
+});
+
+test('GET /api/chronicle/:run_id?type=&actor_id= -- filters', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  await request(app).post('/api/chronicle/run1').send({ type: 'creature_named', actor_id: 'skiv' });
+  await request(app).post('/api/chronicle/run1').send({ type: 'scar_earned', actor_id: 'skiv' });
+  await request(app).post('/api/chronicle/run1').send({ type: 'creature_named', actor_id: 'vega' });
+  const byType = await request(app).get('/api/chronicle/run1?type=creature_named');
+  assert.equal(byType.body.count, 2);
+  const byActor = await request(app).get('/api/chronicle/run1?actor_id=skiv');
+  assert.equal(byActor.body.count, 2);
+});
+
+test('GET /api/chronicle/:run_id/summary -- aggregates by_type + by_tier', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  await request(app).post('/api/chronicle/run1').send({ type: 'creature_named', tier: 'public' });
+  await request(app).post('/api/chronicle/run1').send({ type: 'scar_earned', tier: 'private' });
+  const r = await request(app).get('/api/chronicle/run1/summary');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.total, 2);
+  assert.equal(r.body.by_type.creature_named, 1);
+  assert.equal(r.body.by_tier.private, 1);
+});

--- a/tests/services/chronicleStore.test.js
+++ b/tests/services/chronicleStore.test.js
@@ -1,0 +1,161 @@
+// Chronicle store -- pure unit tests (SPEC-Q M-7, per-branco cross-session narrative).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  ALLOWED_EVENT_TYPES,
+  ALLOWED_TIERS,
+  sanitiseRunId,
+  appendEvent,
+  getChronicle,
+  tailChronicle,
+  summary,
+  _resetChronicleForTest,
+} = require('../../apps/backend/services/chronicle/chronicleStore');
+
+function tmpBaseDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'chronicle-test-'));
+}
+
+test('ALLOWED_EVENT_TYPES: covers SPEC-Q salient narrative events', () => {
+  for (const t of [
+    'creature_named',
+    'creature_death',
+    'mutation_acquired',
+    'scar_earned',
+    'legacy_formed',
+    'run_failed',
+    'biome_wound',
+    'heirloom_created',
+    'mutation_lineage',
+  ]) {
+    assert.ok(ALLOWED_EVENT_TYPES.has(t), `missing ${t}`);
+  }
+});
+
+test('ALLOWED_TIERS: public/private/secret (SPEC-B inherit)', () => {
+  assert.deepEqual([...ALLOWED_TIERS].sort(), ['private', 'public', 'secret']);
+});
+
+test('sanitiseRunId: accepts alnum + dash + underscore, rejects traversal', () => {
+  assert.equal(sanitiseRunId('run_42'), 'run_42');
+  assert.equal(sanitiseRunId('branco-vega-7'), 'branco-vega-7');
+  assert.equal(sanitiseRunId('../etc/passwd'), null);
+  assert.equal(sanitiseRunId('run/foo'), null);
+  assert.equal(sanitiseRunId(''), null);
+  assert.equal(sanitiseRunId(null), null);
+  assert.equal(sanitiseRunId('a'.repeat(97)), null);
+});
+
+test('appendEvent: invalid run_id -> invalid_run_id', () => {
+  const baseDir = tmpBaseDir();
+  const out = appendEvent('../bad', { type: 'creature_named' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'invalid_run_id');
+});
+
+test('appendEvent: invalid type -> invalid_event_type with detail', () => {
+  const baseDir = tmpBaseDir();
+  const out = appendEvent('run1', { type: 'spurious' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'invalid_event_type');
+  assert.equal(out.detail.type, 'spurious');
+});
+
+test('appendEvent: invalid tier -> invalid_tier', () => {
+  const baseDir = tmpBaseDir();
+  const out = appendEvent('run1', { type: 'creature_named', tier: 'cosmic' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'invalid_tier');
+});
+
+test('appendEvent: missing event -> invalid_event', () => {
+  const baseDir = tmpBaseDir();
+  assert.equal(appendEvent('run1', null, { baseDir }).error, 'invalid_event');
+  assert.equal(appendEvent('run1', 'str', { baseDir }).error, 'invalid_event');
+});
+
+test('appendEvent: happy path stamps ts + run_id, defaults tier=public', () => {
+  const baseDir = tmpBaseDir();
+  const out = appendEvent(
+    'run1',
+    { type: 'creature_named', actor_id: 'skiv', payload: { name: 'Vega' } },
+    { baseDir },
+  );
+  assert.equal(out.ok, true);
+  assert.equal(out.event.type, 'creature_named');
+  assert.equal(out.event.actor_id, 'skiv');
+  assert.equal(out.event.run_id, 'run1');
+  assert.equal(out.event.tier, 'public');
+  assert.deepEqual(out.event.payload, { name: 'Vega' });
+  assert.ok(typeof out.event.ts === 'string');
+  const filepath = path.join(baseDir, 'run1.jsonl');
+  assert.ok(fs.existsSync(filepath));
+  assert.ok(fs.readFileSync(filepath, 'utf8').includes('creature_named'));
+});
+
+test('getChronicle: [] for missing run', () => {
+  const baseDir = tmpBaseDir();
+  assert.deepEqual(getChronicle('nope', { baseDir }), []);
+});
+
+test('getChronicle: chronological + per-branco isolation', () => {
+  const baseDir = tmpBaseDir();
+  appendEvent('runA', { type: 'creature_named', actor_id: 'a1' }, { baseDir });
+  appendEvent('runA', { type: 'scar_earned', actor_id: 'a1' }, { baseDir });
+  appendEvent('runB', { type: 'run_failed', actor_id: 'b1' }, { baseDir });
+  const a = getChronicle('runA', { baseDir });
+  const b = getChronicle('runB', { baseDir });
+  assert.equal(a.length, 2);
+  assert.equal(a[0].type, 'creature_named');
+  assert.equal(b.length, 1); // run isolation
+  assert.equal(b[0].type, 'run_failed');
+});
+
+test('getChronicle: filter by actor_id and by type', () => {
+  const baseDir = tmpBaseDir();
+  appendEvent('run1', { type: 'creature_named', actor_id: 'skiv' }, { baseDir });
+  appendEvent('run1', { type: 'scar_earned', actor_id: 'skiv' }, { baseDir });
+  appendEvent('run1', { type: 'creature_named', actor_id: 'vega' }, { baseDir });
+  assert.equal(getChronicle('run1', { baseDir, actor_id: 'skiv' }).length, 2);
+  assert.equal(getChronicle('run1', { baseDir, type: 'creature_named' }).length, 2);
+  assert.equal(
+    getChronicle('run1', { baseDir, actor_id: 'skiv', type: 'creature_named' }).length,
+    1,
+  );
+});
+
+test('tailChronicle: last N + reverse', () => {
+  const baseDir = tmpBaseDir();
+  for (let i = 0; i < 5; i += 1) {
+    appendEvent('run1', { type: 'mutation_acquired', payload: { i } }, { baseDir });
+  }
+  const tail = tailChronicle('run1', { baseDir, limit: 3, reverse: true });
+  assert.equal(tail.length, 3);
+  assert.equal(tail[0].payload.i, 4);
+});
+
+test('summary: aggregates counts per type + by tier', () => {
+  const baseDir = tmpBaseDir();
+  appendEvent('run1', { type: 'creature_named', tier: 'public' }, { baseDir });
+  appendEvent('run1', { type: 'creature_named', tier: 'public' }, { baseDir });
+  appendEvent('run1', { type: 'scar_earned', tier: 'private' }, { baseDir });
+  const out = summary('run1', { baseDir });
+  assert.equal(out.total, 3);
+  assert.equal(out.by_type.creature_named, 2);
+  assert.equal(out.by_tier.private, 1);
+});
+
+test('_resetChronicleForTest: removes file', () => {
+  const baseDir = tmpBaseDir();
+  appendEvent('run1', { type: 'creature_named' }, { baseDir });
+  assert.equal(getChronicle('run1', { baseDir }).length, 1);
+  _resetChronicleForTest('run1', { baseDir });
+  assert.equal(getChronicle('run1', { baseDir }).length, 0);
+});


### PR DESCRIPTION
## Cosa
SPEC-Q M-7 keystone (greenlit). Per-BRANCO cross-session narrative event-store ABOVE the combat event-log (sessionRoundBridge=per-round; diaryStore=per-unit). QF1-A: new service, NOT a 2nd per-unit store (no double-store with diary).

- `services/chronicle/chronicleStore.js` -- JSONL append-only per `run_id`; `appendEvent/getChronicle/tailChronicle/summary`; `chronicle_event {ts,type,actor_id,run_id,tier,payload}`; 9 event-type whitelist (M-1..M-7 + A3/A13); tier public/private/secret (SPEC-B sez.10).
- `routes/chronicle.js` -- `POST /api/chronicle/:run_id` (append) + `GET /api/chronicle/:run_id` (read, `?type=`/`?actor_id=`/`?limit=`/`?reverse=`) + `/summary`. Registered in app.js.
- `.gitignore` data/derived/chronicles/.

## TDD
RED -> GREEN: chronicleStore 14/14 (validation, per-branco isolation, filters, tier) + chronicleRoute 7/7 (201/400/409, filters, summary). diary 8/8 no-regression. prettier clean, governance 0.

## Scope / follow-ups (not in this PR)
Emitters (SPEC-P A3 `run_failed` + A13 `biome_wound`; M-2 `creature_named`; M-3 `mutation_lineage`) call appendEvent at the right lifecycle points. Memory-mode viewer = Godot surface (SPEC-K/D). Path `/api/chronicle/:run_id` (dedicated router, mirrors diary) vs SPEC-Q's `/:id/chronicle-event` sketch -- functionally equivalent.

apps/backend only (no forbidden paths), no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)