### PR TITLE
feat(tools): trait-mirror duplicate-key check + parse canary (F6 #2715)

### DIFF
--- a/tests/test_check_trait_mirror_consistency.py
+++ b/tests/test_check_trait_mirror_consistency.py
@@ -1,0 +1,186 @@
+"""Tests for tools/py/check_trait_mirror_consistency.py -- F6 hardening.
+
+Finding F6 (docs/reports/2026-06-10-electric-channel-n40-evidence.md, PR #2715):
+a duplicate trait key in active_effects.yaml breaks js-yaml load at runtime ->
+loadActiveTraitRegistry returns {} -> entire trait engine silently no-op.
+The mirror validator used a regex key SET, so duplicates were invisible.
+
+Covers:
+- duplicate-key detection on both YAML files (exit 1)
+- parse canary (yaml.safe_load) on YAML-breaking edits (exit 1)
+- skip_keys excluded from duplicate counting
+- real repo files stay green (regression guard)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = PROJECT_ROOT / "tools" / "py" / "check_trait_mirror_consistency.py"
+
+CLEAN_MECH = """schema_version: "0.1"
+traits:
+  alpha_trait:
+    attack_mod: 1
+  beta_trait:
+    defense_mod: 1
+"""
+
+CLEAN_ACTIVE = """version: 1
+traits:
+  alpha_trait:
+    tier: T1
+  beta_trait:
+    tier: T1
+"""
+
+
+def run_checker(*args: str) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), *args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def run_on(tmp_path: Path, mech: str, active: str, *extra: str):
+    mech_path = tmp_path / "trait_mechanics.yaml"
+    active_path = tmp_path / "active_effects.yaml"
+    mech_path.write_text(mech, encoding="utf-8")
+    active_path.write_text(active, encoding="utf-8")
+    return run_checker(
+        "--trait-mechanics", str(mech_path),
+        "--active-effects", str(active_path),
+        "--json", *extra,
+    )
+
+
+def test_real_repo_files_pass() -> None:
+    result = run_checker("--json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["status"] == "PASS"
+    assert report["duplicate_keys"] == {"trait_mechanics": {}, "active_effects": {}}
+    assert report["parse_canary"]["active_effects"] in ("ok", "skipped")
+    assert report["parse_canary"]["trait_mechanics"] in ("ok", "skipped")
+
+
+def test_clean_tmp_files_pass(tmp_path: Path) -> None:
+    result = run_on(tmp_path, CLEAN_MECH, CLEAN_ACTIVE)
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["status"] == "PASS"
+
+
+def test_duplicate_key_in_active_effects_fails(tmp_path: Path) -> None:
+    # F6 reproduction: same trait key twice (stub orphan + new entry).
+    dup_active = CLEAN_ACTIVE + """  alpha_trait:
+    tier: T2
+"""
+    result = run_on(tmp_path, CLEAN_MECH, dup_active)
+    assert result.returncode == 1, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["status"] == "FAIL"
+    assert report["duplicate_keys"]["active_effects"] == {"alpha_trait": 2}
+    assert report["duplicate_keys"]["trait_mechanics"] == {}
+
+
+def test_duplicate_key_in_trait_mechanics_fails(tmp_path: Path) -> None:
+    dup_mech = CLEAN_MECH + """  beta_trait:
+    defense_mod: 2
+"""
+    result = run_on(tmp_path, dup_mech, CLEAN_ACTIVE)
+    assert result.returncode == 1, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["status"] == "FAIL"
+    assert report["duplicate_keys"]["trait_mechanics"] == {"beta_trait": 2}
+
+
+def test_skip_keys_not_counted_as_duplicates(tmp_path: Path) -> None:
+    # Role-category keys (_defaults block) may repeat at column-2 indent;
+    # they are skip_keys, never trait ids -> no duplicate flag.
+    mech = """schema_version: "0.1"
+_defaults:
+  offensive:
+    attack_mod: 1
+  offensive:
+    attack_mod: 2
+traits:
+  alpha_trait:
+    attack_mod: 1
+  beta_trait:
+    defense_mod: 1
+"""
+    result = run_on(tmp_path, mech, CLEAN_ACTIVE)
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["duplicate_keys"]["trait_mechanics"] == {}
+
+
+def test_parse_canary_catches_broken_yaml(tmp_path: Path) -> None:
+    # Unclosed flow sequence: regex key-set extraction is unaffected
+    # (mirror still consistent) but yaml.safe_load explodes -> canary FAIL.
+    broken_active = CLEAN_ACTIVE + """  gamma_extra: [1, 2
+"""
+    result = run_on(tmp_path, CLEAN_MECH, broken_active)
+    assert result.returncode == 1, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["status"] == "FAIL"
+    assert report["parse_canary"]["active_effects"].startswith("fail")
+    assert report["parse_canary"]["trait_mechanics"] == "ok"
+
+
+def _load_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("ctmc", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_node_canary_skips_when_js_yaml_missing(monkeypatch, tmp_path: Path) -> None:
+    # CI docs-governance job: no pip install, no npm ci -> node exists but
+    # js-yaml unresolvable. Must report 'skipped', NOT a false 'fail'.
+    mod = _load_module()
+    yaml_file = tmp_path / "x.yaml"
+    yaml_file.write_text("a: 1\n", encoding="utf-8")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args, returncode=1, stdout="",
+            stderr="Error: Cannot find module 'js-yaml'\n",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    assert mod._node_js_yaml_canary(yaml_file) == "skipped"
+
+
+def test_node_canary_skips_when_node_missing(monkeypatch, tmp_path: Path) -> None:
+    mod = _load_module()
+    yaml_file = tmp_path / "x.yaml"
+    yaml_file.write_text("a: 1\n", encoding="utf-8")
+
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("node not found")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    assert mod._node_js_yaml_canary(yaml_file) == "skipped"
+
+
+def test_human_output_reports_duplicates(tmp_path: Path) -> None:
+    dup_active = CLEAN_ACTIVE + """  alpha_trait:
+    tier: T2
+"""
+    mech_path = tmp_path / "trait_mechanics.yaml"
+    active_path = tmp_path / "active_effects.yaml"
+    mech_path.write_text(CLEAN_MECH, encoding="utf-8")
+    active_path.write_text(dup_active, encoding="utf-8")
+    result = run_checker(
+        "--trait-mechanics", str(mech_path),
+        "--active-effects", str(active_path),
+    )
+    assert result.returncode == 1
+    assert "DUPLICATE" in result.stdout
+    assert "alpha_trait" in result.stdout

--- a/tools/py/check_trait_mirror_consistency.py
+++ b/tools/py/check_trait_mirror_consistency.py
@@ -9,9 +9,18 @@ trait_mechanics.yaml; runtime resolution reads active_effects.yaml ONLY →
 traits silently no-op'd in production. Engine LIVE Surface DEAD anti-pattern
 manifestation despite Gate 5 enforcement.
 
+F6 hardening (2026-06-10, docs/reports/2026-06-10-electric-channel-n40-evidence.md,
+PR #2715): a DUPLICATE trait key in active_effects.yaml makes js-yaml THROW at
+load -> loadActiveTraitRegistry returns {} -> the ENTIRE trait engine silently
+no-ops in production (soft-fail by design). PyYAML is last-wins on duplicates
+(no error), so two extra checks exist:
+  - duplicate-key count per column-2 key (js-yaml-equivalent guard);
+  - parse canary: real yaml.safe_load (fallback: node js-yaml one-liner)
+    so ANY YAML-breaking edit fails the validator, not only duplicates.
+
 Exit codes:
   0 = mirror consistent
-  1 = traits missing in active_effects.yaml (drift detected)
+  1 = drift / duplicate keys / parse failure detected
   2 = file I/O error
 
 Usage (manual):
@@ -29,7 +38,9 @@ Refs:
 
 import argparse
 import re
+import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -39,6 +50,16 @@ ACTIVE_EFFECTS = REPO_ROOT / "data" / "core" / "traits" / "active_effects.yaml"
 # Top-level trait keys appear at column 2 indent (2 spaces) inside `traits:`
 # OR top-level. Pattern: `^  <trait_id>:\s*$` (column-2 indented).
 TRAIT_KEY_RE = re.compile(r"^  ([a-z][a-z0-9_]+):\s*$", re.MULTILINE)
+
+# Top-level section markers (version:, traits:, validation:, references:)
+# which may also match TRAIT_KEY_RE if they happen to be at column 2,
+# plus role-category defaults (_defaults block in trait_mechanics.yaml).
+SKIP_KEYS = {"version", "traits", "validation", "references", "schema_version",
+             "scenario_overrides", "encounter_classes", "enemy_tiers",
+             "player_classes", "resistances", "active_effects", "trigger",
+             "effect", "description_it", "notes",
+             # _defaults block role categories in trait_mechanics.yaml
+             "offensive", "defensive", "utility", "hybrid", "mobility"}
 
 
 def extract_trait_ids(yaml_path):
@@ -55,41 +76,84 @@ def extract_trait_ids(yaml_path):
         print(f"ERROR reading {yaml_path}: {e}", file=sys.stderr)
         return None
 
-    # Skip top-level section markers (version:, traits:, validation:, references:)
-    # which may also match TRAIT_KEY_RE if they happen to be at column 2.
-    # Also skip role-category defaults (_defaults block in trait_mechanics.yaml).
     ids = set()
-    skip_keys = {"version", "traits", "validation", "references", "schema_version",
-                 "scenario_overrides", "encounter_classes", "enemy_tiers",
-                 "player_classes", "resistances", "active_effects", "trigger",
-                 "effect", "description_it", "notes",
-                 # _defaults block role categories in trait_mechanics.yaml
-                 "offensive", "defensive", "utility", "hybrid", "mobility"}
-    # Detect _defaults: block scope — keys inside it are role categories not traits.
-    in_defaults = False
-    defaults_indent = None
-    for line in content.splitlines():
-        stripped = line.rstrip()
-        if not stripped:
-            continue
-        if stripped.startswith("_defaults:"):
-            in_defaults = True
-            defaults_indent = 0
-            continue
-        if in_defaults:
-            # Exit _defaults when we hit a non-indented line.
-            indent = len(line) - len(line.lstrip())
-            if indent <= defaults_indent and not line.startswith(" "):
-                in_defaults = False
-        m = TRAIT_KEY_RE.match(line + "\n" if not line.endswith("\n") else line)
-        # Use line-by-line match since multi-line MULTILINE re may be inconsistent
-    # Re-run simple match approach + filter via skip_keys.
     for m in TRAIT_KEY_RE.finditer(content):
         key = m.group(1)
-        if key in skip_keys:
+        if key in SKIP_KEYS:
             continue
         ids.add(key)
     return ids
+
+
+def find_duplicate_keys(yaml_path):
+    """Count column-2 key occurrences; return {key: count} for count > 1.
+
+    F6 (PR #2715): js-yaml THROWS on a duplicate mapping key ->
+    loadActiveTraitRegistry returns {} -> trait engine silently no-op.
+    PyYAML safe_load is last-wins on duplicates (no error), so the parse
+    canary alone cannot catch this -- the regex count is the
+    js-yaml-equivalent guard. Returns None on read error.
+    """
+    if not yaml_path.exists():
+        return None
+    try:
+        content = yaml_path.read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"ERROR reading {yaml_path}: {e}", file=sys.stderr)
+        return None
+    counts = Counter(
+        m.group(1) for m in TRAIT_KEY_RE.finditer(content)
+        if m.group(1) not in SKIP_KEYS
+    )
+    return {key: n for key, n in sorted(counts.items()) if n > 1}
+
+
+def parse_canary(yaml_path):
+    """Attempt a real YAML parse; returns 'ok' | 'skipped' | 'fail: <reason>'.
+
+    Primary: PyYAML safe_load. Fallback (PyYAML missing): node js-yaml
+    one-liner (the production loader). Neither available -> 'skipped'.
+    Covers ANY YAML-breaking edit, not only duplicate keys.
+    """
+    try:
+        content = yaml_path.read_text(encoding="utf-8")
+    except OSError as e:
+        return f"fail: unreadable ({e})"
+    try:
+        import yaml
+    except ImportError:
+        return _node_js_yaml_canary(yaml_path)
+    try:
+        yaml.safe_load(content)
+        return "ok"
+    except yaml.YAMLError as e:
+        reason = " ".join(str(e).split()) or e.__class__.__name__
+        return f"fail: {reason}"
+
+
+def _node_js_yaml_canary(yaml_path):
+    """Parse via node js-yaml (production loader). 'skipped' if node missing."""
+    one_liner = (
+        "const fs=require('fs');const yaml=require('js-yaml');"
+        "yaml.load(fs.readFileSync(process.argv[1],'utf8'));"
+    )
+    try:
+        proc = subprocess.run(
+            ["node", "-e", one_liner, str(yaml_path)],
+            capture_output=True, text=True, check=False,
+            cwd=str(REPO_ROOT), timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "skipped"
+    if proc.returncode == 0:
+        return "ok"
+    stderr = proc.stderr or ""
+    if "Cannot find module" in stderr:
+        # node present but js-yaml unresolvable (e.g. CI job without npm ci):
+        # tooling gap, not a YAML failure.
+        return "skipped"
+    lines = [ln.strip() for ln in stderr.splitlines() if ln.strip()]
+    return f"fail: {lines[0]}" if lines else "fail: js-yaml parse error"
 
 
 def main():
@@ -97,14 +161,32 @@ def main():
     p.add_argument("--strict", action="store_true",
                    help="Also flag orphans (in active_effects.yaml but not trait_mechanics.yaml)")
     p.add_argument("--json", action="store_true", help="Output JSON report instead of human")
+    p.add_argument("--trait-mechanics", type=Path, default=TRAIT_MECHANICS,
+                   help="Override trait_mechanics.yaml path (tests/fixtures)")
+    p.add_argument("--active-effects", type=Path, default=ACTIVE_EFFECTS,
+                   help="Override active_effects.yaml path (tests/fixtures)")
     args = p.parse_args()
 
-    mech_ids = extract_trait_ids(TRAIT_MECHANICS)
-    active_ids = extract_trait_ids(ACTIVE_EFFECTS)
+    mech_path = args.trait_mechanics
+    active_path = args.active_effects
+
+    mech_ids = extract_trait_ids(mech_path)
+    active_ids = extract_trait_ids(active_path)
 
     if mech_ids is None or active_ids is None:
         print("ERROR: failed to read trait YAML files", file=sys.stderr)
         return 2
+
+    # F6: duplicate column-2 keys break js-yaml load -> registry {} -> engine no-op.
+    mech_dups = find_duplicate_keys(mech_path) or {}
+    active_dups = find_duplicate_keys(active_path) or {}
+
+    # F6: parse canary -- any YAML-breaking edit fails here.
+    canary = {
+        "trait_mechanics": parse_canary(mech_path),
+        "active_effects": parse_canary(active_path),
+    }
+    canary_fails = {k: v for k, v in canary.items() if v.startswith("fail")}
 
     # Missing in active_effects (runtime gap — silent no-op).
     missing = sorted(mech_ids - active_ids)
@@ -112,6 +194,8 @@ def main():
     orphans = sorted(active_ids - mech_ids)
     # Mirrored (good).
     mirrored = sorted(mech_ids & active_ids)
+
+    failed = bool(missing or mech_dups or active_dups or canary_fails)
 
     if args.json:
         import json
@@ -121,10 +205,15 @@ def main():
             "mirrored_count": len(mirrored),
             "missing_in_active_effects": missing,
             "orphans_in_active_effects": orphans,
-            "status": "FAIL" if missing else ("WARN" if (args.strict and orphans) else "PASS"),
+            "duplicate_keys": {
+                "trait_mechanics": mech_dups,
+                "active_effects": active_dups,
+            },
+            "parse_canary": canary,
+            "status": "FAIL" if failed else ("WARN" if (args.strict and orphans) else "PASS"),
         }
         print(json.dumps(report, indent=2, ensure_ascii=False))
-        if missing:
+        if failed:
             return 1
         if args.strict and orphans:
             return 1
@@ -142,6 +231,21 @@ def main():
             print(f"  - {tid}")
         print(f"\nP1 RUNTIME GAP: traits silently no-op'd. Add corresponding entries")
         print(f"to data/core/traits/active_effects.yaml (see ali_ioniche / scarica_ionica template).")
+
+    if mech_dups or active_dups:
+        print(f"\nFAIL -- DUPLICATE keys (F6: js-yaml throws -> registry {{}} -> trait engine no-op):")
+        for label, dups in (("trait_mechanics.yaml", mech_dups),
+                            ("active_effects.yaml", active_dups)):
+            for key, n in dups.items():
+                print(f"  - {label}: {key} x{n}")
+        print(f"\nRemove the stale/orphan entry (keep ONE definition per trait id).")
+
+    if canary_fails:
+        print(f"\nFAIL -- parse canary (YAML does not load):")
+        for label, msg in canary_fails.items():
+            print(f"  - {label}: {msg}")
+
+    if failed:
         return 1
 
     if args.strict and orphans:


### PR DESCRIPTION
## Contesto -- Finding F6 (PR #2715)

`docs/reports/2026-06-10-electric-channel-n40-evidence.md` F6: una chiave trait DUPLICATA in `data/core/traits/active_effects.yaml` (stub orphan `elettromagnete_biologico` in coda al file + nuova entry in testa) rompe il load js-yaml a runtime -> `loadActiveTraitRegistry` ritorna `{}` -> INTERO trait engine no-op silenzioso in production (soft-fail by design). `tools/py/check_trait_mirror_consistency.py` usava un SET di chiavi regex: duplicati invisibili.

## Cosa cambia

`tools/py/check_trait_mirror_consistency.py` (additivo, exit codes invariati 0/1/2):

1. **Duplicate-key check** -- `find_duplicate_keys()`: conta le occorrenze regex `^  ([a-z][a-z0-9_]+):\s*$` per chiave su ENTRAMBI i file (active_effects + trait_mechanics), skip_keys/_defaults esclusi; count>1 -> FAIL exit 1. Guard js-yaml-equivalente: js-yaml THROWA sui duplicati, PyYAML e' last-wins (il canary da solo non li vede).
2. **Parse canary** -- `parse_canary()`: `yaml.safe_load` reale (PyYAML primario; fallback one-liner node js-yaml = loader di produzione; `skipped` se tooling assente). Copre QUALSIASI edit YAML-breaking, non solo i duplicati.
3. **Override path** `--trait-mechanics` / `--active-effects` per fixture di test. Invocazione no-arg invariata (pre-commit + docs-governance CI back-compat).
4. Refactor: rimosso loop `_defaults` vestigiale (calcolava `in_defaults` mai usato), `skip_keys` -> costante modulo `SKIP_KEYS` condivisa.
5. Report JSON esteso: `duplicate_keys` + `parse_canary`.

Test: `tests/test_check_trait_mirror_consistency.py` -- 9 pytest TDD (RED verificato prima dell'implementazione): riproduzione F6 su entrambi i file, skip_keys non flaggati, canary su YAML rotto, canary `skipped` (non falso `fail`) quando js-yaml/node mancano nel job CI, regression guard sui file reali, output umano.

## Evidenza verify

```
9 passed                                  # pytest tests/test_check_trait_mirror_consistency.py
PASS -- mirror consistent (96 mirrored)   # run su file reali origin/main, exit 0
duplicate_keys: {} / parse_canary: ok+ok  # --json su file reali
```

## Copertura onesta + follow-up (decisione DD, fuori scope qui)

- Step CI `trait_mirror_check` in docs-governance resta `continue-on-error: true` (warning-only) e quel job non installa PyYAML/npm -> in CI il canary = `skipped`, il duplicate-check regex = SEMPRE attivo. Promuovere lo step a required e/o aggiungere `pip install pyyaml` = edit `.github/workflows/` (forbidden path) -> chiamata DD separata, one-liner.
- Hook pre-commit locale resta `|| echo` (warning-only) -- invariato.

## Changelog

- feat(tools): trait mirror validator ora rileva chiavi duplicate (F6) + parse canary YAML; report JSON esteso (`duplicate_keys`, `parse_canary`); override path per test; 9 test pytest nuovi.

## Rollback plan (03A)

Revert del singolo commit: cambiamento additivo a script standalone + 1 file di test nuovo; nessun consumer legge i nuovi campi JSON; exit codes e invocazioni CI/hook invariati. Zero migrazioni, zero dipendenze nuove (PyYAML gia' in requirements.txt, usato solo se presente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
