### PR TITLE
feat(combat): SPEC-P PA3 read-side -- expose biome_wounded (anti-brick telegraph)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1749,6 +1749,7 @@ function createSessionRouter(options = {}) {
       const biomeIdRaw = req.body?.biome_id || req.body?.encounter?.biome_id || null;
       let biomeCostsLog = [];
       let ermesBand = null;
+      let biomeWounded = false; // SPEC-P PA3 -- wounded-biome flag (read-side telegraph)
       if (biomeIdRaw) {
         try {
           const biomeCostsRegistry = loadTraitEnvironmentalCosts();
@@ -1772,6 +1773,8 @@ function createSessionRouter(options = {}) {
           } catch {
             /* best-effort -- biome eco still applies without the wound amplifier */
           }
+          // SPEC-P PA3 read-side: surface the wounded-biome state (anti-brick telegraph).
+          biomeWounded = woundedStep > 0;
           units = units.map((u) => {
             if (!u) return u;
             const clone = { ...u };
@@ -2005,6 +2008,9 @@ function createSessionRouter(options = {}) {
         // FASE 3 P4: biome-level eco band (low/med/high) for the diegetic biome
         // chip descriptor ("Bioma calmo/in equilibrio/in tensione").
         ermes_band: ermesBand,
+        // SPEC-P PA3 read-side -- the biome is wounded this run (A13 cross-run).
+        // Diegetic flag for the anti-brick telegraph; the surface renders "bioma ferito".
+        biome_wounded: biomeWounded,
         // QW1 (M-018): runtime knobs derivati da biomes.yaml diff_base +
         // hazard.stress_modifiers. Esposto via /api/session/state per debug
         // + future UI hint. Consumed da round bridge (pressure_mult tick) e

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -495,6 +495,9 @@ function publicSessionView(session) {
     // FASE 3 P4 -- biome eco band (low/med/high) for the diegetic biome chip
     // descriptor ("Bioma calmo/in equilibrio/in tensione"). Null if no biome.
     ermes_band: session.ermes_band || null,
+    // SPEC-P PA3 read-side -- wounded-biome flag (A13 cross-run); the surface
+    // telegraphs it diegetically pre/in-run (anti-brick, no raw number).
+    biome_wounded: !!session.biome_wounded,
     // M1 ADR-2026-05-18 -- campaign scope + Sistema learning state (read-only surface).
     campaign_id: session.campaign_id || null,
     sistema_state: session.sistema_state || { units_observed: {} },

--- a/tests/api/a13BiomeWoundWire.test.js
+++ b/tests/api/a13BiomeWoundWire.test.js
@@ -123,3 +123,38 @@ test('A13 read-side: non-wounded biome -> no wounded eco debuff (backward compat
     .send({ units: LIVE_ECO, campaign_id: cid, biome_id: 'savana' });
   assert.deepEqual(ss.body.biomeCostsLog || [], []); // fresh biome -> no debuff
 });
+
+// SPEC-P PA3 read-side: the wounded-biome state is telegraphed (anti-brick) -- the
+// player must SEE pre/in-run that the biome is wounded, not just feel the debuff.
+test('A13 PA3: wounded biome exposes biome_wounded:true in /session/state', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'a13_pa3' });
+  const cid = start.body.campaign.id;
+  await runEnd(app, cid, DEAD, 'savana'); // wound savana
+  const ss = await request(app)
+    .post('/api/session/start')
+    .send({ units: LIVE_ECO, campaign_id: cid, biome_id: 'savana' });
+  const sid = ss.body.session_id || ss.body.id;
+  const state = await request(app).get('/api/session/state').query({ session_id: sid });
+  assert.equal(state.body.biome_wounded, true, 'wounded biome telegraphed in /state');
+});
+
+test('A13 PA3: fresh biome -> biome_wounded:false (backward compat)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'a13_pa3b' });
+  const cid = start.body.campaign.id;
+  const ss = await request(app)
+    .post('/api/session/start')
+    .send({ units: LIVE_ECO, campaign_id: cid, biome_id: 'savana' });
+  const sid = ss.body.session_id || ss.body.id;
+  const state = await request(app).get('/api/session/state').query({ session_id: sid });
+  assert.equal(state.body.biome_wounded, false);
+});


### PR DESCRIPTION
SPEC-P sez.6 residuo (PA3 read-side): the A13 wounded-biome eco debuff was applied SILENTLY -- the player felt harsher combat without seeing the biome is wounded (violates sez.8 anti-brick: degrade must be telegraphed, visible pre/in-run).

- `/session/start` sets `session.biome_wounded` when the biome is in `campaign.woundedBiomes`.
- `publicSessionView` (GET /api/session/state) exposes `biome_wounded` -- a **diegetic flag** (no raw number, SPEC-P doctrine) the surface renders as 'bioma ferito'.
- The render form/timing = **fork PA3** (Godot surface, item 3 / a small web biomeChip follow-up). This PR = the **backend read-side** only.

TDD: a13BiomeWoundWire +2 (wounded -> biome_wounded:true in /state ; fresh -> false); AI baseline no-break. apps/backend, no forbidden paths. Manual merge.

Coding-Agent: claude-opus-4-8