### PR TITLE
feat(campaign): MA1 part 2 -- emergent branco trait from Form Pulse aggregate

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -805,7 +805,7 @@ function createApp(options = {}) {
   // M7 demo playtest: feedback collection (/api/feedback, /api/feedback/summary)
   app.use('/api', createFeedbackRouter(options.feedback || {}));
   // M10 Phase B: campaign persistence + branching (ADR-2026-04-21)
-  app.use('/api', createCampaignRouter(options.campaign || {}));
+  app.use('/api', createCampaignRouter({ ...(options.campaign || {}), coopStore }));
   // V2 Tri-Sorgente post-match reward (2026-04-26 sprint V2)
   app.use('/api', createRewardsRouter());
   // Tunic decipher Codex (2026-04-27 §H.4 ADOPT) — glyph language progression

--- a/apps/backend/routes/campaign.js
+++ b/apps/backend/routes/campaign.js
@@ -45,6 +45,8 @@ const {
 } = require('../services/campaign/ambitionService');
 const { grantXpToSurvivors } = require('../services/progression/progressionApply');
 const { loadXpCurve } = require('../services/progression/progressionLoader');
+// MA1 part 2 (ADR-2026-06-08) -- emergent shared branco trait from the Form Pulse aggregate.
+const { emergeBrancoTraitFromPulses } = require('../services/identity/brancoTraitEmergence');
 
 // TKT-P2 Brigandine seasonal — Phase C routes (engine Phase A #2251 + content Phase B #2252).
 const seasonalEngine = require('../services/campaign/seasonalEngine');
@@ -140,6 +142,10 @@ function computeEvolveOpportunity(outcome, peEarned) {
 
 function createCampaignRouter(options = {}) {
   const router = express.Router();
+  // MA1 part 2: coopStore (optional, injected by app.js) lets /start read the branco
+  // Form Pulse to emerge the shared branco trait. Absent (tests / solo without a coop
+  // run) -> dormant, per-creature traits only.
+  const coopStore = options.coopStore || null;
 
   // POST /api/campaign/start
   // Body: { player_id, campaign_def_id?, initial_trait_choice? }
@@ -194,11 +200,28 @@ function createCampaignRouter(options = {}) {
       }
     }
 
-    const campaign = createCampaign(player_id, defId, {
+    let campaign = createCampaign(player_id, defId, {
       onboardingChoice,
       acquiredTraits,
       acquiredTraitsByCreature,
     });
+
+    // MA1 part 2 (ADR-2026-06-08): emergent branco trait from the aggregated Form
+    // Pulse. Dormant until the Godot Form-Pulse UX populates coopStore formPulses
+    // (no FP / branco indeciso -> no-op; the branco keeps only per-creature traits).
+    if (coopStore && typeof coopStore.getFormPulses === 'function') {
+      const emergent = emergeBrancoTraitFromPulses(coopStore.getFormPulses(campaign.id));
+      if (emergent) {
+        const mergedTraits = campaign.acquiredTraits.includes(emergent.trait_id)
+          ? campaign.acquiredTraits
+          : [...campaign.acquiredTraits, emergent.trait_id];
+        campaign =
+          updateCampaign(campaign.id, {
+            emergentBrancoTrait: emergent,
+            acquiredTraits: mergedTraits,
+          }) || campaign;
+      }
+    }
 
     // Slice A (live routing, flag ON): a graph-routed run begins at the authored
     // start_node and serves its encounter from the graph; the static onboarding chain is

--- a/apps/backend/services/campaign/campaignStore.js
+++ b/apps/backend/services/campaign/campaignStore.js
@@ -72,6 +72,9 @@ function createCampaign(playerId, campaignDefId = 'default_campaign_mvp', opts =
       opts.acquiredTraitsByCreature && typeof opts.acquiredTraitsByCreature === 'object'
         ? { ...opts.acquiredTraitsByCreature }
         : {},
+    // MA1 part 2 (ADR-2026-06-08) -- emergent shared branco trait from the Form
+    // Pulse aggregate ({ trait_id, axis, pole, magnitude } | null). Set at /start.
+    emergentBrancoTrait: opts.emergentBrancoTrait || null,
     // SPEC-P A13 -- biomi feriti cross-run (degrade bounded, cap 2). Persistito qui.
     woundedBiomes: Array.isArray(opts.woundedBiomes) ? [...opts.woundedBiomes] : [],
     // Sprint 3 §III (2026-04-27) — Wildermyth choice→permanent flag pattern.

--- a/apps/backend/services/identity/brancoTraitEmergence.js
+++ b/apps/backend/services/identity/brancoTraitEmergence.js
@@ -1,0 +1,99 @@
+// =============================================================================
+// Emergent branco-trait -- MA1 part 2 (ADR-2026-06-08, SPEC-M onboarding-identity).
+//
+// MA1 (ratified, opzione C ibrida): ogni player sceglie il trait della PROPRIA
+// creatura (per-creatura, gia' DONE = campaign.acquiredTraitsByCreature) + UN
+// trait-branco EMERGENTE dall'aggregato delle scelte (Form Pulse). Questo modulo
+// e' la seconda meta': aggregato Form Pulse -> 1 trait condiviso di branco.
+//
+// DUE livelli, distinti per governance (stesso pattern di formPulseVc):
+//   - MECCANISMO (oggettivo): aggregato -> asse dominante (max |avg|) sopra soglia
+//     -> polo -> trait. Puro, no-mutate, testato.
+//   - MAPPING + SOGLIA (soggettivi): quale asse-creatura/polo -> quale trait, e
+//     quanto deve essere dominante il branco prima che un trait emerga.
+//     `PROPOSED_*` = proposta ragionata, NON un fiat -- da ratificare via N=40
+//     (MA3 anti-hard-gate), come PROPOSED_FP_VC_MAPPING / MAX_FP_VC_DELTA.
+//
+// Dormant fino a che la Form-Pulse UX (Godot) popola `formPulses`: nessun pulse
+// -> aggregato vuoto -> nessun trait emergente (il branco ha solo i trait
+// per-creatura). Anti-pattern museum `personality-mbti-gates-ghost`: i signal
+// sono input MORBIDI, non fissano archetipo ne' hard-gate-ano rami.
+//
+// Assi Form Pulse (creature-themed, da formPulseVc): ogni asse in [-1,+1].
+// =============================================================================
+
+'use strict';
+
+const { aggregateFormPulses } = require('../formPulseVc');
+
+// PROPOSED (ratify via MA3, master-dd / N=40). Soglia di dominanza: |avg| minimo
+// dell'asse di branco prima che un trait emerga. Sotto soglia = branco indeciso
+// -> nessun trait condiviso (solo i per-creatura). 0.30 = lean chiaro, non rumore.
+const EMERGENCE_THRESHOLD = 0.3;
+
+// PROPOSED (ratify via MA3, master-dd). FP creature axis + pole -> branco trait_id.
+// Tutti i trait_id ESISTONO in data/core/traits/active_effects.yaml (il resolver
+// li applica; mismatch = no-op). Polo "+": vedi annotazioni di formPulseVc.
+//   solitary_swarm  + = Sciame (sociale)      / - = solitario
+//   explore_caution + = Cauto (concreto)      / - = esplorazione
+//   symbiosis_predation + = Predazione (freddo)/ - = simbiosi
+//   memory_instinct + = Memoria (planning)    / - = istinto
+//   agile_robust    + = Robusto (forma)        / - = Agile
+const PROPOSED_BRANCO_TRAIT_MAPPING = {
+  solitary_swarm: { '+': 'legame_di_branco', '-': 'mimetismo_cromatico_passivo' },
+  explore_caution: { '+': 'sensori_sismici', '-': 'sensori_geomagnetici' },
+  symbiosis_predation: { '+': 'ferocia', '-': 'empatia_coordinativa' },
+  memory_instinct: { '+': 'cervello_predittivo', '-': 'cervello_a_bassa_latenza' },
+  agile_robust: { '+': 'pelle_elastomera', '-': 'zampe_a_molla' },
+};
+
+/**
+ * Pure: branco axis aggregate -> 1 emergent branco trait (or null).
+ * Mechanism: dominant axis = argmax|avg| among mapped axes; if |avg| >= threshold
+ * the trait for that axis's pole (sign of avg) emerges. Deterministic tie-break
+ * (mapping definition order, first max wins). No-mutate.
+ *
+ * @param aggregate { [creatureAxis]: Number in [-1,1] } (from aggregateFormPulses)
+ * @param opts      { mapping?, threshold? }
+ * @returns { trait_id, axis, pole: '+'|'-', magnitude } | null
+ */
+function emergeBrancoTrait(aggregate, opts = {}) {
+  if (!aggregate || typeof aggregate !== 'object') return null;
+  const mapping = opts.mapping || PROPOSED_BRANCO_TRAIT_MAPPING;
+  const threshold = Number.isFinite(opts.threshold) ? opts.threshold : EMERGENCE_THRESHOLD;
+
+  let bestAxis = null;
+  let bestMag = -Infinity;
+  let bestAvg = 0;
+  for (const axis of Object.keys(mapping)) {
+    const v = Number(aggregate[axis]);
+    if (!Number.isFinite(v)) continue;
+    const mag = Math.abs(v);
+    if (mag > bestMag) {
+      bestMag = mag;
+      bestAxis = axis;
+      bestAvg = v;
+    }
+  }
+  if (bestAxis === null || bestMag < threshold) return null;
+  const pole = bestAvg >= 0 ? '+' : '-';
+  const trait_id = mapping[bestAxis] && mapping[bestAxis][pole];
+  if (!trait_id) return null;
+  return { trait_id, axis: bestAxis, pole, magnitude: bestMag };
+}
+
+/**
+ * Convenience for the campaign wiring: aggregate per-player Form Pulses (Map or
+ * object, player -> {axes} | {axis:Number}) then emerge. Empty/null -> null.
+ */
+function emergeBrancoTraitFromPulses(fpMap, opts = {}) {
+  const aggregate = aggregateFormPulses(fpMap);
+  return emergeBrancoTrait(aggregate, opts);
+}
+
+module.exports = {
+  EMERGENCE_THRESHOLD,
+  PROPOSED_BRANCO_TRAIT_MAPPING,
+  emergeBrancoTrait,
+  emergeBrancoTraitFromPulses,
+};

--- a/tests/api/campaignBrancoEmergence.test.js
+++ b/tests/api/campaignBrancoEmergence.test.js
@@ -1,0 +1,104 @@
+// MA1 part 2 (ADR-2026-06-08) -- emergent branco trait wired into POST /campaign/start.
+//
+// The mechanism (brancoTraitEmergence) is unit-tested in tests/services. Here we
+// verify the dormant plumb: when coopStore exposes a branco Form Pulse, /start
+// emerges the shared branco trait (stored on the campaign + unioned into
+// acquiredTraits); with no coopStore / no Form Pulse it stays dormant (null).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const http = require('node:http');
+
+const { createCampaignRouter } = require('../../apps/backend/routes/campaign');
+const { _resetStore } = require('../../apps/backend/services/campaign/campaignStore');
+const { _resetCache } = require('../../apps/backend/services/campaign/campaignLoader');
+
+// coopStore stub: getFormPulses returns the seeded pulses for ANY campaign id
+// (the real id is generated inside createCampaign, so the test cannot pre-seed it).
+function startServer(t, coopStore) {
+  _resetStore();
+  _resetCache();
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCampaignRouter(coopStore ? { coopStore } : {}));
+  const server = app.listen(0);
+  t.after(() => server.close());
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+function request(method, url, body = null) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        method,
+        headers: { 'content-type': 'application/json' },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () => {
+          let parsedBody = null;
+          try {
+            parsedBody = data ? JSON.parse(data) : null;
+          } catch {
+            parsedBody = data;
+          }
+          resolve({ status: res.statusCode, body: parsedBody });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+test('POST /campaign/start: Form Pulse leaning swarm -> emergent branco trait stored + unioned', async (t) => {
+  const coopStore = {
+    getFormPulses: () => ({
+      p1: { axes: { solitary_swarm: 0.6 } },
+      p2: { axes: { solitary_swarm: 0.5 } },
+    }),
+  };
+  const url = startServer(t, coopStore);
+  const res = await request('POST', `${url}/api/campaign/start`, { player_id: 'branco_swarm' });
+  assert.equal(res.status, 201);
+  const c = res.body.campaign;
+  assert.ok(c.emergentBrancoTrait, 'emergentBrancoTrait should be set');
+  assert.equal(c.emergentBrancoTrait.axis, 'solitary_swarm');
+  assert.equal(c.emergentBrancoTrait.pole, '+');
+  assert.ok(
+    typeof c.emergentBrancoTrait.trait_id === 'string' && c.emergentBrancoTrait.trait_id.length,
+  );
+  assert.ok(
+    c.acquiredTraits.includes(c.emergentBrancoTrait.trait_id),
+    'emergent trait_id unioned into acquiredTraits (shared branco)',
+  );
+});
+
+test('POST /campaign/start: indecisive branco (pulses cancel) -> dormant (null)', async (t) => {
+  const coopStore = {
+    getFormPulses: () => ({
+      p1: { axes: { solitary_swarm: 0.6 } },
+      p2: { axes: { solitary_swarm: -0.6 } }, // avg 0 < threshold
+    }),
+  };
+  const url = startServer(t, coopStore);
+  const res = await request('POST', `${url}/api/campaign/start`, { player_id: 'branco_split' });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.campaign.emergentBrancoTrait, null);
+});
+
+test('POST /campaign/start: no coopStore -> dormant (null), per-creature traits only', async (t) => {
+  const url = startServer(t, null);
+  const res = await request('POST', `${url}/api/campaign/start`, { player_id: 'branco_none' });
+  assert.equal(res.status, 201);
+  assert.equal(res.body.campaign.emergentBrancoTrait, null);
+});

--- a/tests/services/brancoTraitEmergence.test.js
+++ b/tests/services/brancoTraitEmergence.test.js
@@ -1,0 +1,100 @@
+'use strict';
+// MA1 part 2 -- emergent branco-trait mechanism (SPEC-M / ADR-2026-06-08).
+//
+// MECHANISM (objective, tested here): Form-Pulse aggregate -> dominant creature
+// axis -> 1 emergent branco trait. MAPPING + THRESHOLD are PROPOSED (ratify N=40,
+// same governance as formPulseVc PROPOSED_FP_VC_MAPPING) -- not asserted by value,
+// only by shape, so a ratify-tune does not churn these tests.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  EMERGENCE_THRESHOLD,
+  PROPOSED_BRANCO_TRAIT_MAPPING,
+  emergeBrancoTrait,
+  emergeBrancoTraitFromPulses,
+} = require('../../apps/backend/services/identity/brancoTraitEmergence');
+
+const AXES = [
+  'solitary_swarm',
+  'explore_caution',
+  'symbiosis_predation',
+  'memory_instinct',
+  'agile_robust',
+];
+
+test('PROPOSED mapping covers the 5 Form-Pulse creature axes, both poles, non-empty trait ids', () => {
+  for (const a of AXES) {
+    assert.ok(PROPOSED_BRANCO_TRAIT_MAPPING[a], `axis ${a} mapped`);
+    assert.equal(typeof PROPOSED_BRANCO_TRAIT_MAPPING[a]['+'], 'string');
+    assert.equal(typeof PROPOSED_BRANCO_TRAIT_MAPPING[a]['-'], 'string');
+    assert.ok(PROPOSED_BRANCO_TRAIT_MAPPING[a]['+'].length > 0);
+    assert.ok(PROPOSED_BRANCO_TRAIT_MAPPING[a]['-'].length > 0);
+  }
+});
+
+test('dominant + pole over threshold emerges the + trait', () => {
+  const r = emergeBrancoTrait({ solitary_swarm: 0.5 });
+  assert.equal(r.axis, 'solitary_swarm');
+  assert.equal(r.pole, '+');
+  assert.equal(r.trait_id, PROPOSED_BRANCO_TRAIT_MAPPING.solitary_swarm['+']);
+  assert.equal(r.magnitude, 0.5);
+});
+
+test('dominant - pole over threshold emerges the - trait', () => {
+  const r = emergeBrancoTrait({ symbiosis_predation: -0.4 });
+  assert.equal(r.axis, 'symbiosis_predation');
+  assert.equal(r.pole, '-');
+  assert.equal(r.trait_id, PROPOSED_BRANCO_TRAIT_MAPPING.symbiosis_predation['-']);
+});
+
+test('below threshold -> null (no emergent trait)', () => {
+  assert.equal(emergeBrancoTrait({ solitary_swarm: 0.1 }), null);
+});
+
+test('picks the most dominant axis by |avg|', () => {
+  const r = emergeBrancoTrait({ solitary_swarm: 0.35, symbiosis_predation: -0.6 });
+  assert.equal(r.axis, 'symbiosis_predation');
+  assert.equal(r.pole, '-');
+});
+
+test('exactly at threshold emerges (>=)', () => {
+  const r = emergeBrancoTrait({ memory_instinct: EMERGENCE_THRESHOLD });
+  assert.ok(r);
+  assert.equal(r.axis, 'memory_instinct');
+  assert.equal(r.pole, '+');
+});
+
+test('empty / null aggregate -> null (dormant)', () => {
+  assert.equal(emergeBrancoTrait({}), null);
+  assert.equal(emergeBrancoTrait(null), null);
+  assert.equal(emergeBrancoTrait(undefined), null);
+});
+
+test('unknown axes are ignored', () => {
+  assert.equal(emergeBrancoTrait({ not_an_axis: 0.9 }), null);
+});
+
+test('emergeBrancoTraitFromPulses: aggregates per-player pulses then emerges', () => {
+  const fpMap = {
+    p1: { axes: { solitary_swarm: 0.5 } },
+    p2: { axes: { solitary_swarm: 0.7 } },
+  };
+  const r = emergeBrancoTraitFromPulses(fpMap);
+  assert.equal(r.axis, 'solitary_swarm');
+  assert.equal(r.pole, '+');
+  assert.ok(Math.abs(r.magnitude - 0.6) < 1e-9, `avg magnitude ~0.6, got ${r && r.magnitude}`);
+});
+
+test('emergeBrancoTraitFromPulses: opposing players cancel below threshold -> null', () => {
+  const fpMap = {
+    p1: { axes: { solitary_swarm: 0.5 } },
+    p2: { axes: { solitary_swarm: -0.5 } },
+  };
+  assert.equal(emergeBrancoTraitFromPulses(fpMap), null); // avg 0 < threshold
+});
+
+test('emergeBrancoTraitFromPulses: no pulses -> null (dormant until Godot FP UX)', () => {
+  assert.equal(emergeBrancoTraitFromPulses(null), null);
+  assert.equal(emergeBrancoTraitFromPulses({}), null);
+});


### PR DESCRIPTION
## MA1 part 2 -- emergent branco trait from the Form Pulse aggregate

Completes the **ACCEPTED** [ADR-2026-06-08](docs/adr/ADR-2026-06-08-onboarding-per-creature-trait.md)
residuo: *"trait-branco emergente (Form Pulse aggregato)"*. The per-creature half
(`acquiredTraitsByCreature`) already shipped; this is the emergent shared-branco half.

### Mechanism (objective, TDD) -- `services/identity/brancoTraitEmergence.js`
- Reuses `aggregateFormPulses()` (DRY from `formPulseVc`) -> branco axis-avg map (5 creature axes in [-1,1]).
- `emergeBrancoTrait(aggregate)`: dominant axis = argmax|avg|; if |avg| >= `EMERGENCE_THRESHOLD` -> pole = sign(avg) -> `mapping[axis][pole]`; else `null`. Pure, no-mutate, deterministic tie-break.
- `emergeBrancoTraitFromPulses(fpMap)`: aggregate + emerge (the campaign wiring entry).

### Subjective knobs (PROPOSED -- ratify N=40, identical governance to `PROPOSED_FP_VC_MAPPING`)
- `PROPOSED_BRANCO_TRAIT_MAPPING`: each FP axis pole -> a **real** `active_effects.yaml` trait (all 10 ids verified present): swarm`+`->`legame_di_branco`, predation`+`->`ferocia`, memory`+`->`cervello_predittivo`, robust/agile->`pelle_elastomera`/`zampe_a_molla` (= the onboarding A/B traits), etc.
- `EMERGENCE_THRESHOLD` = 0.30 (how dominant the branco lean must be before a trait emerges).

### Wiring (Gate-5, dormant-safe) -- `POST /campaign/start`
`coopStore.getFormPulses(campaign.id)` -> `emergeBrancoTraitFromPulses` -> store `campaign.emergentBrancoTrait` + union `trait_id` into `acquiredTraits` (the shared-branco component). `coopStore` injected via `app.js` (`createCampaignRouter({...,coopStore})`). **No FP / indecisive branco / no coopStore -> no-op** (dormant until the Godot Form-Pulse UX populates `formPulses` -- exactly like FP->VC).

### Verification (TDD RED->GREEN)
- Mechanism **11/11** (`tests/services/brancoTraitEmergence.test.js`) -- poles, threshold boundary, dominance, dormancy, unknown-axis.
- Wiring **3/3** (`tests/api/campaignBrancoEmergence.test.js`) -- emerges + unions / indecisive-null / no-coopStore-null.
- **No regression**: `campaignRoutes` 36/36 (per-creature MA1) + AI baseline **500/500** (>= 382).

### Merge gate
Production code is all in `apps/backend` (50-line exempt); the 2 **test files** (~185 lines) live outside -> trips gate #6 -> **manual Master-DD merge** (not L3 auto). Forbidden paths: none touched. No new deps.

### Rollback
Revert commit `9634368a8` (additive: new service + dormant plumb; legacy single/per-creature trait flow untouched, `emergentBrancoTrait` defaults `null`).

Coding-Agent: claude-opus-4-8
