### PR TITLE
feat(coop): broadcast creature_named a tutto il branco (#2679 M-2 follow-up)

### DIFF
--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1096,6 +1096,22 @@ function rebroadcastCoopState(room, orch) {
 }
 
 /**
+ * Item-3 follow-up (#2679 / M-2 #2697) -- broadcast the ADDITIVE
+ * `creature_named` transitions folded into an advanceScenarioOrEnd() result.
+ * Pre-fix the array reached ONLY the last lineage submitter (socket ack
+ * `lineage_choice_accepted.advance`) and the next_macro path (inside
+ * `next_macro_committed.advance`); `nido_start_mission_accepted` dropped it
+ * entirely ({phase} only). The Godot client dedupes per transition
+ * (actor|stage|mbti), so the double delivery on the next_macro path is safe.
+ */
+function broadcastCreatureNamed(room, advance) {
+  if (!room || typeof room.broadcast !== 'function') return;
+  const named = advance && Array.isArray(advance.creature_named) ? advance.creature_named : [];
+  if (!named.length) return;
+  room.broadcast({ type: 'creature_named', payload: { named } });
+}
+
+/**
  * Attach a WebSocketServer to an existing http.Server, gated on path.
  * Alternatively, pass `port` to spawn a standalone server (useful for tests).
  *
@@ -1742,6 +1758,9 @@ function createWsServer({
                   ready_list: orch.debriefReadyList(allPids),
                 },
               });
+              // M-2 (#2697): name transitions must reach the whole branco,
+              // not just this (last) submitter via the ack below.
+              broadcastCreatureNamed(room, advance);
               if (advance?.action === 'ended') {
                 room.publishPhaseChange('ended');
               } else if (orch.phase === 'world_setup') {
@@ -1881,6 +1900,10 @@ function createWsServer({
                   advance: result.advance || null,
                 },
               });
+              // M-2 (#2697): dedicated broadcast for uniformity with the
+              // lineage/nido paths (client dedupe absorbs the overlap with
+              // next_macro_committed.advance above).
+              broadcastCreatureNamed(room, result.advance);
               if (result.phase === 'world_setup') {
                 room.publishPhaseChange('world_setup');
               } else if (result.phase === 'ended') {
@@ -1918,6 +1941,9 @@ function createWsServer({
                 return;
               }
               const result = orch.startMissionFromNido(playerId, { hostId: room.hostId });
+              // M-2 (#2697): pre-fix the {phase}-only ack dropped the naming
+              // transitions carried by result.advance.
+              broadcastCreatureNamed(room, result.advance);
               if (result.phase === 'world_setup') {
                 room.publishPhaseChange('world_setup');
               } else if (result.phase === 'ended') {

--- a/tests/services/network/wsSession-creatureNamed.test.js
+++ b/tests/services/network/wsSession-creatureNamed.test.js
@@ -1,0 +1,237 @@
+// Item-3 follow-up (#2679 / M-2 #2697) -- `creature_named` deve raggiungere
+// TUTTO il branco, non solo l'ultimo submitter. Pre-fix: l'array ADDITIVO
+// advance.creature_named (advanceScenarioOrEnd) viaggiava SOLO dentro
+// lineage_choice_accepted (socket.send ack al solo ultimo submitter) e
+// next_macro_committed.advance; nido_start_mission_accepted lo droppava.
+// Fix: room.broadcast({type:'creature_named', payload:{named}}) in tutti i
+// drain che producono un advance (lineage_choice, next_macro,
+// nido_start_mission). Il client Godot dedupa per transizione, quindi la
+// doppia delivery sul path next_macro e' innocua.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const {
+  LobbyService,
+  createWsServer,
+} = require('../../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+
+process.env.AUTH_SECRET = 'test-secret-must-be-at-least-16-chars-long';
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+async function startServer() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  return { lobby, coopStore, wsHandle, port: wsHandle.wss.address().port };
+}
+
+test('M-2: lineage auto-advance -> creature_named broadcast reaches the NON-last submitter', async () => {
+  const { lobby, coopStore, wsHandle, port } = await startServer();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    // Two scenarios so advanceScenarioOrEnd lands on world_setup (juvenile
+    // naming transition), not ended.
+    orch.startRun({ scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'] });
+    orch.namePool = ['Vesh', 'Korr'];
+    orch.submitCharacter(
+      p1.player_id,
+      { name: 'Heron', form_id: 'form_dune_stalker', species_id: 'dune_stalker' },
+      { allPlayerIds: [p1.player_id] },
+    );
+    // Force debrief so submitDebriefChoice is accepted.
+    orch.phase = 'debrief';
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // p1 submits FIRST (will NOT be the last submitter).
+    p1Ws.send(
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'lineage_choice', mutations_to_leave: [] },
+      }),
+    );
+    await waitForMessage(p1Ws, (m) => m.type === 'lineage_choice_accepted', 2000);
+    // Host submits LAST -> triggers advanceScenarioOrEnd + name emergence.
+    hostWs.send(
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'lineage_choice', mutations_to_leave: [] },
+      }),
+    );
+
+    // THE regression: p1 (non-last submitter) must receive the broadcast.
+    const evt = await waitForMessage(p1Ws, (m) => m.type === 'creature_named', 2000);
+    assert.ok(Array.isArray(evt.payload.named), 'payload.named is an array');
+    assert.equal(evt.payload.named.length, 1);
+    const entry = evt.payload.named[0];
+    assert.equal(entry.player_id, p1.player_id);
+    assert.equal(entry.stage, 'juvenile');
+    assert.equal(entry.mbti_reveal, false);
+    assert.ok(['Vesh', 'Korr'].includes(entry.name), 'name picked from pool');
+
+    // Host (last submitter) receives it too.
+    await waitForMessage(hostWs, (m) => m.type === 'creature_named', 2000);
+
+    hostWs.close();
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('M-2: nido_start_mission -> creature_named broadcast to all clients', async () => {
+  const { lobby, coopStore, wsHandle, port } = await startServer();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'] });
+    orch.namePool = ['Vesh'];
+    orch.submitCharacter(
+      p1.player_id,
+      { name: 'Heron', form_id: 'form_dune_stalker', species_id: 'dune_stalker' },
+      { allPlayerIds: [p1.player_id] },
+    );
+    orch.phase = 'nido';
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    hostWs.send(JSON.stringify({ type: 'intent', payload: { action: 'nido_start_mission' } }));
+
+    // Pre-fix nido_start_mission_accepted carried {phase} only and nothing
+    // else: the naming transition was dropped for everyone.
+    const [hostEvt, p1Evt] = await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'creature_named', 2000),
+      waitForMessage(p1Ws, (m) => m.type === 'creature_named', 2000),
+    ]);
+    assert.equal(hostEvt.payload.named[0].name, 'Vesh');
+    assert.equal(p1Evt.payload.named[0].stage, 'juvenile');
+
+    hostWs.close();
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('M-2: advance without emergence (no characters) -> NO creature_named broadcast', async () => {
+  const { lobby, coopStore, wsHandle, port } = await startServer();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'] });
+    orch.phase = 'nido';
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    await waitOpen(hostWs);
+    await waitForMessage(hostWs, (m) => m.type === 'hello');
+
+    hostWs.send(JSON.stringify({ type: 'intent', payload: { action: 'nido_start_mission' } }));
+    await waitForMessage(hostWs, (m) => m.type === 'nido_start_mission_accepted', 2000);
+
+    // No characters -> _applyNameEmergence emitted nothing -> no broadcast.
+    await assert.rejects(
+      waitForMessage(hostWs, (m) => m.type === 'creature_named', 400),
+      /timeout/,
+      'no creature_named expected',
+    );
+
+    hostWs.close();
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## Scopo

Follow-up item-3 (GGv2 PR #463, handoff `Game-Godot-v2/docs/godot-v2/sprints/handoff-2026-06-10-item3-identity-phone-surfaces.md`): le naming transition M-2 (#2697) devono raggiungere TUTTO il branco.

## Gap (verificato sul source)

`advanceScenarioOrEnd()` fold l'array ADDITIVO `creature_named: [{actor_id, player_id, name, stage, mbti_reveal}]` dentro `advance`, ma:

- path **debrief auto-advance** (`submitDebriefChoice`): l'advance viaggia SOLO nell'ack `lineage_choice_accepted` al socket dell'ULTIMO submitter -- i branco-mate non vedono mai la transition (`debrief_ready_list` non la porta);
- path **nido_start_mission**: l'ack `nido_start_mission_accepted` e' `{phase}` only -- transition droppata per TUTTI;
- path **next_macro**: ok (dentro `next_macro_committed.advance`).

## Fix

Helper `broadcastCreatureNamed(room, advance)` -> `room.broadcast({type:'creature_named', payload:{named}})` nei 3 drain (lineage_choice, next_macro, nido_start_mission). No-op se `advance.creature_named` assente/vuoto. Sul path next_macro la delivery e' doppia (committed.advance + broadcast dedicato): il client Godot dedupa per transizione `actor|stage|mbti` (GGv2 `PhoneCreatureNamedReveal`), quindi innocua -- uniformita' > special-case.

## Test (TDD, RED verificato: 2 timeout pre-fix)

`tests/services/network/wsSession-creatureNamed.test.js` (pattern wsSession-nido):
1. regressione: il NON-ultimo submitter riceve il broadcast su lineage auto-advance (payload shape completa asserita);
2. nido_start_mission -> broadcast a tutti;
3. negative: advance senza emergence (zero characters) -> NESSUN broadcast.

Evidence: network suite 13 file 85/85 pass, `test:api` 502/502, `lint:stack` PASS.

## Rollback

Revert singolo commit: il broadcast e' un message type NUOVO un-versionato; i client che non lo gestiscono... NB il client Godot pre-#463 lo farebbe cadere in `unknown_type` toast -- il consumer Godot dedicato arriva nella PR gemella GGv2 (case CoopWsPeer); fino al merge di quella, i phone su main GGv2 mostrerebbero un toast informativo per evento (raro: 1-2 per run). Se indesiderato, merge della PR GGv2 prima del deploy backend.