### PR TITLE
fix(combat): trait resistances mirror in active_effects + channel routing round path

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2923,6 +2923,9 @@ function createSessionRouter(options = {}) {
             actor,
             target,
             requestedCapPt: 0,
+            // M6-#1b channel routing: senza questo il round path (default ON)
+            // forzava ogni attacco a "fisico" e i resist di canale erano no-op.
+            channel: typeof action.channel === 'string' ? action.channel : null,
           });
           results.push({ actor_id: actor.id, action_type: 'attack', result: wrapped });
         } else if (action.type === 'move') {

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -502,6 +502,8 @@ traits:
       kind: extra_damage
       amount: 1
       log_tag: ionic_pulse
+    resistances:
+      - { channel: ionico, modifier_pct: 10 }
     description_it: |
       Scarica ionica baseline. Il colpo ionico riuscito con MoS >= 5 genera
       un impulso elettrico che infligge 1 PT extra (ionic_pulse). Resist
@@ -526,6 +528,8 @@ traits:
       stato: disoriented
       turns: 1
       log_tag: voltaic_arc_disorient
+    resistances:
+      - { channel: ionico, modifier_pct: 15 }
     description_it: |
       Arco voltaico aggressivo. Colpo ionico riuscito con MoS >= 5 induce
       disorient sul bersaglio (1 turno) per shock elettrico al sistema
@@ -868,6 +872,8 @@ traits:
       kind: damage_reduction
       amount: 3
       log_tag: carapace_phase_shift
+    resistances:
+      - { channel: fisico, modifier_pct: 15 }
     description_it: |
       Corazza che varia densit� molecolare per bilanciare difesa e mobilit�.
       Su un colpo solido (MoS >= 5) il carapace si ispessisce drasticamente
@@ -9703,6 +9709,8 @@ traits:
       kind: extra_damage
       amount: 1
       log_tag: frusta_fiammeggiante_lash
+    resistances:
+      - { channel: fuoco, modifier_pct: 10 }
     description_it: |
       Frusta fiammeggiante: +1 damage su attacco melee. Mirror trait_mechanics
       (attack_mod 1 + damage_step 1). Ability ignition (whip_lash) handler
@@ -9718,6 +9726,10 @@ traits:
       kind: damage_reduction
       amount: 1
       log_tag: mantello_meteoritico_block
+    resistances:
+      - { channel: fisico, modifier_pct: 20 }
+      - { channel: fuoco, modifier_pct: 20 }
+      - { channel: earth, modifier_pct: 15 }
     description_it: |
       Mantello meteoritico: -1 damage taken. Mirror trait_mechanics
       (defense_mod 2 → conservative -1 amount). Resistenze multiple
@@ -9733,6 +9745,8 @@ traits:
       kind: extra_damage
       amount: 1
       log_tag: respiro_a_scoppio_burst
+    resistances:
+      - { channel: wind, modifier_pct: 10 }
     description_it: |
       Respiro a scoppio: +1 damage su attacco ranged area. Stub conservativo
       (full area logic ability explosive_rush handler separato — ticket
@@ -9748,6 +9762,8 @@ traits:
       kind: extra_damage
       amount: 1
       log_tag: sangue_piroforico_ignite
+    resistances:
+      - { channel: fuoco, modifier_pct: 10 }
     description_it: |
       Sangue piroforico: +1 damage su melee. Mirror trait_mechanics
       (attack_mod 1 + fuoco res 10%). Ability ignition_surge reactive
@@ -9763,6 +9779,9 @@ traits:
       kind: extra_damage
       amount: 1
       log_tag: spore_psichiche_silenziate_silence
+    resistances:
+      - { channel: mentale, modifier_pct: 15 }
+      - { channel: dark, modifier_pct: 10 }
     description_it: |
       Spore psichiche silenziate: +1 damage stealthed melee. Mirror
       trait_mechanics (attack_mod 1 + damage_step 1 + mentale/dark res).
@@ -9856,6 +9875,9 @@ traits:
       amount: 2
       duration: 2
       log_tag: cute_salt_harden
+    resistances:
+      - { channel: fuoco, modifier_pct: 15 }
+      - { channel: taglio, modifier_pct: 10 }
     description_it: |
       Cute resistente sali: +2 defense_mod buff_stat reactive su receive_damage
       (salt_harden). Mirror trait_mechanics (defense_mod 1 + dual resist
@@ -10023,6 +10045,8 @@ traits:
       amount: 2
       duration: 2
       log_tag: pelage_hydro_shield
+    resistances:
+      - { channel: ionico, modifier_pct: 25 }
     description_it: |
       Pelage idrorepellente avanzato: +2 defense_mod buff_stat 2t (hydro_shield).
       Mirror trait_mechanics defensive base + ionico resist 25%. Resist gestito
@@ -10056,6 +10080,8 @@ traits:
       amount: 2
       duration: 2
       log_tag: struttura_elastic_absorb
+    resistances:
+      - { channel: fisico, modifier_pct: 10 }
     description_it: |
       Struttura elastica amorfa: +2 defense_mod buff_stat 2t (elastic_absorb).
       Mirror trait_mechanics + fisico resist 10%. Identical shape mimetismo_cromatico
@@ -10125,6 +10151,8 @@ traits:
     # Conservative downgrade 2026-05-10: trait_mechanics buff_stat 3/1t spike
     # rischio playtest. Ship 2/1t (vs spec 3) per safer integration. Bump
     # 3 se TKT-M11B-06 playtest signal under-powered.
+    resistances:
+      - { channel: ionico, modifier_pct: 20 }
     description_it: |
       Criostasi adattiva: +2 defense_mod buff_stat 1t (frozen_stasis).
       Cost_ap=3 ability gate appropriate. Amount 2 conservative (vs spec 3)
@@ -10149,6 +10177,8 @@ traits:
       amount: 0
       dice: "1d4+2"
       log_tag: grassi_thermal_pulse
+    resistances:
+      - { channel: fuoco, modifier_pct: 10 }
     description_it: |
       Grassi termici: heal 1d4+2 self (thermal_pulse). Mirror trait_mechanics
       heal ability + fuoco resist 10% (gestito da resistanceEngine).
@@ -10165,6 +10195,8 @@ traits:
       amount: 0
       dice: "1d4+1"
       log_tag: sonno_vigilant_rest
+    resistances:
+      - { channel: mentale, modifier_pct: 10 }
     description_it: |
       Sonno emisferico alternato: heal 1d4+1 self (vigilant_rest). Mirror
       trait_mechanics heal ability + mentale resist 10%. Half-brain alert

--- a/tests/api/contracts-trait-mechanics.test.js
+++ b/tests/api/contracts-trait-mechanics.test.js
@@ -20,6 +20,7 @@ const MECHANICS_PATH = path.join(
   'trait_mechanics.yaml',
 );
 const INVENTORY_PATH = path.join(REPO_ROOT, 'docs', 'catalog', 'traits_inventory.json');
+const ACTIVE_EFFECTS_PATH = path.join(REPO_ROOT, 'data', 'core', 'traits', 'active_effects.yaml');
 
 const SCHEMA_ID = 'contracts://trait-mechanics/catalog';
 
@@ -331,4 +332,47 @@ test('Fase 3-bis: resistances presenti e coerenti (permissivo)', () => {
       );
     }
   }
+});
+
+test('P2 wiring fix 2026-06-10: resistances trait_mechanics specchiate in active_effects (runtime SoT)', () => {
+  // Il combat runtime (session.js performAttack -> loadActiveTraitRegistry)
+  // legge le resistances trait SOLO da active_effects.yaml: una resistance
+  // dichiarata solo in trait_mechanics.yaml e' un no-op silenzioso in
+  // produzione (bug P2 trovato durante TKT-D4-ENRICH #2533, pattern fix
+  // PR #2715 elettromagnete_biologico / seta_conduttiva_elettrica).
+  const catalog = loadCatalog();
+  const active = yaml.load(fs.readFileSync(ACTIVE_EFFECTS_PATH, 'utf8'));
+  assert.ok(active && typeof active.traits === 'object', 'active_effects.yaml parseabile');
+
+  const normalize = (list) =>
+    JSON.stringify(
+      (list || [])
+        .map((r) => ({ channel: r.channel, modifier_pct: r.modifier_pct }))
+        .sort((a, b) => a.channel.localeCompare(b.channel)),
+    );
+
+  const problems = [];
+  for (const [id, entry] of Object.entries(catalog.traits)) {
+    const mechRes = Array.isArray(entry.resistances) ? entry.resistances : [];
+    if (mechRes.length === 0) continue;
+    const aeEntry = active.traits[id];
+    if (!aeEntry) {
+      problems.push(`${id}: entry assente in active_effects.yaml`);
+      continue;
+    }
+    if (!Array.isArray(aeEntry.resistances)) {
+      problems.push(`${id}: campo resistances assente in active_effects.yaml (runtime no-op)`);
+      continue;
+    }
+    if (normalize(aeEntry.resistances) !== normalize(mechRes)) {
+      problems.push(
+        `${id}: resistances divergenti — mechanics=${normalize(mechRes)} active_effects=${normalize(aeEntry.resistances)}`,
+      );
+    }
+  }
+  assert.deepEqual(
+    problems,
+    [],
+    `ogni trait con resistances in trait_mechanics.yaml deve avere mirror identico in active_effects.yaml:\n${problems.join('\n')}`,
+  );
 });

