### PR TITLE
feat(narrative): SPEC-P failure epilogue + codex hook (run-fail -> lore)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3532,6 +3532,34 @@ function createSessionRouter(options = {}) {
       } catch {
         /* best-effort -- never blocks session end */
       }
+      // SPEC-P sez.4/5 -- assemble the failure epilogue + codex hook on run-fail.
+      // Reads the UPDATED woundedBiomes (after the A13 block above). No-op on
+      // victory / no campaign_id. Best-effort -- never blocks session end.
+      try {
+        const { emitFailureEpilogue } = require('../services/narrative/failureEpilogue');
+        const { getCampaign } = require('../services/campaign/campaignStore');
+        const camp = session.campaign_id ? getCampaign(session.campaign_id) : null;
+        const fallen = (session.units || [])
+          .filter((u) => u && u.controlled_by === 'player' && (u.hp ?? 0) <= 0)
+          .map((u) => ({
+            id: u.id,
+            species: u.species || u.species_id || null,
+            name: u.name || u.label || null,
+          }));
+        emitFailureEpilogue(
+          {
+            campaign_id: session.campaign_id,
+            outcome: session.outcome,
+            biome_id: session.biome_id,
+            encounter_id: session.encounter_id,
+            woundedBiomes: camp ? camp.woundedBiomes : [],
+            fallen,
+          },
+          { baseDir: chronicleBaseDir },
+        );
+      } catch {
+        /* best-effort -- chronicle must never break session end */
+      }
       // M1 -- persist Sistema learning (best-effort, never blocks session end).
       try {
         if (session.campaign_id) {

--- a/apps/backend/services/chronicle/chronicleStore.js
+++ b/apps/backend/services/chronicle/chronicleStore.js
@@ -43,6 +43,8 @@ const ALLOWED_EVENT_TYPES = new Set([
   'biome_wound', // A13 biome-wound cross-run (SPEC-P)
   'heirloom_created', // M-1 named heirloom (FFT)
   'mutation_lineage', // M-3 named-mutation lineage (Wildermyth/Godot)
+  'run_epilogue', // SPEC-P sez.4 failure epilogue (run-end lore payload)
+  'codex_update', // SPEC-P sez.5 Codex discovery hook on failure (B14/Hades)
 ]);
 
 const ALLOWED_TIERS = new Set(['public', 'private', 'secret']);

--- a/apps/backend/services/narrative/failureEpilogue.js
+++ b/apps/backend/services/narrative/failureEpilogue.js
@@ -1,0 +1,96 @@
+// =============================================================================
+// Failure-as-Lore epilogue -- SPEC-P sez.4 + sez.5 (backend glue).
+//
+// On run-fail (SPEC-P sez.3 triggers), assemble a bounded epilogue PAYLOAD from
+// the run context + emit two chronicle events:
+//   - `run_epilogue`  (tier public): the structured DATA the Godot PA1 surface
+//     renders as the diegetic Skiv/Custode voice. We assemble the data, NOT the
+//     narrative text (that surface = fork PA1 = Godot, item 3).
+//   - `codex_update { entry_id, on:'failure' }` (tier public): the Hades/B14
+//     discovery hook the SPEC-H Codex consumer collects (SPEC-P does not build
+//     the Codex container, sez.5).
+//
+// Reuses the LIVE pieces (do NOT rebuild): the run_failed event + chronicle (M-7,
+// #2668), the A13 biome degrade (`biomeWound`, sez.6 LIVE), J5 fallen/lineage as
+// input. Best-effort, never throws (session-end must not break on chronicle fail).
+//
+// Doctrine "no numero opaco" (SPEC-P sez.2): degrade is a diegetic tag
+// (`biome_wounded` / `none`), never a raw float.
+// =============================================================================
+
+'use strict';
+
+const { appendEvent } = require('../chronicle/chronicleStore');
+
+// Outcomes that open the failure-as-lore loop (SPEC-P sez.3). `retreated` =
+// voluntary early-end, still a run-fail per the spec. `victory`/`draw` excluded.
+const RUN_FAIL_OUTCOMES = new Set(['wipe', 'timeout', 'defeat', 'objective_failed', 'retreated']);
+
+/**
+ * Pure: run-fail context -> structured epilogue payload (SPEC-P sez.4). No-mutate.
+ * Returns null when the outcome is not a run-fail (or ctx is invalid).
+ *
+ * @param ctx { outcome, biome_id?, encounter_id?, woundedBiomes?:string[], fallen?:object[] }
+ */
+function buildEpilogue(ctx) {
+  if (!ctx || typeof ctx !== 'object') return null;
+  if (!RUN_FAIL_OUTCOMES.has(ctx.outcome)) return null;
+  const biomeId = ctx.biome_id || null;
+  const woundedBiomes = Array.isArray(ctx.woundedBiomes) ? ctx.woundedBiomes : [];
+  const wounded = !!biomeId && woundedBiomes.includes(biomeId);
+  const fallen = (Array.isArray(ctx.fallen) ? ctx.fallen : [])
+    .filter((u) => u && typeof u === 'object' && u.id)
+    .map((u) => ({ id: u.id, species: u.species || null, name: u.name || null }));
+  return {
+    outcome: ctx.outcome,
+    biome_id: biomeId,
+    encounter_id: ctx.encounter_id || null,
+    wounded, // the biome was wounded this run (A13 degrade applied)
+    fallen, // [{ id, species, name }] from J5 (caduti)
+    fallen_count: fallen.length,
+    // diegetic tag (SPEC-P doctrine: no raw number) -- the surface telegraphs it.
+    degrade_summary: wounded ? 'biome_wounded' : 'none',
+  };
+}
+
+/**
+ * Pure: the Codex discovery hook (SPEC-P sez.5). The biome failed-in becomes a
+ * codex_update trigger the SPEC-H consumer collects. Null if no biome.
+ */
+function codexHook(ctx) {
+  const biomeId = ctx && ctx.biome_id ? ctx.biome_id : null;
+  if (!biomeId) return null;
+  return { entry_id: biomeId, on: 'failure' };
+}
+
+/**
+ * Assemble + emit the failure epilogue (run_epilogue + codex_update) to the
+ * chronicle. Best-effort: no campaign_id / not-a-run-fail -> no-op. Never throws.
+ *
+ * @param ctx  buildEpilogue ctx + { campaign_id }
+ * @param opts { baseDir? }
+ * @returns { ok, epilogue, codex } | { ok:false, error }
+ */
+function emitFailureEpilogue(ctx, opts = {}) {
+  if (!ctx || typeof ctx !== 'object') return { ok: false, error: 'no_ctx' };
+  const runId = ctx.campaign_id;
+  if (!runId) return { ok: false, error: 'no_campaign_id' };
+  const epilogue = buildEpilogue(ctx);
+  if (!epilogue) return { ok: false, error: 'not_a_run_fail' };
+  appendEvent(
+    runId,
+    { type: 'run_epilogue', actor_id: null, tier: 'public', payload: epilogue },
+    { baseDir: opts.baseDir },
+  );
+  const codex = codexHook(ctx);
+  if (codex) {
+    appendEvent(
+      runId,
+      { type: 'codex_update', actor_id: null, tier: 'public', payload: codex },
+      { baseDir: opts.baseDir },
+    );
+  }
+  return { ok: true, epilogue, codex: codex || null };
+}
+
+module.exports = { RUN_FAIL_OUTCOMES, buildEpilogue, codexHook, emitFailureEpilogue };

--- a/tests/api/chronicleRunFailedWire.test.js
+++ b/tests/api/chronicleRunFailedWire.test.js
@@ -43,9 +43,13 @@ test('session /end with defeat (wipe) appends run_failed to the campaign chronic
   assert.equal(end.body.outcome, 'wipe');
 
   const chron = getChronicle('run_wire_test', { baseDir });
-  assert.equal(chron.length, 1);
-  assert.equal(chron[0].type, 'run_failed');
-  assert.equal(chron[0].payload.outcome, 'wipe');
+  const rf = chron.find((e) => e.type === 'run_failed');
+  assert.ok(rf, 'run_failed event present');
+  assert.equal(rf.payload.outcome, 'wipe');
+  // SPEC-P: the same run-fail now also assembles the failure epilogue (best-effort wire).
+  const ep = chron.find((e) => e.type === 'run_epilogue');
+  assert.ok(ep, 'run_epilogue event present');
+  assert.equal(ep.payload.outcome, 'wipe');
 });
 
 test('session /end with no campaign_id -> no chronicle event (no_campaign_id no-op)', async (t) => {

--- a/tests/services/failureEpilogue.test.js
+++ b/tests/services/failureEpilogue.test.js
@@ -1,0 +1,142 @@
+'use strict';
+// SPEC-P failure-as-lore -- run-end epilogue assembly + codex hook (backend glue).
+//
+// buildEpilogue = pure run-fail context -> structured payload (the Godot PA1 surface
+// renders the diegetic voice; this is the DATA). emitFailureEpilogue appends 2
+// chronicle events (run_epilogue tier-public + codex_update {on:'failure'} for the
+// SPEC-H Codex consumer). Best-effort, never throws.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildEpilogue,
+  codexHook,
+  emitFailureEpilogue,
+  RUN_FAIL_OUTCOMES,
+} = require('../../apps/backend/services/narrative/failureEpilogue');
+const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fail-epilogue-'));
+}
+
+test('RUN_FAIL_OUTCOMES covers the 4 SPEC-P triggers + retreated', () => {
+  for (const o of ['wipe', 'timeout', 'objective_failed', 'retreated', 'defeat']) {
+    assert.ok(RUN_FAIL_OUTCOMES.has(o), o);
+  }
+  assert.ok(!RUN_FAIL_OUTCOMES.has('victory'));
+});
+
+test('buildEpilogue: run-fail in a wounded biome -> structured payload', () => {
+  const ep = buildEpilogue({
+    outcome: 'wipe',
+    biome_id: 'savana',
+    encounter_id: 'enc_x',
+    woundedBiomes: ['savana'],
+    fallen: [{ id: 'p1', species: 'sp', name: 'Skiv' }],
+  });
+  assert.equal(ep.outcome, 'wipe');
+  assert.equal(ep.biome_id, 'savana');
+  assert.equal(ep.encounter_id, 'enc_x');
+  assert.equal(ep.wounded, true);
+  assert.equal(ep.fallen_count, 1);
+  assert.deepEqual(ep.fallen, [{ id: 'p1', species: 'sp', name: 'Skiv' }]);
+  assert.equal(ep.degrade_summary, 'biome_wounded');
+});
+
+test('buildEpilogue: retreated counts as run-fail', () => {
+  assert.ok(buildEpilogue({ outcome: 'retreated', biome_id: 'b' }));
+});
+
+test('buildEpilogue: victory -> null (not a run-fail)', () => {
+  assert.equal(buildEpilogue({ outcome: 'victory', biome_id: 'b' }), null);
+});
+
+test('buildEpilogue: biome not wounded -> wounded:false, degrade none', () => {
+  const ep = buildEpilogue({ outcome: 'timeout', biome_id: 'savana', woundedBiomes: ['caverna'] });
+  assert.equal(ep.wounded, false);
+  assert.equal(ep.degrade_summary, 'none');
+});
+
+test('buildEpilogue: fallen filters non-objects + missing ids', () => {
+  const ep = buildEpilogue({
+    outcome: 'wipe',
+    biome_id: 'b',
+    fallen: [{ id: 'a' }, null, { name: 'x' }, 'str', 42],
+  });
+  assert.equal(ep.fallen_count, 1);
+  assert.equal(ep.fallen[0].id, 'a');
+});
+
+test('buildEpilogue: null/invalid ctx or no outcome -> null', () => {
+  assert.equal(buildEpilogue(null), null);
+  assert.equal(buildEpilogue('x'), null);
+  assert.equal(buildEpilogue({}), null);
+});
+
+test('codexHook: biome -> {entry_id, on:failure}; no biome -> null', () => {
+  assert.deepEqual(codexHook({ biome_id: 'savana' }), { entry_id: 'savana', on: 'failure' });
+  assert.equal(codexHook({}), null);
+});
+
+test('emitFailureEpilogue: appends run_epilogue + codex_update chronicle events', () => {
+  const baseDir = tmp();
+  const out = emitFailureEpilogue(
+    {
+      campaign_id: 'c1',
+      outcome: 'wipe',
+      biome_id: 'savana',
+      encounter_id: 'e',
+      woundedBiomes: ['savana'],
+      fallen: [{ id: 'p1' }],
+    },
+    { baseDir },
+  );
+  assert.equal(out.ok, true);
+  const chron = getChronicle('c1', { baseDir });
+  assert.equal(chron.length, 2);
+  const ep = chron.find((e) => e.type === 'run_epilogue');
+  const cx = chron.find((e) => e.type === 'codex_update');
+  assert.ok(ep);
+  assert.equal(ep.tier, 'public');
+  assert.equal(ep.payload.outcome, 'wipe');
+  assert.equal(ep.payload.wounded, true);
+  assert.ok(cx);
+  assert.equal(cx.tier, 'public');
+  assert.equal(cx.payload.on, 'failure');
+  assert.equal(cx.payload.entry_id, 'savana');
+});
+
+test('emitFailureEpilogue: victory -> not_a_run_fail no-op (no events)', () => {
+  const baseDir = tmp();
+  const out = emitFailureEpilogue(
+    { campaign_id: 'c', outcome: 'victory', biome_id: 'b' },
+    { baseDir },
+  );
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'not_a_run_fail');
+  assert.equal(getChronicle('c', { baseDir }).length, 0);
+});
+
+test('emitFailureEpilogue: no campaign_id -> no_campaign_id', () => {
+  assert.equal(
+    emitFailureEpilogue({ outcome: 'wipe', biome_id: 'b' }, { baseDir: tmp() }).error,
+    'no_campaign_id',
+  );
+});
+
+test('emitFailureEpilogue: no biome -> run_epilogue only (no codex_update)', () => {
+  const baseDir = tmp();
+  emitFailureEpilogue({ campaign_id: 'c', outcome: 'wipe', biome_id: null }, { baseDir });
+  const chron = getChronicle('c', { baseDir });
+  assert.equal(chron.length, 1);
+  assert.equal(chron[0].type, 'run_epilogue');
+});
+
+test('emitFailureEpilogue: null ctx -> no_ctx', () => {
+  assert.equal(emitFailureEpilogue(null).error, 'no_ctx');
+});


