### PR TITLE
chore(format): prettier su sot-drift-sentinel.yml (forbidden, consenso master-dd)

### DIFF
--- a/.github/workflows/sot-drift-sentinel.yml
+++ b/.github/workflows/sot-drift-sentinel.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # full history: before..sha range must cover every commit in the push
+          fetch-depth: 0 # full history: before..sha range must cover every commit in the push
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
Ultimo file Prettier-dirty del repo. **Forbidden path** \`.github/workflows/\` formattato con **consenso esplicito master-dd** (2026-06-09: "hai il permesso ed Ok per forbidden path").

Segue #2682 (che aveva escluso a monte questo workflow). Dopo questa PR il repo e' **Prettier-clean al 100%** (\`prettier --list-different .\` vuoto).

## Diff
1 riga, solo whitespace: rimossi spazi extra prima del commento inline su \`fetch-depth: 0\`. Zero cambio semantico.

## Verify
- YAML valido (\`yaml.safe_load\` OK)
- \`prettier --list-different .\` -> vuoto (repo interamente clean)

## Rollback
\`git revert d86d84e5b\` (puro whitespace).

Coding-Agent: claude-opus-4-8
Trace-Id: 019eae07-* (vedi commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)