### PR TITLE
feat(worldgen): A13 biome-wound trigger + cross-run persist

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3458,6 +3458,36 @@ function createSessionRouter(options = {}) {
       } catch {
         /* best-effort -- never blocks session end */
       }
+      // SPEC-P A13 -- wound/heal the biome cross-run (persist on campaign). Best-effort.
+      try {
+        const campaignId = session.campaign_id;
+        const biomeId = session.biome_id;
+        if (campaignId && biomeId) {
+          const { getCampaign, updateCampaign } = require('../services/campaign/campaignStore');
+          const {
+            woundBiome,
+            healBiome,
+            emitBiomeWound,
+          } = require('../services/worldgen/biomeWound');
+          const { DEFEAT_OUTCOMES } = require('../services/chronicle/chronicleEmitters');
+          const camp = getCampaign(campaignId);
+          if (camp) {
+            const cur = Array.isArray(camp.woundedBiomes) ? camp.woundedBiomes : [];
+            if (DEFEAT_OUTCOMES.has(session.outcome)) {
+              const r = woundBiome(cur, biomeId);
+              if (r.added) {
+                updateCampaign(campaignId, { woundedBiomes: r.wounded });
+                emitBiomeWound(campaignId, biomeId, { baseDir: chronicleBaseDir });
+              }
+            } else if (session.outcome === 'victory') {
+              const r = healBiome(cur, biomeId);
+              if (r.healed) updateCampaign(campaignId, { woundedBiomes: r.wounded });
+            }
+          }
+        }
+      } catch {
+        /* best-effort -- never blocks session end */
+      }
       // M1 -- persist Sistema learning (best-effort, never blocks session end).
       try {
         if (session.campaign_id) {

--- a/apps/backend/services/campaign/campaignStore.js
+++ b/apps/backend/services/campaign/campaignStore.js
@@ -72,6 +72,8 @@ function createCampaign(playerId, campaignDefId = 'default_campaign_mvp', opts =
       opts.acquiredTraitsByCreature && typeof opts.acquiredTraitsByCreature === 'object'
         ? { ...opts.acquiredTraitsByCreature }
         : {},
+    // SPEC-P A13 -- biomi feriti cross-run (degrade bounded, cap 2). Persistito qui.
+    woundedBiomes: Array.isArray(opts.woundedBiomes) ? [...opts.woundedBiomes] : [],
     // Sprint 3 §III (2026-04-27) — Wildermyth choice→permanent flag pattern.
     // Source: docs/research/2026-04-26-tier-s-extraction-matrix.md #12 Wildermyth.
     // Each flag = { key, value, source_chapter, recorded_at, narrative? }.

--- a/docs/design/evo-tactics-failure-as-lore.md
+++ b/docs/design/evo-tactics-failure-as-lore.md
@@ -125,8 +125,13 @@ SPEC-I resta read-side della pressione.
 **Stato: mechanism LIVE (2026-06-08).** `apps/backend/services/worldgen/biomeWound.js`:
 `woundBiome` (cap 2 PA2, idempotente, no-mutate) + `healBiome` (recupero anti-brick) +
 `pressureDelta` (N feriti -> delta SPEC-I, HARD-bounded ER2 +/-2, PA4) + `emitBiomeWound` ->
-chronicle (M-7). Magnitudine `PRESSURE_PER_BIOME` = PROPOSED (ratify N=40, PA2). Follow-up:
-persistenza meta-network (`metaNetworkResolver`) + trigger (wound su run-fail) + recupero wired.
+chronicle (M-7). Magnitudine `PRESSURE_PER_BIOME` = PROPOSED (ratify N=40, PA2).
+
+**Trigger + persist LIVE (2026-06-08).** A session-end (`routes/session.js`, best-effort):
+sconfitta nel bioma -> `woundBiome` + persist su `campaign.woundedBiomes` (cross-run) +
+`emitBiomeWound`; vittoria nel bioma ferito -> `healBiome` (recupero). Cap 2 rispettato.
+Integration test 3/3 (wound/heal/cap). Follow-up: il read-side SPEC-I (consumare
+`campaign.woundedBiomes` -> `pressureDelta` nella pressione ERMES).
 
 Contratto del degrado:
 

--- a/tests/api/a13BiomeWoundWire.test.js
+++ b/tests/api/a13BiomeWoundWire.test.js
@@ -1,0 +1,80 @@
+// A13 biome-wound wiring integration -- SPEC-P (session-end triggers wound/heal,
+// persisted cross-run on the campaign; emits biome_wound to the chronicle).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+const { getCampaign } = require('../../apps/backend/services/campaign/campaignStore');
+const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'a13-wire-'));
+}
+const DEAD = [
+  { id: 'p1', controlled_by: 'player', hp: 0, max_hp: 10, position: { x: 0, y: 0 } },
+  { id: 's1', controlled_by: 'sistema', hp: 5, max_hp: 5, position: { x: 5, y: 5 } },
+];
+const WIN = [
+  { id: 'p1', controlled_by: 'player', hp: 10, max_hp: 10, position: { x: 0, y: 0 } },
+  { id: 's1', controlled_by: 'sistema', hp: 0, max_hp: 5, position: { x: 5, y: 5 } },
+];
+
+async function runEnd(app, campaignId, units, biomeId) {
+  const ss = await request(app)
+    .post('/api/session/start')
+    .send({ units, campaign_id: campaignId, biome_id: biomeId });
+  return request(app).post('/api/session/end').send({ session_id: ss.body.session_id });
+}
+
+test('A13: defeat in a biome wounds it (persist on campaign + biome_wound chronicle)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'a13_pl1' });
+  const cid = start.body.campaign.id;
+  const end = await runEnd(app, cid, DEAD, 'badlands');
+  assert.equal(end.body.outcome, 'wipe');
+  assert.deepEqual(getCampaign(cid).woundedBiomes, ['badlands']);
+  const wounds = getChronicle(cid, { baseDir }).filter((e) => e.type === 'biome_wound');
+  assert.equal(wounds.length, 1);
+  assert.equal(wounds[0].payload.biome_id, 'badlands');
+});
+
+test('A13: win in a wounded biome heals it (recovery, anti-brick)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'a13_pl2' });
+  const cid = start.body.campaign.id;
+  await runEnd(app, cid, DEAD, 'tundra'); // wound it
+  assert.deepEqual(getCampaign(cid).woundedBiomes, ['tundra']);
+  await runEnd(app, cid, WIN, 'tundra'); // win there -> heal
+  assert.deepEqual(getCampaign(cid).woundedBiomes, []);
+});
+
+test('A13: cap respected -- 3rd wounded biome rejected (max 2)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'a13_pl3' });
+  const cid = start.body.campaign.id;
+  await runEnd(app, cid, DEAD, 'b_one');
+  await runEnd(app, cid, DEAD, 'b_two');
+  await runEnd(app, cid, DEAD, 'b_three'); // over cap -> not added
+  assert.deepEqual(getCampaign(cid).woundedBiomes.sort(), ['b_one', 'b_two']);
+});