### PR DESCRIPTION
## SPEC-P failure epilogue + codex hook (run-fail -> lore, backend glue)

Advances **SPEC-P (failure-as-lore loop)** -- the loop's spec says *"0 hit `failureLore`, l'intero loop e' da costruire"*, but the building blocks are LIVE. This PR adds the missing **glue**: on run-fail, assemble the epilogue + emit the Codex discovery hook.

### Mechanism -- `services/narrative/failureEpilogue.js`
- `buildEpilogue(ctx)` (pure): run-fail context -> structured payload `{outcome, biome_id, wounded, fallen[], fallen_count, degrade_summary}`. This is the **DATA** the Godot **PA1** surface renders as the diegetic Skiv/Custode voice -- we assemble data, not narrative text (sez.4).
- `emitFailureEpilogue(ctx)` -> 2 chronicle events: **`run_epilogue`** (tier public, sez.4) + **`codex_update {entry_id, on:'failure'}`** (the Hades/B14 discovery hook the SPEC-H Codex consumer collects, sez.5). Best-effort, never throws.
- Doctrine "no numero opaco" (sez.2): degrade = diegetic tag (`biome_wounded`/`none`), never a raw float.

### Wired (best-effort) at session-end
After the A13 biome-wound block (`session.js`), so it reads the **updated** `woundedBiomes`. No-op on victory / no campaign_id. Reuses the LIVE pieces (do NOT rebuild): run_failed event + chronicle (#2668), A13 degrade (`biomeWound`, sez.6 LIVE), J5 fallen as input. `chronicleStore` whitelist += `run_epilogue`/`codex_update`.

### Deliberately out of scope
- Godot epilogue **surface** (fork PA1 = item 3) + the diegetic voice text (= surface/data).
- StressWave telegraph wire (sez.7, DEAD wire = combat PR + band-verify).
- Degrade cap/effect forks (PA2/PA4 -- A13 is already bounded ER2).

### Verification (TDD RED->GREEN)
- Service **13** (`tests/services/failureEpilogue.test.js`): build poles, run-fail outcomes, wounded detection, fallen filtering, emit + read-back, no-ops.
- **Wire**: `chronicleRunFailedWire.test.js` updated (a run-fail now also emits `run_epilogue`; find-by-type robust).
- **No regression**: chronicle emitters/store + a13 biome-wound green; **AI baseline no-break**.

### Merge gate
Production all in `apps/backend` (50-line exempt); test files outside -> gate #6 -> **manual Master-DD merge**. Forbidden paths: none. No new deps.

### Rollback
Revert commit (additive service + best-effort wire + 2 whitelist entries; run-fail flow otherwise untouched).

Coding-Agent: claude-opus-4-8
