### PR TITLE
feat(play): overcharge first-use diegetic hint (Gate-5 #2716)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3227,6 +3227,10 @@ function createSessionRouter(options = {}) {
           .status(409)
           .json({ error: outcome.error, detail: outcome.detail || null, actor_id: actor.id });
       }
+      // Gate-5 #2716 — first overcharge of the run. Set once, never cleared
+      // in-run; publicSessionView exposes it as overcharge_used_this_run so
+      // the web surface can fire the diegetic strategic-cost hint exactly once.
+      session.overcharge_used = true;
       const event = {
         event_type: 'overcharge',
         actor_id: actor.id,

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -512,6 +512,11 @@ function publicSessionView(session) {
     // telegraph diegetico public-tier (mai il valore wave, ER3). Flag-gated:
     // resta null finche' STRESSWAVE_EVENTS_ENABLED non e' ON.
     stresswave_event: session.stresswave_event_latest || null,
+    // Gate-5 #2716 -- first-overcharge-of-the-run flag (set once by POST
+    // /overcharge, persists for the whole run). The web surface watches the
+    // false->true transition to fire the one-shot diegetic hint ("il Sistema
+    // reagisce al tuo tempo rubato") -- public tier, no raw numbers (ER3).
+    overcharge_used_this_run: !!session.overcharge_used,
     // M1 ADR-2026-05-18 -- campaign scope + Sistema learning state (read-only surface).
     campaign_id: session.campaign_id || null,
     sistema_state: session.sistema_state || { units_observed: {} },

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -39,6 +39,8 @@ import {
 } from './predictPreviewOverlay.js';
 import { renderObjectiveBar } from './objectivePanel.js';
 import { renderBiomeChip } from './biomeChip.js';
+// Gate-5 #2716 — one-shot diegetic hint at the first overcharge of the run.
+import { maybeShowOverchargeHint } from './overchargeHint.js';
 import { renderCtBar } from './ctBar.js';
 import { renderAmbitionHud } from './ambitionHud.js';
 import {
@@ -1314,6 +1316,9 @@ async function refresh() {
     refreshObjectiveBar();
     // Sprint 11 (Surface-DEAD #6): refresh biome chip post-state-fetch.
     refreshBiomeChip();
+    // Gate-5 #2716: first-overcharge-of-the-run diegetic hint (false->true
+    // transition of overcharge_used_this_run, publicSessionView additive field).
+    maybeShowOverchargeHint(prev, state.world);
     // Action 7 (ADR-2026-04-28 §Action 7): refresh CT bar lookahead 3 turni.
     refreshCtBar();
     // Action 6 (ADR-2026-04-28 §Action 6): refresh ambition HUD long-arc.

--- a/apps/play/src/overchargeHint.js
+++ b/apps/play/src/overchargeHint.js
@@ -1,0 +1,78 @@
+// Gate-5 #2716 — Overcharge first-use diegetic hint (web surface).
+//
+// Engine LIVE: apps/backend/services/combat/overchargeEngine.js — spend a full
+// SG gauge (3) for +1 AP this turn ("borrow tempo"). OD-058 D1 evidence
+// (docs/reports/2026-06-10-overcharge-action-economy-n40-evidence.md) ratified
+// as-built the strategic coupling: faster kills feed sistema_pressure and
+// escalate reinforcements. The player sees the AP bought (gauge) but not that
+// cost — this micro-hint telegraphs it at the FIRST overcharge of the run.
+//
+// Doctrine (issue #2716): wording diegetico, MAI meccanico, niente numeri raw
+// (ER3-style). Pattern: biomeChip label hard-fallback + stresswave telegraph
+// (#2712 — additive publicSessionView field -> state.world -> refresh hook).
+//
+// Detection = witnessed false->true transition of world.overcharge_used_this_run
+// between two state snapshots of the SAME session. No prev snapshot (first
+// fetch / rejoin) → the moment already passed, stay silent. Shown once per run
+// (session_id-keyed), reset only on page reload or a new run.
+
+'use strict';
+
+import { t } from './i18n.js';
+
+const TOAST_MS = 6000;
+
+// Runs (session ids) the hint already fired for in this page load.
+const shownForRun = new Set();
+
+export function _resetOverchargeHintForTest() {
+  shownForRun.clear();
+}
+
+// Pure: diegetic IT label. i18n key `overcharge_hint.label` with hard fallback
+// so the telegraph never shows a raw key (biomeChip woundedLabel pattern).
+export function overchargeHintLabel() {
+  const i18nKey = 'overcharge_hint.label';
+  const label = t(i18nKey);
+  return label === i18nKey ? 'Il Sistema reagisce al tuo tempo rubato' : label;
+}
+
+// Pure: did THIS client witness the first overcharge of the run?
+// Requires both snapshots, same session, flag flipping false -> true.
+export function shouldShowOverchargeHint(prevWorld, world) {
+  if (!prevWorld || !world) return false;
+  if (prevWorld.session_id && world.session_id && prevWorld.session_id !== world.session_id) {
+    return false;
+  }
+  return !prevWorld.overcharge_used_this_run && !!world.overcharge_used_this_run;
+}
+
+// Side effect: show the one-shot toast. Returns true when the hint fired
+// (even headless — the once-per-run mark must hold without a DOM).
+// `doc` injectable for tests; defaults to the browser document.
+export function maybeShowOverchargeHint(
+  prevWorld,
+  world,
+  doc = typeof document !== 'undefined' ? document : null,
+) {
+  if (!shouldShowOverchargeHint(prevWorld, world)) return false;
+  const runKey = world.session_id || 'unknown-run';
+  if (shownForRun.has(runKey)) return false;
+  shownForRun.add(runKey);
+  if (!doc || !doc.body || typeof doc.createElement !== 'function') return true;
+  const el = doc.createElement('div');
+  el.className = 'overcharge-hint-toast';
+  el.setAttribute('role', 'status');
+  el.textContent = `⚡ ${overchargeHintLabel()}`;
+  doc.body.appendChild(el);
+  const timer = setTimeout(() => {
+    try {
+      el.remove();
+    } catch {
+      /* already gone */
+    }
+  }, TOAST_MS);
+  // Node test runner: don't hold the event loop open for the auto-dismiss.
+  if (timer && typeof timer.unref === 'function') timer.unref();
+  return true;
+}

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -2387,6 +2387,43 @@ body.ability-target-mode canvas#grid {
   white-space: nowrap;
 }
 
+/* Gate-5 #2716 — overcharge first-use strategic-cost hint. One-shot diegetic
+   toast (no raw numbers, ER3 doctrine): fade in, hold, fade out; node removed
+   by JS after 6s (overchargeHint.js TOAST_MS keeps the timings in sync). */
+.overcharge-hint-toast {
+  position: fixed;
+  top: 64px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  padding: 8px 16px;
+  background: rgba(20, 16, 8, 0.92);
+  border: 1px solid #b8923e;
+  border-radius: 8px;
+  color: #e8c97a;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  pointer-events: none;
+  animation: overcharge-hint-fade 6s ease forwards;
+}
+@keyframes overcharge-hint-fade {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-6px);
+  }
+  8% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+  85% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 /* Action 7 (ADR-2026-04-28 §Action 7) — CT bar lookahead 3 turni HUD top-strip.
  * FFT-style temporal legibility: current actor pulse + 3 slot futuri con arrow
  * separator. Pillar P1 chiusura gap "chi muove dopo".

--- a/data/i18n/en/common.json
+++ b/data/i18n/en/common.json
@@ -139,6 +139,9 @@
     "label": "Wounded biome",
     "tooltip": "it bears the scars of a failed expedition; the ecosystem reacts more harshly"
   },
+  "overcharge_hint": {
+    "label": "The System reacts to your stolen tempo"
+  },
   "ennea_archetype": {
     "1": "Reformer",
     "2": "Coordinator",

--- a/data/i18n/it/common.json
+++ b/data/i18n/it/common.json
@@ -139,6 +139,9 @@
     "label": "Bioma ferito",
     "tooltip": "porta le cicatrici di una spedizione fallita; l'ecosistema reagisce con più durezza"
   },
+  "overcharge_hint": {
+    "label": "Il Sistema reagisce al tuo tempo rubato"
+  },
   "ennea_archetype": {
     "1": "Riformatore",
     "2": "Coordinatore",

--- a/tests/api/overchargeRoute.test.js
+++ b/tests/api/overchargeRoute.test.js
@@ -160,6 +160,30 @@ test('POST /overcharge: event appended to session.events', async (t) => {
   assert.equal(ev.ap_after, 3);
 });
 
+test('Gate-5 #2716: overcharge_used_this_run false pre, true post, persists across turns', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, [basePlayer({ sg: 3 }), baseSistema()]);
+  // Pre: fresh run, flag false in the public view.
+  const pre = await request(app).get('/api/session/state').query({ session_id: sid });
+  assert.equal(pre.status, 200);
+  assert.equal(pre.body.overcharge_used_this_run, false, 'fresh run -> false');
+  // First overcharge flips it (response state + GET /state agree).
+  const r = await request(app)
+    .post('/api/session/overcharge')
+    .send({ session_id: sid, actor_id: 'p1' });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.state.overcharge_used_this_run, true, 'flipped in response state');
+  // Persists across turn ends (first-of-the-RUN, not per-turn).
+  const turn = await request(app).post('/api/session/turn/end').send({ session_id: sid });
+  assert.equal(turn.status, 200);
+  const post = await request(app).get('/api/session/state').query({ session_id: sid });
+  assert.equal(post.status, 200);
+  assert.equal(post.body.overcharge_used_this_run, true, 'still true after turn end');
+});
+
 test('POST /overcharge: the guard clears after a round so it can be reused later', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {

--- a/tests/play/overchargeHint.test.js
+++ b/tests/play/overchargeHint.test.js
@@ -1,0 +1,168 @@
+// Gate-5 #2716 — Overcharge first-use diegetic hint (web surface).
+//
+// Pure transforms (overchargeHintLabel + shouldShowOverchargeHint) +
+// side-effect maybeShowOverchargeHint via fake DOM document. Mirrors the
+// biomeChip.test.js harness (node:test + dynamic ESM import).
+
+'use strict';
+
+const { test, describe, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadModule() {
+  return import('../../apps/play/src/overchargeHint.js');
+}
+
+function fakeDoc() {
+  const appended = [];
+  return {
+    appended,
+    body: {
+      appendChild(el) {
+        appended.push(el);
+      },
+    },
+    createElement(tag) {
+      const el = {
+        tagName: tag,
+        className: '',
+        textContent: '',
+        attrs: {},
+        setAttribute(k, v) {
+          el.attrs[k] = v;
+        },
+        remove() {
+          const i = appended.indexOf(el);
+          if (i >= 0) appended.splice(i, 1);
+        },
+      };
+      return el;
+    },
+  };
+}
+
+function world(overrides = {}) {
+  return { session_id: 'sess-1', overcharge_used_this_run: false, ...overrides };
+}
+
+describe('overchargeHintLabel', () => {
+  test('IT diegetic wording, never the raw i18n key, no raw numbers', async () => {
+    const { overchargeHintLabel } = await loadModule();
+    const label = overchargeHintLabel();
+    assert.ok(label.includes('Sistema reagisce'), `diegetic IT wording, got: ${label}`);
+    assert.ok(!label.includes('overcharge_hint'), 'must never leak the i18n key');
+    assert.ok(!/\d/.test(label), 'ER3 doctrine: no raw numbers in the telegraph');
+  });
+});
+
+describe('shouldShowOverchargeHint — pure transition detector', () => {
+  test('false -> true transition (same session) → true', async () => {
+    const { shouldShowOverchargeHint } = await loadModule();
+    const prev = world({ overcharge_used_this_run: false });
+    const next = world({ overcharge_used_this_run: true });
+    assert.equal(shouldShowOverchargeHint(prev, next), true);
+  });
+
+  test('no prev snapshot (first fetch / rejoin) → false', async () => {
+    const { shouldShowOverchargeHint } = await loadModule();
+    assert.equal(shouldShowOverchargeHint(null, world({ overcharge_used_this_run: true })), false);
+    assert.equal(
+      shouldShowOverchargeHint(undefined, world({ overcharge_used_this_run: true })),
+      false,
+    );
+  });
+
+  test('already used in prev snapshot → false (moment passed)', async () => {
+    const { shouldShowOverchargeHint } = await loadModule();
+    const prev = world({ overcharge_used_this_run: true });
+    const next = world({ overcharge_used_this_run: true });
+    assert.equal(shouldShowOverchargeHint(prev, next), false);
+  });
+
+  test('never used → false', async () => {
+    const { shouldShowOverchargeHint } = await loadModule();
+    assert.equal(shouldShowOverchargeHint(world(), world()), false);
+  });
+
+  test('null/missing world → false', async () => {
+    const { shouldShowOverchargeHint } = await loadModule();
+    assert.equal(shouldShowOverchargeHint(world(), null), false);
+  });
+
+  test('session_id mismatch (mid-loop session switch) → false', async () => {
+    const { shouldShowOverchargeHint } = await loadModule();
+    const prev = world({ session_id: 'sess-old', overcharge_used_this_run: false });
+    const next = world({ session_id: 'sess-new', overcharge_used_this_run: true });
+    assert.equal(shouldShowOverchargeHint(prev, next), false);
+  });
+});
+
+describe('maybeShowOverchargeHint — once per run, toast side-effect', () => {
+  beforeEach(async () => {
+    const { _resetOverchargeHintForTest } = await loadModule();
+    _resetOverchargeHintForTest();
+  });
+
+  test('first transition → appends toast with class + diegetic label, returns true', async () => {
+    const { maybeShowOverchargeHint } = await loadModule();
+    const doc = fakeDoc();
+    const prev = world({ overcharge_used_this_run: false });
+    const next = world({ overcharge_used_this_run: true });
+    assert.equal(maybeShowOverchargeHint(prev, next, doc), true);
+    assert.equal(doc.appended.length, 1);
+    const el = doc.appended[0];
+    assert.equal(el.className, 'overcharge-hint-toast');
+    assert.ok(el.textContent.includes('Sistema reagisce'), `got: ${el.textContent}`);
+    assert.equal(el.attrs.role, 'status', 'a11y live-region role');
+  });
+
+  test('second transition same session → false, no double toast', async () => {
+    const { maybeShowOverchargeHint } = await loadModule();
+    const doc = fakeDoc();
+    const prev = world({ overcharge_used_this_run: false });
+    const next = world({ overcharge_used_this_run: true });
+    assert.equal(maybeShowOverchargeHint(prev, next, doc), true);
+    assert.equal(maybeShowOverchargeHint(prev, next, doc), false);
+    assert.equal(doc.appended.length, 1, 'no duplicate toast');
+  });
+
+  test('new run (different session_id) → hint fires again', async () => {
+    const { maybeShowOverchargeHint } = await loadModule();
+    const doc = fakeDoc();
+    assert.equal(
+      maybeShowOverchargeHint(
+        world({ session_id: 'run-1' }),
+        world({ session_id: 'run-1', overcharge_used_this_run: true }),
+        doc,
+      ),
+      true,
+    );
+    assert.equal(
+      maybeShowOverchargeHint(
+        world({ session_id: 'run-2' }),
+        world({ session_id: 'run-2', overcharge_used_this_run: true }),
+        doc,
+      ),
+      true,
+    );
+    assert.equal(doc.appended.length, 2, 'one toast per run');
+  });
+
+  test('no transition → false, nothing rendered', async () => {
+    const { maybeShowOverchargeHint } = await loadModule();
+    const doc = fakeDoc();
+    assert.equal(maybeShowOverchargeHint(world(), world(), doc), false);
+    assert.equal(doc.appended.length, 0);
+  });
+
+  test('headless (no document) → still marks shown, no crash', async () => {
+    const { maybeShowOverchargeHint } = await loadModule();
+    const prev = world({ overcharge_used_this_run: false });
+    const next = world({ overcharge_used_this_run: true });
+    assert.equal(maybeShowOverchargeHint(prev, next, null), true);
+    // Once marked, a fake doc afterwards must NOT re-render for the same run.
+    const doc = fakeDoc();
+    assert.equal(maybeShowOverchargeHint(prev, next, doc), false);
+    assert.equal(doc.appended.length, 0);
+  });
+});


### PR DESCRIPTION
Closes #2716

## Cosa
Micro-hint diegetico al **primo overcharge della run** (verdetto master-dd 2026-06-10, ratifica OD-058 D1: coupling pressure intenzionale, merita telegraph dedicato).

- **Backend (additive-only)**: `session.overcharge_used` settato una volta da `POST /overcharge`; `publicSessionView` espone `overcharge_used_this_run` (tier public, sibling di `stresswave_event`, pattern #2712). Mai cleared in-run.
- **Web surface** `apps/play/src/overchargeHint.js`: toast one-shot su transizione testimoniata `false->true` (stessa sessione, prev snapshot richiesto -- rejoin a momento passato resta muto). Once-per-run (keyed su `session_id`). Wording diegetico, MAI numeri raw (doctrine ER3): *"Il Sistema reagisce al tuo tempo rubato"*.
- **i18n**: chiavi `overcharge_hint.label` IT/EN in `data/i18n` (SSOT SPEC-N) + hard-fallback IT nel modulo (pattern biomeChip `woundedLabel`).
- **CSS**: toast top-center fade in/hold/out 6s, `pointer-events:none`, `role="status"` (a11y live region).

## Test (TDD, RED verificato prima di GREEN)
- `tests/play/overchargeHint.test.js` -- 12 test: label fallback senza key leak + no numeri, transition detector puro (no-prev/cross-session/idempotenza), toast side-effect once-per-run su fake DOM, headless safe.
- `tests/api/overchargeRoute.test.js` -- +1 test: flag false pre, true post, persiste oltre `turn/end`.
- Full: `tests/play` 317/317 · `npm run test:api` exit 0 (502 ultimo segmento) · `tests/i18n/parity` 4/4 · `format:check` green.
- Smoke live (server porta 3399): `start -> GET /state (false) -> POST /overcharge (ok, true) -> GET /state (true)`.
- Vite serve sanity: modulo trasformato, import risolto in `main.js`, classe CSS servita.

## Note scope
- Zero forbidden path (`packages/contracts`/migrations/workflows/`services/generation` intoccati); `debrief_payload` pinned #276 non toccato.
- Nuove righe fuori `apps/backend/` (~80 LOC modulo + CSS + test) = scope esplicito dell'issue (surface web), non creep.
- Mirror Godot = "eventuale" nell'issue, fuori scope qui (item 3 Lenovo).

## Changelog
- feat(play): hint diegetico al primo overcharge della run (toast one-shot, flag `overcharge_used_this_run` additive in publicSessionView).

## Rollback (03A)
Revert singolo commit `cb1e97331` -- additive-only, nessuna migrazione/schema; il flag sparisce dalla view e il toast non fira mai (frontend tollera campo assente).
