### PR TITLE
fix(coop): REST lifecycle quorum role-aware (host-plays + misto WS/REST)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -14,6 +14,10 @@ const express = require('express');
 const { listBiomeRoleDemands } = require('../services/coop/ermesExporter');
 const { listAlienaSummaries } = require('../services/coop/alienaGenerator');
 const { buildPhaseChangePayload } = require('../services/coop/phaseChangePayload');
+// #2709 -- REST lifecycle quorum role-aware, stesso self-selecting rule dei
+// drain WS (#2707/#2708): l'host conta SOLO se e' il submitter corrente o
+// possiede gia' un PG (host-plays); la TV-mirror (mai input) resta esclusa.
+const { lifecycleQuorumPids } = require('../services/network/wsSession');
 
 function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = null } = {}) {
   if (!lobby) throw new Error('createCoopRouter: lobby required');
@@ -37,18 +41,22 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
     return p ? { room, player: p } : null;
   }
 
-  function allPlayerIds(room) {
-    return Array.from(room.players.values())
-      .filter((p) => p.id !== room.hostId && p.role !== 'host')
-      .map((p) => p.id);
+  // #2709 -- role-aware REST quorum (mirror WS lifecycleQuorumPids #2707/#2708):
+  // host counts only as current submitter or once it owns a PG (host-plays);
+  // a TV-mirror host (never inputs) stays out, so players-only rooms advance.
+  function quorumPids(room, orch, submitterId = null) {
+    if (!room) return [];
+    return lifecycleQuorumPids(room, orch, submitterId);
   }
 
-  // B-NEW-1 fix 2026-05-08 — connected (WS-attached) non-host player ids.
-  // Used by world vote quorum so a disconnected peer doesn't block phase
-  // advance. Mirror of allPlayerIds with extra `connected` filter.
-  function connectedPlayerIds(room) {
+  // B-NEW-1 fix 2026-05-08 — connected (WS-attached) player ids, used by the
+  // vote quorums so a disconnected peer doesn't block phase advance. #2709:
+  // same role-aware quorum as above, restricted to `connected` peers.
+  function connectedQuorumPids(room, orch) {
+    if (!room) return [];
+    const quorum = new Set(lifecycleQuorumPids(room, orch, null));
     return Array.from(room.players.values())
-      .filter((p) => p.id !== room.hostId && p.role !== 'host' && p.connected)
+      .filter((p) => quorum.has(p.id) && p.connected)
       .map((p) => p.id);
   }
 
@@ -60,13 +68,13 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
     });
     room.broadcast({
       type: 'character_ready_list',
-      payload: orch.characterReadyList(allPlayerIds(room)),
+      payload: orch.characterReadyList(quorumPids(room, orch, null)),
     });
     // M18 — tally world votes if in setup phase.
     if (orch.phase === 'world_setup') {
       room.broadcast({
         type: 'world_tally',
-        payload: orch.worldTally(allPlayerIds(room), connectedPlayerIds(room)),
+        payload: orch.worldTally(quorumPids(room, orch, null), connectedQuorumPids(room, orch)),
       });
     }
     // GAP-C fase-3 — re-surface an open meta-network route choice (phase-agnostic:
@@ -76,7 +84,7 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
       room.broadcast({ type: 'route_choice', payload: { candidates: orch.routeCandidates } });
       room.broadcast({
         type: 'route_tally',
-        payload: orch.routeTally(allPlayerIds(room), connectedPlayerIds(room)),
+        payload: orch.routeTally(quorumPids(room, orch, null), connectedQuorumPids(room, orch)),
       });
     }
     // M19 — debrief ready list if in debrief.
@@ -85,12 +93,12 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
         type: 'debrief_ready_list',
         payload: {
           outcome: orch.run?.outcome || 'victory',
-          ready_list: orch.debriefReadyList(allPlayerIds(room)),
+          ready_list: orch.debriefReadyList(quorumPids(room, orch, null)),
         },
       });
       room.broadcast({
         type: 'mating_tally',
-        payload: orch.matingTally(allPlayerIds(room), connectedPlayerIds(room)),
+        payload: orch.matingTally(quorumPids(room, orch, null), connectedQuorumPids(room, orch)),
       });
       // 2026-05-15 Bundle C follow-up — surface per-actor 4-layer psicologico
       // payload to phone clients when host attached it via /coop/combat/end
