### PR TITLE
feat(sim): OA2 mission-type-aware full-loop (objective-driver + outcome)

### DIFF
--- a/docs/design/evo-tactics-mission-template-library.md
+++ b/docs/design/evo-tactics-mission-template-library.md
@@ -41,16 +41,16 @@ ALIMENTA gli engine LIVE (objectiveEvaluator, encounterLoader), non li riscrive.
 
 ## 2. Baseline LIVE (verificato 2026-06-08, non ricostruire)
 
-| Engine / artefatto                                        | Ruolo / stato                                                                                                                |
-| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `services/combat/objectiveEvaluator.js` (ADR-2026-04-20)  | Registry LIVE di TUTTI e 6 i tipi (elimination/capture_point/escort/sabotage/survival/escape) -> {completed,failed,outcome}. |
-| `services/combat/encounterLoader.js`                      | Carica encounter schema-validi da `docs/planning/encounters/` (+ `encounters-draft/` in graphMode).                          |
-| `schemas/evo/encounter.schema.json`                       | Schema encounter: `objective.type` enum (6 tipi), `waves`, `player_spawn`, `grid_size`, `difficulty_rating`, `tags` (enum).  |
-| `tools/py/author_encounter.py`                            | Authoring + validazione struttura vs schema; `tests/scripts/encounterSchema.test.js` valida tutti i template (AJV).          |
-| `docs/planning/encounters/*.yaml`                         | **12 template schema-validi** (post-SPEC-O): 6/6 tipi coperti (vedi sez. 5).                                                 |
-| `data/core/missions/skydock_siege.yaml`                   | TUNE-LOG (formato `groups`/`party_vc`, NON schema-encounter) -- distinto dai template.                                       |
-| `tools/sim/full-loop-runner.js`                           | Runner full-loop; usa `completion_rate`. NB: NON e' mission-type-aware (scenario fisso) -- vedi sez. 9 / OA2.                |
-| difficulty: `difficulty_rating` (schema 1-5) + class mult | `hardcoreScenario`/`tutorialScenario` moltiplicatore per classe. NESSUN modulo DifficultyCalculator (OA3).                   |
+| Engine / artefatto                                        | Ruolo / stato                                                                                                                                     |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `services/combat/objectiveEvaluator.js` (ADR-2026-04-20)  | Registry LIVE di TUTTI e 6 i tipi (elimination/capture_point/escort/sabotage/survival/escape) -> {completed,failed,outcome}.                      |
+| `services/combat/encounterLoader.js`                      | Carica encounter schema-validi da `docs/planning/encounters/` (+ `encounters-draft/` in graphMode).                                               |
+| `schemas/evo/encounter.schema.json`                       | Schema encounter: `objective.type` enum (6 tipi), `waves`, `player_spawn`, `grid_size`, `difficulty_rating`, `tags` (enum).                       |
+| `tools/py/author_encounter.py`                            | Authoring + validazione struttura vs schema; `tests/scripts/encounterSchema.test.js` valida tutti i template (AJV).                               |
+| `docs/planning/encounters/*.yaml`                         | **12 template schema-validi** (post-SPEC-O): 6/6 tipi coperti (vedi sez. 5).                                                                      |
+| `data/core/missions/skydock_siege.yaml`                   | TUNE-LOG (formato `groups`/`party_vc`, NON schema-encounter) -- distinto dai template.                                                            |
+| `tools/sim/full-loop-runner.js`                           | Runner full-loop; `completion_rate`. OA2 LIVE: mission-type-aware via `combat-adapter` objective-outcome + `combat-policy` zone-pursuit (sez. 9). |
+| difficulty: `difficulty_rating` (schema 1-5) + class mult | `hardcoreScenario`/`tutorialScenario` moltiplicatore per classe. NESSUN modulo DifficultyCalculator (OA3).                                        |
 
 Invarianti ereditate:
 
