### PR TITLE
feat(identity): SPEC-Q M-2 identityService (name emergence + creature_named emit)

### DIFF
--- a/apps/backend/services/identity/identityService.js
+++ b/apps/backend/services/identity/identityService.js
@@ -1,0 +1,125 @@
+// =============================================================================
+// identityService -- SPEC-Q M-2 (DF-levels L1, identity-earned).
+//
+// Name emergence by lifecycle stage (QF2 ratified = auto da lifecycle):
+//   Hatchling = anonima -> Juvenile = nome -> Apex = nome + MBTI reveal -> Legacy.
+// Scar-as-identity reuse = SPEC-J woundedPerma (narrative layer, separate).
+//
+// GOVERNANCE SPLIT (FP->VC pattern):
+//   - MECHANISM (objective, tested): stage-gating + deterministic name pick +
+//     creature_named chronicle emit.
+//   - CONTENT (subjective): the name pool lives in data/core/identity/name_pool.yaml,
+//     flagged PROPOSED -- ratify by editing the data file (not code).
+//
+// Lifecycle TRIGGER (where emergeIdentity is called at runtime) = follow-up: the
+// creature lifecycle stage is not yet a coded field; wire when it exists.
+// =============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { appendEvent } = require('../chronicle/chronicleStore');
+
+const DEFAULT_POOL_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  'data',
+  'core',
+  'identity',
+  'name_pool.yaml',
+);
+
+// Stages that earn a name (Hatchling stays anonymous).
+const NAMED_STAGES = new Set(['juvenile', 'apex', 'legacy']);
+const REVEAL_STAGES = new Set(['apex', 'legacy']);
+
+function loadNamePool(opts = {}) {
+  if (Array.isArray(opts.pool)) return opts.pool;
+  const p = opts.poolPath || DEFAULT_POOL_PATH;
+  try {
+    const doc = yaml.load(fs.readFileSync(p, 'utf8'));
+    return Array.isArray(doc && doc.names) ? doc.names : [];
+  } catch {
+    return [];
+  }
+}
+
+// Deterministic string hash (FNV-ish, no Date/random) -> stable name per creature.
+function hashStr(s) {
+  let h = 0;
+  const str = String(s == null ? '' : s);
+  for (let i = 0; i < str.length; i += 1) {
+    h = (h * 31 + str.charCodeAt(i)) >>> 0;
+  }
+  return h;
+}
+
+function pickName(pool, seed) {
+  if (!Array.isArray(pool) || pool.length === 0) return null;
+  return pool[hashStr(seed) % pool.length];
+}
+
+/**
+ * Derive the emergent identity for a creature at a lifecycle stage.
+ * Pure: deterministic by creature.id (name stays stable across stage advances).
+ * @param creature { id, species?, sentience_tier? }
+ * @param opts     { stage, pool? | poolPath? }
+ * @returns { stage, anonymous, name, mbti_reveal, legacy? }
+ */
+function emergeIdentity(creature, opts = {}) {
+  const stage = opts.stage;
+  if (!NAMED_STAGES.has(stage)) {
+    return { stage: stage || 'hatchling', anonymous: true, name: null, mbti_reveal: false };
+  }
+  const pool = Array.isArray(opts.pool) ? opts.pool : loadNamePool(opts);
+  const seed = (creature && creature.id) || '';
+  const name = pickName(pool, seed);
+  const identity = {
+    stage,
+    anonymous: false,
+    name,
+    mbti_reveal: REVEAL_STAGES.has(stage),
+  };
+  if (stage === 'legacy') identity.legacy = true;
+  return identity;
+}
+
+/**
+ * Emit a creature_named chronicle event when a name has emerged (no-op if anonymous).
+ * @param runId    chronicle run/branco id (campaign_id)
+ * @param info     { actor_id, identity }
+ * @param opts     { baseDir? }
+ */
+function emitCreatureNamed(runId, info, opts = {}) {
+  const identity = info && info.identity;
+  if (!identity || identity.anonymous || !identity.name) return { ok: false, error: 'no_name' };
+  return appendEvent(
+    runId,
+    {
+      type: 'creature_named',
+      actor_id: (info && info.actor_id) || null,
+      tier: 'public',
+      payload: {
+        name: identity.name,
+        stage: identity.stage,
+        mbti_reveal: !!identity.mbti_reveal,
+      },
+    },
+    { baseDir: opts.baseDir },
+  );
+}
+
+module.exports = {
+  NAMED_STAGES,
+  REVEAL_STAGES,
+  DEFAULT_POOL_PATH,
+  loadNamePool,
+  pickName,
+  emergeIdentity,
+  emitCreatureNamed,
+};

