### PR TITLE
fix(identity): empty name-pool -> anonymous identity (coherence)

### DIFF
--- a/apps/backend/services/identity/identityService.js
+++ b/apps/backend/services/identity/identityService.js
@@ -79,6 +79,11 @@ function emergeIdentity(creature, opts = {}) {
   const pool = Array.isArray(opts.pool) ? opts.pool : loadNamePool(opts);
   const seed = (creature && creature.id) || '';
   const name = pickName(pool, seed);
+  // Empty/unloadable pool -> no name emerged: identity stays anonymous
+  // (never {anonymous:false, name:null}).
+  if (name == null) {
+    return { stage, anonymous: true, name: null, mbti_reveal: false };
+  }
   const identity = {
     stage,
     anonymous: false,

--- a/tests/services/identityService.test.js
+++ b/tests/services/identityService.test.js
@@ -67,6 +67,18 @@ test('emergeIdentity: same creature id -> same name (stable identity)', () => {
   assert.equal(a.name, b.name); // name stays stable across stage advances
 });
 
+test('emergeIdentity: named stage with empty pool -> anonymous (no {anonymous:false, name:null})', () => {
+  const id = emergeIdentity({ id: 'u1' }, { stage: 'apex', pool: [] });
+  assert.equal(id.stage, 'apex');
+  assert.equal(id.anonymous, true);
+  assert.equal(id.name, null);
+  assert.equal(id.mbti_reveal, false);
+  // legacy stage: same fallback, no legacy flag on anonymous identity
+  const leg = emergeIdentity({ id: 'u1' }, { stage: 'legacy', pool: [] });
+  assert.equal(leg.anonymous, true);
+  assert.equal('legacy' in leg, false);
+});
+
 test('emergeIdentity: unknown/missing stage -> anonymous', () => {
   assert.equal(emergeIdentity({ id: 'u1' }, { stage: 'whoknows', pool: POOL }).anonymous, true);
   assert.equal(emergeIdentity({ id: 'u1' }, { pool: POOL }).anonymous, true);


### PR DESCRIPTION
## Cosa
`emergeIdentity()` per stage NAMED (juvenile/apex/legacy) ritornava `{anonymous:false, name:null}` quando `pickName()` risolveva `null` (pool vuoto o non caricabile) -- stato semanticamente incoerente. Ora fallback a identita' anonima `{stage, anonymous:true, name:null, mbti_reveal:false}` (nessun flag `legacy` su identita' anonima).

Finding da self-review PR #2697 (P2/P3, Codex rate-limited): il consumer coop (`coopOrchestrator._applyNameEmergence`) si difende gia' con `!identity.anonymous && Boolean(identity.name)`, ma l'engine deve essere coerente da solo. `emitCreatureNamed` gia' guarda `anonymous || !name` -- nessun ripple.

## Test
- Nuovo caso: `emergeIdentity: named stage with empty pool -> anonymous` (apex + legacy, no legacy flag).
- `node --test tests/services/identityService.test.js` -> **11/11 pass**
- `prettier --check` sui 2 file -> clean

## Rollback (03A)
Revert singolo commit -- additive-only (guard 5 righe + 1 test), nessuna migrazione/schema/dep.

## Changelog
- fix(identity): emergeIdentity con name-pool vuoto ritorna identita' anonima coerente invece di `{anonymous:false, name:null}`