### PR TITLE
feat(chronicle): wire A3 run_failed emitter at session-end (M-7 live)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -797,7 +797,10 @@ function createApp(options = {}) {
   }
   const lobby = lobbyOptions.service || new LobbyService(lobbyOptions);
   const coopStore = createCoopStore({ lobby });
-  app.use('/api/session', createSessionRouter({ ...(options.session || {}), coopStore }));
+  app.use(
+    '/api/session',
+    createSessionRouter({ ...(options.session || {}), coopStore, chronicle: options.chronicle }),
+  );
   app.use('/api/party', createPartyRouter());
   // M7 demo playtest: feedback collection (/api/feedback, /api/feedback/summary)
   app.use('/api', createFeedbackRouter(options.feedback || {}));

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -271,6 +271,8 @@ function createSessionRouter(options = {}) {
   const router = Router();
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
   const logsDir = options.logsDir || path.join(repoRoot, 'logs');
+  // SPEC-Q M-7 -- chronicle store baseDir (test override; prod uses store default).
+  const chronicleBaseDir = options.chronicle && options.chronicle.baseDir;
   // TKT-PLAYTEST-SEED: default to the canonical seedable provider so a seed
   // pinned at /start propagates to every combat draw. defaultRng === Math.random
   // behavior until seeded, so production is unchanged.
@@ -3441,6 +3443,13 @@ function createSessionRouter(options = {}) {
         debrief = buildDebriefSummary(session, vcSnapshot, peResult);
       } catch {
         // vc + debrief are best-effort -- don't block session end
+      }
+      // SPEC-Q M-7 -- chronicle the failed run (A3 failure-as-lore). Best-effort.
+      try {
+        const { emitRunFailed } = require('../services/chronicle/chronicleEmitters');
+        emitRunFailed(session, { baseDir: chronicleBaseDir });
+      } catch {
+        /* best-effort -- never blocks session end */
       }
       // M1 -- persist Sistema learning (best-effort, never blocks session end).
       try {

--- a/apps/backend/services/chronicle/chronicleEmitters.js
+++ b/apps/backend/services/chronicle/chronicleEmitters.js
@@ -1,0 +1,47 @@
+// =============================================================================
+// Chronicle emitters -- SPEC-Q M-7 wiring. Helpers that translate engine
+// lifecycle events into chronicle_event appends (services/chronicle/chronicleStore).
+//
+// Keystone link (SPEC-P A3 failure-as-lore): a failed run is a narrative event.
+// `emitRunFailed` is called best-effort at session end (routes/session.js) so the
+// chronicle starts receiving real events. M-2 creature_named / M-3 mutation_lineage
+// emitters land when those systems (identity service / named-mutation) are built.
+// =============================================================================
+
+'use strict';
+
+const { appendEvent } = require('./chronicleStore');
+
+// Loss outcomes that count as a narrative run failure (A3). Victory/draw/abandon excluded.
+const DEFEAT_OUTCOMES = new Set(['wipe', 'timeout', 'defeat', 'objective_failed']);
+
+/**
+ * Append a `run_failed` chronicle event when a session ends in defeat.
+ * Pure-ish: reads session.{campaign_id,outcome,encounter_id,turn}, never throws.
+ * Returns the chronicleStore.appendEvent result, or { ok:false, error } for no-op.
+ *
+ * @param session  combat session (post outcome-normalization)
+ * @param opts     { baseDir? } (test override; prod uses chronicleStore default)
+ */
+function emitRunFailed(session, opts = {}) {
+  if (!session || typeof session !== 'object') return { ok: false, error: 'no_session' };
+  const runId = session.campaign_id;
+  if (!runId) return { ok: false, error: 'no_campaign_id' };
+  if (!DEFEAT_OUTCOMES.has(session.outcome)) return { ok: false, error: 'not_a_defeat' };
+  return appendEvent(
+    runId,
+    {
+      type: 'run_failed',
+      actor_id: null,
+      tier: 'public',
+      payload: {
+        outcome: session.outcome,
+        encounter_id: session.encounter_id || null,
+        turn: Number.isFinite(Number(session.turn)) ? Number(session.turn) : null,
+      },
+    },
+    { baseDir: opts.baseDir },
+  );
+}
+
+module.exports = { emitRunFailed, DEFEAT_OUTCOMES };

--- a/docs/design/evo-tactics-df-levels-narrative-depth.md
+++ b/docs/design/evo-tactics-df-levels-narrative-depth.md
@@ -94,7 +94,9 @@ Event-store narrativo cross-session SOPRA il combat event-log.
 - **Contratto API (LIVE, QF1-A):** `services/chronicle/chronicleStore.js` (JSONL per-branco) +
   `POST /api/chronicle/:run_id` (append) + `GET /api/chronicle/:run_id` (read, filtrabile
   `?type=` / `?actor_id=`) + `/summary`. 9 event-type whitelist + tier public/private/secret.
-  Emitter (A3 `run_failed`, M-2 `creature_named`, M-3 `mutation_lineage`...) + viewer = follow-up.
+  Emitter A3 `run_failed` = LIVE (`chronicleEmitters.emitRunFailed`, best-effort a session-end
+  su `session.campaign_id` + outcome di sconfitta). M-2 `creature_named` / M-3 `mutation_lineage`
+  (servizi non ancora costruiti) + Memory-mode viewer (Godot) = follow-up.
 - **Viewer + Memory-mode home:** Loop Hero visual-emergence, Slay-the-Princess branching-state
   memory, DF template parametrici (QBN/inkjs LIVE, non LLM). Surface Godot = SPEC-K/D consumer.
 - **Keystone:** SPEC-P (A3 failure-as-lore emette chronicle_event; A13 biome-wound cross-run

--- a/tests/api/chronicleRunFailedWire.test.js
+++ b/tests/api/chronicleRunFailedWire.test.js
@@ -1,0 +1,69 @@
+// Chronicle run_failed wiring integration -- SPEC-Q M-7 (A3 failure-as-lore).
+// Ending a session in defeat appends a run_failed chronicle event (best-effort).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'chron-wire-'));
+}
+
+test('session /end with defeat (wipe) appends run_failed to the campaign chronicle', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  // player unit already dead -> elimination outcome = wipe
+  const units = [
+    { id: 'p1', controlled_by: 'player', hp: 0, max_hp: 10, position: { x: 0, y: 0 } },
+    { id: 's1', controlled_by: 'sistema', hp: 5, max_hp: 5, position: { x: 5, y: 5 } },
+  ];
+  const start = await request(app)
+    .post('/api/session/start')
+    .send({ units, campaign_id: 'run_wire_test' });
+  assert.equal(start.status, 200);
+
+  const end = await request(app)
+    .post('/api/session/end')
+    .send({ session_id: start.body.session_id });
+  assert.equal(end.status, 200);
+  assert.equal(end.body.outcome, 'wipe');
+
+  const chron = getChronicle('run_wire_test', { baseDir });
+  assert.equal(chron.length, 1);
+  assert.equal(chron[0].type, 'run_failed');
+  assert.equal(chron[0].payload.outcome, 'wipe');
+});
+
+test('session /end with no campaign_id -> no chronicle event (no_campaign_id no-op)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const units = [
+    { id: 'p1', controlled_by: 'player', hp: 0, max_hp: 10, position: { x: 0, y: 0 } },
+    { id: 's1', controlled_by: 'sistema', hp: 5, max_hp: 5, position: { x: 5, y: 5 } },
+  ];
+  const start = await request(app).post('/api/session/start').send({ units });
+  const end = await request(app)
+    .post('/api/session/end')
+    .send({ session_id: start.body.session_id });
+  assert.equal(end.status, 200);
+  // no campaign_id -> emitter no-op; no chronicle file written for any run
+  assert.equal(fs.readdirSync(baseDir).length, 0);
+});

