### PR TITLE
feat(play): SPEC-P PA3 biomeChip wounded telegraph -- consume biome_wounded (#2677)

### DIFF
--- a/apps/play/src/biomeChip.js
+++ b/apps/play/src/biomeChip.js
@@ -80,10 +80,27 @@ export function ecoBandLabel(band) {
   return label === i18nKey ? '' : label;
 }
 
+// Pure: wounded flag → diegetic IT label (SPEC-P PA3, #2677 read-side).
+// A13 cross-run: a biome wounded by a failed expedition reacts more harshly.
+// Anti-brick doctrine (SPEC-P sez.8): degrade MUST be telegraphed, NO raw number.
+// Falsy flag → '' (no marker). Hard fallback so the telegraph never shows a raw key.
+export function woundedLabel(biomeWounded) {
+  if (!biomeWounded) return '';
+  const i18nKey = 'biome_wounded.label';
+  const label = t(i18nKey);
+  return label === i18nKey ? 'Bioma ferito' : label;
+}
+
 // Pure: payload → HTML chip. Returns empty string se biome_id mancante.
 // Optional biomeModifiers param adds pressure indicator (TKT-ECO-A5).
 // Optional ermesBand (low/med/high) adds eco descriptor (FASE 3 P4).
-export function formatBiomeChip(biomeId, biomeModifiers = null, ermesBand = null) {
+// Optional biomeWounded (bool) adds wounded telegraph (SPEC-P PA3, #2677).
+export function formatBiomeChip(
+  biomeId,
+  biomeModifiers = null,
+  ermesBand = null,
+  biomeWounded = false,
+) {
   if (!biomeId) return '';
   const icon = iconForBiome(biomeId);
   const label = labelForBiome(biomeId);
@@ -96,11 +113,16 @@ export function formatBiomeChip(biomeId, biomeModifiers = null, ermesBand = null
   const ecoHtml = ecoLabel
     ? `<span class="biome-eco biome-eco-${ermesBand}" data-band="${ermesBand}">${escapeHtml(ecoLabel)}</span>`
     : '';
+  const woundedTxt = woundedLabel(biomeWounded);
+  const woundedHtml = woundedTxt
+    ? `<span class="biome-wounded" data-wounded="true">🩸 ${escapeHtml(woundedTxt)}</span>`
+    : '';
   return (
     `<span class="biome-icon">${icon}</span>` +
     `<span class="biome-label">${escapeHtml(label)}</span>` +
     pressureHtml +
-    ecoHtml
+    ecoHtml +
+    woundedHtml
   );
 }
 
@@ -121,9 +143,15 @@ function escapeHtml(s) {
 // Side effect: render biome chip into HUD container element.
 // Idempotent — sostituisce innerHTML. Hide via .biome-hidden class quando biome_id null.
 // TKT-ECO-A5 — optional biomeModifiers param surface pressure tier indicator.
-export function renderBiomeChip(containerEl, biomeId, biomeModifiers = null, ermesBand = null) {
+export function renderBiomeChip(
+  containerEl,
+  biomeId,
+  biomeModifiers = null,
+  ermesBand = null,
+  biomeWounded = false,
+) {
   if (!containerEl || typeof containerEl.innerHTML !== 'string') return;
-  const html = formatBiomeChip(biomeId, biomeModifiers, ermesBand);
+  const html = formatBiomeChip(biomeId, biomeModifiers, ermesBand, biomeWounded);
   if (!html) {
     containerEl.innerHTML = '';
     containerEl.classList.add('biome-hidden');
@@ -148,6 +176,14 @@ export function renderBiomeChip(containerEl, biomeId, biomeModifiers = null, erm
   const ecoLabel = ecoBandLabel(ermesBand);
   if (ecoLabel) {
     tooltip += ` · ${ecoLabel} (reazione del bioma ai tratti in gioco).`;
+  }
+  // SPEC-P PA3: wounded descriptor in tooltip (diegetic, anti-brick, no raw number).
+  const woundedTxt = woundedLabel(biomeWounded);
+  if (woundedTxt) {
+    const wKey = 'biome_wounded.tooltip';
+    const wTip = t(wKey);
+    const wDesc = wTip === wKey ? 'porta le cicatrici di una spedizione fallita' : wTip;
+    tooltip += ` · ${woundedTxt}: ${wDesc}.`;
   }
   containerEl.setAttribute('title', tooltip);
 }

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -1177,7 +1177,10 @@ function refreshBiomeChip() {
   const biomeModifiers = state.world?.biome_modifiers || null;
   // FASE 3 P4 — eco band (low/med/high) diegetic descriptor on the chip.
   const ermesBand = state.world?.ermes_band || null;
-  renderBiomeChip(containerEl, biomeId, biomeModifiers, ermesBand);
+  // SPEC-P PA3 (#2677) — wounded-biome flag (anti-brick telegraph). Top-level
+  // in publicSessionView (sibling of biome_id/ermes_band), so state.world.biome_wounded.
+  const biomeWounded = !!state.world?.biome_wounded;
+  renderBiomeChip(containerEl, biomeId, biomeModifiers, ermesBand, biomeWounded);
 }
 
 // Action 7 (ADR-2026-04-28 §Action 7) — refresh CT bar HUD lookahead 3 turni.

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -2378,6 +2378,14 @@ body.ability-target-mode canvas#grid {
   letter-spacing: 0.05em;
   font-size: 0.78rem;
 }
+/* SPEC-P PA3 (#2677) — wounded-biome telegraph. Diegetic, scar-red tint so the
+   anti-brick degrade is visible at a glance (no raw number, SPEC-P doctrine). */
+.biome-chip .biome-wounded {
+  color: #d98a8a;
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
 
 /* Action 7 (ADR-2026-04-28 §Action 7) — CT bar lookahead 3 turni HUD top-strip.
  * FFT-style temporal legibility: current actor pulse + 3 slot futuri con arrow

--- a/data/i18n/en/common.json
+++ b/data/i18n/en/common.json
@@ -135,6 +135,10 @@
     "med": "Balanced biome",
     "high": "Tense biome"
   },
+  "biome_wounded": {
+    "label": "Wounded biome",
+    "tooltip": "it bears the scars of a failed expedition; the ecosystem reacts more harshly"
+  },
   "ennea_archetype": {
     "1": "Reformer",
     "2": "Coordinator",

--- a/data/i18n/it/common.json
+++ b/data/i18n/it/common.json
@@ -135,6 +135,10 @@
     "med": "Bioma in equilibrio",
     "high": "Bioma in tensione"
   },
+  "biome_wounded": {
+    "label": "Bioma ferito",
+    "tooltip": "porta le cicatrici di una spedizione fallita; l'ecosistema reagisce con più durezza"
+  },
   "ennea_archetype": {
     "1": "Riformatore",
     "2": "Coordinatore",

--- a/tests/play/biomeChip.test.js
+++ b/tests/play/biomeChip.test.js
@@ -306,3 +306,87 @@ describe('ecoBandLabel + eco descriptor (FASE 3 P4)', () => {
     assert.ok(c._attrs.title.includes('Bioma calmo'));
   });
 });
+
+// SPEC-P PA3 — wounded-biome diegetic telegraph (#2677 read-side -> surface).
+// A13 cross-run: a biome wounded by a failed expedition reacts more harshly.
+// Anti-brick doctrine (SPEC-P sez.8): the degrade MUST be telegraphed, no raw number.
+describe('woundedLabel + wounded telegraph (SPEC-P PA3)', () => {
+  function fakeContainer() {
+    const classList = new Set();
+    const attrs = {};
+    return {
+      innerHTML: '',
+      classList: {
+        add: (...c) => c.forEach((x) => classList.add(x)),
+        remove: (...c) => c.forEach((x) => classList.delete(x)),
+        contains: (x) => classList.has(x),
+      },
+      setAttribute: (k, v) => {
+        attrs[k] = v;
+      },
+      removeAttribute: (k) => {
+        delete attrs[k];
+      },
+      _attrs: attrs,
+    };
+  }
+
+  test('woundedLabel(true) → diegetic IT label (never a raw number)', async () => {
+    const { woundedLabel } = await loadModule();
+    assert.equal(woundedLabel(true), 'Bioma ferito');
+    assert.ok(!/\d/.test(woundedLabel(true)));
+  });
+
+  test('woundedLabel falsy → empty string', async () => {
+    const { woundedLabel } = await loadModule();
+    assert.equal(woundedLabel(false), '');
+    assert.equal(woundedLabel(null), '');
+    assert.equal(woundedLabel(undefined), '');
+    assert.equal(woundedLabel(0), '');
+  });
+
+  test('formatBiomeChip — wounded flag appends biome-wounded span + label', async () => {
+    const { formatBiomeChip } = await loadModule();
+    const html = formatBiomeChip('savana', null, null, true);
+    assert.ok(html.includes('biome-wounded'));
+    assert.ok(html.includes('Bioma ferito'));
+    assert.ok(html.includes('data-wounded="true"'));
+  });
+
+  test('formatBiomeChip — no wounded span when flag false/omitted (backward compat)', async () => {
+    const { formatBiomeChip } = await loadModule();
+    assert.ok(!formatBiomeChip('savana', null, null, false).includes('biome-wounded'));
+    assert.ok(!formatBiomeChip('savana').includes('biome-wounded'));
+    assert.ok(!formatBiomeChip('savana', { hp_mult: 1.05 }, 'high').includes('biome-wounded'));
+  });
+
+  test('formatBiomeChip — wounded coexists with pressure tier + eco band', async () => {
+    const { formatBiomeChip } = await loadModule();
+    const html = formatBiomeChip(
+      'abisso_vulcanico',
+      { hp_mult: 1.15, pressure_initial_bonus: 15 },
+      'high',
+      true,
+    );
+    assert.ok(html.includes('biome-pressure-severe'));
+    assert.ok(html.includes('biome-eco-high'));
+    assert.ok(html.includes('biome-wounded'));
+    assert.ok(html.includes('Bioma ferito'));
+  });
+
+  test('renderBiomeChip — wounded descriptor in body + tooltip', async () => {
+    const { renderBiomeChip } = await loadModule();
+    const c = fakeContainer();
+    renderBiomeChip(c, 'savana', null, null, true);
+    assert.ok(c.innerHTML.includes('Bioma ferito'));
+    assert.ok(c._attrs.title.includes('ferito'));
+  });
+
+  test('renderBiomeChip — no wounded marker when flag false (backward compat)', async () => {
+    const { renderBiomeChip } = await loadModule();
+    const c = fakeContainer();
+    renderBiomeChip(c, 'savana', null, null, false);
+    assert.ok(!c.innerHTML.includes('biome-wounded'));
+    assert.ok(!c._attrs.title.includes('ferito'));
+  });
+});


### PR DESCRIPTION
## What

Wires the **web surface** for the `biome_wounded` flag that [#2677](https://github.com/MasterDD-L34D/Game/pull/2677) exposed in `publicSessionView` (`GET /api/session/state`). #2677 added the read-side flag but explicitly left the render fork open (*"the render form/timing = fork PA3 (Godot surface / web biomeChip follow-up)"*). This is the **web biomeChip** half.

When the current biome is wounded (A13 cross-run -- `campaign.woundedBiomes`), the HUD biome chip now shows a diegetic **"Bioma ferito"** telegraph (scar-red 🩸 marker + tooltip). Satisfies **SPEC-P sez.8 anti-brick**: the eco-debuff degrade must be *telegraphed* and visible pre/in-run, with **no raw number** (SPEC-P doctrine).

## Changelog

- `biomeChip.js`: new pure `woundedLabel(biomeWounded)` helper (resolves i18n SSOT `biome_wounded.label`, hard fallback so the telegraph never shows a raw key); `biomeWounded` param threaded through `formatBiomeChip` + `renderBiomeChip` (span + tooltip descriptor).
- `main.js`: `refreshBiomeChip()` reads `state.world.biome_wounded` (top-level in publicSessionView, sibling of `biome_id`/`ermes_band`).
- `data/i18n/{it,en}/common.json`: `biome_wounded.{label,tooltip}` (it: "Bioma ferito"; en: "Wounded biome").
- `style.css`: `.biome-wounded` scar-red rule (visible telegraph).
- `tests/play/biomeChip.test.js`: +7 TDD tests.

## Verification

- **TDD 36/36 green** (`node --test tests/play/biomeChip.test.js`) -- 7 new tests written RED (watched fail: `woundedLabel is not a function` + missing `biome-wounded` span) then GREEN. Covers: label resolution, falsy->empty, span+`data-wounded`, coexistence with pressure-tier + eco-band, tooltip, backward-compat (false/omitted -> no marker).
- **Vite build clean** (`npm run play:build`) -- 50 modules, new i18n key bundles via import-attributes JSON.
- **`prettier --check` clean** on all 6 files.
- Backend read-side already TDD'd by #2677 (`tests/api/a13BiomeWoundWire.test.js`).
- Live browser SKIPPED: preview dev-server blocked by a Windows cwd constraint in the preview wrapper (environment, not this change). Render logic proven via fake-DOM unit + production build; pixel CSS/emoji unverified (low-risk -- valid CSS, emoji literal in a tested HTML string, matches existing 🌾/🌍 chip pattern).

## Rollback (03A)

Additive + backward-compat (param defaults `false`; no schema / `data/core` / contract change). Safe revert: `git revert 81fab6689`. No migration, no data backfill.

## Gates

- Forbidden paths: **none** (apps/play + data/i18n + tests/play only).
- New deps: **none**.
- **>50 new lines outside `apps/backend/`** (144 insertions, 84 of them tests) -> trips sprint 50-line guardrail -> **NOT L3-auto-merge eligible** (gate 6) -> **needs manual master-dd merge**. Codex auto-review rate-limited (2026-06-09) -> manual merge covers the review gate.
- AI baseline untouched (no backend/AI files in diff).

Coding-Agent: claude-opus-4-8
Trace-Id: 019eadd7-b894-760f-afd8-08d1d1c4175e

🤖 Generated with [Claude Code](https://claude.com/claude-code)