### PR TITLE
feat(i18n): PR-4 kickoff -- interop fix + objectivePanel migration + NF4

### DIFF
--- a/apps/play/src/i18n.js
+++ b/apps/play/src/i18n.js
@@ -12,8 +12,11 @@
 import { createT } from './i18nCore.js';
 // data/i18n = sorgente unica (ADR-2026-06-08 QA3). Oggi solo `common.json`
 // (10 namespace dentro); lo split per-namespace = PR-5.
-import itCommon from '../../../data/i18n/it/common.json';
-import enCommon from '../../../data/i18n/en/common.json';
+// Import attributes (`with { type: 'json' }`) -- required by node ESM (test runner)
+// and supported by Vite 8; without them node dynamic-import of any module importing
+// this file throws ERR_IMPORT_ATTRIBUTE_MISSING (breaks the migrated modules' tests).
+import itCommon from '../../../data/i18n/it/common.json' with { type: 'json' };
+import enCommon from '../../../data/i18n/en/common.json' with { type: 'json' };
 
 const MESSAGES = { it: itCommon, en: enCommon };
 

--- a/apps/play/src/i18nCore.js
+++ b/apps/play/src/i18nCore.js
@@ -4,11 +4,11 @@
 //
 // NF1 (ratified): il loader vive frontend (apps/play). Fallback = IT (sorgente
 // autorata completa; EN ~5% -> un EN player vede IT, non key grezze).
-// Interpolation: Mustache {{var}} (matches data/i18n + parity validator).
-//   NF4 ({var} normalize) e' un follow-up PR-4 (atomico con mission-console).
+// Interpolation: single-brace {var} (NF4 ratified; vue-i18n Named Interpolation,
+// matches data/i18n + the parity validator).
 // =============================================================================
 