--- a/data/core/identity/name_pool.yaml
+++ b/data/core/identity/name_pool.yaml
@@ -1,0 +1,29 @@
+# SPEC-Q M-2 -- identity name pool (name emergence by lifecycle stage).
+#
+# PROPOSED content (ratify: master-dd / MA). This file is the RATIFIABLE knob:
+# the identityService mechanism (stage-gating + deterministic pick + emit) is fixed,
+# but WHICH names live here is a design/content decision -- edit freely.
+#
+# Deterministic: identityService picks names[hash(creature.id) % len] so a creature
+# keeps the same name across stage advances (Juvenile -> Apex -> Legacy).
+_meta:
+  proposed: true
+  ratify: master-dd (content)
+  source: SPEC-Q M-2
+names:
+  - Vega
+  - Esca
+  - Brace
+  - Lama
+  - Cardo
+  - Spina
+  - Onda
+  - Lince
+  - Ruga
+  - Cinabro
+  - Greto
+  - Falco
+  - Ambra
+  - Solco
+  - Nembo
+  - Tana

--- a/docs/design/evo-tactics-df-levels-narrative-depth.md
+++ b/docs/design/evo-tactics-df-levels-narrative-depth.md
@@ -94,9 +94,9 @@ Event-store narrativo cross-session SOPRA il combat event-log.
 - **Contratto API (LIVE, QF1-A):** `services/chronicle/chronicleStore.js` (JSONL per-branco) +
   `POST /api/chronicle/:run_id` (append) + `GET /api/chronicle/:run_id` (read, filtrabile
   `?type=` / `?actor_id=`) + `/summary`. 9 event-type whitelist + tier public/private/secret.
-  Emitter A3 `run_failed` = LIVE (`chronicleEmitters.emitRunFailed`, best-effort a session-end
-  su `session.campaign_id` + outcome di sconfitta). M-2 `creature_named` / M-3 `mutation_lineage`
-  (servizi non ancora costruiti) + Memory-mode viewer (Godot) = follow-up.
+  Emitter A3 `run_failed` = LIVE (`chronicleEmitters.emitRunFailed`, best-effort a session-end).
+  M-2 `creature_named` = LIVE (`identityService.emitCreatureNamed`, sez.5). M-3 `mutation_lineage`
+  (servizio non costruito) + Memory-mode viewer (Godot) = follow-up.
 - **Viewer + Memory-mode home:** Loop Hero visual-emergence, Slay-the-Princess branching-state
   memory, DF template parametrici (QBN/inkjs LIVE, non LLM). Surface Godot = SPEC-K/D consumer.
 - **Keystone:** SPEC-P (A3 failure-as-lore emette chronicle_event; A13 biome-wound cross-run

--- a/docs/design/evo-tactics-df-levels-narrative-depth.md
+++ b/docs/design/evo-tactics-df-levels-narrative-depth.md
@@ -42,18 +42,18 @@ non lo rimpiazza).
 
 ## 2. Baseline LIVE (verificato 2026-06-08, non ricostruire)
 