--- a/tests/api/traitResistanceWiring.test.js
+++ b/tests/api/traitResistanceWiring.test.js
@@ -1,0 +1,115 @@
+// tests/api/traitResistanceWiring.test.js
+//
+// P2 wiring fix 2026-06-10 — trait resistances devono arrivare al runtime.
+//
+// performAttack (apps/backend/routes/session.js ~796) risolve le resistances
+// del bersaglio leggendo `traitRegistry[tid].resistances` dal registry di
+// active_effects.yaml (loadActiveTraitRegistry) e le passa a
+// computeUnitResistances -> applyResistance. Una resistance dichiarata solo
+// in trait_mechanics.yaml NON esiste a runtime (no-op silenzioso) anche se la
+// description del trait promette il resist.
+//
+// Repro end-to-end: due sessioni con lo stesso seed (stessa RNG stream, il
+// resist non consuma draw), stesso attacco player sul canale `ionico`,
+// vittima identica salvo il trait `pelage_idrorepellente_avanzato`
+// (ionico +25% in trait_mechanics). ai_auto=false e vittima senza
+// resistance_archetype: l'unica differenza di danno possibile e' il resist
+// del trait. Pre-fix il danno era identico nelle due sessioni.
+//
+// mod 20 vs dc 2 = hit garantito (pattern onHitStatusRoundPersist.test.js).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+const SEED = 31337;
+const ROUNDS = 3;
+
+function units(victimTraits) {
+  return [
+    {
+      id: 'atk',
+      controlled_by: 'player',
+      species: 'chimera_probe_b',
+      job: 'ranger',
+      traits: [],
+      hp: 60,
+      max_hp: 60,
+      mod: 20,
+      dc: 18,
+      ap: 3,
+      attack_range: 2,
+      initiative: 99,
+      position: { x: 1, y: 1 },
+    },
+    {
+      id: 'vic',
+      controlled_by: 'sistema',
+      species: 'cacciatore_corazzato',
+      job: 'vanguard',
+      traits: victimTraits,
+      hp: 80,
+      max_hp: 80,
+      mod: 0,
+      dc: 2,
+      ap: 2,
+      attack_range: 1,
+      initiative: 1,
+      position: { x: 1, y: 2 },
+      status: {},
+    },
+  ];
+}
+
+async function totalIonicDamage(app, victimTraits) {
+  const start = await request(app)
+    .post('/api/session/start')
+    .send({ units: units(victimTraits), seed: SEED, modulation: 'full' });
+  assert.equal(start.status, 200, `start ok: ${JSON.stringify(start.body).slice(0, 200)}`);
+  const sid = start.body.session_id;
+
+  let total = 0;
+  for (let round = 1; round <= ROUNDS; round += 1) {
+    const res = await request(app)
+      .post('/api/session/round/execute')
+      .send({
+        session_id: sid,
+        player_intents: [
+          { actor_id: 'atk', action: { type: 'attack', target_id: 'vic', channel: 'ionico' } },
+        ],
+        ai_auto: false,
+        priority_queue: true,
+      });
+    assert.equal(res.status, 200, `round exec ok: ${JSON.stringify(res.body).slice(0, 200)}`);
+    for (const r of res.body.results || []) {
+      if (r.actor_id !== 'atk' || r.action_type !== 'attack') continue;
+      const dmg = Number((r.result || {}).damage_dealt);
+      if (Number.isFinite(dmg)) total += dmg;
+    }
+  }
+  return total;
+}
+
+test('trait resistance (ionico 25%) riduce il danno in una sessione reale', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const baseline = await totalIonicDamage(app, []);
+  const resisted = await totalIonicDamage(app, ['pelage_idrorepellente_avanzato']);
+
+  assert.ok(baseline >= 2, `baseline deve infliggere danno ionico misurabile (totale ${baseline})`);
+  assert.ok(
+    resisted < baseline,
+    `pelage_idrorepellente_avanzato (ionico +25% in trait_mechanics) deve ridurre il danno: ` +
+      `baseline=${baseline} resisted=${resisted} — se uguali la resistance non arriva a ` +
+      `computeUnitResistances (campo mancante in active_effects.yaml)`,
+  );
+});


