### PR TITLE
feat(combat): A13 SPEC-I read-side -- wounded biome harshens eco (within ER2)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1736,14 +1736,42 @@ function createSessionRouter(options = {}) {
       if (biomeIdRaw) {
         try {
           const biomeCostsRegistry = loadTraitEnvironmentalCosts();
+          // SPEC-P A13 read-side: if this biome is wounded (campaign cross-run state),
+          // the eco effect is harsher (woundedStep, folded into the ER2 +/-2 cap).
+          // PROPOSED magnitude = 1 band (DEGRADE_STEP); ratify N=40. Best-effort lookup.
+          let woundedStep = 0;
+          try {
+            const cid = req.body?.campaign_id;
+            if (cid) {
+              const { getCampaign } = require('../services/campaign/campaignStore');
+              const camp = getCampaign(cid);
+              if (
+                camp &&
+                Array.isArray(camp.woundedBiomes) &&
+                camp.woundedBiomes.includes(biomeIdRaw)
+              ) {
+                woundedStep = 1;
+              }
+            }
+          } catch {
+            /* best-effort -- biome eco still applies without the wound amplifier */
+          }
           units = units.map((u) => {
             if (!u) return u;
             const clone = { ...u };
-            const log = applyBiomeEcoEffects(clone, biomeIdRaw, { biomeCostsRegistry });
+            const log = applyBiomeEcoEffects(clone, biomeIdRaw, {
+              biomeCostsRegistry,
+              woundedStep,
+            });
             // FASE 3 P4: capture biome-level eco band (uniform across units, set
             // even for med where no delta is applied) for the diegetic chip.
             if (log && log.band) ermesBand = log.band;
-            if (log && (log.adr21c.length || log.ermes.length)) {
+            if (
+              log &&
+              (log.adr21c.length ||
+                log.ermes.length ||
+                Object.keys(log.combined_delta || {}).length)
+            ) {
               biomeCostsLog.push({ unit_id: clone.id, ...log });
             }
             return clone;

--- a/apps/backend/services/traitEffects.js
+++ b/apps/backend/services/traitEffects.js
@@ -795,6 +795,14 @@ function applyBiomeEcoEffects(unit, biomeId, opts = {}) {
     ermes = [];
   }
 
+  // SPEC-P A13 read-side: a wounded biome harshens the eco effect (debuff the eco
+  // bonuses), folded into the SAME +/-2 cap (ER2) by the loop below. woundedStep =
+  // PROPOSED magnitude (caller passes DEGRADE_STEP if the biome is wounded; ratify N=40).
+  const woundedStep = Number(opts.woundedStep) || 0;
+  if (woundedStep > 0) {
+    for (const f of BIOME_ECO_FIELDS) unit[f] = Number(unit[f] || 0) - woundedStep;
+  }
+
   const combined_delta = {};
   let capped = false;
   for (const f of BIOME_ECO_FIELDS) {

--- a/docs/design/evo-tactics-failure-as-lore.md
+++ b/docs/design/evo-tactics-failure-as-lore.md
@@ -130,8 +130,13 @@ chronicle (M-7). Magnitudine `PRESSURE_PER_BIOME` = PROPOSED (ratify N=40, PA2).
 **Trigger + persist LIVE (2026-06-08).** A session-end (`routes/session.js`, best-effort):
 sconfitta nel bioma -> `woundBiome` + persist su `campaign.woundedBiomes` (cross-run) +
 `emitBiomeWound`; vittoria nel bioma ferito -> `healBiome` (recupero). Cap 2 rispettato.
-Integration test 3/3 (wound/heal/cap). Follow-up: il read-side SPEC-I (consumare
-`campaign.woundedBiomes` -> `pressureDelta` nella pressione ERMES).
+Integration test 3/3 (wound/heal/cap).
+
+**Read-side SPEC-I LIVE (2026-06-08).** A `/session/start`, se il bioma e' in
+`campaign.woundedBiomes`, `applyBiomeEcoEffects` riceve un `woundedStep` (debuff eco di 1 banda)
+ripiegato nello STESSO cap ER2 (+/-2): un bioma ferito = combat piu' duro, mai oltre il cap.
+Integration 2/2 (wounded debuff / fresh no-op). Magnitudine `woundedStep`=1 = PROPOSED (N=40).
+Residuo: emergent branco-trait + esposizione del degrado nel descrittore pre-run (PA3).
 
 Contratto del degrado:
 

--- a/tests/api/a13BiomeWoundWire.test.js
+++ b/tests/api/a13BiomeWoundWire.test.js
@@ -78,3 +78,48 @@ test('A13: cap respected -- 3rd wounded biome rejected (max 2)', async (t) => {
   await runEnd(app, cid, DEAD, 'b_three'); // over cap -> not added
   assert.deepEqual(getCampaign(cid).woundedBiomes.sort(), ['b_one', 'b_two']);
 });
+
+// SPEC-I read-side: a session in a wounded biome gets a harsher eco (within ER2).
+const LIVE_ECO = [
+  {
+    id: 'p1',
+    controlled_by: 'player',
+    hp: 10,
+    max_hp: 10,
+    attack_mod_bonus: 0,
+    defense_mod_bonus: 0,
+    position: { x: 0, y: 0 },
+  },
+  { id: 's1', controlled_by: 'sistema', hp: 5, max_hp: 5, position: { x: 5, y: 5 } },
+];
+
+test('A13 read-side: session in a wounded biome gets a harsher eco debuff (within ER2)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'a13_rs' });
+  const cid = start.body.campaign.id;
+  await runEnd(app, cid, DEAD, 'savana'); // wound savana
+  const ss = await request(app)
+    .post('/api/session/start')
+    .send({ units: LIVE_ECO, campaign_id: cid, biome_id: 'savana' });
+  const log = (ss.body.biomeCostsLog || []).find((x) => x.unit_id === 'p1');
+  assert.ok(log, 'wounded biome surfaces an eco cost log');
+  assert.equal(log.combined_delta.attack_mod_bonus, -1); // wounded debuff, capped at ER2
+});
+
+test('A13 read-side: non-wounded biome -> no wounded eco debuff (backward compat)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'a13_rs2' });
+  const cid = start.body.campaign.id;
+  const ss = await request(app)
+    .post('/api/session/start')
+    .send({ units: LIVE_ECO, campaign_id: cid, biome_id: 'savana' });
+  assert.deepEqual(ss.body.biomeCostsLog || [], []); // fresh biome -> no debuff
+});

--- a/tests/services/applyBiomeEcoEffects.test.js
+++ b/tests/services/applyBiomeEcoEffects.test.js
@@ -65,3 +65,33 @@ test('R6 gate: never writes creature_epigenome.bias', () => {
   applyBiomeEcoEffects(u, 'b', { biomeCostsRegistry: REG, bucketed: ERMES_LOW });
   assert.equal(u.creature_epigenome, undefined);
 });
+
+// SPEC-P A13 read-side: a wounded biome harshens the eco effect, within the ER2 cap.
+test('A13 woundedStep: wounded biome debuffs eco bonuses (within ER2 cap)', () => {
+  _resetBiomeCostCache();
+  const u = unit();
+  applyBiomeEcoEffects(u, 'b', { woundedStep: 1 });
+  assert.equal(u.attack_mod_bonus, -1); // wounded -1
+  assert.equal(u.defense_mod_bonus, -1);
+});
+
+test('A13 woundedStep: stacks with eco debuff but stays clamped at ER2 (-2)', () => {
+  _resetBiomeCostCache();
+  const u = unit();
+  const log = applyBiomeEcoEffects(u, 'b', {
+    biomeCostsRegistry: REG,
+    bucketed: ERMES_LOW,
+    woundedStep: 1,
+  });
+  // attack: 21c -2 + ermes -1 + wounded -1 = -4 raw -> clamped to -2 (ER2)
+  assert.equal(u.attack_mod_bonus, -2);
+  assert.equal(log.capped, true);
+});
+
+test('A13 woundedStep: absent/0 -> no-op (backward compat)', () => {
+  _resetBiomeCostCache();
+  const u = unit();
+  applyBiomeEcoEffects(u, 'b', {});
+  assert.equal(u.attack_mod_bonus, 0);
+  assert.equal(u.defense_mod_bonus, 0);
+});


### PR DESCRIPTION
## Cosa
Follow-up (greenlit): completes A13 end-to-end. A13 write-side (#2657/#2659) persisted `campaign.woundedBiomes`; this is the **read-side** -- a wounded biome makes combat harsher.

- `applyBiomeEcoEffects(unit, biomeId, { woundedStep })` -- debuffs the eco bonuses by `woundedStep` bands, **folded into the same `BIOME_ECO_COMBINED_CAP` (ER2 +/-2)** -> never exceeds the cap.
- `routes/session.js` -- at `/session/start`, computes `woundedStep` from `campaign.woundedBiomes` (best-effort; no-op if the biome isn't wounded -> backward compat). Surfaces the delta in `biomeCostsLog`.

## Live-smoke (verified)
Wounded savana -> units `{attack_mod_bonus:-1, defense_mod_bonus:-1, mobility:-1, rest_recovery:-1}` (capped at ER2). Fresh savana -> no debuff. Captured as integration tests.

## Tests
applyBiomeEcoEffects 9/9 (3 new woundedStep: debuff / stacks-clamped-at-ER2 / no-op). a13BiomeWoundWire 5/5 (2 new read-side). sessionBiomeEcoEffects no-regression. governance 0, prettier clean.

## Magnitude / residuo
`woundedStep=1` band = PROPOSED (ratify N=40). Residuo: emergent branco-trait; PA3 pre-run degrade descriptor.

apps/backend only (traitEffects additive woundedStep within existing cap; session.js best-effort), no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)