-const MUSTACHE_RE = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+const PARAM_RE = /\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}/g;
 
 /**
  * Resolve a dot-notation key (es. "ui.confirm") against a locale bundle.
@@ -29,12 +29,12 @@ export function resolveKey(bundle, key) {
 }
 
 /**
- * Replace {{var}} tokens with params[var]. Tokens whose param is missing are
+ * Replace {var} tokens with params[var]. Tokens whose param is missing are
  * left untouched (visible in dev -> flags a missing param).
  */
 export function interpolate(str, params) {
   if (typeof str !== 'string' || !params || typeof params !== 'object') return str;
-  return str.replace(MUSTACHE_RE, (m, k) =>
+  return str.replace(PARAM_RE, (m, k) =>
     params[k] !== undefined && params[k] !== null ? String(params[k]) : m,
   );
 }

--- a/apps/play/src/objectivePanel.js
+++ b/apps/play/src/objectivePanel.js
@@ -13,14 +13,9 @@
 
 'use strict';
 
-const TYPE_LABELS = {
-  elimination: 'Elimina i nemici',
-  capture_point: 'Tieni la zona',
-  escort: 'Scorta il bersaglio',
-  sabotage: 'Sabotaggio',
-  survival: 'Sopravvivi',
-  escape: 'Fuggi',
-};
+// SPEC-N PR-4 (NF3): label-map migrated to the i18n loader (data/i18n SSOT).
+// IT values unchanged (objective_short.it == old TYPE_LABELS); EN now covered.
+import { t } from './i18n.js';
 
 const TYPE_ICONS = {
   elimination: '⚔',
@@ -34,8 +29,10 @@ const TYPE_ICONS = {
 // Pure: type → label IT (caps tag). Falls back a type stesso se sconosciuto.
 export function labelForObjectiveType(type) {
   if (!type) return '—';
-  const label = TYPE_LABELS[type];
-  return label || String(type).replace(/_/g, ' ').toUpperCase();
+  const key = `objective_short.${type}`;
+  const label = t(key);
+  // loader returns the key itself when missing -> humanized fallback for unknown types
+  return label === key ? String(type).replace(/_/g, ' ').toUpperCase() : label;
 }
 
 // Pure: type → icon emoji.

--- a/data/i18n/en/common.json
+++ b/data/i18n/en/common.json
@@ -32,7 +32,7 @@
   "combat": {
     "your_turn": "Your Turn",
     "system_turn": "System Turn",
-    "round": "Round {{n}}",
+    "round": "Round {n}",
     "hit": "Hit",
     "miss": "Miss",
     "critical": "Critical!",
@@ -43,9 +43,9 @@
     "defend": "Defend",
     "ability": "Ability",
     "end_turn": "End Turn",
-    "damage_dealt": "Damage dealt: {{n}}",
-    "damage_taken": "Damage taken: {{n}}",
-    "hp_remaining": "HP: {{current}} / {{max}}"
+    "damage_dealt": "Damage dealt: {n}",
+    "damage_taken": "Damage taken: {n}",
+    "hp_remaining": "HP: {current} / {max}"
   },
   "status": {
     "panic": "Panic",
@@ -58,11 +58,19 @@
   },
   "objective": {
     "elimination": "Eliminate all enemies",
-    "capture_point": "Hold the point for {{n}} turns",
-    "escort": "Protect {{target}}",
-    "sabotage": "Sabotage within {{n}} turns",
-    "survival": "Survive {{n}} turns",
+    "capture_point": "Hold the point for {n} turns",
+    "escort": "Protect {target}",
+    "sabotage": "Sabotage within {n} turns",
+    "survival": "Survive {n} turns",
     "escape": "Reach the exit"
+  },
+  "objective_short": {
+    "elimination": "Eliminate enemies",
+    "capture_point": "Hold the zone",
+    "escort": "Escort the target",
+    "sabotage": "Sabotage",
+    "survival": "Survive",
+    "escape": "Escape"
   },
   "result": {
     "victory": "Victory",

--- a/data/i18n/it/common.json
+++ b/data/i18n/it/common.json
@@ -32,7 +32,7 @@
   "combat": {
     "your_turn": "Il tuo turno",
     "system_turn": "Turno del Sistema",
-    "round": "Round {{n}}",
+    "round": "Round {n}",
     "hit": "Colpito",
     "miss": "Mancato",
     "critical": "Critico!",
@@ -43,9 +43,9 @@
     "defend": "Difendi",
     "ability": "Abilità",
     "end_turn": "Fine turno",
-    "damage_dealt": "Danno inflitto: {{n}}",
-    "damage_taken": "Danno subito: {{n}}",
-    "hp_remaining": "HP: {{current}} / {{max}}"
+    "damage_dealt": "Danno inflitto: {n}",
+    "damage_taken": "Danno subito: {n}",
+    "hp_remaining": "HP: {current} / {max}"
   },
   "status": {
     "panic": "Panico",
@@ -58,11 +58,19 @@
   },
   "objective": {
     "elimination": "Elimina tutti i nemici",
-    "capture_point": "Cattura il punto per {{n}} turni",
-    "escort": "Proteggi {{target}}",
-    "sabotage": "Sabota in meno di {{n}} turni",
-    "survival": "Sopravvivi {{n}} turni",
+    "capture_point": "Cattura il punto per {n} turni",
+    "escort": "Proteggi {target}",
+    "sabotage": "Sabota in meno di {n} turni",
+    "survival": "Sopravvivi {n} turni",
     "escape": "Raggiungi l'uscita"
+  },
+  "objective_short": {
+    "elimination": "Elimina i nemici",
+    "capture_point": "Tieni la zona",
+    "escort": "Scorta il bersaglio",
+    "sabotage": "Sabotaggio",
+    "survival": "Sopravvivi",
+    "escape": "Fuggi"
   },
   "result": {
     "victory": "Vittoria",

--- a/docs/design/evo-tactics-localization-i18n.md
+++ b/docs/design/evo-tactics-localization-i18n.md
@@ -61,14 +61,14 @@ Invarianti ereditate:
 
 ## 3. Roadmap di consegna (i18n-strategy PR-1..PR-6)
 
-| PR   | Cosa                                                  | Stato                |
-| ---- | ----------------------------------------------------- | -------------------- |
-| PR-1 | scaffold `data/i18n/{it,en}/common.json`              | **DONE** (#1463)     |
-| PR-2 | parity validator (`validate_i18n_parity.py`)          | **DONE**             |
-| PR-3 | loader runtime + `t()` helper                         | **DONE** (apps/play) |
-| PR-4 | migration mission-console -> data/i18n + debito       | TODO (NF3)           |
-| PR-5 | split namespace combat/tutorial/narrative (file sep.) | TODO                 |
-| PR-6 | CI gate completion_percent + no-hardcoded             | TODO                 |
+| PR   | Cosa                                                  | Stato                           |
+| ---- | ----------------------------------------------------- | ------------------------------- |
+| PR-1 | scaffold `data/i18n/{it,en}/common.json`              | **DONE** (#1463)                |
+| PR-2 | parity validator (`validate_i18n_parity.py`)          | **DONE**                        |
+| PR-3 | loader runtime + `t()` helper                         | **DONE** (apps/play)            |
+| PR-4 | migration mission-console -> data/i18n + debito       | WIP (objectivePanel + NF4 done) |
+| PR-5 | split namespace combat/tutorial/narrative (file sep.) | TODO                            |
+| PR-6 | CI gate completion_percent + no-hardcoded             | TODO                            |
 
 > NB allineamento: la sequenza canonica resta `i18n-strategy.md`. La tabella SPEC-N raggruppa
 > per fase logica; in strategy PR-5 = content-fill combat/tutorial, PR-6 = Ink bilingue export.
@@ -79,10 +79,10 @@ Invarianti ereditate:
 - Namespace: `common` / `combat` / `tutorial` / `narrative`. Oggi tutto dentro `common.json`;
   lo split in file separati = PR-5. Schema formale `_schema/i18n.schema.json` = NF2 (opzionale
   oltre la parity).
-- Formato file: `data/i18n/{it,en}/<namespace>.json`. Interpolazione Mustache `{{var}}`
-  (gia' validata da PR-2). NB: mission-console usa single-brace `{var}` (vue-i18n nativo) ->
-  divergenza di formato, normalizzazione in migrazione = fork NF4.
-- Pluralizzazione: Mustache non gestisce plurali/genere; le stringhe `{{n}}` possono mostrare
+- Formato file: `data/i18n/{it,en}/<namespace>.json`. Interpolazione single-brace `{var}`
+  (NF4 LIVE 2026-06-08: convertito da `{{var}}`, allineato a vue-i18n/mission-console; parity
+  validator + loader aggiornati).
+- Pluralizzazione: `{var}` non gestisce plurali/genere; le stringhe `{n}` possono mostrare
   grammatica errata per n=1 in IT (es. "1 turni"). ICU MessageFormat = post-MVP (debito noto,
   i18n-strategy).
 - Convenzione key: dot-notation per dominio (es. `combat.your_turn`, `ui.confirm`).
@@ -91,8 +91,10 @@ Invarianti ereditate:
 
 **Stato: LIVE (2026-06-08).** `apps/play/src/i18nCore.js` (puro: `createT`/`resolveKey`/
 `interpolate`, testato) + `apps/play/src/i18n.js` (bind a `data/i18n` via Vite JSON import).
-NF1=frontend (apps/play), `fallbackLocale=it`. Interpolation Mustache `{{var}}` (NF4 `{var}` =
-PR-4). I label-map hardcoded NON sono ancora migrati a `t()` (PR-4, NF3 incrementale).
+NF1=frontend (apps/play), `fallbackLocale=it`. Interpolation single-brace `{var}` (NF4 LIVE).
+PR-4 (NF3 incrementale) avviato: `objectivePanel` migrato a `t('objective_short.*')` (IT
+invariato + EN coperto); restano ~7 label-map (biomeChip/ui/...) + mission-console (interop
+JSON-attribute risolto: `import ... with { type: 'json' }`).
 
 - `t(key, params?, locale?)`: risolve la key, applica i params, fallback a IT (sorgente
   completa), ritorna la stringa. NON-LLM, deterministico.

--- a/tests/play/i18nCore.test.js
+++ b/tests/play/i18nCore.test.js
@@ -1,4 +1,4 @@
-// apps/play i18n loader core -- SPEC-N PR-3 (t() + fallback IT + {{var}} interp).
+// apps/play i18n loader core -- SPEC-N PR-3 (t() + fallback IT + {var} interp, NF4).
 // Pure ESM module (no JSON import) -> dynamic-import from CJS test (tests/play pattern).
 
 'use strict';
@@ -12,8 +12,8 @@ async function load() {
 
 const MESSAGES = {
   it: {
-    ui: { confirm: 'Conferma', greet: 'Ciao {{name}}' },
-    combat: { turns: 'Sopravvivi {{n}} turni' },
+    ui: { confirm: 'Conferma', greet: 'Ciao {name}' },
+    combat: { turns: 'Sopravvivi {n} turni' },
   },
   en: { ui: { confirm: 'Confirm' } },
 };
@@ -37,7 +37,7 @@ describe('createT', () => {
     assert.equal(t('ui.greet', { name: 'Y' }), 'Ciao Y');
   });
 
-  test('interpolates {{var}} params', async () => {
+  test('interpolates {var} params', async () => {
     const { createT } = await load();
     const t = createT(MESSAGES, { defaultLocale: 'it' });
     assert.equal(t('combat.turns', { n: 3 }), 'Sopravvivi 3 turni');
@@ -55,10 +55,10 @@ describe('createT', () => {
     assert.equal(t('nope.not_here'), 'nope.not_here');
   });
 
-  test('leaves {{var}} untouched when param absent', async () => {
+  test('leaves {var} untouched when param absent', async () => {
     const { createT } = await load();
     const t = createT(MESSAGES, { defaultLocale: 'it' });
-    assert.equal(t('ui.greet'), 'Ciao {{name}}');
+    assert.equal(t('ui.greet'), 'Ciao {name}');
   });
 });
 
@@ -73,7 +73,7 @@ describe('resolveKey / interpolate', () => {
 
   test('interpolate handles multiple + numeric params', async () => {
     const { interpolate } = await load();
-    assert.equal(interpolate('{{a}}/{{b}}', { a: 1, b: 2 }), '1/2');
+    assert.equal(interpolate('{a}/{b}', { a: 1, b: 2 }), '1/2');
     assert.equal(interpolate('no params', null), 'no params');
   });
 });

--- a/tools/py/validate_i18n_parity.py
+++ b/tools/py/validate_i18n_parity.py
@@ -7,7 +7,7 @@ Verifica parity chiavi fra locale bundles in data/i18n/*/ (it + en al lancio).
 Checks:
 1. Ogni locale ha stesse chiavi (nessuna chiave manca in un locale)
 2. Nessun valore TODO / MISSING / placeholder
-3. Interpolation params (Mustache {{var}}) coerenti fra locale
+3. Interpolation params (single-brace {var}, NF4) coerenti fra locale
 4. _meta.completion_percent coerente con actual translation
 
 Usage:
@@ -30,7 +30,7 @@ import re
 import sys
 from typing import Dict, List, Set, Tuple
 
-MUSTACHE_RE = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+MUSTACHE_RE = re.compile(r"\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}")
 PLACEHOLDER_MARKERS = ("TODO", "MISSING", "FIXME", "XXX")
 
 


### PR DESCRIPTION
## Cosa
Greenlit follow-up. Unblocks + kicks off i18n PR-4 (NF3 incremental).

1. **Interop fix** -- `i18n.js` JSON imports use `with { type: 'json' }` -> resolves in **both** node ESM (test runner) and Vite 8. Was `ERR_IMPORT_ATTRIBUTE_MISSING` (the blocker that stopped any migrated module from importing the loader without breaking its node test).
2. **Migration** -- `objectivePanel` `TYPE_LABELS` -> `t('objective_short.*')`. New `objective_short` keys in data/i18n; **IT values == old TYPE_LABELS -> objectivePanel test 29/29 unchanged**; EN now covered. First surface consuming the loader (Gate-5).
3. **NF4** (ratified) -- data/i18n `{{var}}` -> `{var}` (9+9 occurrences) + parity validator regex + loader regex + test fixtures.

## Verify
i18n:check errors=0 (parity holds, `{var}`). i18nCore 9/9, objectivePanel 29/29, Vite build OK, prettier clean, governance 0.

## Remaining (NF3 incremental, follow-up)
~7 label-maps (biomeChip/ui/enneaVoiceRender/...) -> `t()` (each needs short-keys + careful wording, like objective_short). mission-console -> data/i18n migration (interop now solved). PR-5 namespace split, PR-6 CI gate.

>50 LOC outside apps/backend = the explicitly greenlit i18n work. No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)