### PR TITLE
docs(governance): registra SPEC-A device-input-ledger nel registry

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -8916,6 +8916,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/design/evo-tactics-device-input-ledger.md",
+      "title": "Evo-Tactics Device Input Ledger (SPEC-A)",
+      "doc_status": "review_needed",
+      "doc_owner": "master-dd",
+      "workstream": "flow",
+      "last_verified": "2026-06-07",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "new"
     }
   ]
 }

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-09T23:08:04+00:00",
+  "generated_at": "2026-06-09T23:12:12+00:00",
   "summary": {
     "total": 253,
     "errors": 0,


### PR DESCRIPTION
## Cosa

Catch durante verify post-#2690: `docs/design/evo-tactics-device-input-ledger.md` (SPEC-A, shipped #2618) esiste su disco con frontmatter completo ma **non e' mai stato registrato** in `docs_registry.json` -- registry-sync miss della sessione di ship. Spec evo-tactics nel registry: 16 -> **17/17**.

Entry = mirror esatto del frontmatter (`doc_status: review_needed` invariato -- il flip SPEC-A e' judgment separato, fuori scope).

## Gap tool collegato (non fixato qui)

`check_docs_governance.py` valida registry->disk + frontmatter-vs-registry per entry esistenti, ma e' **cieco sulla direction disk->registry**: un .md governato non registrato non genera ne' error ne' warning. Fix proposto come task separato.

## Verifica

- `check_docs_governance --strict`: errors=0, mismatch=0 (warnings 253 invariate).
- Prettier: green. JSON parse: 17 entry `docs/design/evo-tactics-*`.

## Rollback (03A)

Revert commit singolo `6c610b258` (docs-only). Changelog: registry +SPEC-A entry.

Refs: #2618 (SPEC-A ship) - #2689/#2690 (registry-sync item-1)