### PR DESCRIPTION
## Bug P2 (wiring, no ratifica — valori invariati)

Verificato durante TKT-D4-ENRICH (#2533 / PR #2715): il combat runtime legge le resistances trait SOLO da `data/core/traits/active_effects.yaml` (`performAttack` -> `traitRegistry[tid].resistances`, registry = `loadActiveTraitRegistry`). I trait con `resistances` dichiarate solo in `trait_mechanics.yaml` erano **no-op silenziosi** (le loro `description_it` promettono il resist).

### Fix 1 — mirror `resistances` (14 trait)

Audit completo TM->AE: **14 trait** con `resistances` non vuote senza mirror (0 entry mancanti, 0 mismatch valori). Campo aggiunto con stessi valori, pattern template #2715 (`elettromagnete_biologico`/`seta_conduttiva_elettrica`):

`scarica_ionica`, `arco_voltaico`, `carapace_fase_variabile`, `frusta_fiammeggiante`, `mantello_meteoritico`, `respiro_a_scoppio`, `sangue_piroforico`, `spore_psichiche_silenziate`, `cute_resistente_sali`, `pelage_idrorepellente_avanzato`, `struttura_elastica_amorfa`, `criostasi_adattiva`, `grassi_termici`, `sonno_emisferico_alternato`

### Fix 2 — root-cause scoperto dal test end-to-end: channel routing morto nel round path

`/api/session/round/execute` (round model, default ON) chiamava `handleLegacyAttackViaRound` **senza** `channel` -> ogni attacco round risolveva come `fisico` -> resist/vuln di canale (M6-#1b) mai applicati su quel path. Il legacy `/action` lo passava gia. Fix: 1 riga, propaga `action.channel`.

### TDD (RED verificato prima del fix)

- `contracts-trait-mechanics.test.js` — guard data-driven: ogni trait TM con `resistances` non vuote DEVE avere mirror identico in AE (RED: 14 fail elencati; previene regressioni future).
- `traitResistanceWiring.test.js` (nuovo) — end-to-end: 2 sessioni stesso seed, victim con/senza `pelage_idrorepellente_avanzato` (ionico +25), attack `channel: ionico` -> danno ridotto. RED pre-fix: `baseline=17 resisted=17`.

### Verifiche

- `validate-datasets` OK (14 controlli, 2 avvisi pre-esistenti) · `check_trait_mirror_consistency.py` PASS (post-rebase su #2717 duplicate-key check)
- `tests/ai` 502/502 · `tests/api` 1548 pass / 1 skip / 0 fail · Prettier clean
- Blast radius channel-fix: nessun test assert danni-esatti via round+channel (verificato grep); onHitStatusRoundPersist 4/4 post-rebase.

### Rollback (03A)

Revert singolo commit. Dati: solo campo additivo `resistances` in AE (nessun consumer rompe senza campo — torna al no-op pre-fix). Codice: 1 riga channel.