### PR TITLE
feat(chronicle): M-3 mutation_lineage emitter -- completes M-7 keystone (4/4)

### DIFF
--- a/apps/backend/routes/lineage.js
+++ b/apps/backend/routes/lineage.js
@@ -33,9 +33,13 @@ const {
 const { propagateOffspringRitual } = require('../services/lineage/offspringRitual');
 const offspringStore = require('../services/lineage/offspringStore');
 const { loadMutationsCanonical, listCanonicalIds } = require('../services/lineage/mutationsLoader');
+// SPEC-Q M-3 -- chronicle the offspring-birth mutation_lineage event.
+const { emitMutationLineage } = require('../services/chronicle/chronicleEmitters');
 
-function createLineageRouter() {
+function createLineageRouter(options = {}) {
   const router = Router();
+  // SPEC-Q M-3 -- chronicle baseDir (test override; prod uses chronicleStore default).
+  const chronicleBaseDir = options.chronicle && options.chronicle.baseDir;
 
   /**
    * POST /propagate — body { legacyUnit, species_id, biome_id }.
@@ -204,7 +208,7 @@ function createLineageRouter() {
    */
   router.post('/offspring-ritual', async (req, res) => {
     try {
-      const { session_id, parent_a_id, parent_b_id, mutations } = req.body || {};
+      const { session_id, parent_a_id, parent_b_id, mutations, campaign_id } = req.body || {};
       // Lookup parents in offspringStore per inherit lineage_id se exists.
       // Se parent_a_id non è un offspring (es UnitProgression first-gen), getById
       // returns null e propagateOffspringRitual genera new lineage_id.
@@ -230,6 +234,23 @@ function createLineageRouter() {
         parentB,
         mutations,
       });
+      // SPEC-Q M-3 -- chronicle the offspring-birth mutation_lineage event (best-effort,
+      // dormant if no campaign_id passed). Never breaks the ritual response.
+      if (campaign_id) {
+        try {
+          emitMutationLineage(
+            {
+              campaign_id,
+              mutations: offspring && offspring.mutations,
+              lineage_id: offspring && offspring.lineage_id,
+              source: 'offspring_birth',
+            },
+            { baseDir: chronicleBaseDir },
+          );
+        } catch {
+          /* best-effort -- chronicle must never break the ritual */
+        }
+      }
       return res.status(201).json(offspring);
     } catch (err) {
       const msg = String(err.message || '');

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1172,7 +1172,23 @@ function createSessionRouter(options = {}) {
         const speciesId = target.species_id || target.species || null;
         const biomeId = session.biome_id || null;
         if (speciesId && biomeId) {
-          propagateLineage(target, speciesId, biomeId);
+          const prop = propagateLineage(target, speciesId, biomeId);
+          // SPEC-Q M-3 -- chronicle the mutation_lineage event (best-effort, never blocks).
+          try {
+            const { emitMutationLineage } = require('../services/chronicle/chronicleEmitters');
+            emitMutationLineage(
+              {
+                campaign_id: session.campaign_id,
+                mutations: prop && prop.written_traits,
+                species_id: speciesId,
+                biome_id: biomeId,
+                source: 'legacy_death',
+              },
+              { baseDir: chronicleBaseDir },
+            );
+          } catch {
+            /* best-effort -- chronicle must never break combat */
+          }
         }
       } catch (err) {
         // Non-blocking: lineage failure must never break combat.

--- a/apps/backend/services/chronicle/chronicleEmitters.js
+++ b/apps/backend/services/chronicle/chronicleEmitters.js
@@ -4,8 +4,9 @@
 //
 // Keystone link (SPEC-P A3 failure-as-lore): a failed run is a narrative event.
 // `emitRunFailed` is called best-effort at session end (routes/session.js) so the
-// chronicle starts receiving real events. M-2 creature_named / M-3 mutation_lineage
-// emitters land when those systems (identity service / named-mutation) are built.
+// chronicle starts receiving real events. M-3 `emitMutationLineage` (below) fires on
+// lineage propagation (legacy death @ session.js + offspring birth @ routes/lineage.js).
+// M-2 creature_named lands via the identity service.
 // =============================================================================
 
 'use strict';
@@ -44,4 +45,41 @@ function emitRunFailed(session, opts = {}) {
   );
 }
 
-module.exports = { emitRunFailed, DEFEAT_OUTCOMES };
+/**
+ * Append a `mutation_lineage` chronicle event when mutations propagate through a
+ * lineage -- legacy death (a dying unit's mutations enter the species/biome pool)
+ * or offspring birth (a newborn carries selected mutations). M-3, completes the
+ * M-7 keystone (4/4 emitters). Best-effort: no campaign_id / no mutations -> no-op.
+ * Never throws (combat / ritual must not break on chronicle failure).
+ *
+ * @param ctx  { campaign_id, mutations:string[], species_id?, biome_id?, lineage_id?, source?, actor_id? }
+ * @param opts { baseDir? }
+ */
+function emitMutationLineage(ctx, opts = {}) {
+  if (!ctx || typeof ctx !== 'object') return { ok: false, error: 'no_ctx' };
+  const runId = ctx.campaign_id;
+  if (!runId) return { ok: false, error: 'no_campaign_id' };
+  const mutations = Array.isArray(ctx.mutations)
+    ? ctx.mutations.filter((m) => typeof m === 'string' && m)
+    : [];
+  if (mutations.length === 0) return { ok: false, error: 'no_mutations' };
+  return appendEvent(
+    runId,
+    {
+      type: 'mutation_lineage',
+      actor_id: ctx.actor_id || null,
+      tier: 'public',
+      payload: {
+        mutations,
+        count: mutations.length,
+        species_id: ctx.species_id || null,
+        biome_id: ctx.biome_id || null,
+        lineage_id: ctx.lineage_id || null,
+        source: ctx.source || null,
+      },
+    },
+    { baseDir: opts.baseDir },
+  );
+}
+
+module.exports = { emitRunFailed, emitMutationLineage, DEFEAT_OUTCOMES };

--- a/tests/api/mutationLineageWire.test.js
+++ b/tests/api/mutationLineageWire.test.js
@@ -1,0 +1,74 @@
+// SPEC-Q M-3 -- mutation_lineage emitter wiring (offspring-birth path).
+//
+// POST /api/v1/lineage/offspring-ritual with a campaign_id appends a
+// mutation_lineage chronicle event (best-effort). Without campaign_id it stays
+// dormant. The legacy-death path (session.js kill-propagate) reuses the same
+// emitMutationLineage, unit-tested in tests/services/chronicleEmitters.test.js.
+//
+// The router is mounted standalone with a tmp chronicle baseDir (prod plugin-load
+// passes no opts -> chronicleStore default baseDir, which is correct for prod).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const express = require('express');
+const request = require('supertest');
+
+const { createLineageRouter } = require('../../apps/backend/routes/lineage');
+const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
+const offspringStore = require('../../apps/backend/services/lineage/offspringStore');
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mut-lin-wire-'));
+}
+
+function appWith(baseDir) {
+  offspringStore._resetMemory();
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/lineage', createLineageRouter({ chronicle: { baseDir } }));
+  return app;
+}
+
+test('offspring-ritual with campaign_id -> mutation_lineage chronicle event (offspring_birth)', async () => {
+  const baseDir = tmp();
+  const app = appWith(baseDir);
+  const res = await request(app)
+    .post('/api/v1/lineage/offspring-ritual')
+    .send({
+      session_id: 'sess-1',
+      parent_a_id: 'a',
+      parent_b_id: 'b',
+      mutations: ['armatura_residua', 'cuore_doppio'],
+      campaign_id: 'run_branco_x',
+    })
+    .expect(201);
+
+  const chron = getChronicle('run_branco_x', { baseDir });
+  assert.equal(chron.length, 1);
+  assert.equal(chron[0].type, 'mutation_lineage');
+  assert.equal(chron[0].tier, 'public');
+  assert.equal(chron[0].payload.source, 'offspring_birth');
+  assert.deepEqual(chron[0].payload.mutations, ['armatura_residua', 'cuore_doppio']);
+  assert.equal(chron[0].payload.count, 2);
+  assert.equal(chron[0].payload.lineage_id, res.body.lineage_id);
+});
+
+test('offspring-ritual WITHOUT campaign_id -> dormant (no chronicle written)', async () => {
+  const baseDir = tmp();
+  const app = appWith(baseDir);
+  await request(app)
+    .post('/api/v1/lineage/offspring-ritual')
+    .send({
+      session_id: 'sess-2',
+      parent_a_id: 'a',
+      parent_b_id: 'b',
+      mutations: ['armatura_residua'],
+    })
+    .expect(201);
+  assert.equal(fs.readdirSync(baseDir).length, 0);
+});

--- a/tests/services/chronicleEmitters.test.js
+++ b/tests/services/chronicleEmitters.test.js
@@ -8,7 +8,10 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { emitRunFailed } = require('../../apps/backend/services/chronicle/chronicleEmitters');
+const {
+  emitRunFailed,
+  emitMutationLineage,
+} = require('../../apps/backend/services/chronicle/chronicleEmitters');
 const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
 
 function tmp() {
@@ -53,4 +56,70 @@ test('emitRunFailed: missing campaign_id -> no_campaign_id (no crash)', () => {
 
 test('emitRunFailed: missing/invalid session -> no_session', () => {
   assert.equal(emitRunFailed(null).error, 'no_session');
+});
+
+// SPEC-Q M-3 -- mutation_lineage emitter (4th chronicle emitter, completes M-7).
+test('emitMutationLineage: legacy_death appends a mutation_lineage event', () => {
+  const baseDir = tmp();
+  const out = emitMutationLineage(
+    {
+      campaign_id: 'c1',
+      mutations: ['m_a', 'm_b'],
+      species_id: 'sp',
+      biome_id: 'savana',
+      source: 'legacy_death',
+    },
+    { baseDir },
+  );
+  assert.equal(out.ok, true);
+  const chron = getChronicle('c1', { baseDir });
+  assert.equal(chron.length, 1);
+  assert.equal(chron[0].type, 'mutation_lineage');
+  assert.equal(chron[0].tier, 'public');
+  assert.deepEqual(chron[0].payload.mutations, ['m_a', 'm_b']);
+  assert.equal(chron[0].payload.count, 2);
+  assert.equal(chron[0].payload.species_id, 'sp');
+  assert.equal(chron[0].payload.biome_id, 'savana');
+  assert.equal(chron[0].payload.source, 'legacy_death');
+});
+
+test('emitMutationLineage: offspring_birth carries lineage_id', () => {
+  const baseDir = tmp();
+  const out = emitMutationLineage(
+    { campaign_id: 'c2', mutations: ['m_c'], lineage_id: 'lin_7', source: 'offspring_birth' },
+    { baseDir },
+  );
+  assert.equal(out.ok, true);
+  const ev = getChronicle('c2', { baseDir })[0];
+  assert.equal(ev.payload.source, 'offspring_birth');
+  assert.equal(ev.payload.lineage_id, 'lin_7');
+  assert.equal(ev.payload.count, 1);
+});
+
+test('emitMutationLineage: filters non-string mutations', () => {
+  const baseDir = tmp();
+  emitMutationLineage({ campaign_id: 'c3', mutations: ['ok', '', null, 5, 'ok2'] }, { baseDir });
+  assert.deepEqual(getChronicle('c3', { baseDir })[0].payload.mutations, ['ok', 'ok2']);
+});
+
+test('emitMutationLineage: no campaign_id -> no_campaign_id (no event)', () => {
+  const baseDir = tmp();
+  const out = emitMutationLineage({ mutations: ['m'] }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'no_campaign_id');
+  assert.equal(fs.readdirSync(baseDir).length, 0);
+});
+
+test('emitMutationLineage: no mutations -> no_mutations no-op (dormant)', () => {
+  const baseDir = tmp();
+  assert.equal(
+    emitMutationLineage({ campaign_id: 'c', mutations: [] }, { baseDir }).error,
+    'no_mutations',
+  );
+  assert.equal(emitMutationLineage({ campaign_id: 'c' }, { baseDir }).error, 'no_mutations');
+});
+
+test('emitMutationLineage: null/invalid ctx -> no_ctx', () => {
+  assert.equal(emitMutationLineage(null).error, 'no_ctx');
+  assert.equal(emitMutationLineage('x').error, 'no_ctx');
 });


### PR DESCRIPTION
## M-3 mutation_lineage emitter -- completes the M-7 chronicle keystone (4/4)

### Scope reframe (important)
The task framed item 6 as `services/generation/lineagePropagator.js + Godot draft`, but
**`lineagePropagator.js` already exists** and the propagation is LIVE (`/legacy-ritual`,
`/offspring-ritual`, kill-propagate in `session.js`, `lineage_choice` debrief). The actual
missing piece -- per `chronicleEmitters.js`'s own comment -- is the **M-3 `mutation_lineage`
chronicle emitter** (the 4th, after `run_failed` / `creature_named` / `biome_wound`). So this
PR adds the emitter + hooks it to the existing propagation. **`services/generation/` is NOT
touched** (forbidden path avoided; read-only inspection only).

### Mechanism
`emitMutationLineage(ctx, opts)` in `services/chronicle/chronicleEmitters.js` -> appends a
`mutation_lineage` chronicle event (tier public, payload `{mutations, count, species_id,
biome_id, lineage_id, source}`), keyed by `campaign_id`. Best-effort: no `campaign_id` / no
mutations -> no-op. Never throws (combat / ritual must not break on chronicle failure).

### Wiring (both lineage ends, best-effort)
- **legacy death** -- `session.js` kill-propagate (`session.campaign_id` in scope) -> emits
  `source:'legacy_death'` with `propagateLineage().written_traits`.
- **offspring birth** -- `routes/lineage.js` `/offspring-ritual` -> emits `source:'offspring_birth'`
  with the offspring `mutations` + `lineage_id`, **dormant unless `campaign_id` is in the body**
  (no store injection; prod uses chronicleStore default baseDir).

### Godot contract
The `mutation_lineage` chronicle event shape IS the contract the Memory-mode viewer (item 3)
consumes. Godot-v2 draft = cross-repo / later.

### Verification (TDD)
- Emitter **11 cases** (`tests/services/chronicleEmitters.test.js`): both sources, threshold
  edges, no-campaign-id / no-mutations / null-ctx no-ops, mutation filtering.
- Offspring-birth **wire integration** (`tests/api/mutationLineageWire.test.js`): REST
  `/offspring-ritual` with/without `campaign_id` -> chronicle event / dormant.
- **No regression**: chronicle + offspring-ritual routes + chronicleStore green; **AI 500/500**.
- legacy-death wire sits directly on the pre-existing `propagateLineage` call with unit-tested
  inputs (mirrors the integration-tested `emitRunFailed` pattern).

### Merge gate
Production code all in `apps/backend` (50-line exempt); the 2 test files live outside ->
trips gate #6 -> **manual Master-DD merge**. Forbidden paths: none. No new deps.

### Rollback
Revert commit (additive emitter + 2 best-effort hooks; propagation flow untouched).

Coding-Agent: claude-opus-4-8
