### PR TITLE
feat(coop): companion voice from creature axes + confirmWorld FP fallback (#2679)

### DIFF
--- a/apps/backend/services/companion/companionPicker.js
+++ b/apps/backend/services/companion/companionPicker.js
@@ -85,18 +85,18 @@ function _resolveBiomePool(pool, biomeId, allowFallback = true) {
 }
 
 function _resolveVoiceModifier(pool, formAxes = {}) {
+  // #2679 -- reads creature axes (signed [-1,+1]); aligned to formPulseVc
+  // (symbiosis_predation <-> T_F, explore_caution <-> S_N). Was MBTI T/F/N/S.
+  //   +Predazione -> fredda_analitica   / -Simbiosi -> empatica_branco
+  //   -Esplorazione -> visionaria_intuitiva / +Cauto -> sensoriale_presente
   const threshold = 0.6;
-  const t = Number.isFinite(formAxes.T) ? formAxes.T : 0.5;
-  const f = Number.isFinite(formAxes.F) ? formAxes.F : 0.5;
-  const n = Number.isFinite(formAxes.N) ? formAxes.N : 0.5;
-  const s = Number.isFinite(formAxes.S) ? formAxes.S : 0.5;
+  const sp = Number.isFinite(formAxes.symbiosis_predation) ? formAxes.symbiosis_predation : 0;
+  const ec = Number.isFinite(formAxes.explore_caution) ? formAxes.explore_caution : 0;
   const mods = (pool && pool.generative_rules && pool.generative_rules.mbti_personality_bias) || {};
-  if (t >= threshold && t > f) return mods.solitari_t_high?.voice_modifier || 'fredda_analitica';
-  if (f >= threshold && f > t) return mods.simbionti_f_high?.voice_modifier || 'empatica_branco';
-  if (n >= threshold && n > s)
-    return mods.esploratori_n_high?.voice_modifier || 'visionaria_intuitiva';
-  if (s >= threshold && s > n)
-    return mods.sensoriali_s_high?.voice_modifier || 'sensoriale_presente';
+  if (sp >= threshold) return mods.solitari_t_high?.voice_modifier || 'fredda_analitica';
+  if (sp <= -threshold) return mods.simbionti_f_high?.voice_modifier || 'empatica_branco';
+  if (ec <= -threshold) return mods.esploratori_n_high?.voice_modifier || 'visionaria_intuitiva';
+  if (ec >= threshold) return mods.sensoriali_s_high?.voice_modifier || 'sensoriale_presente';
   return '';
 }
 
@@ -141,7 +141,7 @@ function _resolveEnneaArchetype(pool, biomeOriginId) {
  * @param {object} opts
  * @param {string} [opts.poolPath]            — skiv_archetype_pool.yaml path
  * @param {string} opts.biomeId               — primary biome slug
- * @param {object} [opts.formAxes]            — party MBTI {T,F,N,S} ∈ [0,1]
+ * @param {object} [opts.formAxes]            -- party creature axes signed [-1,+1]
  * @param {number} [opts.runSeed=0]           — deterministic name+closing seed
  * @param {boolean} [opts.trainerCanonical]   — B3 hybrid override flag
  * @returns {object} CompanionInstance or {} when pool missing

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -10,6 +10,7 @@ const { createSistemaStateStore } = require('../ai/sistemaStateStore');
 const { createRosterStore } = require('../campaign/rosterStore');
 const { checkNidoUnlock } = require('../../routes/sessionHelpers');
 const { emergeBrancoTraitFromPulses } = require('../identity/brancoTraitEmergence');
+const { aggregateFormPulses } = require('../formPulseVc');
 
 // CAMP-1/CAMP-2 - run.id is the SistemaState persistence key (server writes
 // SistemaState under run.id; Godot client keys CampaignState.campaign_id on
@@ -507,7 +508,13 @@ class CoopOrchestrator {
         // role reported as fully under-represented (false negative).
         enrichedWorld = enricher.enrichWorld({
           biomeId,
-          formAxes: formAxes || {},
+          // #2679 -- fall back to the aggregated form-pulse creature axes when the
+          // caller passes none (Godot confirm_world omits form_axes); lets the
+          // companion voice reflect the branco lean.
+          formAxes:
+            formAxes && Object.keys(formAxes).length
+              ? formAxes
+              : aggregateFormPulses(this.formPulses),
           party: Array.from(this.characters.values()),
           runSeed: Number.isFinite(runSeed) ? runSeed : 0,
           trainerCanonical: Boolean(trainerCanonical),

--- a/apps/backend/services/coop/worldEnricher.js
+++ b/apps/backend/services/coop/worldEnricher.js
@@ -32,7 +32,7 @@ const companionPickerDefault = require('../companion/companionPicker');
  *
  * @param {object} input
  * @param {string} input.biomeId — primary biome slug
- * @param {object} [input.formAxes] — party MBTI {T,F,N,S}
+ * @param {object} [input.formAxes] -- party creature axes signed [-1,+1]
  * @param {Array} [input.party] — W5.5: Array of player dicts with .job_id
  *   (or Array[String] job_ids) — used by ermes role_gap compute
  * @param {number} [input.runSeed=0] — deterministic name+closing seed

--- a/tests/services/companion/companionPicker.test.js
+++ b/tests/services/companion/companionPicker.test.js
@@ -75,33 +75,33 @@ test('unknown biome falls back to savana pool', () => {
 
 // --- MBTI voice modifier ---
 
-test('T-dominant assigns solitari modifier', () => {
+test('Predazione assigns fredda_analitica', () => {
   reset();
-  const c = pick({ biomeId: 'savana', formAxes: { T: 0.85, F: 0.15, N: 0.5, S: 0.5 } });
+  const c = pick({ biomeId: 'savana', formAxes: { symbiosis_predation: 0.85 } });
   assert.equal(c.voice_modifier, 'fredda_analitica');
 });
 
-test('F-dominant assigns simbionti modifier', () => {
+test('Simbiosi assigns empatica_branco', () => {
   reset();
-  const c = pick({ biomeId: 'savana', formAxes: { T: 0.2, F: 0.8, N: 0.5, S: 0.5 } });
+  const c = pick({ biomeId: 'savana', formAxes: { symbiosis_predation: -0.85 } });
   assert.equal(c.voice_modifier, 'empatica_branco');
 });
 
-test('N-dominant assigns esploratori modifier', () => {
+test('Esplorazione assigns visionaria_intuitiva', () => {
   reset();
-  const c = pick({ biomeId: 'savana', formAxes: { T: 0.5, F: 0.5, N: 0.8, S: 0.2 } });
+  const c = pick({ biomeId: 'savana', formAxes: { explore_caution: -0.85 } });
   assert.equal(c.voice_modifier, 'visionaria_intuitiva');
 });
 
-test('S-dominant assigns sensoriali modifier', () => {
+test('Cauto assigns sensoriale_presente', () => {
   reset();
-  const c = pick({ biomeId: 'savana', formAxes: { T: 0.5, F: 0.5, N: 0.2, S: 0.8 } });
+  const c = pick({ biomeId: 'savana', formAxes: { explore_caution: 0.85 } });
   assert.equal(c.voice_modifier, 'sensoriale_presente');
 });
 
 test('neutral axes no modifier', () => {
   reset();
-  const c = pick({ biomeId: 'savana', formAxes: { T: 0.5, F: 0.5, N: 0.5, S: 0.5 } });
+  const c = pick({ biomeId: 'savana', formAxes: {} });
   assert.equal(c.voice_modifier, '');
 });
 

--- a/tests/services/coop/coopOrchestrator-w5bb.test.js
+++ b/tests/services/coop/coopOrchestrator-w5bb.test.js
@@ -115,3 +115,12 @@ test('confirmWorld preserves backward-compat (legacy callers)', () => {
   assert.equal(result.enriched_world, null);
   assert.equal(orch.enrichedWorld, null);
 });
+
+test('confirmWorld with no formAxes uses aggregated form pulses for companion voice (#2679)', () => {
+  const orch = buildOrch();
+  // Player submits a creature-axis form pulse leaning Predazione.
+  orch.submitFormPulse('p_a', { axes: { symbiosis_predation: 0.85 } }, { allPlayerIds: ['p_a'] });
+  // confirmWorld omits formAxes (Godot host does) -> falls back to this.formPulses.
+  const result = orch.confirmWorld({ scenarioId: 'enc_tutorial_01', biomeId: 'savana' });
+  assert.equal(result.enriched_world.custode.voice_modifier, 'fredda_analitica');
+});

--- a/tests/services/coop/worldEnricher.test.js
+++ b/tests/services/coop/worldEnricher.test.js
@@ -56,10 +56,10 @@ test('enrichWorld B3 hybrid override Skiv canonical', () => {
   assert.equal(r.custode.voice_modifier, 'canonical');
 });
 
-test('enrichWorld MBTI bias propagates to custode', () => {
+test('enrichWorld creature-axis bias propagates to custode', () => {
   const r = enrichWorld({
     biomeId: 'savana',
-    formAxes: { T: 0.85, F: 0.15, N: 0.5, S: 0.5 },
+    formAxes: { symbiosis_predation: 0.85 },
   });
   assert.equal(r.custode.voice_modifier, 'fredda_analitica');
 });


### PR DESCRIPTION
## What (Game#2679 backend-companion follow-on, 2a + 2b)

- **2a** `companionPicker._resolveVoiceModifier` reads creature axes
  (`symbiosis_predation` + `explore_caution` poles) instead of MBTI `T/F/N/S`;
  aligned to `formPulseVc`, same 4 voice flavors. `worldEnricher` passes through.
- **2b** `coopOrchestrator.confirmWorld` falls back to
  `aggregateFormPulses(this.formPulses)` when the caller passes no `formAxes`
  (Godot `confirm_world` omits it) -> the companion voice now reflects the
  branco's submitted Form Pulse **end-to-end** (was always neutral). Explicit
  `formAxes` still wins (backward-compat).

No Godot change needed (the backend reads its own `formPulses`).

## Verify

`node:test`: companion + worldEnricher voice tests re-keyed to creature axes + a
new `confirmWorld` FP-fallback test; coop + companion suites **280/280** green;
`prettier --check` clean.

Closes the backend-companion slice of Game#2679. Remaining: Opt 3 OUTPUT
derivation, J_P ratification, name-emergence, device playtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)