@@ -133,12 +133,14 @@ Dopo SPEC-O, `docs/planning/encounters/` copre tutti i 6 tipi (12 template schem
 ## 9. Calibrazione full-loop
 
 - Metrica: `completion_rate` target **0.40-0.70** per template (mirror band full-loop).
-- **Prerequisito (verificato) -- la calibrazione dei tipi non-elimination e' OGGI IMPOSSIBILE:**
-  `tools/sim/scenario-enemies.js` ha `SUPPORTED_OBJECTIVES = {elimination}` (`:52`) -> per
-  qualsiasi altro tipo `buildScenarioEnemies` ritorna null -> il runner cade sul nemico-fisso
-  DEBOLE -> `completion_rate` degenera (~1.0, non misurabile). Serve (OA2): (a) estendere
-  `SUPPORTED_OBJECTIVES`, (b) un DRIVER che guidi le meccaniche objective non-elim nel loop sim
-  (hold zone / escape race / escort survival), (c) `mission_type`-awareness del runner.
+- **OA2 LIVE (2026-06-08): la calibrazione non-elimination e' ora possibile.** (a)
+  `SUPPORTED_OBJECTIVES` esteso a tutti e 6 i tipi (`scenario-enemies.js`); (b) DRIVER
+  objective-aware (`combat-policy` zone-pursuit + hold: i PG vanno verso `target_zone` e
+  tengono la zona) + objective-OUTCOME (`combat-adapter` legge l'evaluation: completed->victory
+  / failed->defeat, NON solo elimination); (c) il runner e' mission-type-aware. Verificato:
+  `enc_sabotage_01` completa via objective con un nemico immortale (hp300) = NON elimination.
+  Elimination resta a costo-zero (poll evaluation solo per non-elim -> nessuna regressione/flake).
+  Residuo: tuning `completion_rate` N=40 + traversal multi-unit con `min_units_in_zone>1`.
 - Gate di promozione: un template passa da DRAFT a "ratificato" solo con `completion_rate`
   in banda su N=40 (mirror SPEC-I/ERMES gate), senza regressione fuori banda.
 
@@ -219,9 +221,10 @@ SPEC-O e' implementabile/chiudibile quando:
 
 1. i 6 tipi-obiettivo (sez. 3) hanno ciascuno >=1 template schema-valido in
    `docs/planning/encounters/` (FATTO: 6/6, `encounterSchema.test.js` verde);
-2. OA2 e' risolto+implementato (`SUPPORTED_OBJECTIVES` esteso in scenario-enemies.js + driver
-   objective non-elim nel runner) E i 2 nuovi template (sabotage/escape) sono CALIBRATI
-   (`completion_rate` 0.40-0.70 su N=40 col ROSTER REALE, non il nemico-fisso) -- oggi DRAFT;
+2. OA2 e' risolto+implementato (LIVE: `SUPPORTED_OBJECTIVES` esteso + driver zone-pursuit
+   (`combat-policy`) + objective-outcome (`combat-adapter`)); resta la CALIBRAZIONE dei template
+   sabotage/escape (`completion_rate` 0.40-0.70 su N=40 col ROSTER REALE) + traversal
+   `min_units_in_zone>1` -- oggi DRAFT;
 3. l'integrazione `mission_type` con SPEC-D (scene grammar) + SPEC-I (pressione per tipo) e'
    contrattualizzata secondo l'ownership OA1 (addendum D/I);
 4. il difficulty profile (OA3) e' deciso (field+mult vs DifficultyCalculator);

--- a/tests/sim/combatAdapter.test.js
+++ b/tests/sim/combatAdapter.test.js
@@ -123,3 +123,52 @@ test('combatAdapter.runEncounter: a fixed seed replays deterministically (Codex 
   assert.equal(a.outcome, b.outcome);
   assert.equal(a.rounds, b.rounds);
 });