@@ -161,7 +169,7 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
       const spec = orch.submitCharacter(
         playerId,
         { name, form_id, species_id, job_id },
-        { allPlayerIds: allPlayerIds(room) },
+        { allPlayerIds: quorumPids(room, orch, playerId) },
       );
       // B-NEW-5 fix 2026-05-08 — skip rebroadcast on idempotent resubmit.
       if (!spec._deduplicated) {
@@ -184,7 +192,7 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
     const room = lobby.getRoom(code);
     return res.json({
       snapshot: orch.snapshot(),
-      character_ready_list: room ? orch.characterReadyList(allPlayerIds(room)) : [],
+      character_ready_list: room ? orch.characterReadyList(quorumPids(room, orch, null)) : [],
     });
   });
 
@@ -205,8 +213,8 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
       const tally = orch.voteWorld(playerId, {
         scenarioId,
         accept,
-        allPlayerIds: allPlayerIds(room),
-        connectedPlayerIds: connectedPlayerIds(room),
+        allPlayerIds: quorumPids(room, orch, playerId),
+        connectedPlayerIds: connectedQuorumPids(room, orch),
       });
       broadcastCoopState(room, orch);
       return res.json({ phase: orch.phase, tally });
@@ -228,8 +236,8 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
     const orch = coopStore.get(code);
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
     try {
-      const allPids = allPlayerIds(room);
-      const connectedPids = connectedPlayerIds(room);
+      const allPids = quorumPids(room, orch, playerId);
+      const connectedPids = connectedQuorumPids(room, orch);
       const tally = orch.voteMating(playerId, pairId, {
         allPlayerIds: allPids,
         connectedPlayerIds: connectedPids,
@@ -321,7 +329,7 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
     try {
       const result = orch.submitDebriefChoice(playerId, choice, {
-        allPlayerIds: allPlayerIds(room),
+        allPlayerIds: quorumPids(room, orch, playerId),
       });
       broadcastCoopState(room, orch);
       return res.json({
@@ -420,7 +428,7 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
       room.broadcast({ type: 'route_choice', payload: { candidates: stored } });
       room.broadcast({
         type: 'route_tally',
-        payload: orch.routeTally(allPlayerIds(room), connectedPlayerIds(room)),
+        payload: orch.routeTally(quorumPids(room, orch, null), connectedQuorumPids(room, orch)),
       });
       return res.json({ ok: true, candidates: stored });
     } catch (err) {

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -2245,4 +2245,8 @@ module.exports = {
   generateRoomCode,
   ROOM_CODE_ALPHABET,
   ROOM_CODE_LENGTH,
+  // #2709: shared with routes/coop.js so the REST lifecycle quorum stays in
+  // lockstep with the WS drains (#2707/#2708) -- one self-selecting rule,
+  // no third copy of the host-exclusion bug.
+  lifecycleQuorumPids,
 };

--- a/tests/api/coopRestQuorumHostPlays.test.js
+++ b/tests/api/coopRestQuorumHostPlays.test.js
@@ -1,0 +1,76 @@
+// #2709 -- REST lifecycle quorum role-aware (mirror del fix WS #2707/#2708).
+// Bug: routes/coop.js allPlayerIds() esclude SEMPRE l'host -> (1) host-plays via
+// REST = bounce F-3 player_not_in_room; (2) flusso misto WS/REST = stallo del
+// gate strict-size (characters include host, expected no). Fix: quorum
+// self-selecting (host conta solo se submitter o gia' proprietario di un PG).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app, coopStore };
+}
+
+async function bootstrap(app) {
+  const { body: h } = await request(app).post('/api/lobby/create').send({ host_name: 'Capo' });
+  const { body: p1 } = await request(app)
+    .post('/api/lobby/join')
+    .send({ code: h.code, player_name: 'Alice' });
+  await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+  return { h, p1 };
+}
+
+function submitChar(app, code, pid, token, name) {
+  return request(app).post('/api/coop/character/create').send({
+    code,
+    player_id: pid,
+    player_token: token,
+    name,
+    form_id: 'istj',
+  });
+}
+
+async function phaseOf(app, code) {
+  const res = await request(app).get(`/api/coop/state?code=${code}`);
+  return res.body.snapshot.phase;
+}
+
+test('host-plays: host character/create via REST accepted (was F-3 bounce)', async () => {
+  const { app } = buildApp();
+  const { h } = await bootstrap(app);
+  const res = await submitChar(app, h.code, h.host_id, h.host_token, 'CapoPG');
+  assert.ok(res.status < 300, `expected 2xx, got ${res.status}: ${JSON.stringify(res.body)}`);
+});
+
+test('mixed quorum: host PG + player PG -> world_setup (was permanent stall)', async () => {
+  const { app } = buildApp();
+  const { h, p1 } = await bootstrap(app);
+  const hostRes = await submitChar(app, h.code, h.host_id, h.host_token, 'CapoPG');
+  assert.ok(hostRes.status < 300, `host submit failed: ${hostRes.status}`);
+  // host has a PG -> counts in the quorum -> phase must NOT advance yet
+  assert.equal(await phaseOf(app, h.code), 'character_creation');
+  const p1Res = await submitChar(app, h.code, p1.player_id, p1.player_token, 'Aria');
+  assert.ok(p1Res.status < 300, `p1 submit failed: ${p1Res.status}`);
+  assert.equal(await phaseOf(app, h.code), 'world_setup', 'both PGs in -> advance');
+});
+
+test('TV-mirror regression: host never submits -> players-only quorum advances', async () => {
+  const { app } = buildApp();
+  const { h, p1 } = await bootstrap(app);
+  const p1Res = await submitChar(app, h.code, p1.player_id, p1.player_token, 'Aria');
+  assert.ok(p1Res.status < 300);
+  assert.equal(await phaseOf(app, h.code), 'world_setup', 'host (TV) excluded from quorum');
+});


### PR DESCRIPTION
## Summary

Chiude [#2709](https://github.com/MasterDD-L34D/Game/issues/2709) (istruttoria Lenovo da #2708 punto 3): il path REST escludeva SEMPRE l'host dal quorum lifecycle -> host-plays via REST rimbalzato dal gate F-3 (`player_not_in_room`, coopOrchestrator:460) e flusso misto WS/REST in stallo permanente sul gate strict-size (`expected.size === characters.size`, :491 -- characters include l'host submittato via WS, expected no).

## Fix (stesso principio ratificato con #2707/#2708)

- `lifecycleQuorumPids` ora **esportato** da wsSession e riusato in routes/coop.js: UNA regola self-selecting (host conta solo se submitter corrente o gia' proprietario di un PG), niente terza copia del bug.
- Sostituiti TUTTI i call-site REST: `submitCharacter`/`voteWorld`/`voteMating`/`submitDebriefChoice` con submitter; tally/broadcast/state con `null` (host conta se ha PG). `connectedQuorumPids` = stessa regola + filtro `connected` (copre anche il NB dell'issue su voteWorld/submitDebriefChoice).
- TV-mirror invariata: host che non inputta resta fuori dal quorum (regression test dedicato).

## Test

- TDD (RED verificato: `player_not_in_room` 400 riprodotto): **3 nuovi** -- host-plays REST 2xx; misto host+player -> `world_setup` (era stallo); TV-mirror advance players-only.
- Regression: coop + network **240/240** · AI baseline verde · prettier clean.

## Changelog

- fix(coop): host-plays via REST accettato nel quorum lifecycle; stallo misto WS/REST risolto.

## Rollback plan (03A)

Revert singolo commit: il quorum torna host-excluding (bug #2709 ricompare, nessun altro impatto).

Closes #2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)