### PR TITLE
feat: personalityAxes Opt 3 output core + debrief payload fold (#2679)

### DIFF
--- a/apps/backend/services/coop/vcSnapshotToDebriefPayload.js
+++ b/apps/backend/services/coop/vcSnapshotToDebriefPayload.js
@@ -18,13 +18,16 @@
 //       <uid>: {
 //         sentience_tier: "T0"-"T6",
 //         conviction_axis: { utility, liberty, morality },  // 3 keys, int
-//         ennea_archetype: "<canonical IT name>"             // single primary
+//         ennea_archetype: "<canonical IT name>",            // single primary
+//         personality_axes: { <5 EN creature keys>: float }  // optional, Opt 3 #2679
 //       }
 //     }
 //   }
 //
 // Cross-stack contract: PR #276 schema parity snapshot Godot v2.
 'use strict';
+
+const { deriveFromVcActor, hasSignal } = require('../personalityAxes');
 
 const CANONICAL_AXIS_KEYS = ['utility', 'liberty', 'morality'];
 
@@ -34,7 +37,7 @@ const CANONICAL_AXIS_KEYS = ['utility', 'liberty', 'morality'];
  * @param {object} vcSnapshot — output of vcScoring.buildVcSnapshot(session, config)
  * @returns {object} debrief_payload `{per_actor: {<uid>: {...3 layers...}}}`
  */
-function vcSnapshotToDebriefPayload(vcSnapshot) {
+function vcSnapshotToDebriefPayload(vcSnapshot, unitStatsById = null) {
   const payload = { per_actor: {} };
   if (!vcSnapshot || typeof vcSnapshot !== 'object') return payload;
   const perActor = vcSnapshot.per_actor;
@@ -78,6 +81,19 @@ function vcSnapshotToDebriefPayload(vcSnapshot) {
       // never emits bare strings).
       else if (typeof ennea[0] === 'string') {
         entry.ennea_archetype = ennea[0];
+      }
+    }
+
+    // Opt 3 OUTPUT (#2679) -- additive personality_axes fold (PROPOSED
+    // constants, ratify N=40). Skipped when the actor carries no derivable
+    // signal (pure-neutral pentagon = payload bloat). Mirror: Godot
+    // DebriefState.to_debrief_payload personality_axes fold.
+    if (hasSignal(actorData)) {
+      const stats =
+        unitStatsById && typeof unitStatsById === 'object' ? unitStatsById[uid] || null : null;
+      const personality = deriveFromVcActor(actorData, stats);
+      if (personality) {
+        entry.personality_axes = personality;
       }
     }
 

--- a/apps/backend/services/personalityAxes.js
+++ b/apps/backend/services/personalityAxes.js
@@ -1,0 +1,169 @@
+// =============================================================================
+// Opt 3 OUTPUT derivation (#2679) -- post-match 5-axis personality from combat.
+//
+// Pure scalar core: 8 inputs in [0,1] (or null/absent) -> 5 display axes in
+// [0,1] keyed by the canonical EN creature keys (radar order). 0.5 = neutral.
+// +pole = 1.0 per the canonical display contract: Predazione / Cauto / Sciame /
+// Memoria / Robusto. MBTI direction follows the ENGINE letter convention
+// (vcScoring deriveMbtiType: value HIGH = I/S/T/J) -- the 2026-04-27 research
+// doc formulas are pole-local; here they are re-expressed against the contract.
+//
+// MIRROR: Game-Godot-v2 scripts/ai/personality_axes.gd (parity fixtures in both
+// test suites). Stat normalization is an ADAPTER concern (stack scales differ).
+//
+// GOVERNANCE -- PROPOSED constants (ratify N=40, SPEC-M item 2, NOT fiat):
+// blend weights + stat bounds below. Flagged inconsistencies (NOT resolved
+// here, same N=40 batch):
+//   - J_P: input formPulseVc maps memory_instinct <-> J_P; this output spends
+//     J_P in explore_caution and derives memory_instinct behaviourally.
+//   - E_I: PROPOSED_FP_VC_MAPPING comments "+Sciame -> +E_I (extraversion
+//     proxy)" but the engine convention is E_I HIGH = Introvert; this output
+//     uses the engine convention (solitary_swarm = 1 - E_I).
+// Spec: Game-Godot-v2 docs/superpowers/specs/
+//   2026-06-09-personality-axes-output-derivation-design.md
+// =============================================================================
+'use strict';
+
+const AXIS_KEYS = [
+  'symbiosis_predation',
+  'explore_caution',
+  'solitary_swarm',
+  'memory_instinct',
+  'agile_robust',
+];
+
+const NEUTRAL = 0.5;
+
+// PROPOSED (N=40): blend weights.
+const EXPLORE_SN_WEIGHT = 0.6;
+const EXPLORE_JP_WEIGHT = 0.4;
+const MEMORY_SWITCH_WEIGHT = 0.5;
+const MEMORY_SETUP_WEIGHT = 0.5;
+const AGILE_SPEED_WEIGHT = 0.7;
+const AGILE_HP_WEIGHT = 0.3;
+
+// PROPOSED (N=40): backend species-scale stat bounds (research-suggested).
+const STAT_BOUNDS = {
+  speed: { min: 1, max: 6 },
+  hp: { min: 6, max: 20 },
+};
+
+function clamp01(x) {
+  return Math.max(0, Math.min(1, x));
+}
+
+function num(v) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Linear [min,max] -> [0,1] with clamp. Null on non-finite value or
+ * degenerate bounds (caller treats null as "stat not derivable").
+ */
+function normalizeStat(value, min, max) {
+  const v = num(value);
+  if (v === null || !(max > min)) return null;
+  return clamp01((v - min) / (max - min));
+}
+
+/**
+ * Pure core: derive the 5 display axes from 8 scalar inputs.
+ * Any missing/null required input degrades THAT axis to 0.5 (neutral).
+ *
+ * @param {object} inputs — { t_f, e_i, s_n, j_p, action_switch_rate,
+ *   setup_ratio, speed_norm, hp_norm } each [0,1] or null/absent
+ * @returns {object} { <5 EN creature keys>: float [0,1] }
+ */
+function deriveAxes(inputs = {}) {
+  const tF = num(inputs.t_f);
+  const eI = num(inputs.e_i);
+  const sN = num(inputs.s_n);
+  const jP = num(inputs.j_p);
+  const switchRate = num(inputs.action_switch_rate);
+  const setupRatio = num(inputs.setup_ratio);
+  const speedNorm = num(inputs.speed_norm);
+  const hpNorm = num(inputs.hp_norm);
+
+  return {
+    // T_F high = T = Predazione (+pole right).
+    symbiosis_predation: tF === null ? NEUTRAL : clamp01(tF),
+    // S (concrete) + J (planner) = Cauto (+pole right).
+    explore_caution:
+      sN === null || jP === null
+        ? NEUTRAL
+        : clamp01(EXPLORE_SN_WEIGHT * clamp01(sN) + EXPLORE_JP_WEIGHT * clamp01(jP)),
+    // E_I high = I = Solitario -> invert for +pole Sciame.
+    solitary_swarm: eI === null ? NEUTRAL : clamp01(1 - clamp01(eI)),
+    // Low switch + high setup = Memoria (display domain: 1.0 = Memoria).
+    memory_instinct:
+      switchRate === null || setupRatio === null
+        ? NEUTRAL
+        : clamp01(
+            MEMORY_SWITCH_WEIGHT * (1 - clamp01(switchRate)) +
+              MEMORY_SETUP_WEIGHT * clamp01(setupRatio),
+          ),
+    // Slow + tanky = Robusto (+pole right) -> invert the research agile axis.
+    agile_robust:
+      speedNorm === null || hpNorm === null
+        ? NEUTRAL
+        : clamp01(
+            AGILE_SPEED_WEIGHT * (1 - clamp01(speedNorm)) + AGILE_HP_WEIGHT * clamp01(hpNorm),
+          ),
+  };
+}
+
+function axisValue(axis) {
+  return axis && typeof axis === 'object' ? num(axis.value) : null;
+}
+
+/**
+ * True when the actor entry carries at least one derivable signal (a finite
+ * mbti axis value or a finite behavioural raw metric). Serializers use this
+ * to skip pure-neutral payload bloat.
+ */
+function hasSignal(actorEntry) {
+  if (!actorEntry || typeof actorEntry !== 'object') return false;
+  const axes = actorEntry.mbti_axes || {};
+  for (const key of ['T_F', 'E_I', 'S_N', 'J_P']) {
+    if (axisValue(axes[key]) !== null) return true;
+  }
+  const raw = actorEntry.raw_metrics || {};
+  return num(raw.action_switch_rate) !== null || num(raw.setup_ratio) !== null;
+}
+
+/**
+ * Adapter from a buildVcSnapshot per_actor entry (+ optional unit stats).
+ *
+ * @param {object} actorEntry — per_actor[uid] (mbti_axes {value,coverage},
+ *   raw_metrics {action_switch_rate, setup_ratio})
+ * @param {object|null} unitStats — { speed, hp_max } in backend species scale
+ * @param {object} [opts] — { bounds } override for STAT_BOUNDS
+ * @returns {object|null} 5-axis map, or null on non-object actorEntry
+ */
+function deriveFromVcActor(actorEntry, unitStats = null, opts = {}) {
+  if (!actorEntry || typeof actorEntry !== 'object') return null;
+  const axes = actorEntry.mbti_axes || {};
+  const raw = actorEntry.raw_metrics || {};
+  const bounds = opts.bounds || STAT_BOUNDS;
+  return deriveAxes({
+    t_f: axisValue(axes.T_F),
+    e_i: axisValue(axes.E_I),
+    s_n: axisValue(axes.S_N),
+    j_p: axisValue(axes.J_P),
+    action_switch_rate: num(raw.action_switch_rate),
+    setup_ratio: num(raw.setup_ratio),
+    speed_norm: unitStats
+      ? normalizeStat(unitStats.speed, bounds.speed.min, bounds.speed.max)
+      : null,
+    hp_norm: unitStats ? normalizeStat(unitStats.hp_max, bounds.hp.min, bounds.hp.max) : null,
+  });
+}
+
+module.exports = {
+  AXIS_KEYS,
+  STAT_BOUNDS,
+  deriveAxes,
+  deriveFromVcActor,
+  normalizeStat,
+  hasSignal,
+};

--- a/tests/api/vcSnapshotToDebriefPayload.test.js
+++ b/tests/api/vcSnapshotToDebriefPayload.test.js
@@ -182,3 +182,43 @@ test('mixed triggered/untriggered picks first triggered', () => {
   const out = vcSnapshotToDebriefPayload(_snap({ pg: actor }));
   assert.equal(out.per_actor.pg.ennea_archetype, 'enn_b');
 });
+
+// Opt 3 OUTPUT (#2679) -- additive personality_axes fold.
+test('personality_axes: folded additively when actor has signal', () => {
+  const actor = _fullActor();
+  actor.mbti_axes = {
+    T_F: { value: 0.9, coverage: 'full' },
+    E_I: { value: 0.2, coverage: 'full' },
+    S_N: { value: 0.7, coverage: 'full' },
+    J_P: { value: 0.6, coverage: 'full' },
+  };
+  actor.raw_metrics = { action_switch_rate: 0.25, setup_ratio: 0.8 };
+  const out = vcSnapshotToDebriefPayload(_snap({ u1: actor }), {
+    u1: { speed: 3.5, hp_max: 13 },
+  });
+  const axes = out.per_actor.u1.personality_axes;
+  assert.ok(axes, 'personality_axes expected');
+  assert.ok(Math.abs(axes.symbiosis_predation - 0.9) < 1e-9);
+  assert.ok(Math.abs(axes.solitary_swarm - 0.8) < 1e-9);
+  // speed 3.5 in [1,6] -> 0.5; hp 13 in [6,20] -> 0.5 -> agile_robust 0.5
+  assert.ok(Math.abs(axes.agile_robust - 0.5) < 1e-9);
+});
+
+test('personality_axes: omitted when no derivable signal (back-compat)', () => {
+  const actor = _fullActor({ sent: { tier: 'T1', source: 'default-fallback' } });
+  actor.mbti_axes = { T_F: null, E_I: null, S_N: null, J_P: null };
+  actor.raw_metrics = {};
+  const out = vcSnapshotToDebriefPayload(_snap({ u1: actor }));
+  assert.equal('personality_axes' in out.per_actor.u1, false);
+  assert.equal(out.per_actor.u1.sentience_tier, 'T1');
+});
+
+test('personality_axes: no unitStats arg -> agile_robust neutral (back-compat single-arg call)', () => {
+  const actor = _fullActor();
+  actor.mbti_axes = { T_F: { value: 1, coverage: 'full' } };
+  const out = vcSnapshotToDebriefPayload(_snap({ u1: actor }));
+  const axes = out.per_actor.u1.personality_axes;
+  assert.ok(axes);
+  assert.equal(axes.symbiosis_predation, 1);
+  assert.equal(axes.agile_robust, 0.5);
+});

--- a/tests/services/personalityAxes.test.js
+++ b/tests/services/personalityAxes.test.js
@@ -1,0 +1,145 @@
+// Opt 3 OUTPUT derivation (#2679) -- pure core tests.
+// PARITY FIXTURES: keep in sync with GGv2 tests/unit/test_personality_axes.gd
+// (same scalar inputs -> same expected outputs, both stacks).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  AXIS_KEYS,
+  deriveAxes,
+  deriveFromVcActor,
+  normalizeStat,
+  hasSignal,
+} = require('../../apps/backend/services/personalityAxes');
+
+const NEUTRAL_INPUTS = {
+  t_f: 0.5,
+  e_i: 0.5,
+  s_n: 0.5,
+  j_p: 0.5,
+  action_switch_rate: 0.5,
+  setup_ratio: 0.5,
+  speed_norm: 0.5,
+  hp_norm: 0.5,
+};
+
+test('AXIS_KEYS: the 5 canonical EN creature keys in radar order', () => {
+  assert.deepEqual(AXIS_KEYS, [
+    'symbiosis_predation',
+    'explore_caution',
+    'solitary_swarm',
+    'memory_instinct',
+    'agile_robust',
+  ]);
+});
+
+test('parity fixture: neutral -> all 0.5', () => {
+  const axes = deriveAxes(NEUTRAL_INPUTS);
+  for (const key of AXIS_KEYS) {
+    assert.ok(Math.abs(axes[key] - 0.5) < 1e-9, `${key} expected 0.5 got ${axes[key]}`);
+  }
+});
+
+test('parity fixture: predator-planner poles', () => {
+  const axes = deriveAxes({
+    ...NEUTRAL_INPUTS,
+    t_f: 1,
+    e_i: 1,
+    s_n: 1,
+    j_p: 1,
+    action_switch_rate: 0,
+    setup_ratio: 1,
+  });
+  assert.equal(axes.symbiosis_predation, 1); // T_F high = T = Predazione (+pole)
+  assert.equal(axes.solitary_swarm, 0); // E_I high = I = Solitario -> 1 - e_i
+  assert.equal(axes.explore_caution, 1); // S + J = Cauto (+pole)
+  assert.equal(axes.memory_instinct, 1); // no switch + setup = Memoria (+pole)
+});
+
+test('parity fixture: swarm-improviser poles', () => {
+  const axes = deriveAxes({
+    ...NEUTRAL_INPUTS,
+    t_f: 0,
+    e_i: 0,
+    s_n: 0,
+    j_p: 0,
+    action_switch_rate: 1,
+    setup_ratio: 0,
+  });
+  assert.equal(axes.symbiosis_predation, 0);
+  assert.equal(axes.solitary_swarm, 1); // E behaviour -> Sciame
+  assert.equal(axes.explore_caution, 0); // N + P -> Esplorativo
+  assert.equal(axes.memory_instinct, 0); // all switch, no setup -> Istinto
+});
+
+test('parity fixture: glass-cannon / tank agile_robust orientation', () => {
+  const glass = deriveAxes({ ...NEUTRAL_INPUTS, speed_norm: 1, hp_norm: 0 });
+  assert.equal(glass.agile_robust, 0); // fast + fragile = Agile (0; +pole is Robusto)
+  const tank = deriveAxes({ ...NEUTRAL_INPUTS, speed_norm: 0, hp_norm: 1 });
+  assert.equal(tank.agile_robust, 1); // slow + tanky = Robusto (+pole)
+});
+
+test('parity fixture: missing inputs degrade per-axis to 0.5', () => {
+  const axes = deriveAxes({ t_f: 0.8 });
+  assert.ok(Math.abs(axes.symbiosis_predation - 0.8) < 1e-9);
+  assert.equal(axes.solitary_swarm, 0.5);
+  assert.equal(axes.explore_caution, 0.5);
+  assert.equal(axes.memory_instinct, 0.5);
+  assert.equal(axes.agile_robust, 0.5);
+});
+
+test('deriveAxes clamps out-of-range inputs', () => {
+  const axes = deriveAxes({ ...NEUTRAL_INPUTS, t_f: 1.7, e_i: -0.3 });
+  assert.equal(axes.symbiosis_predation, 1);
+  assert.equal(axes.solitary_swarm, 1); // 1 - clamp01(-0.3) = 1 - 0 = 1
+});
+
+test('normalizeStat: linear clamp01, null on bad bounds / non-finite', () => {
+  assert.equal(normalizeStat(3.5, 1, 6), 0.5);
+  assert.equal(normalizeStat(0, 1, 6), 0); // below min clamps
+  assert.equal(normalizeStat(99, 1, 6), 1); // above max clamps
+  assert.equal(normalizeStat('x', 1, 6), null);
+  assert.equal(normalizeStat(3, 6, 6), null); // degenerate bounds
+});
+
+test('deriveFromVcActor: real vcSnapshot per_actor shape', () => {
+  const actor = {
+    mbti_axes: {
+      T_F: { value: 0.9, coverage: 'full' },
+      E_I: { value: 0.2, coverage: 'partial' },
+      S_N: { value: 0.7, coverage: 'full' },
+      J_P: { value: 0.6, coverage: 'partial' },
+    },
+    raw_metrics: { action_switch_rate: 0.25, setup_ratio: 0.8 },
+  };
+  const axes = deriveFromVcActor(actor, { speed: 3.5, hp_max: 13 });
+  assert.ok(Math.abs(axes.symbiosis_predation - 0.9) < 1e-9);
+  assert.ok(Math.abs(axes.solitary_swarm - 0.8) < 1e-9);
+  assert.ok(Math.abs(axes.explore_caution - (0.6 * 0.7 + 0.4 * 0.6)) < 1e-9);
+  assert.ok(Math.abs(axes.memory_instinct - (0.5 * 0.75 + 0.5 * 0.8)) < 1e-9);
+  // speed 3.5 in [1,6] -> 0.5; hp 13 in [6,20] -> 0.5 -> agile_robust 0.5
+  assert.ok(Math.abs(axes.agile_robust - 0.5) < 1e-9);
+});
+
+test('deriveFromVcActor: null-coverage axes + no stats -> per-axis neutral', () => {
+  const actor = {
+    mbti_axes: { T_F: { value: 0.9 }, E_I: null, S_N: null, J_P: null },
+    raw_metrics: { action_switch_rate: null, setup_ratio: 0.4 },
+  };
+  const axes = deriveFromVcActor(actor, null);
+  assert.ok(Math.abs(axes.symbiosis_predation - 0.9) < 1e-9);
+  assert.equal(axes.solitary_swarm, 0.5);
+  assert.equal(axes.explore_caution, 0.5);
+  assert.equal(axes.memory_instinct, 0.5); // switch null -> neutral
+  assert.equal(axes.agile_robust, 0.5);
+});
+
+test('hasSignal: true with one finite mbti value, false when all null/absent', () => {
+  assert.equal(hasSignal({ mbti_axes: { T_F: { value: 0.7 } } }), true);
+  assert.equal(hasSignal({ raw_metrics: { setup_ratio: 0.3 } }), true);
+  assert.equal(hasSignal({ mbti_axes: { T_F: null, E_I: null }, raw_metrics: {} }), false);
+  assert.equal(hasSignal(null), false);
+  assert.equal(hasSignal({}), false);
+});


### PR DESCRIPTION
## Opt 3 OUTPUT derivation (#2679 follow-on) -- canonical mechanism

Combat -> 5 display personality axes ([0,1], EN creature keys). Canonical pure core; Godot port mirrors it (GGv2 PR #460, same branch name; parity fixture table duplicated in both suites).

### What ships
- `apps/backend/services/personalityAxes.js` -- pure scalar core `deriveAxes` + `deriveFromVcActor` adapter (vcSnapshot per_actor shape) + `normalizeStat` + `hasSignal`. Pole-corrected vs the 2026-04-27 research doc: formulas re-expressed against the canonical +pole contract (Predazione/Cauto/Sciame/Memoria/Robusto) using the engine letter convention (T_F/E_I/S_N/J_P HIGH = T/I/S/J).
- `vcSnapshotToDebriefPayload.js` -- additive optional `personality_axes` fold (+ optional `unitStatsById` second param). Mirror of Godot `DebriefState.to_debrief_payload`.

### Governance
- Blend weights + stat bounds **PROPOSED -- ratify N=40 (SPEC-M item 2)**, not fiat (same posture as `PROPOSED_FP_VC_MAPPING`).
- Flags recorded, NOT resolved (same N=40 batch): J_P input/output mapping; **NEW: formPulseVc E_I sign** (the "+Sciame -> +E_I extraversion proxy" comment conflicts with the engine E_I-high=Introvert convention; output uses the engine convention, solitary_swarm = 1 - E_I).

### Verification
- node --test tests/services/personalityAxes.test.js 11/11; tests/api/vcSnapshotToDebriefPayload.test.js 19/19 (3 new).
- FULL npm test green (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)