+
+// OA2 (SPEC-O): a NON-elimination objective completes via the objective-driver + the
+// objective-outcome wiring (sabotage progress while in the zone), NOT elimination.
+test('combatAdapter.runEncounter: OA2 -- sabotage objective completes (not elimination)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = supertestHttp(app);
+  // One unit in the sabotage zone [4,4,6,6]; a TOUGH FAR foe (hp 300) that cannot be
+  // killed -> victory MUST come from the objective (sabotage ticks), proving OA2.
+  const roster = [
+    {
+      id: 'c1',
+      hp: 60,
+      max_hp: 60,
+      ap: 4,
+      mod: 20,
+      attack_range: 2,
+      initiative: 18,
+      position: { x: 4, y: 4 },
+      controlled_by: 'player',
+      status: {},
+    },
+  ];
+  const toughFoe = [
+    {
+      id: 'f1',
+      hp: 300,
+      max_hp: 300,
+      ap: 1,
+      mod: 0,
+      dc: 1,
+      attack_range: 1,
+      initiative: 1,
+      position: { x: 9, y: 9 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+  const res = await runEncounter(http, {
+    roster,
+    enemies: toughFoe,
+    scenarioId: 'enc_sabotage_01',
+    seed: 'oa2-test',
+    maxRounds: 120, // ample margin: sabotage ticks slowly via turn/end; avoid edge flake
+  });
+  assert.equal(res.outcome, 'victory', `expected objective victory, got ${res.outcome}`);
+});

--- a/tests/sim/combatPolicy.test.js
+++ b/tests/sim/combatPolicy.test.js
@@ -30,3 +30,41 @@ test('selectPlayerAction: returns null when no alive enemy', () => {
   const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 0, position: { x: 1, y: 0 } }];
   assert.equal(selectPlayerAction(actor, units), null);
 });
+
+// OA2 (SPEC-O): objective-aware zone-pursuit so non-elimination objectives complete in the sim.
+test('zone objective + actor outside zone -> moves toward the zone, NOT the enemy', () => {
+  const actor = { id: 'p', position: { x: 5, y: 5 }, attack_range: 1, ap_remaining: 3 };
+  const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 9, y: 9 } }];
+  const obj = { type: 'capture_point', config: { target_zone: [0, 0, 2, 2] } }; // centroid (1,1) up-left
+  const a = selectPlayerAction(actor, units, obj);
+  assert.equal(a.action_type, 'move');
+  assert.deepEqual(a.target_position, { x: 4, y: 5 }); // toward zone (-x), not enemy (+x)
+});
+
+test('zone objective + actor INSIDE zone + adjacent enemy -> attacks (in range)', () => {
+  const actor = { id: 'p', position: { x: 5, y: 5 }, attack_range: 1, ap_remaining: 3 };
+  const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 5, y: 6 } }];
+  const obj = { type: 'sabotage', config: { target_zone: [4, 4, 6, 6] } };
+  const a = selectPlayerAction(actor, units, obj);
+  assert.deepEqual(a, { action_type: 'attack', target_id: 'e' });
+});
+
+test('zone objective + actor IN zone + FAR enemy -> HOLDS (null), does not chase out', () => {
+  const actor = { id: 'p', position: { x: 5, y: 5 }, attack_range: 1, ap_remaining: 3 };
+  const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 9, y: 9 } }];
+  const obj = { type: 'capture_point', config: { target_zone: [4, 4, 6, 6] } };
+  assert.equal(selectPlayerAction(actor, units, obj), null); // hold -> objective ticks
+});
+
+test('elimination objective -> closest-enemy (unchanged)', () => {
+  const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 1, ap_remaining: 3 };
+  const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 4, y: 0 } }];
+  const a = selectPlayerAction(actor, units, { type: 'elimination' });
+  assert.deepEqual(a.target_position, { x: 1, y: 0 }); // toward enemy
+});
+
+test('no objective arg -> backward compat (closest enemy)', () => {
+  const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 1, ap_remaining: 3 };
+  const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 4, y: 0 } }];
+  assert.deepEqual(selectPlayerAction(actor, units).target_position, { x: 1, y: 0 });
+});

