### PR TITLE
feat(worldgen): SPEC-P A13 biomeWound write-side (degrade + recovery)

### DIFF
--- a/apps/backend/services/worldgen/biomeWound.js
+++ b/apps/backend/services/worldgen/biomeWound.js
@@ -1,0 +1,87 @@
+// =============================================================================
+// biomeWound -- SPEC-P A13 write-side (DF-levels: biome degrade cross-run).
+//
+// QA1 ratified: SPEC-P owns the A13 write-side (degrade); SPEC-I is read-side of
+// the pressure. PA2 ratified: cap stretto + recupero (max 2 biomi feriti, step 1
+// banda, recovery vincendo nel bioma ferito = anti-brick). PA4 ratified: entrambi
+// meccanico (pressione SPEC-I entro ER2 +/-2) + narrativo/Codex.
+//
+// MECHANISM (objective, tested): bounded wound set + cap + recovery + pressure
+// mapping (within ER2) + biome_wound chronicle emit (M-7).
+// MAGNITUDE (`PRESSURE_PER_BIOME`) = PROPOSED, ratify N=40 (PA2, mirror SPEC-I gate).
+//
+// Persistence (the wounded set lives cross-run in the meta-network state,
+// `services/worldgen/metaNetworkResolver`) + the TRIGGER (wound on run-fail in a
+// biome) = follow-up wiring (this module is the pure mechanism).
+// =============================================================================
+
+'use strict';
+
+const { appendEvent } = require('../chronicle/chronicleStore');
+
+const MAX_WOUNDED_BIOMES = 2; // PA2: cap stretto
+const ER2_PRESSURE_CAP = 2; // PA4: within ER2 +/-2 combined cap (anti overconstrain)
+const DEGRADE_STEP = 1; // PA2: 1 eco-band step per wound
+const PRESSURE_PER_BIOME = 1; // PROPOSED magnitude -- ratify N=40 (PA2)
+
+/**
+ * Mark a biome wounded (additive, capped, idempotent). Pure: returns a new array.
+ * @returns { wounded, added, capped? }
+ */
+function woundBiome(wounded, biomeId) {
+  const list = Array.isArray(wounded) ? wounded.slice() : [];
+  if (!biomeId) return { wounded: list, added: false };
+  if (list.includes(biomeId)) return { wounded: list, added: false };
+  if (list.length >= MAX_WOUNDED_BIOMES) return { wounded: list, added: false, capped: true };
+  list.push(biomeId);
+  return { wounded: list, added: true };
+}
+
+/**
+ * Recovery (anti-brick): winning in a wounded biome heals it. Pure.
+ * @returns { wounded, healed }
+ */
+function healBiome(wounded, biomeId) {
+  const list = Array.isArray(wounded) ? wounded.slice() : [];
+  const i = list.indexOf(biomeId);
+  if (i === -1) return { wounded: list, healed: false };
+  list.splice(i, 1);
+  return { wounded: list, healed: true };
+}
+
+/**
+ * PA4 mechanical mapping: N wounded biomes -> SPEC-I pressure delta, HARD-bounded
+ * by ER2 (never exceeds +/-2 combined, even if the set somehow grows past the cap).
+ */
+function pressureDelta(wounded) {
+  const n = Array.isArray(wounded) ? wounded.length : 0;
+  return Math.min(n * PRESSURE_PER_BIOME, ER2_PRESSURE_CAP);
+}
+
+/**
+ * Emit a biome_wound chronicle event (M-7). No-op if biomeId missing.
+ */
+function emitBiomeWound(runId, biomeId, opts = {}) {
+  if (!biomeId) return { ok: false, error: 'no_biome' };
+  return appendEvent(
+    runId,
+    {
+      type: 'biome_wound',
+      actor_id: null,
+      tier: 'public',
+      payload: { biome_id: biomeId, step: DEGRADE_STEP },
+    },
+    { baseDir: opts.baseDir },
+  );
+}
+
+module.exports = {
+  MAX_WOUNDED_BIOMES,
+  ER2_PRESSURE_CAP,
+  DEGRADE_STEP,
+  PRESSURE_PER_BIOME,
+  woundBiome,
+  healBiome,
+  pressureDelta,
+  emitBiomeWound,
+};

--- a/docs/design/evo-tactics-failure-as-lore.md
+++ b/docs/design/evo-tactics-failure-as-lore.md
@@ -122,6 +122,12 @@ Il fallimento e' un trigger di scoperta Codex (pattern Hades, B14):
 QA1 (ratificato): **SPEC-P possiede il write-side di A13** (degrado biome cross-run);
 SPEC-I resta read-side della pressione.
 
+**Stato: mechanism LIVE (2026-06-08).** `apps/backend/services/worldgen/biomeWound.js`:
+`woundBiome` (cap 2 PA2, idempotente, no-mutate) + `healBiome` (recupero anti-brick) +
+`pressureDelta` (N feriti -> delta SPEC-I, HARD-bounded ER2 +/-2, PA4) + `emitBiomeWound` ->
+chronicle (M-7). Magnitudine `PRESSURE_PER_BIOME` = PROPOSED (ratify N=40, PA2). Follow-up:
+persistenza meta-network (`metaNetworkResolver`) + trigger (wound su run-fail) + recupero wired.
+
 Contratto del degrado:
 
 - Un bioma in cui la run fallisce diventa "ferito": stato persistente cross-run sulla
@@ -273,9 +279,9 @@ SPEC-P e' implementabile/chiudibile quando:
    in PA1, e consuma l'output J5 (QA2);
 3. l'aggancio Codex (sez. 5) emette eventi che il consumer SPEC-H raccoglie (no Codex
    costruito qui);