--- a/tests/services/chronicleEmitters.test.js
+++ b/tests/services/chronicleEmitters.test.js
@@ -1,0 +1,56 @@
+// Chronicle emitters -- SPEC-Q M-7 wiring (A3 failure-as-lore: run_failed at session end).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { emitRunFailed } = require('../../apps/backend/services/chronicle/chronicleEmitters');
+const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'chron-emit-'));
+}
+
+test('emitRunFailed: defeat outcome appends a run_failed chronicle event', () => {
+  const baseDir = tmp();
+  const session = { campaign_id: 'c1', outcome: 'wipe', encounter_id: 'enc_x', turn: 7 };
+  const out = emitRunFailed(session, { baseDir });
+  assert.equal(out.ok, true);
+  const chron = getChronicle('c1', { baseDir });
+  assert.equal(chron.length, 1);
+  assert.equal(chron[0].type, 'run_failed');
+  assert.equal(chron[0].tier, 'public');
+  assert.equal(chron[0].payload.outcome, 'wipe');
+  assert.equal(chron[0].payload.encounter_id, 'enc_x');
+  assert.equal(chron[0].payload.turn, 7);
+});
+
+test('emitRunFailed: each defeat outcome (timeout/defeat/objective_failed) emits', () => {
+  for (const outcome of ['timeout', 'defeat', 'objective_failed']) {
+    const baseDir = tmp();
+    const out = emitRunFailed({ campaign_id: 'c', outcome }, { baseDir });
+    assert.equal(out.ok, true, `outcome ${outcome}`);
+    assert.equal(getChronicle('c', { baseDir })[0].payload.outcome, outcome);
+  }
+});
+
+test('emitRunFailed: victory -> no-op (not_a_defeat, no event)', () => {
+  const baseDir = tmp();
+  const out = emitRunFailed({ campaign_id: 'c1', outcome: 'victory' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'not_a_defeat');
+  assert.equal(getChronicle('c1', { baseDir }).length, 0);
+});
+
+test('emitRunFailed: missing campaign_id -> no_campaign_id (no crash)', () => {
+  const baseDir = tmp();
+  assert.equal(emitRunFailed({ outcome: 'wipe' }, { baseDir }).error, 'no_campaign_id');
+});
+
+test('emitRunFailed: missing/invalid session -> no_session', () => {
+  assert.equal(emitRunFailed(null).error, 'no_session');
+});


### PR DESCRIPTION
## Cosa
Follow-up #1 (greenlit "continuiamo con i follow up"): makes the chronicle store (M-7, shipped #2650) receive real events -- the SPEC-P A3 (failure-as-lore) keystone link.

- `services/chronicle/chronicleEmitters.js` -- `emitRunFailed(session, opts)`: defeat outcome (wipe/timeout/defeat/objective_failed) + `campaign_id` -> appends a `run_failed` chronicle event; no-op otherwise. Never throws.
- `routes/session.js` -- best-effort call at session-end (mirrors the existing M1/Epigenome best-effort blocks; never blocks `/end`). chronicle baseDir threaded via session router options (DI for tests).
- `app.js` -- passes `options.chronicle` to the session router.

## Live smoke (verified)
POST `/api/session/start` (dead player unit + campaign_id) -> POST `/api/session/end` -> outcome `wipe` -> `run_failed` event in the campaign chronicle. Captured as integration test.

## TDD / tests
chronicleEmitters 5/5 (each defeat outcome, victory no-op, no-campaign no-op). Wire integration 2/2 (defeat appends; no-campaign no-op). End-flow no-regression 6/6 (sessionEndResponse + sessionDebriefRoute). governance 0, prettier clean.

## Follow-ups
M-2 `creature_named` / M-3 `mutation_lineage` emitters land when the identity / named-mutation services are built. Memory-mode viewer = Godot (SPEC-K/D).

apps/backend only (session.js = additive best-effort block), no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)