### PR TITLE
fix(coop): role-aware lifecycle quorum vs TV-mirror host (playtest P2)

### DIFF
--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1112,6 +1112,31 @@ function broadcastCreatureNamed(room, advance) {
 }
 
 /**
+ * Finding P2 2026-06-10 (item-3 AI playtest, finding 2) -- role-aware quorum
+ * for the lifecycle ready-gates (character_create / lineage_choice drains).
+ * A TV-as-mirror host (ADR-2026-06-07: TV = splash/mirror, never input)
+ * never submits: counting it in `allPlayerIds` stalls the orchestrator gates
+ * (expected.size === characters.size, debriefChoices.size >= expected.size)
+ * forever. But a hard host filter would break the legacy phone-only flow
+ * where the host phone PLAYS and submits its own PG: the phase would advance
+ * before the host PG lands, or bounce it via the F-3 player_not_in_room
+ * gate. Self-selecting quorum: the host counts only while it acts as a
+ * player -- it is the current submitter, or it already owns a character.
+ * Mirrors routes/coop.js allPlayerIds() host exclusion (Codex P2 #2073) for
+ * the TV-mirror case.
+ */
+function lifecycleQuorumPids(room, orch, submitterId) {
+  return Array.from(room.players.values())
+    .filter(
+      (p) =>
+        (p.id !== room.hostId && p.role !== 'host') ||
+        p.id === submitterId ||
+        Boolean(orch.characters?.has?.(p.id)),
+    )
+    .map((p) => p.id);
+}
+
+/**
  * Attach a WebSocketServer to an existing http.Server, gated on path.
  * Alternatively, pass `port` to spawn a standalone server (useful for tests).
  *
@@ -1475,7 +1500,7 @@ function createWsServer({
                 );
                 return;
               }
-              const allPids = Array.from(room.players.values()).map((p) => p.id);
+              const allPids = lifecycleQuorumPids(room, orch, playerId);
               const speciesId =
                 typeof msg.payload?.species_id === 'string' ? msg.payload.species_id : '';
               const formIdRaw = typeof msg.payload?.form_id === 'string' ? msg.payload.form_id : '';
@@ -1742,7 +1767,7 @@ function createWsServer({
                 );
                 return;
               }
-              const allPids = Array.from(room.players.values()).map((p) => p.id);
+              const allPids = lifecycleQuorumPids(room, orch, playerId);
               const choice = {
                 mutations_to_leave: Array.isArray(msg.payload?.mutations_to_leave)
                   ? msg.payload.mutations_to_leave

--- a/tests/services/network/wsSession-lifecycleQuorum.test.js
+++ b/tests/services/network/wsSession-lifecycleQuorum.test.js
@@ -1,0 +1,326 @@
+// Finding P2 2026-06-10 (item-3 AI playtest, Game-Godot-v2
+// docs/godot-v2/qa/2026-06-10-item3-ai-playtest.md finding 2) -- lifecycle
+// ready-gate quorum vs TV-as-mirror host (ADR-2026-06-07: la TV e'
+// splash/mirror, MAI input). Pre-fix the character_create and lineage_choice
+// drains counted the host in allPids (`Array.from(room.players.values())`):
+// a TV host never submits, so the orchestrator gates
+// (expected.size === characters.size / debriefChoices.size >= expected.size)
+// never fired -> run stalled forever in character_creation (and debrief).
+// Back-compat: in the legacy phone-only flow the host phone PLAYS and
+// submits its own PG -- a hard host filter would advance the phase before
+// the host PG lands (or reject it via the F-3 player_not_in_room gate).
+// Fix: role-aware self-selecting quorum -- the host counts only if it is
+// the current submitter or already owns a character.
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const {
+  LobbyService,
+  createWsServer,
+} = require('../../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+
+process.env.AUTH_SECRET = 'test-secret-must-be-at-least-16-chars-long';
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+async function startServer() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  return { lobby, coopStore, wsHandle, port: wsHandle.wss.address().port };
+}
+
+function characterCreateIntent(name) {
+  return JSON.stringify({
+    type: 'intent',
+    payload: { action: 'character_create', name, species_id: 'dune_stalker' },
+  });
+}
+
+const lineageIntent = JSON.stringify({
+  type: 'intent',
+  payload: { action: 'lineage_choice', mutations_to_leave: [] },
+});
+
+const isWorldSetup = (m) => m.type === 'phase_change' && m.payload?.phase === 'world_setup';
+
+test('P2: TV-mirror host never submits -> character gate closes with players only', async () => {
+  const { lobby, coopStore, wsHandle, port } = await startServer();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Alice' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    const p2Ws = openWs(port, { code: room.code, player_id: p2.player_id, token: p2.player_token });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws), waitOpen(p2Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+      waitForMessage(p2Ws, (m) => m.type === 'hello'),
+    ]);
+
+    p1Ws.send(characterCreateIntent('Alice'));
+    await waitForMessage(p1Ws, (m) => m.type === 'character_accepted');
+    p2Ws.send(characterCreateIntent('Bob'));
+    const ack = await waitForMessage(p2Ws, (m) => m.type === 'character_accepted');
+
+    // THE stall: pre-fix the host (never a submitter) kept the gate open
+    // forever -> no world_setup, run stuck in character_creation.
+    assert.equal(ack.payload.phase, 'world_setup');
+    await Promise.all([
+      waitForMessage(hostWs, isWorldSetup),
+      waitForMessage(p1Ws, isWorldSetup),
+      waitForMessage(p2Ws, isWorldSetup),
+    ]);
+    assert.equal(orch.phase, 'world_setup');
+
+    // Ready-list broadcast must not surface a phantom host row.
+    const list = await waitForMessage(
+      p1Ws,
+      (m) => m.type === 'character_ready_list' && m.payload.length === 2,
+    );
+    assert.ok(
+      list.payload.every((e) => e.player_id !== room.host_id),
+      'host must not appear in the ready list',
+    );
+
+    hostWs.close();
+    p1Ws.close();
+    p2Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('P2 back-compat: legacy host-plays flow -> world_setup only after the host PG', async () => {
+  const { lobby, coopStore, wsHandle, port } = await startServer();
+  try {
+    const room = lobby.createRoom({ hostName: 'HostPhone' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Alice' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // Host phone PLAYS: submits its own PG (self-selects into the quorum).
+    hostWs.send(characterCreateIntent('Capo'));
+    const hostAck = await waitForMessage(hostWs, (m) => m.type === 'character_accepted');
+    assert.equal(hostAck.payload.phase, 'character_creation', 'host PG accepted, gate still open');
+
+    // Host now visible in the ready list, ready and counted.
+    const list = await waitForMessage(
+      hostWs,
+      (m) =>
+        m.type === 'character_ready_list' &&
+        m.payload.some((e) => e.player_id === room.host_id && e.ready === true),
+    );
+    assert.equal(list.payload.length, 2);
+
+    // Gate must NOT close before Alice (host alone is not the quorum).
+    await assert.rejects(waitForMessage(hostWs, isWorldSetup, 400), /timeout/);
+
+    p1Ws.send(characterCreateIntent('Alice'));
+    const ack = await waitForMessage(p1Ws, (m) => m.type === 'character_accepted');
+    assert.equal(ack.payload.phase, 'world_setup');
+    await Promise.all([waitForMessage(hostWs, isWorldSetup), waitForMessage(p1Ws, isWorldSetup)]);
+
+    hostWs.close();
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('P2: TV-mirror host never chooses -> debrief gate closes with players only', async () => {
+  const { lobby, coopStore, wsHandle, port } = await startServer();
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Alice' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    // Two scenarios so advanceScenarioOrEnd lands on world_setup, not ended.
+    orch.startRun({ scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'] });
+    orch.submitCharacter(
+      p1.player_id,
+      { name: 'Alice', form_id: 'form_dune_stalker', species_id: 'dune_stalker' },
+      { allPlayerIds: [p1.player_id, p2.player_id] },
+    );
+    orch.submitCharacter(
+      p2.player_id,
+      { name: 'Bob', form_id: 'form_dune_stalker', species_id: 'dune_stalker' },
+      { allPlayerIds: [p1.player_id, p2.player_id] },
+    );
+    // Force debrief so submitDebriefChoice is accepted.
+    orch.phase = 'debrief';
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    const p2Ws = openWs(port, { code: room.code, player_id: p2.player_id, token: p2.player_token });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws), waitOpen(p2Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+      waitForMessage(p2Ws, (m) => m.type === 'hello'),
+    ]);
+
+    p1Ws.send(lineageIntent);
+    const first = await waitForMessage(p1Ws, (m) => m.type === 'lineage_choice_accepted');
+    assert.equal(first.payload.advance, null, 'gate still open after first player');
+
+    p2Ws.send(lineageIntent);
+    const last = await waitForMessage(p2Ws, (m) => m.type === 'lineage_choice_accepted');
+
+    // THE stall: pre-fix the host (never a chooser) kept the debrief gate
+    // open forever -> advance never fired.
+    assert.equal(last.payload.advance?.action, 'next_scenario');
+    await Promise.all([
+      waitForMessage(hostWs, isWorldSetup),
+      waitForMessage(p1Ws, isWorldSetup),
+      waitForMessage(p2Ws, isWorldSetup),
+    ]);
+
+    // debrief_ready_list broadcast must not surface a phantom host row.
+    const ready = await waitForMessage(p1Ws, (m) => m.type === 'debrief_ready_list');
+    assert.ok(
+      ready.payload.ready_list.every((e) => e.player_id !== room.host_id),
+      'host must not appear in the debrief ready list',
+    );
+
+    hostWs.close();
+    p1Ws.close();
+    p2Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('P2 back-compat: legacy host-plays debrief -> advance only after the host choice', async () => {
+  const { lobby, coopStore, wsHandle, port } = await startServer();
+  try {
+    const room = lobby.createRoom({ hostName: 'HostPhone' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Alice' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'] });
+    // Host phone played the run: it owns a character -> stays in the quorum.
+    orch.submitCharacter(
+      room.host_id,
+      { name: 'Capo', form_id: 'form_dune_stalker', species_id: 'dune_stalker' },
+      { allPlayerIds: [room.host_id, p1.player_id] },
+    );
+    orch.submitCharacter(
+      p1.player_id,
+      { name: 'Alice', form_id: 'form_dune_stalker', species_id: 'dune_stalker' },
+      { allPlayerIds: [room.host_id, p1.player_id] },
+    );
+    orch.phase = 'debrief';
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    p1Ws.send(lineageIntent);
+    const first = await waitForMessage(p1Ws, (m) => m.type === 'lineage_choice_accepted');
+    assert.equal(first.payload.advance, null, 'gate must wait for the playing host');
+    await assert.rejects(waitForMessage(p1Ws, isWorldSetup, 400), /timeout/);
+
+    hostWs.send(lineageIntent);
+    const last = await waitForMessage(hostWs, (m) => m.type === 'lineage_choice_accepted');
+    assert.equal(last.payload.advance?.action, 'next_scenario');
+    await Promise.all([waitForMessage(hostWs, isWorldSetup), waitForMessage(p1Ws, isWorldSetup)]);
+
+    hostWs.close();
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});


### PR DESCRIPTION
## Finding P2 — playtest AI item-3 2026-06-10 (finding 2)

Report: Game-Godot-v2 `docs/godot-v2/qa/2026-06-10-item3-ai-playtest.md`.

I drain WS `character_create` e `lineage_choice` calcolavano `allPids` con TUTTI i player della room INCLUSO l'host (`Array.from(room.players.values()).map(p=>p.id)`), mentre `form_pulse_submit` filtra l'host (Codex P2 #2073). Con host TV-as-mirror (ADR-2026-06-07: la TV e' splash/mirror, MAI input) i gate orchestrator (`expected.size === characters.size` / `debriefChoices.size >= expected.size`) non si chiudono mai -> stallo permanente in `character_creation` e `debrief` (riprodotto col driver sintetico).

## Fix — opzione (b) role-aware self-selecting

Helper `lifecycleQuorumPids(room, orch, submitterId)`: host nel quorum SOLO se (a) e' il submitter corrente o (b) possiede gia' un PG in `orch.characters`. Niente filtro secco: il flusso phone-only legacy (host phone GIOCA e submitta il suo PG) resta intero — un filtro hard avrebbe fatto avanzare la fase prima del PG host o l'avrebbe rigettato via gate F-3 `player_not_in_room`.

Limite noto (accettato col design self-selecting): nel flusso legacy, se l'host submitta DOPO che tutti i player hanno gia' submittato, il gate chiude prima del PG host (race inerente: nessun segnale "host giochera'" prima del primo submit). Mitigazione naturale: host-creator di norma submitta col gruppo.

## Test (TDD, RED verificato su main)

`tests/services/network/wsSession-lifecycleQuorum.test.js` (pattern mirror di `wsSession-creatureNamed.test.js`):
1. TV-mirror: host mai submitter -> `world_setup` coi soli player (RED su main: stallo riprodotto)
2. Legacy host-gioca: PG host accettato + `world_setup` SOLO dopo tutti (guard, verde anche pre-fix)
3. TV-mirror debrief: advance coi soli player + host assente dal ready_list (RED su main)
4. Legacy debrief: host con PG resta nel quorum, advance solo dopo la sua scelta (guard)

## Verifiche

- nuovo file: 4/4 verde (2 RED su main pre-fix)
- `tests/services/network/*.test.js`: 60/60
- regressione coop/lobby/ws (`tests/api/coop* lobby* ws*` + `tests/services/coop*` + offspring): 357/357
- `tests/ai/*.test.js`: 502/502 (baseline >=382)
- `tests/e2e/lobbyEndToEnd.test.mjs`: 12/12
- `npx prettier --check`: clean

## Note scope

- Test file (~330 righe) fuori `apps/backend/` = richiesto esplicitamente dal task (regola 50-righe: conferma preventiva nel mandato).
- Follow-up NON toccati (stesso pattern allPids-con-host, fuori scope finding): drain `reveal_acknowledge` (gate `all_ready` conta l'host -> candidato stallo in `world_seed_reveal` con TV-mirror) e path REST `submitCharacter` (helper host-excluding + gate strict-size = host-plays via REST gia' incoerente pre-fix). Segnalo per istruttoria separata.

## Rollback (03A)

Revert del singolo commit (`git revert db81deb3`): helper + 2 call site + test file, nessuna migrazione/schema/contract. Ripristina il comportamento pre-fix (stallo TV-mirror) senza effetti collaterali.

## Changelog

- fix(coop): ready-gate `character_create`/`lineage_choice` role-aware — host TV-as-mirror escluso dal quorum (self-selecting), stallo `character_creation`/`debrief` risolto; flusso legacy host-gioca preservato.
