### PR TITLE
fix(sim): OA2 zone-pursuit multi-unit traversal (min_units_in_zone>1 satisfiable)

### DIFF
--- a/tests/sim/combatPolicy.test.js
+++ b/tests/sim/combatPolicy.test.js
@@ -68,3 +68,53 @@ test('no objective arg -> backward compat (closest enemy)', () => {
   const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 4, y: 0 } }];
   assert.deepEqual(selectPlayerAction(actor, units).target_position, { x: 1, y: 0 });
 });
+
+// OA2 item 7: min_units_in_zone > 1 must be satisfiable. Pursuers must spread
+// across DISTINCT free zone tiles instead of funneling onto one entry tile --
+// single-tile occupancy (session.js "niente overlap") otherwise strands the 2nd
+// unit one tile outside the zone forever, capping units_in_zone at 1.
+test('zone pursuit: two units from adjacent spawns BOTH reach the zone (min_units=2)', () => {
+  const ZONE = [4, 4, 6, 6]; // enc_capture_01
+  const obj = { type: 'capture_point', config: { target_zone: ZONE } };
+  const units = [
+    {
+      id: 'p1',
+      controlled_by: 'player',
+      hp: 10,
+      ap_remaining: 2,
+      attack_range: 1,
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: 'p2',
+      controlled_by: 'player',
+      hp: 10,
+      ap_remaining: 2,
+      attack_range: 1,
+      position: { x: 0, y: 1 },
+    },
+    { id: 'e1', controlled_by: 'sistema', hp: 10, attack_range: 1, position: { x: 9, y: 9 } },
+  ];
+  const players = units.filter((u) => u.controlled_by === 'player');
+  const occupiedBy = (x, y, selfId) =>
+    units.find(
+      (u) => u.id !== selfId && (u.hp ?? 0) > 0 && u.position.x === x && u.position.y === y,
+    );
+  // Mirror the backend turn+occupancy loop: one move per player per tick; a move
+  // onto an occupied tile is rejected (backend returns 400 "casella occupata").
+  for (let t = 0; t < 60; t += 1) {
+    for (const p of players) {
+      const a = selectPlayerAction(p, units, obj);
+      if (!a || a.action_type !== 'move') continue;
+      if (occupiedBy(a.target_position.x, a.target_position.y, p.id)) continue;
+      p.position = { x: a.target_position.x, y: a.target_position.y };
+    }
+  }
+  const inZoneTile = (pos) => pos.x >= 4 && pos.x <= 6 && pos.y >= 4 && pos.y <= 6;
+  const count = players.filter((p) => inZoneTile(p.position)).length;
+  assert.equal(
+    count,
+    2,
+    `both players must hold the zone (got ${count}: ${players.map((p) => `${p.id}@[${p.position.x},${p.position.y}]`).join(' ')})`,
+  );
+});

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -31,17 +31,82 @@ function stepToward(actor, dest) {
   return { action_type: 'move', target_position };
 }
 