### PR DESCRIPTION
## Cosa
Follow-up (greenlit): wires the A13 `biomeWound` mechanism (shipped #2657) LIVE end-to-end.

- `routes/session.js` (session-end, best-effort): **defeat** in `session.biome_id` -> `woundBiome` + persist on `campaign.woundedBiomes` (cross-run) + `emitBiomeWound` -> chronicle. **Victory** in a wounded biome -> `healBiome` (recovery, anti-brick). Cap 2 (PA2) respected.
- `campaignStore.createCampaign` -- `woundedBiomes: []` (cross-run persisted state).

## Live-smoke (verified)
Probe: `/campaign/start` -> `/session/start` (dead player, biome_id) -> `/session/end` (wipe) -> `campaign.woundedBiomes = ['badlands']` + biome_wound chronicle event. Captured as integration test.

## Tests
A13 wire 3/3 (wound on defeat / heal on win / cap-2). No-regression 48/48 (biomeWound 10 + campaignRoutes 36 + sessionEnd 2). governance 0, prettier clean.

## Follow-up
**SPEC-I read-side**: consume `campaign.woundedBiomes` -> `pressureDelta` in the ERMES pressure (within ER2). Magnitude N=40 ratify (PA2).

apps/backend only (session.js = additive best-effort block, mirrors M1/chronicle), no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)