-4. il degrado meta-network (sez. 6, A13 write-side) ha la NATURA decisa in PA4; se meccanico,
-   e' bounded col cap PA2 + la funzione di mapping `N biomi degradati -> delta pressione`
-   ENTRO il cap ER2 di SPEC-I, + una via di recupero;
+4. il degrado meta-network (sez. 6, A13 write-side) -- NATURA PA4 (entrambi); mechanism LIVE
+   (`biomeWound`: cap PA2 + mapping `N -> delta` bounded ER2 + recupero); restano persistenza
+   meta-network + trigger + magnitudine N=40;
 5. il telegraph (sez. 7) e il recovery-telegraph (PA3) sono diegetici (nessun float, nessuna
    sigla; visibile PRE-run; il wire StressWave va attivato lato combat);
 6. l'invariante anti-brick (sez. 8) e' verificabile con un test AUTOMATICO esplicito (es.

--- a/tests/services/biomeWound.test.js
+++ b/tests/services/biomeWound.test.js
@@ -1,0 +1,86 @@
+// biomeWound -- SPEC-P A13 write-side (biome degrade cross-run, bounded + recovery).
+// PA2 ratified: cap ~2 biomi, step 1 band, recovery by winning. PA4: mechanical (pressure
+// within ER2 +/-2) + narrative. Mechanism objective/tested; magnitude N=40-ratify.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  MAX_WOUNDED_BIOMES,
+  ER2_PRESSURE_CAP,
+  woundBiome,
+  healBiome,
+  pressureDelta,
+  emitBiomeWound,
+} = require('../../apps/backend/services/worldgen/biomeWound');
+const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
+
+test('constants: PA2 cap = 2 biomes, PA4 pressure cap = ER2 (2)', () => {
+  assert.equal(MAX_WOUNDED_BIOMES, 2);
+  assert.equal(ER2_PRESSURE_CAP, 2);
+});
+
+test('woundBiome: adds a biome to the wounded set', () => {
+  const r = woundBiome([], 'badlands');
+  assert.equal(r.added, true);
+  assert.deepEqual(r.wounded, ['badlands']);
+});
+
+test('woundBiome: already-wounded -> no-op (idempotent)', () => {
+  const r = woundBiome(['badlands'], 'badlands');
+  assert.equal(r.added, false);
+  assert.deepEqual(r.wounded, ['badlands']);
+});
+
+test('woundBiome: respects PA2 cap (max 2) -> 3rd rejected', () => {
+  const r = woundBiome(['a', 'b'], 'c');
+  assert.equal(r.added, false);
+  assert.equal(r.capped, true);
+  assert.deepEqual(r.wounded, ['a', 'b']); // unchanged
+});
+
+test('woundBiome: does not mutate input array', () => {
+  const input = ['a'];
+  woundBiome(input, 'b');
+  assert.deepEqual(input, ['a']);
+});
+
+test('healBiome: recovery removes a biome (anti-brick)', () => {
+  const r = healBiome(['a', 'b'], 'a');
+  assert.equal(r.healed, true);
+  assert.deepEqual(r.wounded, ['b']);
+});
+
+test('healBiome: not-wounded -> no-op', () => {
+  const r = healBiome(['a'], 'zzz');
+  assert.equal(r.healed, false);
+  assert.deepEqual(r.wounded, ['a']);
+});
+
+test('pressureDelta: N wounded -> delta, bounded by ER2 cap (+2)', () => {
+  assert.equal(pressureDelta([]), 0);
+  assert.equal(pressureDelta(['a']), 1);
+  assert.equal(pressureDelta(['a', 'b']), 2);
+  // even if somehow > cap, never exceeds ER2 (overconstrain guard)
+  assert.equal(pressureDelta(['a', 'b', 'c', 'd']), ER2_PRESSURE_CAP);
+});
+
+test('emitBiomeWound: appends biome_wound chronicle event', () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bw-'));
+  const out = emitBiomeWound('run1', 'badlands', { baseDir });
+  assert.equal(out.ok, true);
+  const chron = getChronicle('run1', { baseDir });
+  assert.equal(chron.length, 1);
+  assert.equal(chron[0].type, 'biome_wound');
+  assert.equal(chron[0].payload.biome_id, 'badlands');
+});
+
+test('emitBiomeWound: missing biome -> no-op', () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bw-'));
+  assert.equal(emitBiomeWound('run1', null, { baseDir }).ok, false);
+});


### PR DESCRIPTION
## Cosa
Greenlit feature (SPEC-P A13 write-side, DF-levels biome degrade cross-run). Design ratified (PA2/PA4).

- `services/worldgen/biomeWound.js` -- `woundBiome` (cap **2** PA2, idempotent, no-mutate) + `healBiome` (recovery = anti-brick, PA2) + `pressureDelta` (N wounded -> SPEC-I pressure, **HARD-bounded ER2 +/-2**, PA4 mechanical) + `emitBiomeWound` -> `biome_wound` chronicle event (M-7).

## Governance split
- **Mechanism** (cap + recovery + bounded mapping + emit) = objective, ratified design -> 10/10 TDD.
- **Magnitude** `PRESSURE_PER_BIOME` = PROPOSED, ratify N=40 (PA2, mirror SPEC-I gate).

## Tests
biomeWound 10/10 (cap, idempotent, no-mutate, recovery, pressure bound, emit). chronicle 14/14 no-regression. governance 0, prettier clean.

## Follow-ups
Persist the wounded set cross-run in the meta-network (`metaNetworkResolver`); trigger `woundBiome` on run-fail in a biome; wire recovery (win in wounded biome). Magnitude ratification.

apps/backend only, no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)