### PR TITLE
chore(sim): ratify post-#2669 calibration -- cm5/hp3/dc1/mod1 (L-069)

### DIFF
--- a/tests/sim/fullLoopBatch.test.js
+++ b/tests/sim/fullLoopBatch.test.js
@@ -150,6 +150,9 @@ test('calibrationScaling: FL_ENEMY_* env overrides each knob (robust to baked de
   const baked = calibrationScaling();
   assert.equal(baked.countMult, 5, 'baked countMult (calibration)');
   assert.equal(baked.hpAdd, 3, 'baked hpAdd (calibration)');
+  // post-#2669 re-cal (OA2-completion fix raised completion -> re-tuned UP via the fine knobs).
+  assert.equal(baked.dcAdd, 1, 'baked dcAdd (post-#2669 re-cal, fine knob)');
+  assert.equal(baked.modAdd, 1, 'baked modAdd (post-#2669 re-cal, fine knob)');
   process.env.FL_ENEMY_COUNT_MULT = '7';
   process.env.FL_ENEMY_DC_ADD = '9';
   try {
@@ -176,7 +179,16 @@ test('calibrationScaling: graph-mode (META_NETWORK_ROUTING) re-calibrates to cou
     delete process.env.META_NETWORK_ROUTING;
     assert.equal(calibrationScaling().hpAdd, 3, 'static-chain hpAdd default unchanged');
     assert.equal(calibrationScaling().countMult, 5, 'static-chain countMult default unchanged');
-    assert.equal(calibrationScaling().dcAdd, 0, 'static-chain dcAdd default unchanged');
+    assert.equal(
+      calibrationScaling().dcAdd,
+      1,
+      'static-chain dcAdd (post-#2669 re-cal, fine knob)',
+    );
+    assert.equal(
+      calibrationScaling().modAdd,
+      1,
+      'static-chain modAdd (post-#2669 re-cal, fine knob)',
+    );
     process.env.META_NETWORK_ROUTING = 'true';
     assert.equal(calibrationScaling().hpAdd, 2, 'graph-mode re-calibrated hpAdd (real rosters)');
     assert.equal(

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -256,16 +256,24 @@ function calibrationScaling() {
   // hpAdd 2->3 jumps ~0.77->~0.2). N=40 lands all three policies in the tight 0.4-0.7 band (greedy
   // 0.675 / ESFP 0.70 / INTJ 0.60). KEY: the original 0/10 was a CALIBRATION ARTIFACT of the stale
   // fallback-tuned overlay, NOT an inherent climax gate -- the terminal climax is winnable, so NO
-  // retry-allowance mechanic is needed (option-C Phase 2 dropped). The static default (countMult 5,
-  // hpAdd 3) is unchanged -> the ratified static cave_path bands hold.
+  // retry-allowance mechanic is needed (option-C Phase 2 dropped).
+  //
+  // Post-#2669 re-calibration (OA2 objective-completion fix): A/B/C restored survival/capture/
+  // sabotage/escape completion (they used to fall through to elimination), so at the old static
+  // cm5/hp3 the AI completed MORE -> completion_rate rose ~0.6 -> 0.825 (OOB-high). Re-tuned the
+  // static default UP via the FINE knobs (dcAdd + modAdd, both 1): hpAdd/countMult are too coarse
+  // (hpAdd 4 -> 0.4 low-edge, countMult 6 -> 0.0). cm5/hp3/dcAdd1/modAdd1 lands greedy N=49 at
+  // completion 0.51 -- dead centre of the ratified 0.4-0.7 band, all 7 meta-metrics in-band
+  // (master-dd ratify 2026-06-09, L-069). NB graph-mode (cm3/hp2/dc1) is NOT re-verified post-fix
+  // -> re-run META_NETWORK_ROUTING=true N=40 before trusting its band.
   const graphMode = process.env.META_NETWORK_ROUTING === 'true';
   return {
     countMult: num('FL_ENEMY_COUNT_MULT', graphMode ? 3 : 5),
     countAdd: num('FL_ENEMY_COUNT_ADD', 0),
     hpMult: num('FL_ENEMY_HP_MULT', 1),
     hpAdd: num('FL_ENEMY_HP_ADD', graphMode ? 2 : 3),
-    modAdd: num('FL_ENEMY_MOD_ADD', 0),
-    dcAdd: num('FL_ENEMY_DC_ADD', graphMode ? 1 : 0),
+    modAdd: num('FL_ENEMY_MOD_ADD', graphMode ? 0 : 1),
+    dcAdd: num('FL_ENEMY_DC_ADD', 1),
   };
 }
 


### PR DESCRIPTION
Follow-up to #2669 (merged via L3 auto-merge). The re-cal commit **raced** that auto-merge and missed the squash -- this PR lands it.

## Why
#2669 (A/B/C) restored OA2 objective-completion -> at the old static `cm5/hp3` the full-loop AI completes more -> completion_rate **0.6 -> 0.825** (OOB-high vs the ratified 0.4-0.7 band).

## What
Re-tuned the static baked calibration UP via the **fine knobs** (`dcAdd` + `modAdd`, both 1; hpAdd/countMult too coarse).

| setting | completion | note |
|---|---|---|
| dc0 (old) | 0.825 | OOB-high (post-fix) |
| dc2 | 0.414 | low-edge, N=29 |
| hp4 | 0.4 | low-edge |
| **dc1+mod1** | **0.51** | **centre, N=49, 7/7 in-band** |

`cm5/hp3/dcAdd1/modAdd1` -> greedy N=49 completion **0.51** (dead centre), all 7 meta-metrics in-band. **master-dd ratify 2026-06-09 (L-069).** Band ranges unchanged (already ratified 2026-06-03). Graph-mode (cm3/hp2/dc1) NOT re-verified post-fix -- flagged in-code.

## Verification
`node --test tests/sim/*.test.js` -> **125/125** (calibrationScaling assertions updated to lock dc1/mod1).

## Scope / safety
`tools/sim/` only (full-loop-batch.js calibration default + its test). No mechanic change, no forbidden paths, no deps. Rollback: revert.
