### PR TITLE
feat(i18n): SPEC-N PR-3 loader for apps/play (t() + IT fallback)

### DIFF
--- a/apps/play/src/i18n.js
+++ b/apps/play/src/i18n.js
@@ -1,0 +1,25 @@
+// =============================================================================
+// i18n entry -- SPEC-N PR-3 (apps/play). Binds the loader core (i18nCore.js) to
+// the canonical data/i18n bundles (QA3 SSOT). Vite bundles the JSON imports.
+//
+// Usage:  import { t } from './i18n.js';  t('ui.confirm');  t('combat.turns', { n: 3 });
+//
+// Locale: window.__EVO_LOCALE__ (runtime-config) || 'it'. Fallback always 'it' (NF1).
+// Migrazione dei label-map hardcoded (biomeChip/ui/objectivePanel/...) a t() =
+// PR-4 (NF3 incrementale) -- questo file e' solo il loader.
+// =============================================================================
+
+import { createT } from './i18nCore.js';
+// data/i18n = sorgente unica (ADR-2026-06-08 QA3). Oggi solo `common.json`
+// (10 namespace dentro); lo split per-namespace = PR-5.
+import itCommon from '../../../data/i18n/it/common.json';
+import enCommon from '../../../data/i18n/en/common.json';
+
+const MESSAGES = { it: itCommon, en: enCommon };
+
+const DEFAULT_LOCALE = (typeof window !== 'undefined' && window.__EVO_LOCALE__) || 'it';
+
+export const t = createT(MESSAGES, { defaultLocale: DEFAULT_LOCALE, fallbackLocale: 'it' });
+
+export { createT, resolveKey, interpolate } from './i18nCore.js';
+export { MESSAGES };

