### PR TITLE
feat(i18n): migrate thoughtsPanel AXIS_LABELS to t('mbti_axis.*')

### DIFF
--- a/apps/play/src/thoughtsPanel.js
+++ b/apps/play/src/thoughtsPanel.js
@@ -7,6 +7,9 @@
 // Depends on: api.thoughts(sid) + getSelectedUnit.
 
 import { api } from './api.js';
+// SPEC-N PR-4 (NF3): MBTI axis labels migrated to the i18n loader (data/i18n SSOT).
+// IT values unchanged (mbti_axis.it == old AXIS_LABELS); EN now covered.
+import { t } from './i18n.js';
 
 const STATE = {
   overlayEl: null,
@@ -15,12 +18,6 @@ const STATE = {
   lastData: null,
   catalog: null,
   lastActionError: null,
-};
-
-const AXIS_LABELS = {
-  E_I: 'Estroversione ⇄ Introversione',
-  S_N: 'Sensazione ⇄ Intuizione',
-  J_P: 'Giudicare ⇄ Percepire',
 };
 
 function injectStyles() {
@@ -417,7 +414,7 @@ function renderAxis(axis, ctx) {
     .join('');
   return `
     <div class="thoughts-axis">
-      <div class="thoughts-axis-head">${escapeHtml(AXIS_LABELS[axis])}</div>
+      <div class="thoughts-axis-head">${escapeHtml(t('mbti_axis.' + axis))}</div>
       <div class="thoughts-tiers">${cards}</div>
     </div>
   `;

--- a/data/i18n/en/common.json
+++ b/data/i18n/en/common.json
@@ -72,6 +72,12 @@
     "survival": "Survive",
     "escape": "Escape"
   },
+  "mbti_axis": {
+    "E_I": "Extraversion ⇄ Introversion",
+    "S_N": "Sensing ⇄ Intuition",
+    "T_F": "Thinking ⇄ Feeling",
+    "J_P": "Judging ⇄ Perceiving"
+  },
   "result": {
     "victory": "Victory",
     "defeat": "Defeat",

--- a/data/i18n/it/common.json
+++ b/data/i18n/it/common.json
@@ -72,6 +72,12 @@
     "survival": "Sopravvivi",
     "escape": "Fuggi"
   },
+  "mbti_axis": {
+    "E_I": "Estroversione ⇄ Introversione",
+    "S_N": "Sensazione ⇄ Intuizione",
+    "T_F": "Pensiero ⇄ Sentimento",
+    "J_P": "Giudicare ⇄ Percepire"
+  },
   "result": {
     "victory": "Vittoria",
     "defeat": "Sconfitta",

--- a/docs/design/evo-tactics-localization-i18n.md
+++ b/docs/design/evo-tactics-localization-i18n.md
@@ -92,9 +92,10 @@ Invarianti ereditate:
 **Stato: LIVE (2026-06-08).** `apps/play/src/i18nCore.js` (puro: `createT`/`resolveKey`/
 `interpolate`, testato) + `apps/play/src/i18n.js` (bind a `data/i18n` via Vite JSON import).
 NF1=frontend (apps/play), `fallbackLocale=it`. Interpolation single-brace `{var}` (NF4 LIVE).
-PR-4 (NF3 incrementale) avviato: `objectivePanel` migrato a `t('objective_short.*')` (IT
-invariato + EN coperto); restano ~7 label-map (biomeChip/ui/...) + mission-console (interop
-JSON-attribute risolto: `import ... with { type: 'json' }`).
+PR-4 (NF3 incrementale) avviato: `objectivePanel` -> `t('objective_short.*')` + `thoughtsPanel`
+-> `t('mbti_axis.*')` (IT invariato + EN coperto); restano ~6 label-map (biomeChip/ui/
+characterPanel/enneaVoiceRender/...) + mission-console (interop JSON-attribute risolto:
+`import ... with { type: 'json' }`).
 
 - `t(key, params?, locale?)`: risolve la key, applica i params, fallback a IT (sorgente
   completa), ritorna la stringa. NON-LLM, deterministico.


### PR DESCRIPTION
## Cosa
i18n PR-4 increment (greenlit). 2nd label-map migrated to the loader (after objectivePanel #2655).

- `data/i18n` `mbti_axis` keys (it == old AXIS_LABELS exactly -> zero visible change; en added).
- `thoughtsPanel` imports the loader + `t('mbti_axis.' + axis)`.

## Verify
`t('mbti_axis.E_I')` = 'Estroversione ⇄ Introversione' (IT-faithful). i18n:check errors=0, Vite build OK, prettier clean, governance 0. No node test on thoughtsPanel (interop fix from #2655 makes any future one safe).

## Remaining (NF3 incremental queue)
~6 label-maps (biomeChip / ui STATUS_LABELS / characterPanel rich-axis / enneaVoiceRender / innerVoiceRender / speciesNames) + mission-console migration. Each needs short-keys + care (some change displayed text it<->en).

>50 LOC? No (small). apps/play + data, greenlit i18n. No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)