### PR TITLE
feat(i18n): NF3 PR-5 -- 4 panel label-maps to t() (biome/ennea/inner/character)

### DIFF
--- a/apps/play/src/biomeChip.js
+++ b/apps/play/src/biomeChip.js
@@ -15,20 +15,9 @@
 
 'use strict';
 
-// Pure: biome_id → IT label umano. Mappa canonical, fallback caps trasformazione.
-const BIOME_LABELS = {
-  savana: 'Savana',
-  caverna: 'Caverna',
-  caverna_risonante: 'Caverna risonante',
-  caverna_sotterranea: 'Caverna sotterranea',
-  foresta: 'Foresta',
-  pianura_aperta: 'Pianura aperta',
-  rovine_planari: 'Rovine planari',
-  abisso_vulcanico: 'Abisso vulcanico',
-  atollo_obsidiana: 'Atollo di Obsidiana',
-  cattedrale_apex: "Cattedrale dell'Apex",
-  frattura_stellare: 'Frattura stellare',
-};
+// SPEC-N PR-5 (NF3): label-maps migrated to the i18n loader (data/i18n SSOT).
+// IT values unchanged (biome_label/biome_eco.it == old hardcoded maps); EN now covered.
+import { t } from './i18n.js';
 
 const BIOME_ICONS = {
   savana: '🌾',
@@ -50,7 +39,9 @@ const DEFAULT_ICON = '🌍';
 export function labelForBiome(biomeId) {
   if (!biomeId) return '';
   const key = String(biomeId).toLowerCase();
-  if (BIOME_LABELS[key]) return BIOME_LABELS[key];
+  const i18nKey = `biome_label.${key}`;
+  const label = t(i18nKey);
+  if (label !== i18nKey) return label;
   // Fallback: snake_case → Title Case
   return key
     .split('_')
@@ -83,16 +74,10 @@ export function pressureTier(biomeModifiers) {
 // ADR "Per il giocatore" doctrine: il nome "ERMES" non appare MAI al player.
 // low = calmo, med = in equilibrio, high = in tensione. Unknown → ''.
 export function ecoBandLabel(band) {
-  switch (band) {
-    case 'low':
-      return 'Bioma calmo';
-    case 'med':
-      return 'Bioma in equilibrio';
-    case 'high':
-      return 'Bioma in tensione';
-    default:
-      return '';
-  }
+  if (!band) return '';
+  const i18nKey = `biome_eco.${band}`;
+  const label = t(i18nKey);
+  return label === i18nKey ? '' : label;
 }
 
 // Pure: payload → HTML chip. Returns empty string se biome_id mancante.

--- a/apps/play/src/characterPanel.js
+++ b/apps/play/src/characterPanel.js
@@ -22,6 +22,7 @@
 
 import { api } from './api.js';
 import { renderPortraitPanel } from './portraitPanel.js';
+import { t } from './i18n.js';
 
 const STATE = {
   overlayEl: null,
@@ -30,13 +31,38 @@ const STATE = {
   lastVc: null,
 };
 
-// Italian axis labels (allineato a apps/backend/services/mbtiSurface.js).
-const AXIS_LABELS = {
-  E_I: { label: 'Energia sociale', lo: 'Estroversione', hi: 'Introversione' },
-  S_N: { label: 'Percezione', lo: 'Intuizione', hi: 'Sensazione' },
-  T_F: { label: 'Decisione', lo: 'Sentimento', hi: 'Pensiero' },
-  J_P: { label: 'Stile', lo: 'Percezione', hi: 'Giudizio' },
-};
+// SPEC-N PR-5 (NF3): axis + ennea labels migrated to the i18n loader (data/i18n
+// SSOT). IT values unchanged (mbti_axis_detail/ennea_archetype/ennea_desc.it ==
+// old hardcoded maps); EN now covered. Allineato a backend/services/mbtiSurface.js.
+export function axisLabel(axis) {
+  const base = `mbti_axis_detail.${axis}`;
+  return {
+    label: t(`${base}.label`),
+    lo: t(`${base}.lo`),
+    hi: t(`${base}.hi`),
+  };
+}
+
+// Pure: ennea archetype_id ('Architetto(5)') -> IT label/desc via i18n.
+// Number parsed from id parens; empty string if unknown.
+function enneaNum(id) {
+  const m = /\((\d)\)/.exec(String(id || ''));
+  return m ? m[1] : null;
+}
+export function enneaLabel(id) {
+  const n = enneaNum(id);
+  if (!n) return '';
+  const key = `ennea_archetype.${n}`;
+  const v = t(key);
+  return v === key ? '' : v;
+}
+export function enneaDesc(id) {
+  const n = enneaNum(id);
+  if (!n) return '';
+  const key = `ennea_desc.${n}`;
+  const v = t(key);
+  return v === key ? '' : v;
+}
 
 // Sprint v3.5 — Conviction badge color palette (mirror backend mbtiSurface.AXIS_COLORS).
 const CONVICTION_COLORS = {
@@ -50,25 +76,18 @@ const CONVICTION_BADGE_DURATION_MS = 3000;
 let _convictionBadgeTimer = null;
 const _seenBadgeKeys = new Set();
 
-// Ennea archetypes label/icon (italiano evocativo, no numeri).
+// Ennea archetype icons (locale-neutral UI). Labels + descriptions = i18n SSOT
+// (enneaLabel/enneaDesc -> ennea_archetype/ennea_desc namespaces).
 const ENNEA_META = {
-  'Riformatore(1)': { icon: '⚖️', label: 'Riformatore', desc: 'Setup metodico, alta precisione.' },
-  'Coordinatore(2)': { icon: '🤝', label: 'Coordinatore', desc: 'Coesione di squadra.' },
-  'Conquistatore(3)': { icon: '🔥', label: 'Conquistatore', desc: 'Aggressione e rischio.' },
-  'Individualista(4)': {
-    icon: '🌙',
-    label: 'Individualista',
-    desc: 'Resilienza in zona critica.',
-  },
-  'Architetto(5)': {
-    icon: '🏛️',
-    label: 'Architetto',
-    desc: 'Strategia metodica, basso rischio.',
-  },
-  'Lealista(6)': { icon: '🛡️', label: 'Lealista', desc: 'Vigilanza e supporto attivo.' },
-  'Esploratore(7)': { icon: '🧭', label: 'Esploratore', desc: 'Scoperta e mobilità.' },
-  'Cacciatore(8)': { icon: '🏹', label: 'Cacciatore', desc: 'Mordi-e-fuggi mirato.' },
-  'Stoico(9)': { icon: '🗿', label: 'Stoico', desc: 'Endurance sotto pressione.' },
+  'Riformatore(1)': { icon: '⚖️' },
+  'Coordinatore(2)': { icon: '🤝' },
+  'Conquistatore(3)': { icon: '🔥' },
+  'Individualista(4)': { icon: '🌙' },
+  'Architetto(5)': { icon: '🏛️' },
+  'Lealista(6)': { icon: '🛡️' },
+  'Esploratore(7)': { icon: '🧭' },
+  'Cacciatore(8)': { icon: '🏹' },
+  'Stoico(9)': { icon: '🗿' },
 };
 
 function injectStyles() {
@@ -319,7 +338,7 @@ function renderMbtiSection(actorVc) {
 
   const axisRows = ['E_I', 'S_N', 'T_F', 'J_P']
     .map((axis) => {
-      const labels = AXIS_LABELS[axis];
+      const labels = axisLabel(axis);
       const entry = axes[axis];
       const revealed = revealedMap.revealed[axis];
       const hidden = revealedMap.hidden[axis];
@@ -369,12 +388,14 @@ function renderEnneaSection(actorVc) {
   }
   const cards = archetypes
     .map((a) => {
-      const meta = ENNEA_META[a.id] || { icon: '◯', label: a.id, desc: '' };
+      const meta = ENNEA_META[a.id] || { icon: '◯' };
+      const label = enneaLabel(a.id) || a.id;
+      const desc = enneaDesc(a.id);
       const cls = a.triggered ? 'ennea-badge triggered' : 'ennea-badge';
       return `
         <div class="${cls}" data-archetype="${escapeHtml(a.id)}">
-          <span class="ennea-icon">${meta.icon}</span><span class="ennea-label">${escapeHtml(meta.label)}</span>
-          <div class="ennea-desc">${escapeHtml(meta.desc)}</div>
+          <span class="ennea-icon">${meta.icon}</span><span class="ennea-label">${escapeHtml(label)}</span>
+          <div class="ennea-desc">${escapeHtml(desc)}</div>
         </div>
       `;
     })

--- a/apps/play/src/enneaVoiceRender.js
+++ b/apps/play/src/enneaVoiceRender.js
@@ -22,30 +22,41 @@
 // `<mbti axis="X">...</mbti>` via mbtiTaggedLine usando il polo dominante
 // dell'attore; qui lo renderizziamo a colori (forceReveal — la voce È il reveal).
 import { renderMbtiTaggedHtml } from './dialogueRender.js';
+import { t } from './i18n.js';
 
 // Mapping archetype_id → metadata UI (icon + label + color).
 // Color = Disco-Elysium thought cabinet aesthetic (subtle gradient bg).
 const ARCHETYPE_META = {
-  'Riformatore(1)': { icon: '◉', label: 'Riformatore', cls: 'archetype-1' },
-  'Coordinatore(2)': { icon: '◈', label: 'Coordinatore', cls: 'archetype-2' },
-  'Conquistatore(3)': { icon: '◆', label: 'Conquistatore', cls: 'archetype-3' },
-  'Individualista(4)': { icon: '◇', label: 'Individualista', cls: 'archetype-4' },
-  'Architetto(5)': { icon: '⌬', label: 'Architetto', cls: 'archetype-5' },
-  'Lealista(6)': { icon: '◬', label: 'Lealista', cls: 'archetype-6' },
-  'Esploratore(7)': { icon: '✦', label: 'Esploratore', cls: 'archetype-7' },
-  'Cacciatore(8)': { icon: '⬢', label: 'Cacciatore', cls: 'archetype-8' },
-  'Stoico(9)': { icon: '○', label: 'Stoico', cls: 'archetype-9' },
+  'Riformatore(1)': { icon: '◉', cls: 'archetype-1' },
+  'Coordinatore(2)': { icon: '◈', cls: 'archetype-2' },
+  'Conquistatore(3)': { icon: '◆', cls: 'archetype-3' },
+  'Individualista(4)': { icon: '◇', cls: 'archetype-4' },
+  'Architetto(5)': { icon: '⌬', cls: 'archetype-5' },
+  'Lealista(6)': { icon: '◬', cls: 'archetype-6' },
+  'Esploratore(7)': { icon: '✦', cls: 'archetype-7' },
+  'Cacciatore(8)': { icon: '⬢', cls: 'archetype-8' },
+  'Stoico(9)': { icon: '○', cls: 'archetype-9' },
 };
 
-// Beat label IT per UI tooltip / hint.
-const BEAT_LABEL_IT = {
-  victory_solo: 'Vittoria',
-  defeat_critical: 'Sconfitta',
-  combat_attack_committed: 'Attacco',
-  combat_defense_braced: 'Difesa',
-  exploration_new_tile: 'Esplorazione',
-  low_hp_warning: 'Crisi',
-};
+// SPEC-N PR-5 (NF3): archetype + beat labels migrated to the i18n loader
+// (data/i18n SSOT). IT values unchanged (ennea_archetype/ennea_beat.it == old
+// hardcoded maps); EN now covered. Archetype number parsed from id parens.
+export function archetypeLabel(archetypeId) {
+  const m = /\((\d)\)/.exec(String(archetypeId || ''));
+  if (!m) return '';
+  const key = `ennea_archetype.${m[1]}`;
+  const label = t(key);
+  return label === key ? '' : label;
+}
+
+// Pure: beat_id -> IT label via i18n; raw beat_id fallback if unknown.
+export function beatLabel(beatId) {
+  const id = String(beatId || '');
+  if (!id) return '';
+  const key = `ennea_beat.${id}`;
+  const label = t(key);
+  return label === key ? id : label;
+}
 
 // Pure: voice payload → HTML card. Empty string se payload invalido.
 export function formatVoiceLine(voice) {
@@ -56,16 +67,17 @@ export function formatVoiceLine(voice) {
   if (!archetypeId || !text) return '';
   const meta = ARCHETYPE_META[archetypeId];
   if (!meta) return '';
+  const label = archetypeLabel(archetypeId);
   const beatId = String(voice.beat_id || '').trim();
-  const beatLabel = BEAT_LABEL_IT[beatId] || beatId;
+  const beatText = beatLabel(beatId);
   const actorAttr = actorId ? ` data-actor-id="${escapeHtml(actorId)}"` : '';
-  const beatHtml = beatLabel
-    ? `<span class="db-ennea-voice-beat">${escapeHtml(beatLabel)}</span>`
+  const beatHtml = beatText
+    ? `<span class="db-ennea-voice-beat">${escapeHtml(beatText)}</span>`
     : '';
   return `<div class="db-ennea-voice ${meta.cls}"${actorAttr}>
     <div class="db-ennea-voice-header">
       <span class="db-ennea-voice-icon">${meta.icon}</span>
-      <span class="db-ennea-voice-label">${escapeHtml(meta.label)}</span>
+      <span class="db-ennea-voice-label">${escapeHtml(label)}</span>
       ${beatHtml}
     </div>
     <div class="db-ennea-voice-text">"${renderMbtiTaggedHtml(text, null, { forceReveal: true })}"</div>
@@ -110,8 +122,7 @@ export function renderEnneaVoices(sectionEl, listEl, payload) {
   listEl.innerHTML = html;
 }
 
-// Test hook: expose ARCHETYPE_META + BEAT_LABEL_IT for parity tests.
+// Test hook: expose ARCHETYPE_META (icon + cls) for palette tests.
 export const _internals = {
   ARCHETYPE_META,
-  BEAT_LABEL_IT,
 };

--- a/apps/play/src/innerVoiceRender.js
+++ b/apps/play/src/innerVoiceRender.js
@@ -17,13 +17,18 @@
 // Color-coding: backend wraps `voice_it` in `<mbti axis="X">...</mbti>` via
 // mbtiTaggedLine; here we colorize it (forceReveal — the voice IS the reveal).
 import { renderMbtiTaggedHtml } from './dialogueRender.js';
+import { t } from './i18n.js';
 
-// Tier label IT for the intensity badge (whisper → shout).
-const TIER_LABEL_IT = {
-  whisper: 'sussurro',
-  voice: 'voce',
-  shout: 'grido',
-};
+// SPEC-N PR-5 (NF3): tier label migrated to the i18n loader (data/i18n SSOT).
+// IT values unchanged (voice_tier.it == old TIER_LABEL_IT); EN now covered.
+// Pure: tier -> IT label via i18n; raw tier fallback if unknown.
+export function tierLabel(tier) {
+  const id = String(tier || '');
+  if (!id) return '';
+  const key = `voice_tier.${id}`;
+  const label = t(key);
+  return label === key ? id : label;
+}
 
 // Pure: inner voice payload → HTML card. Empty string if payload invalid.
 export function formatInnerVoiceLine(voice) {
@@ -39,10 +44,10 @@ export function formatInnerVoiceLine(voice) {
   const axisAttr = axis ? ` data-axis="${escapeHtml(axis)}"` : '';
   const label = String(voice.label || '').trim();
   const tier = String(voice.tier || '').trim();
-  const tierLabel = TIER_LABEL_IT[tier] || tier;
+  const tierText = tierLabel(tier);
   const labelHtml = label ? `<span class="db-inner-voice-label">${escapeHtml(label)}</span>` : '';
-  const tierHtml = tierLabel
-    ? `<span class="db-inner-voice-tier">${escapeHtml(tierLabel)}</span>`
+  const tierHtml = tierText
+    ? `<span class="db-inner-voice-tier">${escapeHtml(tierText)}</span>`
     : '';
   const poleIcon = pole ? `<span class="db-inner-voice-pole">${escapeHtml(pole)}</span>` : '';
   return `<div class="db-inner-voice${poleCls}"${actorAttr}${poleAttr}${axisAttr}>
@@ -92,5 +97,4 @@ export function renderInnerVoices(sectionEl, listEl, payload) {
   listEl.innerHTML = html;
 }
 
-// Test hook: expose TIER_LABEL_IT for parity tests.
-export const _internals = { TIER_LABEL_IT };
+// tierLabel() is exported directly above for i18n parity tests (SPEC-N PR-5).

--- a/data/i18n/en/common.json
+++ b/data/i18n/en/common.json
@@ -116,5 +116,80 @@
     "deaf_hoh_enabled": "Deaf/HoH mode enabled",
     "colorblind_enabled": "Colorblind mode enabled",
     "reduce_motion_enabled": "Reduce motion enabled"
+  },
+  "biome_label": {
+    "savana": "Savanna",
+    "caverna": "Cavern",
+    "caverna_risonante": "Resonant Cavern",
+    "caverna_sotterranea": "Underground Cavern",
+    "foresta": "Forest",
+    "pianura_aperta": "Open Plain",
+    "rovine_planari": "Planar Ruins",
+    "abisso_vulcanico": "Volcanic Abyss",
+    "atollo_obsidiana": "Obsidian Atoll",
+    "cattedrale_apex": "Apex Cathedral",
+    "frattura_stellare": "Stellar Fracture"
+  },
+  "biome_eco": {
+    "low": "Calm biome",
+    "med": "Balanced biome",
+    "high": "Tense biome"
+  },
+  "ennea_archetype": {
+    "1": "Reformer",
+    "2": "Coordinator",
+    "3": "Conqueror",
+    "4": "Individualist",
+    "5": "Architect",
+    "6": "Loyalist",
+    "7": "Explorer",
+    "8": "Hunter",
+    "9": "Stoic"
+  },
+  "ennea_beat": {
+    "victory_solo": "Victory",
+    "defeat_critical": "Defeat",
+    "combat_attack_committed": "Attack",
+    "combat_defense_braced": "Defense",
+    "exploration_new_tile": "Exploration",
+    "low_hp_warning": "Crisis"
+  },
+  "ennea_desc": {
+    "1": "Methodical setup, high precision.",
+    "2": "Team cohesion.",
+    "3": "Aggression and risk.",
+    "4": "Resilience in the critical zone.",
+    "5": "Methodical strategy, low risk.",
+    "6": "Vigilance and active support.",
+    "7": "Discovery and mobility.",
+    "8": "Targeted hit-and-run.",
+    "9": "Endurance under pressure."
+  },
+  "voice_tier": {
+    "whisper": "whisper",
+    "voice": "voice",
+    "shout": "shout"
+  },
+  "mbti_axis_detail": {
+    "E_I": {
+      "label": "Social energy",
+      "lo": "Extraversion",
+      "hi": "Introversion"
+    },
+    "S_N": {
+      "label": "Perception",
+      "lo": "Intuition",
+      "hi": "Sensing"
+    },
+    "T_F": {
+      "label": "Decision",
+      "lo": "Feeling",
+      "hi": "Thinking"
+    },
+    "J_P": {
+      "label": "Style",
+      "lo": "Perceiving",
+      "hi": "Judging"
+    }
   }
 }

--- a/data/i18n/it/common.json
+++ b/data/i18n/it/common.json
@@ -116,5 +116,80 @@
     "deaf_hoh_enabled": "Modalità Sordi/HoH attiva",
     "colorblind_enabled": "Modalità Daltonismo attiva",
     "reduce_motion_enabled": "Riduci animazioni attivo"
+  },
+  "biome_label": {
+    "savana": "Savana",
+    "caverna": "Caverna",
+    "caverna_risonante": "Caverna risonante",
+    "caverna_sotterranea": "Caverna sotterranea",
+    "foresta": "Foresta",
+    "pianura_aperta": "Pianura aperta",
+    "rovine_planari": "Rovine planari",
+    "abisso_vulcanico": "Abisso vulcanico",
+    "atollo_obsidiana": "Atollo di Obsidiana",
+    "cattedrale_apex": "Cattedrale dell'Apex",
+    "frattura_stellare": "Frattura stellare"
+  },
+  "biome_eco": {
+    "low": "Bioma calmo",
+    "med": "Bioma in equilibrio",
+    "high": "Bioma in tensione"
+  },
+  "ennea_archetype": {
+    "1": "Riformatore",
+    "2": "Coordinatore",
+    "3": "Conquistatore",
+    "4": "Individualista",
+    "5": "Architetto",
+    "6": "Lealista",
+    "7": "Esploratore",
+    "8": "Cacciatore",
+    "9": "Stoico"
+  },
+  "ennea_beat": {
+    "victory_solo": "Vittoria",
+    "defeat_critical": "Sconfitta",
+    "combat_attack_committed": "Attacco",
+    "combat_defense_braced": "Difesa",
+    "exploration_new_tile": "Esplorazione",
+    "low_hp_warning": "Crisi"
+  },
+  "ennea_desc": {
+    "1": "Setup metodico, alta precisione.",
+    "2": "Coesione di squadra.",
+    "3": "Aggressione e rischio.",
+    "4": "Resilienza in zona critica.",
+    "5": "Strategia metodica, basso rischio.",
+    "6": "Vigilanza e supporto attivo.",
+    "7": "Scoperta e mobilità.",
+    "8": "Mordi-e-fuggi mirato.",
+    "9": "Endurance sotto pressione."
+  },
+  "voice_tier": {
+    "whisper": "sussurro",
+    "voice": "voce",
+    "shout": "grido"
+  },
+  "mbti_axis_detail": {
+    "E_I": {
+      "label": "Energia sociale",
+      "lo": "Estroversione",
+      "hi": "Introversione"
+    },
+    "S_N": {
+      "label": "Percezione",
+      "lo": "Intuizione",
+      "hi": "Sensazione"
+    },
+    "T_F": {
+      "label": "Decisione",
+      "lo": "Sentimento",
+      "hi": "Pensiero"
+    },
+    "J_P": {
+      "label": "Stile",
+      "lo": "Percezione",
+      "hi": "Giudizio"
+    }
   }
 }

--- a/tests/play/characterPanel.test.js
+++ b/tests/play/characterPanel.test.js
@@ -1,0 +1,67 @@
+// SPEC-N PR-5 (NF3) -- characterPanel i18n label helpers.
+//
+// axisLabel + enneaLabel + enneaDesc resolve from the data/i18n SSOT. IT values
+// are byte-identical to the old AXIS_LABELS / ENNEA_META hardcoded maps (so the
+// IT player sees no change); EN parity is covered by tests/i18n/parity.test.js.
+// Pure helpers only -- no DOM, no api fetch exercised at import.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadModule() {
+  return import('../../apps/play/src/characterPanel.js');
+}
+
+describe('axisLabel -- MBTI axis detail labels (i18n)', () => {
+  test('canonical axes -> IT {label, lo, hi} byte-identical to old AXIS_LABELS', async () => {
+    const { axisLabel } = await loadModule();
+    assert.deepEqual(axisLabel('E_I'), {
+      label: 'Energia sociale',
+      lo: 'Estroversione',
+      hi: 'Introversione',
+    });
+    assert.deepEqual(axisLabel('S_N'), {
+      label: 'Percezione',
+      lo: 'Intuizione',
+      hi: 'Sensazione',
+    });
+    assert.deepEqual(axisLabel('T_F'), {
+      label: 'Decisione',
+      lo: 'Sentimento',
+      hi: 'Pensiero',
+    });
+    assert.deepEqual(axisLabel('J_P'), {
+      label: 'Stile',
+      lo: 'Percezione',
+      hi: 'Giudizio',
+    });
+  });
+});
+
+describe('enneaLabel / enneaDesc -- archetype labels + descriptions (i18n)', () => {
+  test('id parens -> IT label byte-identical to old ENNEA_META', async () => {
+    const { enneaLabel } = await loadModule();
+    assert.equal(enneaLabel('Riformatore(1)'), 'Riformatore');
+    assert.equal(enneaLabel('Architetto(5)'), 'Architetto');
+    assert.equal(enneaLabel('Cacciatore(8)'), 'Cacciatore');
+    assert.equal(enneaLabel('Stoico(9)'), 'Stoico');
+  });
+
+  test('id parens -> IT desc byte-identical to old ENNEA_META (ASCII subset)', async () => {
+    const { enneaDesc } = await loadModule();
+    assert.equal(enneaDesc('Riformatore(1)'), 'Setup metodico, alta precisione.');
+    assert.equal(enneaDesc('Conquistatore(3)'), 'Aggressione e rischio.');
+    assert.equal(enneaDesc('Stoico(9)'), 'Endurance sotto pressione.');
+  });
+
+  test('unknown / malformed id -> empty strings (graceful)', async () => {
+    const { enneaLabel, enneaDesc } = await loadModule();
+    assert.equal(enneaLabel('Unknown(99)'), ''); // 2-digit, no single-digit key
+    assert.equal(enneaLabel('garbage'), ''); // no parens
+    assert.equal(enneaLabel(null), '');
+    assert.equal(enneaDesc('garbage'), '');
+    assert.equal(enneaDesc(undefined), '');
+  });
+});

--- a/tests/play/enneaVoiceRender.test.js
+++ b/tests/play/enneaVoiceRender.test.js
@@ -62,16 +62,26 @@ describe('formatVoiceLine — pure HTML formatter', () => {
     }
   });
 
-  test('beat_id mapping IT — known beats translate to label', async () => {
-    const { formatVoiceLine, _internals } = await loadModule();
-    assert.equal(_internals.BEAT_LABEL_IT.victory_solo, 'Vittoria');
-    assert.equal(_internals.BEAT_LABEL_IT.defeat_critical, 'Sconfitta');
+  test('beat_id mapping IT — known beats translate to label (i18n)', async () => {
+    const { formatVoiceLine, beatLabel } = await loadModule();
+    assert.equal(beatLabel('victory_solo'), 'Vittoria');
+    assert.equal(beatLabel('defeat_critical'), 'Sconfitta');
     const html = formatVoiceLine({
       archetype_id: 'Cacciatore(8)',
       beat_id: 'defeat_critical',
       text: 'tear',
     });
     assert.ok(html.includes('Sconfitta'));
+  });
+
+  test('archetypeLabel — id parens → IT label via i18n (SPEC-N PR-5)', async () => {
+    const { archetypeLabel } = await loadModule();
+    assert.equal(archetypeLabel('Riformatore(1)'), 'Riformatore');
+    assert.equal(archetypeLabel('Architetto(5)'), 'Architetto');
+    assert.equal(archetypeLabel('Stoico(9)'), 'Stoico');
+    assert.equal(archetypeLabel('Unknown(99)'), ''); // 2-digit / no key → empty
+    assert.equal(archetypeLabel('garbage'), ''); // no parens → empty
+    assert.equal(archetypeLabel(null), '');
   });
 
   test('unknown beat_id falls back to raw beat_id (no exception)', async () => {


### PR DESCRIPTION
## NF3 PR-5 -- migrate 4 panel label-maps to the i18n loader

SPEC-N NF3 grind, continuation of PR-4 (objectivePanel/thoughtsPanel). Moves discrete
**label-map dictionaries** from 4 `apps/play` panels into the `data/i18n` SSOT, IT values
**byte-identical** (no displayed-text change for IT players), EN now covered.

### Migrated (4 panels)
| Panel | Maps -> i18n namespace |
|---|---|
| biomeChip | `BIOME_LABELS` -> `biome_label.*` (11) · `ecoBandLabel` -> `biome_eco.*` (3) |
| enneaVoiceRender | `ARCHETYPE_META.label` -> `ennea_archetype.*` (9) · `BEAT_LABEL_IT` -> `ennea_beat.*` (6) |
| innerVoiceRender | `TIER_LABEL_IT` -> `voice_tier.*` (3) |
| characterPanel | `AXIS_LABELS` -> `mbti_axis_detail.*` (12) · `ENNEA_META` label/desc -> `ennea_archetype`/`ennea_desc.*` (18) |

Emoji icons stay inline (locale-neutral, like the prior `TYPE_ICONS`). New pure i18n-backed
exports: `archetypeLabel` / `beatLabel` / `tierLabel` / `axisLabel` / `enneaLabel` / `enneaDesc`.

### Verification
- `tools/py/validate_i18n_parity.py` -> **errors=0** (it<->en parity + interpolation).
- **352** play + i18n tests green (existing exact-IT-string assertions = byte-identical guard; enneaVoice beat test repointed to `beatLabel()`; new `characterPanel.test.js`).
- `npm run play:build` (vite) OK -- 50 modules.
- Prettier clean.

### Scope decisions (deliberately out of this PR)
- **speciesNames.js** `SPECIES_DISPLAY_IT` -- YAML content-mirror (`species.yaml` SoT), EN undefined; not UI chrome (same class as thoughtsPanel `CLIENT_CATALOG`). Belongs to species-YAML enrichment workstream.
- **ui.js** `STATUS_LABELS` -- EN abbreviations ("Panic"/"Stun") + key-mismatch vs existing `status` ns + color/svg entangled = displayed-text change, separate design call.
- **debriefPanel.js** carries a self-contained `ENNEA_META` mirror (independent copy, NOT broken by this PR) -> **NF3 PR-6** candidate to dedupe against the new shared namespaces.

### Merge gate
Net ~248 new lines **outside `apps/backend`** -> exceeds the 50-line gate (L3 auto-merge gate #6)
-> **manual Master-DD merge** (no auto-merge). Forbidden paths: none touched.

### Rollback
Revert commit `d5d437ee9` (additive label-maps + JSON; no schema/runtime contract change).

Coding-Agent: claude-opus-4-8