--- a/apps/play/src/i18nCore.js
+++ b/apps/play/src/i18nCore.js
@@ -1,0 +1,60 @@
+// =============================================================================
+// i18n loader core -- SPEC-N PR-3 (apps/play). Pure ESM, no JSON import (testable
+// under node:test via dynamic import). The JSON-bound entry lives in i18n.js.
+//
+// NF1 (ratified): il loader vive frontend (apps/play). Fallback = IT (sorgente
+// autorata completa; EN ~5% -> un EN player vede IT, non key grezze).
+// Interpolation: Mustache {{var}} (matches data/i18n + parity validator).
+//   NF4 ({var} normalize) e' un follow-up PR-4 (atomico con mission-console).
+// =============================================================================
+
+const MUSTACHE_RE = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+
+/**
+ * Resolve a dot-notation key (es. "ui.confirm") against a locale bundle.
+ * Returns the string value, or undefined if missing / not a leaf string.
+ */
+export function resolveKey(bundle, key) {
+  if (!bundle || typeof bundle !== 'object') return undefined;
+  const parts = String(key).split('.');
+  let cur = bundle;
+  for (const p of parts) {
+    if (cur && typeof cur === 'object' && Object.prototype.hasOwnProperty.call(cur, p)) {
+      cur = cur[p];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof cur === 'string' ? cur : undefined;
+}
+
+/**
+ * Replace {{var}} tokens with params[var]. Tokens whose param is missing are
+ * left untouched (visible in dev -> flags a missing param).
+ */
+export function interpolate(str, params) {
+  if (typeof str !== 'string' || !params || typeof params !== 'object') return str;
+  return str.replace(MUSTACHE_RE, (m, k) =>
+    params[k] !== undefined && params[k] !== null ? String(params[k]) : m,
+  );
+}
+
+/**
+ * Build a t() bound to a messages map { [locale]: bundle }.
+ * t(key, params?, locale?) -> resolved + interpolated string, or the key if missing.
+ * Fallback order: requested locale -> fallbackLocale (default 'it').
+ */
+export function createT(messages, opts = {}) {
+  const msgs = messages && typeof messages === 'object' ? messages : {};
+  const defaultLocale = opts.defaultLocale || 'it';
+  const fallbackLocale = opts.fallbackLocale || 'it';
+  return function t(key, params, locale) {
+    const loc = locale || defaultLocale;
+    let val = resolveKey(msgs[loc], key);
+    if (val === undefined && fallbackLocale !== loc) {
+      val = resolveKey(msgs[fallbackLocale], key);
+    }
+    if (val === undefined) return key;
+    return interpolate(val, params);
+  };
+}

--- a/docs/design/evo-tactics-localization-i18n.md
+++ b/docs/design/evo-tactics-localization-i18n.md
@@ -46,7 +46,7 @@ l'infra esistente, non la ricostruisce.
 | `apps/mission-console/src/locales/`                       | Runtime vue-i18n COMPLETO ma con locali PROPRI (DEFAULT_LOCALE=it, FALLBACK_LOCALE=en); NON consuma data/i18n.                                                                                       |
 | `docs/architecture/i18n-strategy.md` (LOCAL, active)      | Roadmap PR-1..PR-6 (scaffold/parity/loader/migration/split/CI-gate).                                                                                                                                 |
 | `ADR-2026-06-08-i18n-unify-data-i18n` (QA3)               | data/i18n = SSOT; mission-console + nuove surface migrano; en->it fallback; gate no-hardcoded forward-only.                                                                                          |
-| **404 / da costruire**                                    | loader runtime + `t()` (PR-3); migration mission-console (PR-4); split namespace separati (PR-5); schema formale (opz).                                                                              |
+| **404 / da costruire**                                    | migration mission-console + label-map apps/play (PR-4); split namespace separati (PR-5); schema formale (opz). (loader PR-3 = LIVE, sez.5)                                                           |
 
 Invarianti ereditate:
 
@@ -61,14 +61,14 @@ Invarianti ereditate:
 
 ## 3. Roadmap di consegna (i18n-strategy PR-1..PR-6)
 
-| PR   | Cosa                                                  | Stato            |
-| ---- | ----------------------------------------------------- | ---------------- |
-| PR-1 | scaffold `data/i18n/{it,en}/common.json`              | **DONE** (#1463) |
-| PR-2 | parity validator (`validate_i18n_parity.py`)          | **DONE**         |
-| PR-3 | loader runtime + `t()` helper                         | TODO (NF1)       |
-| PR-4 | migration mission-console -> data/i18n + debito       | TODO (NF3)       |
-| PR-5 | split namespace combat/tutorial/narrative (file sep.) | TODO             |
-| PR-6 | CI gate completion_percent + no-hardcoded             | TODO             |
+| PR   | Cosa                                                  | Stato                |
+| ---- | ----------------------------------------------------- | -------------------- |
+| PR-1 | scaffold `data/i18n/{it,en}/common.json`              | **DONE** (#1463)     |
+| PR-2 | parity validator (`validate_i18n_parity.py`)          | **DONE**             |
+| PR-3 | loader runtime + `t()` helper                         | **DONE** (apps/play) |
+| PR-4 | migration mission-console -> data/i18n + debito       | TODO (NF3)           |
+| PR-5 | split namespace combat/tutorial/narrative (file sep.) | TODO                 |
+| PR-6 | CI gate completion_percent + no-hardcoded             | TODO                 |
 
 > NB allineamento: la sequenza canonica resta `i18n-strategy.md`. La tabella SPEC-N raggruppa
 > per fase logica; in strategy PR-5 = content-fill combat/tutorial, PR-6 = Ink bilingue export.
@@ -88,6 +88,11 @@ Invarianti ereditate:
 - Convenzione key: dot-notation per dominio (es. `combat.your_turn`, `ui.confirm`).
 
 ## 5. Loader runtime + `t()` (PR-3)
+
+**Stato: LIVE (2026-06-08).** `apps/play/src/i18nCore.js` (puro: `createT`/`resolveKey`/
+`interpolate`, testato) + `apps/play/src/i18n.js` (bind a `data/i18n` via Vite JSON import).
+NF1=frontend (apps/play), `fallbackLocale=it`. Interpolation Mustache `{{var}}` (NF4 `{var}` =
+PR-4). I label-map hardcoded NON sono ancora migrati a `t()` (PR-4, NF3 incrementale).
 
 - `t(key, params?, locale?)`: risolve la key, applica i params, fallback a IT (sorgente
   completa), ritorna la stringa. NON-LLM, deterministico.
@@ -193,8 +198,8 @@ SPEC-N e' implementabile/chiudibile quando:
 
 1. lo scaffold (`data/i18n/{it,en}/common.json`) + la parity (`validate_i18n_parity.py`) sono
    LIVE (FATTO: PR-1/PR-2);
-2. il loader `t()` (PR-3) e' costruito con `fallbackLocale=it` (sorgente completa), nel layer
-   deciso da NF1;
+2. il loader `t()` (PR-3) e' costruito (LIVE: `apps/play/src/i18nCore.js` + `i18n.js`,
+   `fallbackLocale=it`, NF1 frontend); la migrazione dei consumer (label-map) = PR-4;
 3. lo schema formale e' deciso (NF2: skip o build);
 4. la migrazione (PR-4) su `data/i18n` segue l'approccio NF3, con il debito hardcoded
    (biomeChip/briefing) migrato o ticketato;

--- a/tests/play/i18nCore.test.js
+++ b/tests/play/i18nCore.test.js
@@ -1,0 +1,79 @@
+// apps/play i18n loader core -- SPEC-N PR-3 (t() + fallback IT + {{var}} interp).
+// Pure ESM module (no JSON import) -> dynamic-import from CJS test (tests/play pattern).
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function load() {
+  return import('../../apps/play/src/i18nCore.js');
+}
+
+const MESSAGES = {
+  it: {
+    ui: { confirm: 'Conferma', greet: 'Ciao {{name}}' },
+    combat: { turns: 'Sopravvivi {{n}} turni' },
+  },
+  en: { ui: { confirm: 'Confirm' } },
+};
+
+describe('createT', () => {
+  test('resolves key in the current locale', async () => {
+    const { createT } = await load();
+    const t = createT(MESSAGES, { defaultLocale: 'en', fallbackLocale: 'it' });
+    assert.equal(t('ui.confirm'), 'Confirm');
+  });
+
+  test('falls back to IT when key missing in locale (NF1)', async () => {
+    const { createT } = await load();
+    const t = createT(MESSAGES, { defaultLocale: 'en', fallbackLocale: 'it' });
+    assert.equal(t('ui.greet', { name: 'X' }), 'Ciao X');
+  });
+
+  test('default fallbackLocale is it even if unspecified (NF1)', async () => {
+    const { createT } = await load();
+    const t = createT(MESSAGES, { defaultLocale: 'en' });
+    assert.equal(t('ui.greet', { name: 'Y' }), 'Ciao Y');
+  });
+
+  test('interpolates {{var}} params', async () => {
+    const { createT } = await load();
+    const t = createT(MESSAGES, { defaultLocale: 'it' });
+    assert.equal(t('combat.turns', { n: 3 }), 'Sopravvivi 3 turni');
+  });
+
+  test('explicit locale arg overrides default', async () => {
+    const { createT } = await load();
+    const t = createT(MESSAGES, { defaultLocale: 'en', fallbackLocale: 'it' });
+    assert.equal(t('ui.confirm', null, 'it'), 'Conferma');
+  });
+
+  test('missing key returns the key itself', async () => {
+    const { createT } = await load();
+    const t = createT(MESSAGES, { defaultLocale: 'it' });
+    assert.equal(t('nope.not_here'), 'nope.not_here');
+  });
+
+  test('leaves {{var}} untouched when param absent', async () => {
+    const { createT } = await load();
+    const t = createT(MESSAGES, { defaultLocale: 'it' });
+    assert.equal(t('ui.greet'), 'Ciao {{name}}');
+  });
+});
+
+describe('resolveKey / interpolate', () => {
+  test('resolveKey walks dot-path, returns undefined for non-string/missing', async () => {
+    const { resolveKey } = await load();
+    assert.equal(resolveKey(MESSAGES.it, 'ui.confirm'), 'Conferma');
+    assert.equal(resolveKey(MESSAGES.it, 'ui'), undefined); // object, not string
+    assert.equal(resolveKey(MESSAGES.it, 'ui.nope'), undefined);
+    assert.equal(resolveKey(null, 'x'), undefined);
+  });
+
+  test('interpolate handles multiple + numeric params', async () => {
+    const { interpolate } = await load();
+    assert.equal(interpolate('{{a}}/{{b}}', { a: 1, b: 2 }), '1/2');
+    assert.equal(interpolate('no params', null), 'no params');
+  });
+});


### PR DESCRIPTION
## Cosa
SPEC-N PR-3 (greenlit). The i18n loader was the only missing piece of the i18n foundation (scaffold + parity validator already LIVE).

- `apps/play/src/i18nCore.js` -- pure: `createT(messages, opts)` + `resolveKey` (dot-path) + `interpolate` ({{var}} Mustache). `fallbackLocale=it` (NF1: IT = complete authored source). Testable (no JSON import).
- `apps/play/src/i18n.js` -- binds the core to `data/i18n/{it,en}/common.json` (QA3 SSOT) via Vite JSON import. `t('ui.confirm')`, `t('combat.turns', { n: 3 })`.

## TDD
i18nCore 9/9 (resolve, IT fallback incl. default, {{var}} interp, locale override, missing->key, resolveKey/interpolate units). Vite build smoke green (JSON path resolves). prettier clean, governance 0.

## Decisions honored
- NF1 = frontend (apps/play); no backend loader.
- Interpolation stays Mustache `{{var}}` (matches current data/i18n + parity validator). **NF4 ({var} normalize) deferred to PR-4** (atomic with mission-console migration) -- avoids touching data/i18n + the validator now.

## Follow-ups (PR-4, NF3 incremental)
Migrate the 8 hardcoded apps/play label-maps (biomeChip/ui/objectivePanel/...) to `t()`; NF4 normalize; mission-console -> data/i18n. (Not migrated here to avoid ESM/CJS/Vite-JSON interop breaking existing node tests.)

NB >50 LOC outside apps/backend -- this is the explicitly greenlit i18n loader. No new deps (existing vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)