--- a/tests/sim/scenarioEnemies.test.js
+++ b/tests/sim/scenarioEnemies.test.js
@@ -37,14 +37,12 @@ test('buildScenarioEnemies: tiers scale hp/mod (base < elite < apex)', () => {
   assert.ok(TIER_MOD.base < TIER_MOD.elite && TIER_MOD.elite < TIER_MOD.apex, 'mod scales by tier');
 });
 
-test('buildScenarioEnemies: missing or unsupported YAML -> null (runner falls back)', () => {
+test('buildScenarioEnemies: missing YAML -> null; OA2 -> non-elim objectives supported', () => {
   assert.equal(buildScenarioEnemies('enc_does_not_exist_zzz'), null, 'missing -> null');
-  // Only elimination is supported (the combat-adapter resolves victory = all foes dead).
-  // Non-elimination objectives -> null -> fallback, so we never misreport a survival/
-  // capture encounter as an elimination 'scenario' fight (Codex #2567 P2).
-  assert.equal(buildScenarioEnemies('enc_escort_01'), null, 'escort -> null');
-  assert.equal(buildScenarioEnemies('enc_tutorial_02'), null, 'survival -> null');
-  assert.equal(buildScenarioEnemies('enc_caverna_02'), null, 'capture_point -> null');
+  // OA2 (SPEC-O): non-elimination objectives are now SUPPORTED -> authored roster (not
+  // null). The combat-adapter objective-driver (zone-pursuit + objective-outcome) makes
+  // them complete in the sim, so they no longer fall back to the weak fixed enemy.
+  assert.ok(buildScenarioEnemies('enc_caverna_02'), 'capture_point -> roster (OA2)');
 });
 
 // fase-2c difficulty calibration (Finding 1: completion_rate 1.0 OOB). The authored

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -28,11 +28,44 @@ async function runEncounter(http, { roster, enemies, scenarioId, seed, maxRounds
   let rounds = 0;
   let outcome = 'timeout';
   let lastUnits = [];
+  // OA2 (SPEC-O): fetch the objective ONCE -- config drives the policy. Only a
+  // NON-elimination objective polls the live evaluation in-loop; elimination keeps the
+  // alive-count outcome, so the common full-loop path adds ZERO per-round /objective
+  // calls (no evaluator churn -> no flake / no determinism break, Codex #2561).
+  let objective = null;
+  let pollObjective = false;
+  try {
+    const ob = (await http.get(`/api/session/${sessionId}/objective`)).body;
+    if (ob && ob.objective) {
+      objective = ob.objective;
+      pollObjective = !!(objective.type && objective.type !== 'elimination');
+    }
+  } catch {
+    /* objective optional -> elimination fallback */
+  }
   while (rounds < maxRounds) {
     rounds += 1;
     const st = await http.get('/api/session/state', { session_id: sessionId });
     const units = (st.body && st.body.units) || [];
     lastUnits = units;
+    // Non-elimination objective: poll the live evaluation for the outcome.
+    if (pollObjective) {
+      try {
+        const ev = (await http.get(`/api/session/${sessionId}/objective`)).body;
+        if (ev && ev.evaluation) {
+          if (ev.evaluation.completed) {
+            outcome = 'victory';
+            break;
+          }
+          if (ev.evaluation.failed) {
+            outcome = 'defeat';
+            break;
+          }
+        }
+      } catch {
+        /* fall back to alive-count */
+      }
+    }
     const players = units.filter((u) => u.controlled_by === 'player' && (u.hp ?? 0) > 0);
     const foes = units.filter((u) => u.controlled_by === 'sistema' && (u.hp ?? 0) > 0);
     if (foes.length === 0) {
@@ -51,7 +84,7 @@ async function runEncounter(http, { roster, enemies, scenarioId, seed, maxRounds
       await http.post('/api/session/turn/end', { session_id: sessionId });
       continue;
     }
-    const action = selectPlayerAction(active, units);
+    const action = selectPlayerAction(active, units, objective);
     if (!action) {
       await http.post('/api/session/turn/end', { session_id: sessionId });
       continue;

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -1,14 +1,65 @@
 'use strict';
-// Pure player-side AI policy, extracted verbatim from tests/smoke/ai-driven-sim.js
+// Pure player-side AI policy, extracted from tests/smoke/ai-driven-sim.js
 // (minimal closest-enemy attack; never spends cap_pt to keep fairness intact).
 // Reused by the full-loop combatAdapter so the meta-loop combat runs the SAME
 // player policy as the combat-sim, with no co-op lobby coupling.
+//
+// OA2 (SPEC-O): objective-aware. For zone-based objectives (capture_point /
+// sabotage / escape / escort) the policy DRIVES units toward the target zone so
+// non-elimination encounters can complete in the sim (making completion_rate a
+// meaningful calibration metric). In-zone -- or elimination / survival -- falls
+// back to closest-enemy. `objective` is optional: omitted => legacy behavior.
+
+const ZONE_PURSUIT_OBJECTIVES = new Set(['capture_point', 'sabotage', 'escape', 'escort']);
 
 function dist(a, b) {
   return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
 }
 
-function selectPlayerAction(actor, units) {
+function inZone(pos, zone) {
+  return pos.x >= zone[0] && pos.x <= zone[2] && pos.y >= zone[1] && pos.y <= zone[3];
+}
+
+// One-tile greedy step toward a destination (Manhattan, x-axis tie-break).
+function stepToward(actor, dest) {
+  const dx = Math.sign(dest.x - actor.position.x);
+  const dy = Math.sign(dest.y - actor.position.y);
+  const stepX = Math.abs(dest.x - actor.position.x) >= Math.abs(dest.y - actor.position.y);
+  const target_position = stepX
+    ? { x: actor.position.x + dx, y: actor.position.y }
+    : { x: actor.position.x, y: actor.position.y + dy };
+  return { action_type: 'move', target_position };
+}
+
+function selectPlayerAction(actor, units, objective) {
+  // OA2 zone-pursuit: a zone objective + actor outside the zone -> move toward it.
+  const objType = objective && objective.type;
+  const zone = objective && objective.config && objective.config.target_zone;
+  if (ZONE_PURSUIT_OBJECTIVES.has(objType) && Array.isArray(zone) && zone.length >= 4) {
+    if (!inZone(actor.position, zone)) {
+      const centroid = {
+        x: Math.round((zone[0] + zone[2]) / 2),
+        y: Math.round((zone[1] + zone[3]) / 2),
+      };
+      return stepToward(actor, centroid);
+    }
+    // IN zone: HOLD. Attack only an already-in-range enemy; NEVER leave the zone to
+    // chase a far foe (that would break the hold and the objective would never tick).
+    const foes = units.filter((u) => u.controlled_by === 'sistema' && (u.hp ?? 0) > 0);
+    const tgt = foes.length
+      ? foes.sort((a, b) => dist(actor.position, a.position) - dist(actor.position, b.position))[0]
+      : null;
+    if (
+      tgt &&
+      dist(actor.position, tgt.position) <= (actor.attack_range || 1) &&
+      (actor.ap_remaining ?? 0) >= 1
+    ) {
+      return { action_type: 'attack', target_id: tgt.id };
+    }
+    return null; // hold position -> the zone objective ticks
+  }
+
+  // Default / in-zone / elimination / survival: closest-enemy attack-or-approach.
   const enemies = units.filter((u) => u.controlled_by === 'sistema' && (u.hp ?? 0) > 0);
   if (enemies.length === 0) return null;
   const target = enemies.sort(
@@ -18,15 +69,7 @@ function selectPlayerAction(actor, units) {
   if (dist(actor.position, target.position) <= range && (actor.ap_remaining ?? 0) >= 1) {
     return { action_type: 'attack', target_id: target.id };
   }
-  const dx = Math.sign(target.position.x - actor.position.x);
-  const dy = Math.sign(target.position.y - actor.position.y);
-  const stepX =
-    Math.abs(target.position.x - actor.position.x) >=
-    Math.abs(target.position.y - actor.position.y);
-  const target_position = stepX
-    ? { x: actor.position.x + dx, y: actor.position.y }
-    : { x: actor.position.x, y: actor.position.y + dy };
-  return { action_type: 'move', target_position };
+  return stepToward(actor, target.position);
 }
 
-module.exports = { dist, selectPlayerAction };
+module.exports = { dist, inZone, selectPlayerAction, ZONE_PURSUIT_OBJECTIVES };

--- a/tools/sim/scenario-enemies.js
+++ b/tools/sim/scenario-enemies.js
@@ -49,7 +49,19 @@ const GRID_SAFE_MAX = 5;
 // be a DIFFERENT fight than authored. We return null (-> fallback to the weak-fixed enemy)
 // instead of misreporting it as an elimination 'scenario' fight (Codex #2567 P2). Faithful
 // survival/capture staging + the authored grid are deferred to fase-2c.
-const SUPPORTED_OBJECTIVES = new Set(['elimination']);
+// OA2 (SPEC-O): all 6 objective types get their authored scaled roster -- the
+// combat-adapter objective-driver (combat-policy zone-pursuit) + objective-outcome
+// make non-elimination encounters actually complete in the sim, so completion_rate
+// is a meaningful band metric (was: only 'elimination', non-elim fell back to a
+// weak fixed enemy -> degenerate calibration).
+const SUPPORTED_OBJECTIVES = new Set([
+  'elimination',
+  'capture_point',
+  'sabotage',
+  'escort',
+  'survival',
+  'escape',
+]);
 
 // `scaling` is the band-batch calibration overlay (fase-2c). Faithful default = {} (no
 // scaling = the authored 2-base-unit fight). countMult/countAdd scale the roster SIZE (the


### PR DESCRIPTION
## Cosa
Greenlit (deep). Makes NON-elimination encounters actually complete in the full-loop sim -- was `SUPPORTED_OBJECTIVES={elimination}` -> non-elim fell back to a weak fixed enemy -> degenerate `completion_rate`.

1. **combat-policy** (objective-aware): zone-pursuit (move toward `target_zone`) + **HOLD in-zone** (attack only an in-range enemy, never leave to chase -> the hold ticks so capture/sabotage complete).
2. **combat-adapter** (objective-OUTCOME): reads `/objective` evaluation -> completed=victory / failed=defeat. Fetched ONCE for config; **polled in-loop ONLY for non-elimination** -> the elimination full-loop path adds ZERO per-round `/objective` calls (no evaluator churn -> determinism preserved).
3. **scenario-enemies** `SUPPORTED_OBJECTIVES` = all 6 (non-elim get their authored roster).

## Live-smoke (verified)
`enc_sabotage_01` completes via the objective against an IMMORTAL foe (hp 300) -> victory = objective (not elimination). Captured as an integration test.

## Tests
combatPolicy 9/9 (zone-pursuit / in-zone hold / FAR-enemy-hold / elimination-unchanged / backward-compat). combatAdapter 3/3. scenarioEnemies updated (non-elim now supported). **Full sim suite 122/122 stable x3** (an earlier OA2 draft flaked the suite by polling `/objective` -- which live-ticks the evaluator -- every round incl. elimination; fixed by the once-fetch + non-elim-only poll).

## Residuo
`completion_rate` N=40 tuning of the sabotage/escape DRAFT templates; multi-unit traversal for `min_units_in_zone>1` (capture min=2 needs both units to reach + hold).

tools/sim only (no backend/forbidden paths), no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)