### PR TITLE
fix(sim): restore OA2 objective-completion (3 shape/wire bugs)

### DIFF
--- a/apps/backend/services/combat/objectiveEvaluator.js
+++ b/apps/backend/services/combat/objectiveEvaluator.js
@@ -58,7 +58,12 @@ function countFactionAlive(session, faction) {
 
 function pointInBox(pos, box) {
   if (!pos || !box || box.length < 4) return false;
-  const [x, y] = pos;
+  // Unit positions are `{x, y}` objects throughout the engine; accept that shape (and a
+  // legacy `[x, y]` array, defensively). The old `const [x, y] = pos` array-destructure threw
+  // `TypeError: pos is not iterable` on the real object shape -> 500 in /turn/end + a caught
+  // null evaluation in /objective, so zone objectives (capture/escort/escape) never completed.
+  const x = Array.isArray(pos) ? pos[0] : pos.x;
+  const y = Array.isArray(pos) ? pos[1] : pos.y;
   const [x1, y1, x2, y2] = box;
   const minX = Math.min(x1, x2);
   const maxX = Math.max(x1, x2);

--- a/tests/services/combat/objectiveEvaluatorPos.test.js
+++ b/tests/services/combat/objectiveEvaluatorPos.test.js
@@ -1,0 +1,37 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  _internals,
+  evaluateObjective,
+} = require('../../../apps/backend/services/combat/objectiveEvaluator');
+
+// Regression: pointInBox did `const [x, y] = pos` (array-destructure), but unit positions
+// are `{x, y}` objects throughout the engine (session.js, encounter_to_units, etc.). That
+// threw `TypeError: pos is not iterable` -> in /turn/end it surfaced as a 500 (blocking the
+// non-elim calibration tool); in the /objective route it was caught -> evaluation=null ->
+// zone objectives (capture/escort/escape) could NEVER complete. Accept BOTH shapes.
+test('pointInBox accepts {x,y} object positions (the real engine shape)', () => {
+  assert.equal(_internals.pointInBox({ x: 4, y: 4 }, [4, 4, 5, 5]), true);
+  assert.equal(_internals.pointInBox({ x: 9, y: 9 }, [4, 4, 5, 5]), false);
+  // array form still works (defensive / back-compat)
+  assert.equal(_internals.pointInBox([4, 4], [4, 4, 5, 5]), true);
+  assert.equal(_internals.pointInBox([9, 9], [4, 4, 5, 5]), false);
+});
+
+test('capture_point evaluation does not throw with {x,y} player positions', () => {
+  const session = {
+    units: [
+      { id: 'p1', controlled_by: 'player', hp: 10, position: { x: 4, y: 4 } },
+      { id: 's1', controlled_by: 'sistema', hp: 7, position: { x: 9, y: 9 } },
+    ],
+    turn: 1,
+  };
+  const encounter = {
+    objective: { type: 'capture_point', target_zone: [4, 4, 5, 5], hold_turns: 3 },
+  };
+  // before the fix this threw (pos not iterable); now it must return a clean evaluation.
+  const ev = evaluateObjective(session, encounter);
+  assert.equal(ev.failed, false);
+  assert.equal(ev.progress.units_in_zone, 1);
+});

--- a/tests/sim/combatPolicyZoneShape.test.js
+++ b/tests/sim/combatPolicyZoneShape.test.js
@@ -1,0 +1,32 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { selectPlayerAction } = require('../../tools/sim/combat-policy');
+
+// Regression (bug C, #2662-era OA2): zone-pursuit read `objective.config.target_zone`, but the
+// objective shape returned by GET /:id/objective (and consumed by the evaluator) carries
+// `target_zone` at the TOP level. So `zone` was undefined -> the zone-pursuit branch never
+// fired -> players fell through to closest-enemy and never moved to the capture/sabotage/escape
+// zone -> those objectives could not complete in the sim. Drive on the real (top-level) shape.
+test('zone-pursuit drives toward the zone (top-level target_zone), not the far enemy', () => {
+  const actor = {
+    id: 'p1',
+    position: { x: 0, y: 0 },
+    attack_range: 2,
+    ap_remaining: 3,
+    controlled_by: 'player',
+  };
+  // Enemy far in +y; the zone centroid is in +x -> the two intents yield DIFFERENT first moves,
+  // so the test distinguishes zone-pursuit from the closest-enemy fallback.
+  const units = [actor, { id: 'foe', controlled_by: 'sistema', hp: 10, position: { x: 0, y: 9 } }];
+  const objective = { type: 'capture_point', target_zone: [4, 4, 6, 6] };
+  const action = selectPlayerAction(actor, units, objective);
+  assert.equal(action.action_type, 'move');
+  // zone centroid (5,5): from (0,0) the x-axis tie-break steps to {x:1,y:0}. The BUG (config
+  // undefined -> closest-enemy at (0,9)) steps to {x:0,y:1}.
+  assert.deepEqual(
+    action.target_position,
+    { x: 1, y: 0 },
+    'must pursue the zone, not the far enemy',
+  );
+});

--- a/tests/sim/fullLoopObjectiveWire.test.js
+++ b/tests/sim/fullLoopObjectiveWire.test.js
@@ -1,0 +1,95 @@
+'use strict';
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runEncounter } = require('../../tools/sim/combat-adapter');
+
+function supertestHttp(app) {
+  return {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+// Regression guard #2662 (full-loop completion 0.9 -> 0.0). The sim kill-wire session must
+// LOAD the encounter objective so a NON-elimination encounter completes via the objective-
+// driver, not only by elimination. Root cause: combat-adapter sent `scenario_id`, but
+// /api/session/start loads the objective from `encounter_id` -> session.encounter was null
+// -> the /objective evaluation was null -> pollObjective never fired -> survival/capture
+// encounters fell through to elimination. With a REAL (un-eliminable) roster that times out.
+//
+// This test pins it on SURVIVAL: vs an un-killable harmless foe the party CANNOT win by
+// elimination, so victory MUST come from the survival objective (survive_turns reached) --
+// at the runner's own maxRounds=40 budget.
+test('OA2 wire: survival objective completes (not elimination) at runner maxRounds=40', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = supertestHttp(app);
+  const roster = [
+    {
+      id: 'c1',
+      hp: 60,
+      max_hp: 60,
+      ap: 3,
+      mod: 20,
+      attack_range: 2,
+      initiative: 18,
+      position: { x: 3, y: 3 },
+      controlled_by: 'player',
+      status: {},
+    },
+    {
+      id: 'c2',
+      hp: 60,
+      max_hp: 60,
+      ap: 3,
+      mod: 18,
+      attack_range: 2,
+      initiative: 16,
+      position: { x: 4, y: 4 },
+      controlled_by: 'player',
+      status: {},
+    },
+  ];
+  // hp 9999 >> any damage the party can deal over 40 rounds -> un-killable; mod 0 -> harmless
+  // so the party survives. Victory can ONLY come from the survival objective.
+  const unkillableFoe = [
+    {
+      id: 'f1',
+      hp: 9999,
+      max_hp: 9999,
+      ap: 1,
+      mod: 0,
+      dc: 1,
+      attack_range: 1,
+      initiative: 1,
+      position: { x: 0, y: 0 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+  const res = await runEncounter(http, {
+    roster,
+    enemies: unkillableFoe,
+    scenarioId: 'enc_tutorial_02',
+    seed: 'surv-wire-1',
+    maxRounds: 40,
+  });
+  assert.equal(
+    res.outcome,
+    'victory',
+    `survival must complete via the objective at maxRounds=40, got ${res.outcome}`,
+  );
+});

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -14,6 +14,12 @@ async function runEncounter(http, { roster, enemies, scenarioId, seed, maxRounds
   const startBody = {
     units: [...(roster || []), ...(enemies || [])],
     scenario_id: scenarioId,
+    // OA2 (#2662 regression fix): /api/session/start loads the encounter -- and thus its
+    // objective (session.encounter, read by GET /:id/objective) -- from `encounter_id`, NOT
+    // `scenario_id` (that is telemetry-only). Without it session.encounter is null, the
+    // objective evaluation is null, pollObjective never fires, and a NON-elimination encounter
+    // (survival/capture/sabotage) can only win by elimination -> a real roster times out.
+    ...(scenarioId ? { encounter_id: scenarioId } : {}),
     // /api/session/start seeds the per-session deterministic RNG from `seed`
     // (session.js:1637), NOT `run_seed` (that is the co-op WS world_confirm field).
     // Codex #2561 P2 — sending `seed` makes full-loop encounters replayable.

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -100,7 +100,13 @@ function stepTowardZone(actor, zone, units) {
 function selectPlayerAction(actor, units, objective) {
   // OA2 zone-pursuit: a zone objective + actor outside the zone -> move toward it.
   const objType = objective && objective.type;
-  const zone = objective && objective.config && objective.config.target_zone;
+  // bug C (#2662-era OA2): GET /:id/objective + the evaluator carry `target_zone` at the TOP
+  // level (matching the encounter YAML), NOT under `.config`. Reading only `config.target_zone`
+  // left `zone` undefined -> zone-pursuit never fired -> players never moved to the
+  // capture/sabotage/escape zone -> those objectives could not complete. Prefer top-level.
+  const zone =
+    (objective && objective.target_zone) ||
+    (objective && objective.config && objective.config.target_zone);
   if (ZONE_PURSUIT_OBJECTIVES.has(objType) && Array.isArray(zone) && zone.length >= 4) {
     if (!inZone(actor.position, zone)) {
       // OA2 fix (item 7): pursue a DISTINCT free zone tile + route around allies


### PR DESCRIPTION
## Summary

Three shape/wire bugs (the #2662-era OA2 "mission-type-aware full-loop" regression) left non-elimination objectives unable to complete in the sim. Full-loop `completion_rate` had collapsed to **0.0** (the prior ~0.9 was degenerate-easy: non-elim encounters fought weak-fixed enemies, so they were "won" by elimination). Fixing all three restores it to **0.5 (in the provisional 0.4-0.7 band)**.

Found while following the Lenovo handoff (#2667) for item-2 OA2 calibration -- the calibration tool 500'd, which surfaced the cascade.

## The three bugs (each verified RED -> GREEN)

| | File | Bug |
|---|---|---|
| **A** | `tools/sim/combat-adapter.js` | adapter sent `scenario_id`, but `/api/session/start` loads the objective from `encounter_id` -> `session.encounter` null -> `/objective` null -> `pollObjective` never fired -> non-elim encounters fell through to elimination |
| **B** | `apps/backend/services/combat/objectiveEvaluator.js` | `pointInBox` did `const [x,y] = pos`, but positions are `{x,y}` objects -> `TypeError: pos is not iterable` -> **500** in `/turn/end`, caught null eval in `/objective` |
| **C** | `tools/sim/combat-policy.js` | zone-pursuit read `objective.config.target_zone`, but the objective carries `target_zone` top-level -> `zone` undefined -> players never moved to the capture/sabotage/escape zone |

## Verification

- New tests RED->GREEN: `fullLoopObjectiveWire` (A), `objectiveEvaluatorPos` (B), `combatPolicyZoneShape` (C).
- `tests/sim/*` -> **125/125**; `tests/services/combat/*` -> **23/23**; `tests/ai/*` -> **500/500**; prettier clean.
- `node tools/sim/full-loop-batch.js --runs 10`: `completion_rate` **0.0 -> 0.5** (in band).

## Scope / safety

- Sim-side (`tools/sim/`) + one combat-evaluator shape guard. **No mechanic change** (additions-only shape handling). No forbidden paths, no new deps, no dataset change (validator N/A).
- **Rollback**: revert this commit.

## Out of scope (flagged for follow-up)

The per-template calibration tool `tools/py/batch_calibrate_non_elim.py` has a **separate structural gap**: it drives via `/turn/end` auto-resolve with **no objective-aware player AI**, so it cannot move units to zones -> zone templates measure `completion_rate` 0 even with A/B/C fixed. Item-2 zone calibration needs an objective-aware harness (the full-loop path is now one). Not addressed here.
