### PR TITLE
feat(combat): SPEC-I ER1 role-gap wire flag-gated, default OFF

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1775,12 +1775,42 @@ function createSessionRouter(options = {}) {
           }
           // SPEC-P PA3 read-side: surface the wounded-biome state (anti-brick telegraph).
           biomeWounded = woundedStep > 0;
+          // SPEC-I ER1 (ratificato 2026-06-08) -- party role gap -> +1 soft sui
+          // NEMICI (max-headroom stat, dentro il cap ER2 condiviso). Flag-gated
+          // default OFF: spec sez.8, l'effetto passa ON solo post playtest N=40
+          // GREEN (verdetto master-dd). Party legacy senza ruoli canonici ERMES
+          // (job non in BIOME_ROLE_DEMANDS) -> no-op conservativo. Step PROPOSED=1.
+          let roleGapStep = 0;
+          if (process.env.ERMES_ROLE_GAP_ENABLED === 'true') {
+            try {
+              const {
+                computeRoleGap,
+                BIOME_ROLE_DEMANDS,
+              } = require('../services/coop/ermesExporter');
+              const ermesRoles = new Set(
+                Object.values(BIOME_ROLE_DEMANDS).flatMap((d) => Object.keys(d)),
+              );
+              const partyJobs = units
+                .filter(
+                  (u) => u && u.controlled_by === 'player' && ermesRoles.has(String(u.job || '')),
+                )
+                .map((u) => String(u.job));
+              if (partyJobs.length) {
+                const gap = computeRoleGap(partyJobs, biomeIdRaw);
+                if (Object.values(gap).some((v) => Number(v) < 0)) roleGapStep = 1;
+              }
+            } catch {
+              /* best-effort -- biome eco still applies without the role-gap nudge */
+            }
+          }
           units = units.map((u) => {
             if (!u) return u;
             const clone = { ...u };
             const log = applyBiomeEcoEffects(clone, biomeIdRaw, {
               biomeCostsRegistry,
               woundedStep,
+              // ER1: "alza la pressione" = only enemy units get the nudge.
+              roleGapStep: clone.controlled_by === 'player' ? 0 : roleGapStep,
             });
             // FASE 3 P4: capture biome-level eco band (uniform across units, set
             // even for med where no delta is applied) for the diegetic chip.

--- a/apps/backend/services/traitEffects.js
+++ b/apps/backend/services/traitEffects.js
@@ -803,6 +803,29 @@ function applyBiomeEcoEffects(unit, biomeId, opts = {}) {
     for (const f of BIOME_ECO_FIELDS) unit[f] = Number(unit[f] || 0) - woundedStep;
   }
 
+  // SPEC-I ER1 (ratificato 2026-06-08): party role gap -> +1 soft su UNA stat
+  // dell'unit (caller la passa SOLO per i nemici: "alza la pressione"). Targeting
+  // = mitigazione spec sez.11/ER1: la stat col MAX headroom verso +cap (mai una
+  // gia' spinta dall'eco); budget ER2 +/-2 condiviso (il clamp sotto vale anche
+  // qui). Se tutto saturo -> assorbito (applied null, ER2 opzione A by design).
+  // step PROPOSED = 1 (caller); ratify N=40 (gate sez.8).
+  const roleGapStep = Number(opts.roleGapStep) || 0;
+  let roleGapLog;
+  if (roleGapStep > 0) {
+    let target = null;
+    let bestHeadroom = 0;
+    for (const f of BIOME_ECO_FIELDS) {
+      const delta = Number(unit[f] || 0) - base[f];
+      const headroom = BIOME_ECO_COMBINED_CAP - delta;
+      if (headroom > bestHeadroom) {
+        bestHeadroom = headroom;
+        target = f;
+      }
+    }
+    if (target) unit[target] = Number(unit[target] || 0) + roleGapStep;
+    roleGapLog = { applied: target, step: roleGapStep };
+  }
+
   const combined_delta = {};
   let capped = false;
   for (const f of BIOME_ECO_FIELDS) {
@@ -816,7 +839,7 @@ function applyBiomeEcoEffects(unit, biomeId, opts = {}) {
   const ecoItem = Array.isArray(ermes)
     ? ermes.find((a) => a && a.bucket === 'eco_pressure_score')
     : null;
-  return {
+  const out = {
     adr21c,
     ermes,
     combined_delta,
@@ -824,6 +847,8 @@ function applyBiomeEcoEffects(unit, biomeId, opts = {}) {
     biome_id: biomeId,
     band: ecoItem ? ecoItem.band : null,
   };
+  if (roleGapLog) out.role_gap = roleGapLog; // ER1 telegraph (additive, public tier)
+  return out;
 }
 
 /**

--- a/docs/design/evo-tactics-runtime-feature-inventory-reconcile.md
+++ b/docs/design/evo-tactics-runtime-feature-inventory-reconcile.md
@@ -152,17 +152,17 @@ gia' product-ready e quali sono ancora host legacy o partial.
 
 ### 4.5 Worldgen, Descent, ERMES, ALIENA
 
-| Sistema                    | Stato          | Evidenza                                                            | Surface                       | Prossima azione                        |
-| -------------------------- | -------------- | ------------------------------------------------------------------- | ----------------------------- | -------------------------------------- |
-| Meta-network graph routing | `LIVE_GATED`   | `metaNetworkRouting.js`, resolver/completability tests              | campaign API + Godot route UI | flip `META_NETWORK_ROUTING` dopo smoke |
-| Graph route real combat    | `LIVE_GATED`   | Game #2601/#2603 on `origin/main`, encounter loader graphMode tests | Godot routed roster           | branch alignment                       |
-| Foodweb spawn filter       | `LIVE`         | `worldgen/foodwebFilter.js`, reinforcement tests                    | backend spawn behavior        | telegraph ERMES/ALIENA                 |
-| Cross-event pressure       | `LIVE`         | `worldgen/crossEventEngine.js`, tests                               | session pressure              | surface debrief/world reveal           |
-| Seasonal loop              | `LIVE_PARTIAL` | `seasonalEngine.js`, campaign seasonal routes/tests                 | API + Godot seasonal client   | decide product loop                    |
-| ERMES exporter/role gap    | `LIVE_PARTIAL` | `ermesExporter.js`, `ermesRunner.js`, tests, Godot role gap         | world reveal/debrief          | SPEC-I runtime pressure                |
-| ALIENA scorer              | `LIVE`         | `authorial/alienaCoherence.js`, tests                               | diagnostics/surface           | link to lore enforcement               |
-| ALIENA enforcement         | `LIVE_GATED`   | `biomeSpawnBias.js`, `reinforcementSpawner.js`, policy tests        | backend spawn bias            | decide soft-on campaigns               |
-| ALIENA telemetry           | `LIVE_PARTIAL` | `alienaTelemetryEndpoint`, Godot `aliena_api.gd`                    | phone chart/world reveal      | unify product copy                     |
+| Sistema                    | Stato          | Evidenza                                                                                                                                               | Surface                       | Prossima azione                        |
+| -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- | -------------------------------------- |
+| Meta-network graph routing | `LIVE_GATED`   | `metaNetworkRouting.js`, resolver/completability tests                                                                                                 | campaign API + Godot route UI | flip `META_NETWORK_ROUTING` dopo smoke |
+| Graph route real combat    | `LIVE_GATED`   | Game #2601/#2603 on `origin/main`, encounter loader graphMode tests                                                                                    | Godot routed roster           | branch alignment                       |
+| Foodweb spawn filter       | `LIVE`         | `worldgen/foodwebFilter.js`, reinforcement tests                                                                                                       | backend spawn behavior        | telegraph ERMES/ALIENA                 |
+| Cross-event pressure       | `LIVE`         | `worldgen/crossEventEngine.js`, tests                                                                                                                  | session pressure              | surface debrief/world reveal           |
+| Seasonal loop              | `LIVE_PARTIAL` | `seasonalEngine.js`, campaign seasonal routes/tests                                                                                                    | API + Godot seasonal client   | decide product loop                    |
+| ERMES exporter/role gap    | `LIVE_PARTIAL` | `ermesExporter.js`, `ermesRunner.js`, tests, Godot role gap; ER1 effect wire BUILT flag-gated OFF (`ERMES_ROLE_GAP_ENABLED`, spec sez.8: ON post N=40) | world reveal/debrief          | SPEC-I runtime pressure                |
+| ALIENA scorer              | `LIVE`         | `authorial/alienaCoherence.js`, tests                                                                                                                  | diagnostics/surface           | link to lore enforcement               |
+| ALIENA enforcement         | `LIVE_GATED`   | `biomeSpawnBias.js`, `reinforcementSpawner.js`, policy tests                                                                                           | backend spawn bias            | decide soft-on campaigns               |
+| ALIENA telemetry           | `LIVE_PARTIAL` | `alienaTelemetryEndpoint`, Godot `aliena_api.gd`                                                                                                       | phone chart/world reveal      | unify product copy                     |
 
 Decisione:
 

--- a/docs/hubs/combat.md
+++ b/docs/hubs/combat.md
@@ -60,6 +60,7 @@ Per una panoramica e mappa completa dei doc del workstream vedi [docs/combat/REA
 - `apps/backend/services/combat/timeOfDayModifier.js` — Wesnoth time-of-day modifier (lawful/chaotic/neutral × dawn/day/dusk/night) wired in `session.js#performAttack` (Sprint 1 PR #1934, Tier S #5)
 - `apps/backend/services/combat/defenderAdvantageModifier.js` — AI War defender's advantage asymmetric (player→sistema gated, +1 def CD su SIS-defender) (Sprint 1 PR #1934, Tier S #10)
 - `apps/backend/services/species/biomeAffinity.js` — Subnautica habitat lifecycle modifier per phase (preferred biome → +1 atk/+1 def, non-affine → -1 def, apex_free) wired in `session.js#performAttack` (Sprint 2 PR #1935, Tier A #9)
+- `apps/backend/services/traitEffects.js#applyBiomeEcoEffects` — orchestratore eco unificato ADR-21c + ERMES + A13 woundedStep + **ER1 role gap** (SPEC-I, ratificato 2026-06-08): party senza un ruolo demanded dal bioma → +1 soft su UNA stat dei nemici, targeting max-headroom (mai una stat gia' spinta dall'eco), dentro il budget ER2 +/-2 condiviso. Flag-gated `ERMES_ROLE_GAP_ENABLED` default OFF (spec sez.8: ON solo post playtest N=40 GREEN, verdetto master-dd). Caller `session.js` start: ruoli canonici da `BIOME_ROLE_DEMANDS`, party legacy senza ruoli → no-op conservativo. Telegraph: `role_gap` in `biomeCostsLog` (public tier sez.9).
 
 ### Tool di generazione
 

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-10T00:58:33+00:00",
+  "generated_at": "2026-06-10T01:40:37+00:00",
   "summary": {
     "total": 397,
     "errors": 0,

--- a/tests/api/sessionBiomeEcoEffects.test.js
+++ b/tests/api/sessionBiomeEcoEffects.test.js
@@ -51,6 +51,59 @@ test('session/start surfaces ERMES band in biomeCostsLog (cryosteppe HIGH)', asy
   );
 });
 
+// SPEC-I ER1 -- role gap wire: flag-gated (default OFF, spec sez.8: ON solo
+// post N=40 GREEN). Con flag ON e party senza un ruolo demanded dal bioma,
+// i nemici ricevono +1 soft (max-headroom stat) dentro il cap ER2.
+test('ER1 flag ON: missing demanded role -> role_gap applied to enemy units only', async (t) => {
+  process.env.ERMES_ROLE_GAP_ENABLED = 'true';
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    delete process.env.ERMES_ROLE_GAP_ENABLED;
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const units = (await getTutorialUnits(app)).map((u) =>
+    u.controlled_by === 'player' ? { ...u, job: 'guerriero' } : u,
+  );
+  // badlands demand = { guerriero: 1, esploratore: 1 } -> esploratore mancante.
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units, biome_id: 'badlands' })
+    .expect(200);
+
+  const log = res.body.biomeCostsLog || [];
+  const withGap = log.filter((e) => e.role_gap && e.role_gap.applied);
+  assert.ok(withGap.length > 0, `expected role_gap entries; log=${JSON.stringify(log)}`);
+  const playerIds = new Set(units.filter((u) => u.controlled_by === 'player').map((u) => u.id));
+  for (const entry of withGap) {
+    assert.ok(
+      !playerIds.has(entry.unit_id),
+      `role_gap must hit enemies only, got ${entry.unit_id}`,
+    );
+  }
+});
+
+test('ER1 flag OFF (default): no role_gap in log even with missing role', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const units = (await getTutorialUnits(app)).map((u) =>
+    u.controlled_by === 'player' ? { ...u, job: 'guerriero' } : u,
+  );
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units, biome_id: 'badlands' })
+    .expect(200);
+
+  const log = res.body.biomeCostsLog || [];
+  assert.ok(
+    log.every((e) => !e.role_gap),
+    `expected no role_gap with flag OFF; log=${JSON.stringify(log)}`,
+  );
+});
+
 test('session/start without biome_id -> no biome eco log', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {

--- a/tests/services/applyBiomeEcoEffects.test.js
+++ b/tests/services/applyBiomeEcoEffects.test.js
@@ -95,3 +95,64 @@ test('A13 woundedStep: absent/0 -> no-op (backward compat)', () => {
   assert.equal(u.attack_mod_bonus, 0);
   assert.equal(u.defense_mod_bonus, 0);
 });
+
+// SPEC-I ER1 (ratificato 2026-06-08): role gap -> +1 soft su UNA stat nemica,
+// targeting = max headroom (mitigazione spec: mai una stat gia' spinta dall'eco),
+// SEMPRE dentro il budget ER2 +/-2 condiviso. Step PROPOSED -> ratify N=40.
+test('ER1 roleGapStep: +1 on first field when nothing else applied', () => {
+  _resetBiomeCostCache();
+  const e = { id: 'e1', traits: [], attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  const log = applyBiomeEcoEffects(e, 'b', { roleGapStep: 1 });
+  assert.equal(e.attack_mod_bonus, 1); // tie-break: first BIOME_ECO_FIELDS order
+  assert.equal(log.role_gap.applied, 'attack_mod_bonus');
+  assert.equal(log.role_gap.step, 1);
+});
+
+test('ER1 roleGapStep: targeting avoids eco-pushed stats (max headroom)', () => {
+  _resetBiomeCostCache();
+  const e = { id: 'e1', traits: [], attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  const log = applyBiomeEcoEffects(e, 'b', { bucketed: ERMES_HIGH, roleGapStep: 1 });
+  // eco HIGH pushes attack +1 and defense +1 -> headroom 1 each; mobility/rest
+  // untouched -> headroom 2 -> role gap lands on mobility (first max).
+  assert.equal(e.attack_mod_bonus, 1);
+  assert.equal(e.defense_mod_bonus, 1);
+  assert.equal(e.mobility || 0, 1);
+  assert.equal(log.role_gap.applied, 'mobility');
+});
+
+test('ER1 roleGapStep: fully saturated budget -> absorbed (applied null, ER2 cap holds)', () => {
+  _resetBiomeCostCache();
+  const SATURATE = {
+    buckets: {
+      eco_pressure_score: {
+        band: 'high',
+        def: { delta: { attack_mod: 2, defense_mod: 2, mobility: 2, rest_recovery: 2 } },
+      },
+    },
+    caps: { max_delta_any_stat: 2, max_buckets_active_per_unit: 3 },
+  };
+  const e = { id: 'e1', traits: [], attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  const log = applyBiomeEcoEffects(e, 'b', { bucketed: SATURATE, roleGapStep: 1 });
+  assert.equal(log.role_gap.applied, null); // absorbed by design (ER2 option A)
+  for (const f of ['attack_mod_bonus', 'defense_mod_bonus', 'mobility', 'rest_recovery']) {
+    assert.ok(Math.abs(Number(e[f] || 0)) <= 2, `${f} stays within ER2 cap`);
+  }
+});
+
+test('ER1 roleGapStep: 0/absent -> no role_gap log entry (backward compat)', () => {
+  _resetBiomeCostCache();
+  const e = { id: 'e1', traits: [], attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  const log = applyBiomeEcoEffects(e, 'b', {});
+  assert.equal(log.role_gap, undefined);
+});
+
+test('ER1 + A13: role gap and wounded combine, final values within ER2 cap', () => {
+  _resetBiomeCostCache();
+  const e = { id: 'e1', traits: [], attack_mod_bonus: 0, defense_mod_bonus: 0 };
+  const log = applyBiomeEcoEffects(e, 'b', { woundedStep: 1, roleGapStep: 1 });
+  // wounded -1 on all four fields, role gap +1 on the max-headroom one.
+  assert.ok(log.role_gap.applied, 'role gap applied somewhere');
+  for (const f of ['attack_mod_bonus', 'defense_mod_bonus', 'mobility', 'rest_recovery']) {
+    assert.ok(Math.abs(Number(e[f] || 0)) <= 2, `${f} within cap`);
+  }
+});


### PR DESCRIPTION
## Summary

Primo pezzo engine di SPEC-I (item-1, dopo il flip SPEC-M): **ER1 -- effetto runtime del role gap** (fork ratificato 2026-06-08, opzione A) era calcolato+esposto ma MAI implementato in combat (`grep role_gap apps/backend/services/combat/` = zero). Ora e' wired -- **flag-gated default OFF** perche' la spec sez.8 e' esplicita: *"una banda/cap (o l'attivazione di un effetto, es. role gap ER1) passa da OFF a ON SOLO dopo un playtest N=40 GREEN"*.

## Design (esecuzione spec, zero fork nuovi)

- **Effetto** (`traitEffects.applyBiomeEcoEffects`, mirror del pattern A13 `woundedStep`): `opts.roleGapStep` -> +1 soft su UNA stat dell'unit. **Targeting = mitigazione raccomandata dalla spec** (ER1 rischio cap-saturo): la stat col massimo headroom verso +cap -- mai una gia' spinta dall'eco; budget **ER2 +/-2 condiviso** (stesso clamp ADR-21c+ERMES+wounded); tutto saturo -> assorbito by design (`role_gap.applied: null`, ER2 opzione A).
- **Caller** (`routes/session.js` start): ruoli canonici derivati da `BIOME_ROLE_DEMANDS` (no hardcode duplicato); party legacy senza ruoli ERMES (job tipo `skirmisher`) -> **no-op conservativo** (evita falso-positivo permanente del gap); nudge applicato SOLO alle unit non-player (ER1: "alza la pressione").
- **Telegraph**: `role_gap {applied, step}` in `biomeCostsLog` (response) = tier public "modificatori applicati" (matrice sez.9). Hint per-player private = surface device (item 3, fuori scope).
- **Flag**: `ERMES_ROLE_GAP_ENABLED` (env, default OFF). Step PROPOSED=1.

## Band-safety

Default OFF = zero impatto bande correnti by construction. Attivazione = verdetto master-dd post playtest N=40 con party role-aware (il pilota badlands sim usa job `skirmisher` -> servira' party a ruoli per esercitare l'effetto; follow-up dichiarato).

## Test

- TDD (RED verificato): unit **14/14** (`applyBiomeEcoEffects`: targeting headroom, saturazione assorbita, combinazione con woundedStep nel cap, backward-compat) + api **5/5** (flag ON -> role_gap solo sui nemici; flag OFF -> assente).
- AI baseline **502/502** · governance errors=0 · prettier clean.
- DoD: hub combat + SPEC-L runtime inventory aggiornati (role gap effect = BUILT flag-gated).

## Changelog

- feat(combat): ER1 role-gap -> nudge nemici flag-gated (`ERMES_ROLE_GAP_ENABLED`, default OFF), telegraph in biomeCostsLog.

## Rollback plan (03A)

Revert singolo commit. Flag default OFF -> nessun comportamento runtime cambia senza opt-in esplicito; il wire e' additivo (opts nuovo, log additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)