+// OA2 (item 7): tiles occupied by OTHER live units -- move targets the backend
+// rejects with 400 "casella occupata" (session.js "niente overlap").
+function occupiedSet(units, selfId) {
+  const occ = new Set();
+  for (const u of units || []) {
+    if (!u || u.id === selfId || !u.position || (u.hp ?? 0) <= 0) continue;
+    occ.add(`${u.position.x},${u.position.y}`);
+  }
+  return occ;
+}
+
+// Nearest (Manhattan) zone tile not occupied by a live unit. Deterministic
+// tie-break (x then y ascending). Null only if EVERY zone tile is taken.
+function nearestFreeZoneTile(pos, zone, occ) {
+  let best = null;
+  let bestD = Infinity;
+  for (let x = zone[0]; x <= zone[2]; x += 1) {
+    for (let y = zone[1]; y <= zone[3]; y += 1) {
+      if (occ.has(`${x},${y}`)) continue;
+      const d = Math.abs(pos.x - x) + Math.abs(pos.y - y);
+      if (d < bestD) {
+        bestD = d;
+        best = { x, y };
+      }
+    }
+  }
+  return best;
+}
+
+// Step toward a DISTINCT free zone tile, routing around occupied tiles: primary
+// axis, then secondary axis, then a perpendicular sidestep. Lets 2+ units occupy
+// the zone (min_units_in_zone > 1) instead of funneling onto one entry tile where
+// the 2nd unit blocks forever. Null only if fully boxed (caller holds the tick
+// rather than spamming a move the backend rejects).
+function stepTowardZone(actor, zone, units) {
+  const occ = occupiedSet(units, actor.id);
+  const dest = nearestFreeZoneTile(actor.position, zone, occ) || {
+    x: Math.round((zone[0] + zone[2]) / 2),
+    y: Math.round((zone[1] + zone[3]) / 2),
+  };
+  const { x, y } = actor.position;
+  const dx = Math.sign(dest.x - x);
+  const dy = Math.sign(dest.y - y);
+  const primaryX = Math.abs(dest.x - x) >= Math.abs(dest.y - y);
+  const ordered = primaryX
+    ? [
+        { x: x + dx, y },
+        { x, y: y + dy },
+        { x, y: y + 1 },
+        { x, y: y - 1 },
+      ]
+    : [
+        { x, y: y + dy },
+        { x: x + dx, y },
+        { x: x + 1, y },
+        { x: x - 1, y },
+      ];
+  for (const c of ordered) {
+    if (c.x === x && c.y === y) continue; // no-op (axis delta 0)
+    if (c.x < 0 || c.y < 0) continue; // off-board lower bound
+    if (occ.has(`${c.x},${c.y}`)) continue; // would be rejected by occupancy
+    return { action_type: 'move', target_position: c };
+  }
+  return null; // boxed in -> hold this tick
+}
+
 function selectPlayerAction(actor, units, objective) {
   // OA2 zone-pursuit: a zone objective + actor outside the zone -> move toward it.
   const objType = objective && objective.type;
   const zone = objective && objective.config && objective.config.target_zone;
   if (ZONE_PURSUIT_OBJECTIVES.has(objType) && Array.isArray(zone) && zone.length >= 4) {
     if (!inZone(actor.position, zone)) {
-      const centroid = {
-        x: Math.round((zone[0] + zone[2]) / 2),
-        y: Math.round((zone[1] + zone[3]) / 2),
-      };
-      return stepToward(actor, centroid);
+      // OA2 fix (item 7): pursue a DISTINCT free zone tile + route around allies
+      // so min_units_in_zone > 1 objectives are satisfiable (was: a shared
+      // centroid funneled every unit to one tile -> 2nd unit blocked outside).
+      return stepTowardZone(actor, zone, units);
     }
     // IN zone: HOLD. Attack only an already-in-range enemy; NEVER leave the zone to
     // chase a far foe (that would break the hold and the objective would never tick).


### PR DESCRIPTION
## OA2 fix: zone-pursuit spreads pursuers to distinct free tiles (`min_units_in_zone` > 1)

### Root cause (reproduced, not guessed)
The OA2 zone-pursuit policy (`tools/sim/combat-policy.js`) sent **every** pursuing unit to the
**same zone centroid** via an identical greedy `stepToward`. Units from adjacent spawns converge
on the same zone-entry tile; with single-tile occupancy enforced (`session.js` "niente overlap" ->
move onto an occupied tile returns **400**), the 2nd unit blocks **one tile outside the zone**
forever. So `playersInZone` caps at 1 and any objective with `min_units_in_zone >= 2`
(`enc_capture_01` min=2, plus sabotage/escape) **never completes** in the full-loop sim.

A throwaway repro confirmed it: `p1@[4,3] (outside)`, `p2@[4,4]`, `inZoneCount=1`, **73 blocked moves**.

### Fix
`stepTowardZone`: pursue the **nearest UNOCCUPIED zone tile** (recomputed each tick) and, when the
greedy step is blocked by an ally, **sidestep** (primary axis -> secondary axis -> perpendicular).
Returns `null` (hold) only if fully boxed, so a unit never spams a move the backend rejects.

Post-fix repro: `p1@[5,4]`, `p2@[4,4]` (distinct tiles), `inZoneCount=2`, **0 blocked moves**.

### Verification (TDD)
- **RED -> GREEN**: new test `two units from adjacent spawns BOTH reach the zone (min_units=2)` --
  a deterministic multi-tick sim with occupancy. Failed (`got 1: p1@[4,3] p2@[4,4]`) -> passes.
- **32 sim tests green** (`combatPolicy` + `combatAdapter` + `fullLoopRunner` + `scenarioEnemies`).
- Existing zone tests **unchanged** (actor`[5,5]`/zone`[0,0,2,2]` still steps to `[4,5]`; in-zone
  HOLD / attack / elimination / legacy-no-objective paths untouched).

### Impact
Unblocks the OA2 `completion_rate` calibration metric for capture/sabotage/escape with
`min_units_in_zone > 1` (previously structurally un-completable -> 0% completion). No change to
`apps/backend`, the live combat engine, or the legacy smoke path (`ai-driven-sim.js` still calls
the no-objective branch).

### Merge gate
120 insertions in `tools/sim` + `tests/sim` -> exceeds the 50-line-outside-`apps/backend` gate
(L3 auto-merge gate #6) -> **manual Master-DD merge**. Forbidden paths: none touched.

### Rollback
Revert commit `f1df038d1` (isolated policy change; restores the prior shared-centroid step).

Coding-Agent: claude-opus-4-8