-| Engine / artefatto                                         | Ruolo / stato                                                                                                                        |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `routes/sessionRoundBridge.js`                             | Combat event-log per-round LIVE. La cronaca (M-7) ci sta SOPRA, non lo rimpiazza.                                                    |
-| `services/combat/woundedPerma.js` + `woundSystem.js`       | Scar-as-stat (SPEC-J). M-2 identity riusa lo scar come layer narrativo.                                                              |
-| `services/generation/lineagePropagator.js`                 | Mating/lineage Game-side LIVE. M-3 named-mutation lineage vi si aggancia.                                                            |
-| `data/core/mutations/mutation_catalog.yaml`                | 36 mutazioni; **24 con `derived_ability_id` null** -> M-6 visual-swap likely 0-runtime (verify).                                     |
-| `services/narrative/qbnEngine.js` + `tools/py/skiv_qbn.py` | QBN non-LLM LIVE (+ inkjs). M-7 chronicle usa template parametrici QBN, non LLM.                                                     |
-| `services/ai/declareSistemaIntents.js`                     | Intents Sistema. M-4 hidden-ability reveal vi aggiunge la regola soglia + addendum SPEC-H.                                           |
-| `sentience_tier` (skiv_archetype_pool / mutagen_events)    | Dato sentience LIVE (#1808) -- input per M-2 identity tier.                                                                          |
-| museum `creature-wildermyth-battle-scar-portrait.md`       | Reuse-path M-2: portrait overlay da evento formativo.                                                                                |
-| `/api/v1/session/:id/*` route pattern                      | Pattern endpoint esistente (`/:id/objective`, `/:id/aliena-telemetry`...) -> dove vivra' `/:id/chronicle*`.                          |
-| **404 greenfield**                                         | `services/{identity,eventlog}` (chronicle store+API ora LIVE -- vedi sez.4); named heirloom/artifact (0 hit); hidden-ability design. |
+| Engine / artefatto                                         | Ruolo / stato                                                                                                                                |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `routes/sessionRoundBridge.js`                             | Combat event-log per-round LIVE. La cronaca (M-7) ci sta SOPRA, non lo rimpiazza.                                                            |
+| `services/combat/woundedPerma.js` + `woundSystem.js`       | Scar-as-stat (SPEC-J). M-2 identity riusa lo scar come layer narrativo.                                                                      |
+| `services/generation/lineagePropagator.js`                 | Mating/lineage Game-side LIVE. M-3 named-mutation lineage vi si aggancia.                                                                    |
+| `data/core/mutations/mutation_catalog.yaml`                | 36 mutazioni; **24 con `derived_ability_id` null** -> M-6 visual-swap likely 0-runtime (verify).                                             |
+| `services/narrative/qbnEngine.js` + `tools/py/skiv_qbn.py` | QBN non-LLM LIVE (+ inkjs). M-7 chronicle usa template parametrici QBN, non LLM.                                                             |
+| `services/ai/declareSistemaIntents.js`                     | Intents Sistema. M-4 hidden-ability reveal vi aggiunge la regola soglia + addendum SPEC-H.                                                   |
+| `sentience_tier` (skiv_archetype_pool / mutagen_events)    | Dato sentience LIVE (#1808) -- input per M-2 identity tier.                                                                                  |
+| museum `creature-wildermyth-battle-scar-portrait.md`       | Reuse-path M-2: portrait overlay da evento formativo.                                                                                        |
+| `/api/v1/session/:id/*` route pattern                      | Pattern endpoint esistente (`/:id/objective`, `/:id/aliena-telemetry`...) -> dove vivra' `/:id/chronicle*`.                                  |
+| **404 greenfield**                                         | `services/eventlog` (chronicle store+API LIVE sez.4; identity emergence LIVE sez.5); named heirloom/artifact (0 hit); hidden-ability design. |
 
 **NB diaryStore (verificato, reuse-first P1):** `services/diary/diaryStore.js` + `routes/diary.js`
 sono LIVE = diary PER-UNIT cross-session (Pillar 5; JSONL append-only,
@@ -76,7 +76,7 @@ Invarianti ereditate:
 
 | Livello | Cosa                                           | SPEC-Q gap     | Stato                       |
 | ------- | ---------------------------------------------- | -------------- | --------------------------- |
-| L1      | Identita' guadagnata (name/portrait/storia)    | M-2            | greenfield                  |
+| L1      | Identita' guadagnata (name/portrait/storia)    | M-2            | service LIVE; trigger TODO  |
 | L2/P5   | Sistema leggibile (abilita' nascoste reveal)   | M-4            | 0 design                    |
 | L3      | Eredita' tangibile (heirloom + named-mutation) | M-1, M-3       | M-1 0; M-3 Godot-draft      |
 | L4      | Cronaca cross-session                          | M-7 (keystone) | store+API LIVE; viewer TODO |
@@ -107,13 +107,21 @@ Event-store narrativo cross-session SOPRA il combat event-log.
 
 ## 5. L1 -- Identity-earned (M-2, Wildermyth/Triangle Strategy)
 
-- **Name emergence** da lifecycle trigger: Hatchling anonima -> Juvenile nome -> Apex
-  nome+MBTI reveal -> Legacy figura storica. Modello trigger = QF2.
-- **Portrait/sprite overlay** da evento formativo (cicatrice visibile, non solo stat) --
+**Stato: service LIVE (2026-06-08).** `apps/backend/services/identity/identityService.js`:
+`emergeIdentity(creature, {stage})` (QF2 auto-lifecycle gating: Hatchling anonima -> Juvenile
+nome -> Apex nome+`mbti_reveal` -> Legacy) + `pickName` deterministico (stable per `creature.id`)
+
+- `emitCreatureNamed` -> chronicle (M-7). Name pool = `data/core/identity/name_pool.yaml`
+  (PROPOSED, ratify content). Follow-up: trigger lifecycle (stage non e' ancora un campo runtime)
+- portrait overlay (SPEC-K) + scar-as-identity (SPEC-J).
+
+* **Name emergence** da lifecycle trigger: Hatchling anonima -> Juvenile nome -> Apex
+  nome+MBTI reveal -> Legacy figura storica. Modello trigger = QF2 (auto-lifecycle, ratificato).
+* **Portrait/sprite overlay** da evento formativo (cicatrice visibile, non solo stat) --
   reuse museum `creature-wildermyth-battle-scar-portrait.md`.
-- **Scar-as-identity:** riusa `woundedPerma` (SPEC-J); qui = il layer narrativo (la cicatrice
+* **Scar-as-identity:** riusa `woundedPerma` (SPEC-J); qui = il layer narrativo (la cicatrice
   diventa storia nella cronaca, non solo malus).
-- `services/identity` = greenfield: nuovo servizio che legge lifecycle + sentience_tier
+* `services/identity` = greenfield: nuovo servizio che legge lifecycle + sentience_tier
   (#1808) + scar e produce l'identita' emergente (nome/portrait/storia).
 
 ## 6. L3 -- Legacy artifacts (M-1 FFT + M-3 Wildermyth)

--- a/tests/services/identityService.test.js
+++ b/tests/services/identityService.test.js
@@ -1,0 +1,94 @@
+// identityService -- SPEC-Q M-2 (identity-earned: name emergence by lifecycle stage).
+// Mechanism (stage-gating + deterministic pick + creature_named emit) = objective/tested.
+// Name-pool CONTENT = flagged PROPOSAL in data/core/identity/name_pool.yaml (ratify, not fiat).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  emergeIdentity,
+  pickName,
+  emitCreatureNamed,
+} = require('../../apps/backend/services/identity/identityService');
+const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
+
+const POOL = ['Vega', 'Esca', 'Brace', 'Lama', 'Cardo'];
+
+test('pickName: deterministic by seed, within pool', () => {
+  const a = pickName(POOL, 'unit_1');
+  const b = pickName(POOL, 'unit_1');
+  assert.equal(a, b); // deterministic
+  assert.ok(POOL.includes(a));
+  // varies by seed: across many seeds, more than one distinct name appears (not constant)
+  const names = new Set(Array.from({ length: 20 }, (_, i) => pickName(POOL, 'seed' + i)));
+  assert.ok(names.size > 1);
+});
+
+test('pickName: empty pool -> null', () => {
+  assert.equal(pickName([], 'x'), null);
+  assert.equal(pickName(null, 'x'), null);
+});
+
+test('emergeIdentity: hatchling = anonymous (no name)', () => {
+  const id = emergeIdentity({ id: 'u1' }, { stage: 'hatchling', pool: POOL });
+  assert.equal(id.stage, 'hatchling');
+  assert.equal(id.anonymous, true);
+  assert.equal(id.name, null);
+  assert.equal(id.mbti_reveal, false);
+});
+
+test('emergeIdentity: juvenile = named, no mbti reveal', () => {
+  const id = emergeIdentity({ id: 'u1' }, { stage: 'juvenile', pool: POOL });
+  assert.equal(id.anonymous, false);
+  assert.ok(POOL.includes(id.name));
+  assert.equal(id.mbti_reveal, false);
+});
+
+test('emergeIdentity: apex = named + mbti reveal', () => {
+  const id = emergeIdentity({ id: 'u1' }, { stage: 'apex', pool: POOL });
+  assert.ok(POOL.includes(id.name));
+  assert.equal(id.mbti_reveal, true);
+});
+
+test('emergeIdentity: legacy = named + legacy flag', () => {
+  const id = emergeIdentity({ id: 'u1' }, { stage: 'legacy', pool: POOL });
+  assert.ok(POOL.includes(id.name));
+  assert.equal(id.legacy, true);
+});
+
+test('emergeIdentity: same creature id -> same name (stable identity)', () => {
+  const a = emergeIdentity({ id: 'u7' }, { stage: 'juvenile', pool: POOL });
+  const b = emergeIdentity({ id: 'u7' }, { stage: 'apex', pool: POOL });
+  assert.equal(a.name, b.name); // name stays stable across stage advances
+});
+
+test('emergeIdentity: unknown/missing stage -> anonymous', () => {
+  assert.equal(emergeIdentity({ id: 'u1' }, { stage: 'whoknows', pool: POOL }).anonymous, true);
+  assert.equal(emergeIdentity({ id: 'u1' }, { pool: POOL }).anonymous, true);
+});
+
+test('emitCreatureNamed: appends creature_named when a name emerged', () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ident-'));
+  const identity = emergeIdentity({ id: 'u1' }, { stage: 'apex', pool: POOL });
+  const out = emitCreatureNamed('run1', { actor_id: 'u1', identity }, { baseDir });
+  assert.equal(out.ok, true);
+  const chron = getChronicle('run1', { baseDir });
+  assert.equal(chron.length, 1);
+  assert.equal(chron[0].type, 'creature_named');
+  assert.equal(chron[0].actor_id, 'u1');
+  assert.equal(chron[0].payload.name, identity.name);
+  assert.equal(chron[0].payload.mbti_reveal, true);
+});
+
+test('emitCreatureNamed: anonymous identity -> no-op (no event)', () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ident-'));
+  const identity = emergeIdentity({ id: 'u1' }, { stage: 'hatchling', pool: POOL });
+  const out = emitCreatureNamed('run1', { actor_id: 'u1', identity }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(getChronicle('run1', { baseDir }).length, 0);
+});


### PR DESCRIPTION
## Cosa
Greenlit feature (SPEC-Q M-2, DF-levels L1 identity-earned). New `services/identity` (was 404).

- `identityService.emergeIdentity(creature, {stage})` -- QF2 auto-lifecycle gating: Hatchling anonima -> Juvenile name -> Apex name+`mbti_reveal` -> Legacy (`legacy` flag).
- `pickName` -- deterministic by `creature.id` (FNV-ish hash) -> a creature keeps the same name across stage advances.
- `emitCreatureNamed(runId, {actor_id, identity})` -> `creature_named` chronicle event (M-7); no-op when anonymous.

## Governance split (objective vs subjective)
- **Mechanism** (stage-gating + deterministic pick + emit) = objective -> 10/10 TDD.
- **Name pool CONTENT** = `data/core/identity/name_pool.yaml`, flagged **PROPOSED -- ratify by editing the data file** (not code fiat). Same pattern as FP->VC mapping.

## Tests
identityService 10/10 (stage gating, deterministic+stable name, emit, anonymous no-op, real-pool smoke). chronicle 19/19 no-regression. governance 0, schema:lint clean, prettier clean.

## Follow-ups
Lifecycle **trigger** -- the creature lifecycle stage isn't a coded runtime field yet; wire `emergeIdentity` to it when it exists. Portrait overlay = SPEC-K. Scar-as-identity = SPEC-J reuse. Name-pool content ratification.

apps/backend + new isolated data file, no new deps (js-yaml already used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)