### PR TITLE
feat(campaign): MA1 per-creature onboarding trait + A3 SoT edit

### DIFF
--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -147,7 +147,8 @@ function createCampaignRouter(options = {}) {
   //   → resolves trait via campaign.onboarding.choices[] (V1 Phase B).
   //   → applied to roster as acquiredTraits[] (shared branco).
   router.post('/campaign/start', (req, res) => {
-    const { player_id, campaign_def_id, initial_trait_choice } = req.body || {};
+    const { player_id, campaign_def_id, initial_trait_choice, initial_trait_choices } =
+      req.body || {};
     if (!player_id || typeof player_id !== 'string') {
       return res.status(400).json({ error: 'player_id richiesto (string)' });
     }
@@ -163,21 +164,41 @@ function createCampaignRouter(options = {}) {
     const onboarding = getOnboarding(defDoc);
     let onboardingChoice = null;
     let acquiredTraits = [];
+    let acquiredTraitsByCreature = {};
     if (onboarding && Array.isArray(onboarding.choices) && onboarding.choices.length > 0) {
-      const requested = typeof initial_trait_choice === 'string' ? initial_trait_choice : null;
       const validKeys = onboarding.choices.map((c) => c.option_key);
-      const effectiveKey =
-        requested && validKeys.includes(requested)
-          ? requested
-          : onboarding.default_choice_on_timeout || validKeys[0];
-      const traitId = resolveOnboardingTrait(defDoc, effectiveKey);
-      if (traitId) {
-        onboardingChoice = { option_key: effectiveKey, trait_id: traitId };
-        acquiredTraits = [traitId];
+      const defaultKey = onboarding.default_choice_on_timeout || validKeys[0];
+      const resolveKey = (k) => (typeof k === 'string' && validKeys.includes(k) ? k : defaultKey);
+      // MA1 (ADR-2026-06-08): per-creature choices map { creatureId: option_key }. Each
+      // invalid key falls back to the default INDIVIDUALLY. Legacy single choice = shared.
+      if (
+        initial_trait_choices &&
+        typeof initial_trait_choices === 'object' &&
+        !Array.isArray(initial_trait_choices)
+      ) {
+        for (const [creatureId, key] of Object.entries(initial_trait_choices)) {
+          const tid = resolveOnboardingTrait(defDoc, resolveKey(key));
+          if (tid) acquiredTraitsByCreature[creatureId] = tid;
+        }
+        // backward-compat: acquiredTraits = union of per-creature traits.
+        acquiredTraits = [...new Set(Object.values(acquiredTraitsByCreature))];
+      } else {
+        const effectiveKey = resolveKey(
+          typeof initial_trait_choice === 'string' ? initial_trait_choice : null,
+        );
+        const traitId = resolveOnboardingTrait(defDoc, effectiveKey);
+        if (traitId) {
+          onboardingChoice = { option_key: effectiveKey, trait_id: traitId };
+          acquiredTraits = [traitId];
+        }
       }
     }
 
-    const campaign = createCampaign(player_id, defId, { onboardingChoice, acquiredTraits });
+    const campaign = createCampaign(player_id, defId, {
+      onboardingChoice,
+      acquiredTraits,
+      acquiredTraitsByCreature,
+    });
 
     // Slice A (live routing, flag ON): a graph-routed run begins at the authored
     // start_node and serves its encounter from the graph; the static onboarding chain is

--- a/apps/backend/services/campaign/campaignStore.js
+++ b/apps/backend/services/campaign/campaignStore.js
@@ -66,6 +66,12 @@ function createCampaign(playerId, campaignDefId = 'default_campaign_mvp', opts =
     // V1 Onboarding Phase B — trait permanent pre-Act 0 shared roster
     onboardingChoice: opts.onboardingChoice || null, // { option_key, trait_id }
     acquiredTraits: Array.isArray(opts.acquiredTraits) ? [...opts.acquiredTraits] : [],
+    // MA1 (ADR-2026-06-08) -- per-creature onboarding traits { creatureId: traitId }.
+    // Empty for legacy single-choice (degenere = trait condiviso via acquiredTraits).
+    acquiredTraitsByCreature:
+      opts.acquiredTraitsByCreature && typeof opts.acquiredTraitsByCreature === 'object'
+        ? { ...opts.acquiredTraitsByCreature }
+        : {},
     // Sprint 3 §III (2026-04-27) — Wildermyth choice→permanent flag pattern.
     // Source: docs/research/2026-04-26-tier-s-extraction-matrix.md #12 Wildermyth.
     // Each flag = { key, value, source_chapter, recorded_at, narrative? }.

--- a/docs/adr/ADR-2026-06-08-onboarding-per-creature-trait.md
+++ b/docs/adr/ADR-2026-06-08-onboarding-per-creature-trait.md
@@ -50,12 +50,13 @@ richiede esplicitamente questo ADR come prerequisito non-negoziabile PRIMA dell'
 
 ## Conseguenze
 
-- **Follow-up GATED (Eduardo)**: l'edit effettivo di `51-ONBOARDING-60S` (A3 SoT) per
-  riflettere il modello per-creatura NON e' in questo ADR. L'ADR REGISTRA la decisione (il gate
-  richiesto da MA1); l'edit dell'A3 SoT resta owner-gated.
-- **Impl GATED**: la modifica data-model campaign (`campaign.js`, `default_campaign_mvp.yaml`,
-  `tests/api/campaignRoutes.test.js`) + il wiring per-creatura (il `coopOrchestrator` e' gia'
-  per-player #2638) = follow-up implementativi separati.
+- **SoT EDIT DONE (2026-06-08, Eduardo greenlit):** `51-ONBOARDING-60S` (A3 SoT) aggiornato al
+  modello per-creatura (MA1 note + TL;DR + last_verified).
+- **Data-model DONE (2026-06-08):** `campaign.acquiredTraitsByCreature { creatureId: traitId }`
+  (`campaignStore.createCampaign`) + `campaign.js` accetta `initial_trait_choices` (per-creatura)
+  con fallback-per-creatura; `acquiredTraits[]` = union backward-compat (legacy single = degenere).
+  Test `campaignRoutes` 36/36 (3 per-creature + 33 backward-compat). Residuo: trait-branco
+  emergente (Form Pulse aggregato) + wiring roster->creatura (mapping player->unit).
 - **Canon-compatibile** la parte "trait-branco emergente" (aggregato, gia' previsto dal Form
   Pulse / bias Custode ADR-2026-06-07 punto 4); SOLO la parte "per-creatura" supera l'A3.
 - **MA1 sbloccato**: con questo ADR ACCEPTED, l'acceptance #2 di SPEC-M e' soddisfatta per la

--- a/docs/core/51-ONBOARDING-60S.md
+++ b/docs/core/51-ONBOARDING-60S.md
@@ -3,7 +3,7 @@ title: 'Onboarding narrativo 60s — 3 scelte identitarie pre-Act 0'
 doc_status: active
 doc_owner: master-dd
 workstream: combat
-last_verified: '2026-06-06'
+last_verified: '2026-06-08'
 source_of_truth: true
 language: it
 review_cycle_days: 30
@@ -23,9 +23,11 @@ related:
 
 **Re-verify 2026-06-06**: contenuto ancora canonico. `data/core/campaign/default_campaign_mvp.yaml` conserva `onboarding:`; `apps/backend/routes/campaign.js` espone `campaign_def.onboarding` e applica `initial_trait_choice` a `campaign.onboardingChoice` + `acquiredTraits[]`; `tests/api/campaignRoutes.test.js` copre default, option_b, option_c e fallback invalido. Il flow co-op/Godot in `apps/backend/services/coop/coopOrchestrator.js` ha una fase `onboarding`, ma il vecchio wording host-only va trattato come debito di riallineamento: la TV è mirror, gli input arrivano dai device.
 
+**MA1 2026-06-08 (ADR-2026-06-08-onboarding-per-creature-trait, SUPERSEDE):** il modello canonico passa da "1 trait condiviso di branco" a **per-creatura** -- ogni player sceglie il trait della PROPRIA creatura -- + un **trait-branco emergente** dall'aggregato (Form Pulse). Data-model LIVE: `campaign.acquiredTraitsByCreature { creatureId: traitId }` (`campaign.js` accetta `initial_trait_choices`); `acquiredTraits[]` resta come union backward-compat (legacy single-choice = caso degenere). Tempi / 3-opzioni / auto-A invariati. Residuo: trait-branco emergente (Form Pulse aggregato) + wiring roster per-creatura.
+
 ## TL;DR
 
-Prima di Act 0 (tutorial_01), player compie **1 scelta identitaria** in 60 secondi. La scelta determina un trait iniziale pre-assegnato a tutto il branco. **Nessuna spiegazione regole in minute-0**. Regole introdotte nel tutorial_01 stesso (Act 0 chapter 1).
+Prima di Act 0 (tutorial_01), ogni player compie **1 scelta identitaria** in 60 secondi. La scelta determina un trait iniziale **per-creatura** (+ trait-branco emergente) -- MA1, vedi nota sopra; il modello legacy = trait condiviso di branco (caso degenere). **Nessuna spiegazione regole in minute-0**. Regole introdotte nel tutorial_01 stesso (Act 0 chapter 1).
 
 ## Motivazione
 

--- a/docs/design/evo-tactics-onboarding-identity-flow.md
+++ b/docs/design/evo-tactics-onboarding-identity-flow.md
@@ -269,9 +269,10 @@ SPEC-M e' implementabile/chiudibile quando:
 
 1. la catena 60s (sez. 3) rispetta il canon 51-ONBOARDING (budget/timer/auto-A) con input
    device per-player;
-2. le 3 scelte sono wired al `initial_trait_choice` LIVE, con la semantica MA1 decisa; se
-   MA1=A/C, l'ADR-supersede di 51-ONBOARDING-60S e' filato + il data-model campaign
-   (trait per-creatura, non `acquiredTraits` singolo condiviso) e' esteso;
+2. **MA1 LIVE (2026-06-08):** ADR-supersede di 51-ONBOARDING-60S filato + A3 SoT aggiornato +
+   data-model campaign esteso (`acquiredTraitsByCreature { creatureId: traitId }`, `campaign.js`
+   accetta `initial_trait_choices`, `acquiredTraits[]` = union backward-compat). Residuo:
+   trait-branco emergente (Form Pulse aggregato) + wiring roster->creatura;
 3. il modello per-player (#2638) e' wired end-to-end: wsSession passa `allPlayerIds` +
    broadcast `onboarding_ready_list` (con strip choice-content, sez. 9) + Godot invia
    `onboarding_choice` per-player + timeout server-side anti-deadlock (sez. 5) + debito

--- a/tests/api/campaignRoutes.test.js
+++ b/tests/api/campaignRoutes.test.js
@@ -121,6 +121,45 @@ test('POST /api/campaign/start: initial_trait_choice option_c → denti_seghetta
   assert.equal(res.body.campaign.onboardingChoice.trait_id, 'denti_seghettati');
 });
 
+// MA1 (ADR-2026-06-08): per-creature onboarding traits + backward-compat.
+test('POST /api/campaign/start: per-creature initial_trait_choices -> acquiredTraitsByCreature', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/campaign/start`, {
+    player_id: 'p1',
+    initial_trait_choices: { c1: 'option_a', c2: 'option_b' },
+  });
+  assert.equal(res.status, 201);
+  const c = res.body.campaign;
+  assert.equal(c.acquiredTraitsByCreature.c1, 'zampe_a_molla');
+  assert.equal(c.acquiredTraitsByCreature.c2, 'pelle_elastomera');
+  // backward-compat: acquiredTraits = union of per-creature traits
+  assert.deepEqual([...c.acquiredTraits].sort(), ['pelle_elastomera', 'zampe_a_molla']);
+});
+
+test('POST /api/campaign/start: per-creature invalid key falls back to default per creature', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/campaign/start`, {
+    player_id: 'p1',
+    initial_trait_choices: { c1: 'bogus', c2: 'option_c' },
+  });
+  assert.equal(res.status, 201);
+  const c = res.body.campaign;
+  assert.equal(c.acquiredTraitsByCreature.c1, 'zampe_a_molla'); // fallback default (option_a)
+  assert.equal(c.acquiredTraitsByCreature.c2, 'denti_seghettati');
+});
+
+test('POST /api/campaign/start: legacy single choice -> empty per-creature map (backward compat)', async (t) => {
+  const { url } = startTestServer(t);
+  const res = await request('POST', `${url}/api/campaign/start`, {
+    player_id: 'p1',
+    initial_trait_choice: 'option_b',
+  });
+  assert.equal(res.status, 201);
+  const c = res.body.campaign;
+  assert.deepEqual(c.acquiredTraits, ['pelle_elastomera']); // unchanged shared
+  assert.deepEqual(c.acquiredTraitsByCreature, {}); // legacy -> no per-creature map
+});
+
 test('POST /api/campaign/start: invalid initial_trait_choice fallback su default', async (t) => {
   const { url } = startTestServer(t);
   const res = await request('POST', `${url}/api/campaign/start`, {


### PR DESCRIPTION
## Cosa
Greenlit (build code + SoT edit). Implements MA1 (ADR-2026-06-08): onboarding model branco-shared -> **per-creatura**.

- `campaignStore.createCampaign` -- new `acquiredTraitsByCreature { creatureId: traitId }` (empty for legacy).
- `campaign.js` `POST /campaign/start` -- accepts `initial_trait_choices` (per-creature map; each invalid key falls back to default individually). `acquiredTraits[]` = **union backward-compat**. Legacy single `initial_trait_choice` path unchanged (shared).
- **A3 SoT `51-ONBOARDING-60S` edited** (Eduardo greenlit the SoT edit) -- MA1 note + TL;DR + last_verified to the per-creature model.

## Tests
campaignRoutes **36/36** (3 new per-creature: map, per-creature fallback, legacy-empty-map; 33 backward-compat). Campaign suite no-regression (integration 6, metaNetworkRouting 10, roster 2, seasonal 11). governance 0, prettier clean. Not a contracts/forbidden path.

## Residuo (follow-up)
Emergent **branco-trait** (Form Pulse aggregate, separate signal). Roster->creature wiring (map player_id -> unit_id so the per-creature trait lands on the right roster unit). N=40 nothing here (no magnitude knob).

Docs: SPEC-M acceptance #2 + ADR conseguenze marked LIVE (was gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)