### PR TITLE
feat(vc): plumb branco formPulses into debrief VC (FP->VC chain complete)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3434,6 +3434,13 @@ function createSessionRouter(options = {}) {
       let vcSnapshot = null;
       let debrief = null;
       try {
+        // SPEC-M FP->VC plumb: attach the branco Form Pulse (if a coop room is
+        // linked) so the debrief VC reflects the soft nudge. Dormant until the
+        // Form Pulse UX (Godot) populates it; no-op otherwise (backward compat).
+        if (coopStore && session.campaign_id && !session.formPulses) {
+          const fp = coopStore.getFormPulses(session.campaign_id);
+          if (fp) session.formPulses = fp;
+        }
         vcSnapshot = buildVcSnapshot(session, telemetryConfig);
         const { computeSessionPE, buildDebriefSummary } = require('../services/rewardEconomy');
         const peResult = computeSessionPE(vcSnapshot, {

--- a/apps/backend/services/coop/coopStore.js
+++ b/apps/backend/services/coop/coopStore.js
@@ -61,7 +61,17 @@ function createCoopStore({ lobby } = {}) {
     return false;
   }
 
-  return { getOrCreate, get, remove, list, clear, linkSession };
+  // SPEC-M FP->VC plumb -- resolve the branco Form Pulse map by campaign_id
+  // (run.id == campaign_id). Lets the combat session feed formPulses to vcScoring.
+  function getFormPulses(campaignId) {
+    if (!campaignId) return null;
+    for (const orch of orchestrators.values()) {
+      if (orch?.run?.id === campaignId) return orch.formPulses || null;
+    }
+    return null;
+  }
+
+  return { getOrCreate, get, remove, list, clear, linkSession, getFormPulses };
 }
 
 module.exports = { createCoopStore };

--- a/docs/design/evo-tactics-onboarding-identity-flow.md
+++ b/docs/design/evo-tactics-onboarding-identity-flow.md
@@ -277,8 +277,9 @@ SPEC-M e' implementabile/chiudibile quando:
    `onboarding_choice` per-player + timeout server-side anti-deadlock (sez. 5) + debito
    host-only rimosso (Gate-5 cross-repo);
 4. il wiring `formPulses -> VC axis delta` e' costruito (LIVE: `formPulseVc` soft+bounded in
-   `buildVcSnapshot`, no-op se assente); restano da ratificare il mapping (MA3) + tarare la
-   magnitudine N=40 + plumbing `session.formPulses` al call-site + UX swipe (MA2/SPEC-K);
+   `buildVcSnapshot`) + plumbing al call-site del debrief (`coopStore.getFormPulses` per
+   `campaign_id`, dormiente finche' la UX Form Pulse Godot non popola gli assi); restano da
+   ratificare il mapping (MA3) + tarare la magnitudine N=40 + UX swipe (MA2/SPEC-K);
 5. biome-form landing (MA4) + social ritual sono wired (oggi DESIGN-ONLY);
 6. il mapping VC/MBTI/Ennea/Conviction resta soft (no hard-gate), engine-owned;
 7. la visibilita' (sez. 9) e' coerente con SPEC-B (scelta `private`+opt-in F6, Form Pulse

--- a/tests/services/coopStoreFormPulses.test.js
+++ b/tests/services/coopStoreFormPulses.test.js
@@ -1,0 +1,44 @@
+// coopStore.getFormPulses -- SPEC-M FP->VC plumb: resolve a branco's Form Pulse
+// map by campaign_id (run.id) so the combat session can feed it to vcScoring.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+
+function mkStore() {
+  return createCoopStore({ lobby: { getRoom: () => ({ hostId: 'h' }) } });
+}
+
+test('getFormPulses: returns the orchestrator formPulses for matching campaign run.id', () => {
+  const store = mkStore();
+  const orch = store.getOrCreate('ROOM1');
+  orch.run = { id: 'camp1' };
+  orch.formPulses = new Map([['p1', { axes: { solitary_swarm: 1 } }]]);
+  const fp = store.getFormPulses('camp1');
+  assert.ok(fp instanceof Map);
+  assert.equal(fp.get('p1').axes.solitary_swarm, 1);
+});
+
+test('getFormPulses: null for unknown campaign id', () => {
+  const store = mkStore();
+  const orch = store.getOrCreate('ROOM1');
+  orch.run = { id: 'camp1' };
+  assert.equal(store.getFormPulses('does_not_exist'), null);
+});
+
+test('getFormPulses: null for falsy id', () => {
+  const store = mkStore();
+  assert.equal(store.getFormPulses(null), null);
+  assert.equal(store.getFormPulses(''), null);
+});
+
+test('getFormPulses: null when matching orch has no formPulses', () => {
+  const store = mkStore();
+  const orch = store.getOrCreate('ROOM1');
+  orch.run = { id: 'camp1' };
+  orch.formPulses = null;
+  assert.equal(store.getFormPulses('camp1'), null);
+});


### PR DESCRIPTION
## Cosa
Follow-up #2: completes the FP->VC backend chain (transform shipped #2651 was LIVE-but-dormant -- nothing fed it `session.formPulses`).

- `coopStore.getFormPulses(campaignId)` -- resolves the branco Form Pulse map by `run.id == campaign_id` (mirrors `linkSession`).
- `routes/session.js` -- attaches it to `session.formPulses` before the **debrief** `buildVcSnapshot` (guarded: coopStore + campaign_id + not already set). 

## Behaviour
Dormant until the Form Pulse UX (Godot, currently DESIGN-ONLY) populates `formPulses` via `submitFormPulse`. No-op otherwise -> backward compat. When populated, the debrief VC reflects the soft+bounded nudge.

## Tests
coopStore.getFormPulses 4/4 (match/unknown/falsy/no-formPulses). /end no-regression 6/6 (sessionEndResponse + chronicleRunFailedWire + formPulseVcWire). Chain verified piece-wise: accessor -> attach (guarded) -> buildVcSnapshot nudge (formPulseVcWire 2/2). governance 0, prettier clean.

## Still open (your call)
Mapping (`PROPOSED_FP_VC_MAPPING`) + magnitude (`MAX_FP_VC_DELTA`) = ratify MA3 (N=40) before the Form Pulse UX goes live. Other (non-debrief) buildVcSnapshot sites = future centralization if needed.

apps/backend only, no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)