### PR TITLE
feat(combat): OD-058 D3 vcSnapshot coop server-side ledger replay + parity

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -797,10 +797,15 @@ function createApp(options = {}) {
   }
   const lobby = lobbyOptions.service || new LobbyService(lobbyOptions);
   const coopStore = createCoopStore({ lobby });
-  app.use(
-    '/api/session',
-    createSessionRouter({ ...(options.session || {}), coopStore, chronicle: options.chronicle }),
-  );
+  // OD-058 D3 (#2531): keep the router instance -- it exposes getSessionById,
+  // the read-only accessor the coop router uses to replay the linked combat
+  // session's event ledger server-side at /coop/combat/end.
+  const sessionRouter = createSessionRouter({
+    ...(options.session || {}),
+    coopStore,
+    chronicle: options.chronicle,
+  });
+  app.use('/api/session', sessionRouter);
   app.use('/api/party', createPartyRouter());
   // M7 demo playtest: feedback collection (/api/feedback, /api/feedback/summary)
   app.use('/api', createFeedbackRouter(options.feedback || {}));
@@ -822,7 +827,17 @@ function createApp(options = {}) {
   // roll offspring server-side (WS handler + REST parity). Prisma-gated; the
   // resolver degrades gracefully when prisma is absent (dev/demo/tests).
   const metaStoreFactory = (campaignId) => createMetaStore({ prisma: repo.prisma, campaignId });
-  app.use('/api', createCoopRouter({ lobby, coopStore, metaStoreFactory, prisma: repo.prisma }));
+  app.use(
+    '/api',
+    createCoopRouter({
+      lobby,
+      coopStore,
+      metaStoreFactory,
+      prisma: repo.prisma,
+      // OD-058 D3: ledger-replay seam (server-side vcSnapshot at combat end).
+      getCombatSession: sessionRouter.getSessionById,
+    }),
+  );
   // 2026-05-20 — Combat readonly diagnostic (status-penalties + biome-modifiers).
   app.use('/api/combat', createCombatRouter());
   app.use('/api', createCompanionRouter());

--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -18,8 +18,24 @@ const { buildPhaseChangePayload } = require('../services/coop/phaseChangePayload
 // drain WS (#2707/#2708): l'host conta SOLO se e' il submitter corrente o
 // possiede gia' un PG (host-plays); la TV-mirror (mai input) resta esclusa.
 const { lifecycleQuorumPids } = require('../services/network/wsSession');
+// OD-058 D3 (#2531) -- server-side vcSnapshot replay dal ledger della sessione
+// combat linkata (coopStore.linkSession): il debrief coop non e' piu'
+// trust-the-host.
+const {
+  isLedgerReplayEnabled,
+  replayDebriefFromLedger,
+} = require('../services/coop/vcLedgerReplay');
+const { isDeepStrictEqual } = require('node:util');
 
-function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = null } = {}) {
+function createCoopRouter({
+  lobby,
+  coopStore,
+  metaStoreFactory = null,
+  prisma = null,
+  // OD-058 D3 -- read-only accessor (session router getSessionById) for the
+  // linked combat session; absent -> legacy host-payload behavior.
+  getCombatSession = null,
+} = {}) {
   if (!lobby) throw new Error('createCoopRouter: lobby required');
   if (!coopStore) throw new Error('createCoopRouter: coopStore required');
   const router = express.Router();
@@ -386,16 +402,65 @@ function createCoopRouter({ lobby, coopStore, metaStoreFactory = null, prisma = 
     const orch = coopStore.get(code);
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
     try {
+      // OD-058 D3 (#2531) -- replay-from-event-log: quando una sessione combat
+      // server-side e' linkata (coopStore.linkSession) e il suo ledger ha
+      // eventi attribuiti ad attori, il server ricostruisce vcSnapshot +
+      // debrief_payload dal PROPRIO ledger (stesso path vcScoring del flusso
+      // single: buildVcSnapshot -> vcSnapshotToDebriefPayload) e il payload
+      // host viene ignorato (divergenza loggata + surfaced). Fallback host:
+      // nessuna sessione linkata / ledger inerte (solo lifecycle, combat
+      // client-side Godot) / kill switch COOP_VC_LEDGER_REPLAY=0. Outcome,
+      // survivors e xp restano host-reported (Opzione 2: la resolution del
+      // combat resta client-side; qui si sposta SOLO la derivazione VC).
+      let effectiveDebrief = debriefPayload;
+      let debriefSource = debriefPayload ? 'host' : null;
+      let hostPayloadDivergent = null;
+      if (isLedgerReplayEnabled() && typeof getCombatSession === 'function' && orch.sessionId) {
+        try {
+          const combatSession = getCombatSession(orch.sessionId);
+          if (combatSession) {
+            // SPEC-M FP->VC parity con /end (routes/session.js): il branco
+            // Form Pulse della run viene idratato nel replay (no-op se vuoto).
+            const formPulses =
+              typeof coopStore.getFormPulses === 'function'
+                ? coopStore.getFormPulses(orch.run?.id)
+                : null;
+            const replay = replayDebriefFromLedger(combatSession, { formPulses });
+            if (replay && replay.actor_events_count > 0) {
+              if (debriefPayload) {
+                hostPayloadDivergent = !isDeepStrictEqual(debriefPayload, replay.debrief_payload);
+                if (hostPayloadDivergent) {
+                  console.warn(
+                    `[coop] debrief_payload host divergente dal ledger replay (code=${code}, session=${orch.sessionId}) -- server-authoritative`,
+                  );
+                }
+              }
+              effectiveDebrief = replay.debrief_payload;
+              debriefSource = 'ledger_replay';
+            }
+          }
+        } catch (replayErr) {
+          // Best-effort: il replay non blocca MAI la chiusura del combat.
+          console.warn(`[coop] ledger replay fallito (code=${code}):`, replayErr.message);
+        }
+      }
       const result = orch.endCombat({
         outcome,
         xpEarned,
         survivors,
-        debriefPayload,
+        debriefPayload: effectiveDebrief,
         sistemaObservations,
         recruitCandidates,
       });
       broadcastCoopState(room, orch);
-      return res.json({ phase: orch.phase, result });
+      return res.json({
+        phase: orch.phase,
+        result,
+        // OD-058 D3 -- additive: provenance del debrief ('ledger_replay' |
+        // 'host' | null) + divergenza host vs replay (null = non applicabile).
+        debrief_source: debriefSource,
+        host_payload_divergent: hostPayloadDivergent,
+      });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'combat_end_failed' });
     }

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -51,6 +51,9 @@ const { filterForTvMirror } = require('../services/deviceInput/tierFilter');
 // TKT-ORPHAN-VCSNAP — Game-side serializer that flattens a vc snapshot to the
 // Godot-parity debrief_payload (sentience_tier + conviction_axis + ennea_archetype).
 const { vcSnapshotToDebriefPayload } = require('../services/coop/vcSnapshotToDebriefPayload');
+// OD-058 D3 (#2531) -- unitStatsById moved to the shared ledger-replay module
+// (single canonical impl for the /end + /:id/vc + coop replay paths).
+const { unitStatsById } = require('../services/coop/vcLedgerReplay');
 // P4 Thought Cabinet: Phase 1 (threshold unlock) + Phase 2 (research → internalize).
 const {
   evaluateThoughts: evaluateMbtiThoughts,
@@ -3821,30 +3824,8 @@ function createSessionRouter(options = {}) {
     }
   });
 
-  // Verdetto #2679 Q2-bis (2026-06-10) -- per-unit stats for the personality
-  // agile_robust derivation. speed + EXPLICIT max_hp only: current hp never
-  // leaks into the "birth physique" axis (end-of-mission damage is not
-  // physique). Units without stats are omitted -> the axis degrades to the
-  // 0.5 neutral by design. NB: a canonical per-species base-stats dataset does
-  // NOT exist yet (the research's species.yaml is a ghost) -- when it lands,
-  // bounds become data-derived (see the #2679 follow-up ticket).
-  function unitStatsById(session) {
-    const out = {};
-    for (const u of (session && session.units) || []) {
-      if (!u || !u.id) continue;
-      const stats = {};
-      // Explicit null/undefined guards: Number(null) === 0 is finite, so a
-      // bare Number.isFinite check would turn "no speed" into speed 0.
-      if (u.speed !== null && u.speed !== undefined && Number.isFinite(Number(u.speed))) {
-        stats.speed = Number(u.speed);
-      }
-      if (u.max_hp !== null && u.max_hp !== undefined && Number.isFinite(Number(u.max_hp))) {
-        stats.hp_max = Number(u.max_hp);
-      }
-      if (Object.keys(stats).length) out[u.id] = stats;
-    }
-    return out;
-  }
+  // Verdetto #2679 Q2-bis unitStatsById: ora canonical in
+  // services/coop/vcLedgerReplay.js (OD-058 D3, condiviso col replay coop).
 
   // 2026-05-30 P4 debrief wire — GET /:id/debrief. Non-destructive sibling of
   // POST /end: returns the same buildDebriefSummary payload (ennea_voices /
@@ -4463,6 +4444,15 @@ function createSessionRouter(options = {}) {
 
   // Round endpoints mounted from sessionRoundBridge.js (token optimization).
   roundBridge.mountRoundEndpoints(router);
+
+  // OD-058 D3 (#2531) -- expose a read-only session accessor so the coop
+  // router can replay the event ledger of the linked combat session
+  // (coopStore.linkSession) server-side at /coop/combat/end. Exact-id lookup
+  // only (no activeSessionId fallback: the coop link is always explicit).
+  router.getSessionById = (sessionId) => {
+    if (!sessionId) return null;
+    return sessions.get(String(sessionId)) || null;
+  };
 
   return router;
 }

--- a/apps/backend/services/coop/vcLedgerReplay.js
+++ b/apps/backend/services/coop/vcLedgerReplay.js
@@ -1,0 +1,124 @@
+// OD-058 D3 (issue #2531) -- coop vcSnapshot server-side, replay-from-event-log.
+//
+// The coop debrief used to be trust-the-host: the host computed a vcSnapshot
+// client-side (GET /:id/debrief or its own resolver) and POSTed the flattened
+// debrief_payload to /coop/combat/end. This module rebuilds the snapshot from
+// the server's OWN event ledger (session.events of the combat session linked
+// via coopStore.linkSession) through the exact same vcScoring path the
+// single-player flow uses:
+//
+//   session.events (ledger) -> buildVcSnapshot -> vcSnapshotToDebriefPayload
+//
+// Parity coop<->single is therefore by construction (Node mirror of the Godot
+// parity-contract pattern, test_combat_engine_parity_contract.gd #371).
+//
+// Scope guard (Opzione 2, issue #2531 D3): combat resolution stays client-side;
+// outcome/survivors/xp remain host-reported. Only the VC/debrief derivation
+// moves server-side. Kill switch: COOP_VC_LEDGER_REPLAY=0|false|off.
+'use strict';
+
+const { loadTelemetryConfig, buildVcSnapshot } = require('../vcScoring');
+const { vcSnapshotToDebriefPayload } = require('./vcSnapshotToDebriefPayload');
+
+// Default telemetry config, loaded lazily once (session.js loads its own copy
+// at factory init from the same DEFAULT_TELEMETRY_PATH -> identical values).
+let _defaultConfig = null;
+function _telemetryConfig() {
+  if (!_defaultConfig) {
+    _defaultConfig = loadTelemetryConfig(undefined, { log: () => {}, warn: () => {} });
+  }
+  return _defaultConfig;
+}
+
+/**
+ * Kill switch -- default ON. COOP_VC_LEDGER_REPLAY=0|false|off restores the
+ * legacy trust-the-host behavior on /coop/combat/end.
+ */
+function isLedgerReplayEnabled() {
+  const raw = String(process.env.COOP_VC_LEDGER_REPLAY ?? '')
+    .trim()
+    .toLowerCase();
+  return !['0', 'false', 'off'].includes(raw);
+}
+
+/**
+ * Verdetto #2679 Q2-bis -- per-unit stats for the personality agile_robust
+ * derivation. speed + EXPLICIT max_hp only: current hp never leaks into the
+ * "birth physique" axis (end-of-mission damage is not physique). Units
+ * without stats are omitted -> the axis degrades to the 0.5 neutral by
+ * design. NB: a canonical per-species base-stats dataset does NOT exist yet
+ * (the research's species.yaml is a ghost) -- when it lands, bounds become
+ * data-derived (see the #2679 follow-up ticket).
+ *
+ * Moved here from routes/session.js (closure) so the coop ledger-replay path
+ * shares the single canonical implementation (anti-drift).
+ */
+function unitStatsById(session) {
+  const out = {};
+  for (const u of (session && session.units) || []) {
+    if (!u || !u.id) continue;
+    const stats = {};
+    // Explicit null/undefined guards: Number(null) === 0 is finite, so a
+    // bare Number.isFinite check would turn "no speed" into speed 0.
+    if (u.speed !== null && u.speed !== undefined && Number.isFinite(Number(u.speed))) {
+      stats.speed = Number(u.speed);
+    }
+    if (u.max_hp !== null && u.max_hp !== undefined && Number.isFinite(Number(u.max_hp))) {
+      stats.hp_max = Number(u.max_hp);
+    }
+    if (Object.keys(stats).length) out[u.id] = stats;
+  }
+  return out;
+}
+
+/**
+ * Rebuild the vcSnapshot from the session's event ledger.
+ *
+ * @param {object} session -- live combat session (the coop-linked one)
+ * @param {object} [opts]
+ * @param {Map|object|null} [opts.formPulses] -- branco Form Pulse map from
+ *   coopStore.getFormPulses(campaignId). Applied ONLY when the session does
+ *   not already carry its own (mirror of the /end hydration guard,
+ *   routes/session.js `!session.formPulses`). Read-only: the session object
+ *   is never mutated.
+ * @param {object} [opts.telemetryConfig] -- injected config (tests); default
+ *   lazy-loads the canonical telemetry.yaml.
+ * @returns {object|null} buildVcSnapshot output, or null on invalid session.
+ */
+function replayVcSnapshotFromLedger(session, { formPulses = null, telemetryConfig = null } = {}) {
+  if (!session || typeof session !== 'object') return null;
+  const cfg = telemetryConfig || _telemetryConfig();
+  const source =
+    !session.formPulses && formPulses ? Object.assign({}, session, { formPulses }) : session;
+  return buildVcSnapshot(source, cfg);
+}
+
+/**
+ * Full D3 replay product: vc_snapshot + pinned debrief_payload (Godot #276
+ * shape via vcSnapshotToDebriefPayload -- the serializer is produced by the
+ * replay, not only by the host-driven /end flow) + events_count so the
+ * caller can apply the empty-ledger host-fallback policy.
+ *
+ * @returns {{vc_snapshot: object, debrief_payload: object, events_count: number}|null}
+ */
+function replayDebriefFromLedger(session, opts = {}) {
+  const snapshot = replayVcSnapshotFromLedger(session, opts);
+  if (!snapshot) return null;
+  const events = Array.isArray(session.events) ? session.events : [];
+  return {
+    vc_snapshot: snapshot,
+    debrief_payload: vcSnapshotToDebriefPayload(snapshot, unitStatsById(session)),
+    events_count: events.length,
+    // Actor-attributed events only: lifecycle markers (session_start, actor
+    // null) do NOT make a ledger replayable -- a linked-but-never-fought
+    // server session (Godot client-side combat) must keep the host fallback.
+    actor_events_count: events.filter((e) => e && e.actor_id).length,
+  };
+}
+
+module.exports = {
+  isLedgerReplayEnabled,
+  unitStatsById,
+  replayVcSnapshotFromLedger,
+  replayDebriefFromLedger,
+};

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12192,6 +12192,19 @@
       "review_cycle_days": 90,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/reports/2026-06-10-od058-d3-vcsnapshot-replay-evidence.md",
+      "title": "OD-058 D3 -- coop vcSnapshot server-side (ledger replay) evidence",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "combat",
+      "last_verified": "2026-06-10",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "new"
     }
   ]
 }

--- a/docs/reports/2026-06-10-od058-d3-vcsnapshot-replay-evidence.md
+++ b/docs/reports/2026-06-10-od058-d3-vcsnapshot-replay-evidence.md
@@ -1,0 +1,113 @@
+---
+title: 'OD-058 D3 -- coop vcSnapshot server-side (ledger replay) evidence'
+date: 2026-06-10
+type: report
+doc_status: active
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-06-10'
+source_of_truth: false
+language: it
+review_cycle_days: 90
+tags: [evo-tactics, od-058, vc, coop, debrief, replay, parity, trust-the-host]
+---
+
+# OD-058 D3 -- coop vcSnapshot server-side dal ledger (replay) -- evidence
+
+Issue tracker: #2531 (blocco D3, 3 box -- ULTIMO residuo OD-058).
+Contesto: il debrief coop arrivava SOLO dall'host via `POST /coop/combat/end`
+(`debrief_payload` host-authored, Bundle C 2026-05-15) = trust-the-host. D3
+sposta la derivazione VC server-side: replay-from-event-log sul ledger della
+sessione combat linkata (`coopStore.linkSession`, `session.events`).
+
+## Cosa e' stato costruito (3 box D3)
+
+### Box 1 -- ricostruzione vcSnapshot server-side dal ledger coop
+
+`apps/backend/services/coop/vcLedgerReplay.js` (nuovo, thin):
+
+- `replayVcSnapshotFromLedger(session, {formPulses, telemetryConfig})` --
+  rebuild via `vcScoring.buildVcSnapshot` sullo STESSO ledger
+  (`session.events`) che il round engine (`roundOrchestrator` /
+  `sessionRoundBridge`) e l'ingest SPEC-A (`/device-event`) popolano.
+  Idratazione Form Pulse parity con `/end` (guard `!session.formPulses`,
+  read-only: la sessione NON viene mutata).
+- `replayDebriefFromLedger(...)` -- aggiunge `debrief_payload` (serializer
+  pinned) + `events_count` + `actor_events_count` (solo eventi attribuiti:
+  `session_start` lifecycle con actor null NON rende un ledger replayable).
+- `unitStatsById` -- spostata qui da `routes/session.js` (closure) = impl
+  canonical unica per /end + /:id/vc + replay coop (anti-drift, semantica
+  verdetto #2679 Q2-bis preservata).
+- Kill switch: `COOP_VC_LEDGER_REPLAY=0|false|off` (default ON).
+
+Wire: `app.js` passa `getCombatSession` (accessor read-only
+`sessionRouter.getSessionById`) a `createCoopRouter`; `/coop/combat/end`
+ricostruisce e usa il payload server quando il ledger ha eventi attribuiti.
+
+### Box 2 -- vcSnapshotToDebriefPayload non piu' orphan (prodotto dal replay)
+
+Prima: serializer prodotto solo dal flusso session (`/end` + `/:id/vc`,
+#2463) -- il path coop lo riceveva pre-composto dall'host. Ora
+`/coop/combat/end` lo PRODUCE dal replay del proprio ledger:
+`buildVcSnapshot -> vcSnapshotToDebriefPayload(snapshot, unitStatsById)` --
+identico pipeline del flusso single. Il payload host e' ignorato quando il
+replay e' disponibile (divergenza loggata + `host_payload_divergent` nella
+response, additive). `run.debrief` resta shape PINNED Godot #276 (solo
+`per_actor` + `recruit_candidates` opzionale): nessun campo nuovo dentro il
+payload broadcast.
+
+### Box 3 -- parity-check coop<->single (pattern Godot #371, versione Node)
+
+`tests/api/coopVcLedgerReplay.test.js` -- contract: stesso ledger ->
+`run.debrief` (path coop replay) `deepEqual` `GET /:id/vc debrief_payload`
+(path single). Mirror Node di `test_combat_engine_parity_contract.gd`
+(Game-Godot-v2 #371): due path che leggono lo stesso event log devono
+produrre payload byte-identici.
+
+## Policy fallback (Opzione 2: combat resolution resta client-side)
+
+| Caso                                                  | Esito                                  |
+| ----------------------------------------------------- | -------------------------------------- |
+| Sessione linkata + ledger con eventi attribuiti       | replay server AUTHORITATIVE (`ledger_replay`) |
+| Host payload presente e divergente dal replay         | replay vince, `host_payload_divergent: true` + warn log |
+| Nessuna sessione linkata (orch.sessionId null)        | legacy host passthrough (`host`)       |
+| Ledger inerte (solo `session_start`, combat client-side Godot) | host fallback (`host`)         |
+| `COOP_VC_LEDGER_REPLAY=0`                             | legacy host passthrough (kill switch)  |
+
+Outcome / survivors / xp restano host-reported: D3 sposta SOLO la derivazione
+VC (scope lettera issue #2531 "Opzione 2, combat stays client-side").
+
+## Evidence (TDD, run 2026-06-10)
+
+- RED verificato: 3 unit fail (`actor_events_count` assente) + 7/7 API fail
+  (wire assente) PRIMA dell'implementazione.
+- GREEN: unit `tests/services/coop/vcLedgerReplay.test.js` **11/11** + API
+  `tests/api/coopVcLedgerReplay.test.js` **7/7** (incl. parity contract +
+  spoof-rejection: actor host-inventato NON sopravvive al replay).
+- Area regression: 56/56 (sessionVcDebriefPayload, vcSnapshotToDebriefPayload,
+  coopBroadcastDebriefPayload, coop-recruit-candidates, coopDebrief,
+  coopRoutes) -- back-compat legacy intatta (i test coop esistenti non linkano
+  sessioni -> path invariato).
+- Suite: tests/services area 175/175 -- tests/ai 502/502 -- full `tests/api`
+  vedi PR (gate pre-push).
+
+## Vincoli rispettati
+
+- Raw event schema `{action_type,turn,actor_id,target_id,damage_dealt,result,
+  position_from,position_to}` -- INVARIATO (replay = solo lettura).
+- `debrief_payload` schema PINNED Godot #276 -- INVARIATO (i campi additive
+  `debrief_source`/`host_payload_divergent` stanno nella response REST di
+  `/coop/combat/end`, NON nel payload broadcast).
+- `packages/contracts/` -- non toccato.
+
+## Caveat / forward-work
+
+- **Ledger sparso Godot**: se in futuro il client Godot streama QUALCHE evento
+  attribuito (device decision-events con actor bound) senza streamare il
+  combat completo, il replay diventa authoritative su un ledger parziale ->
+  payload piu' povero del client-side host. Mitigazione attuale = soglia
+  `actor_events_count > 0` + kill switch. Knob da rivedere quando il flusso
+  Godot streaming sara' definito (non bloccante oggi: il path Godot coop senza
+  sessione server non linka -> fallback host pulito).
+- `host_payload_divergent` e' telemetria di transizione: quando i client
+  smettono di POSTare `debrief_payload`, il campo muore naturalmente.

--- a/tests/api/coopVcLedgerReplay.test.js
+++ b/tests/api/coopVcLedgerReplay.test.js
@@ -1,0 +1,246 @@
+// OD-058 D3 (issue #2531) -- /coop/combat/end server-side ledger replay wire
+// + parity-check coop<->single (Node mirror of the Godot parity-contract
+// pattern, test_combat_engine_parity_contract.gd #371).
+//
+// Boxes covered:
+//   D3.1 server rebuilds the vcSnapshot from ITS OWN event ledger (the combat
+//        session linked via coopStore.linkSession), not from the host blob;
+//   D3.2 vcSnapshotToDebriefPayload is produced by the replay path (not only
+//        by the host-driven flow);
+//   D3.3 parity contract: the coop replay debrief == the single-flow
+//        GET /:id/vc debrief_payload on the SAME ledger.
+//
+// Policy (Opzione 2, combat resolution stays client-side):
+//   - linked session + actor-attributed events -> server replay AUTHORITATIVE
+//     (host payload ignored; divergence surfaced);
+//   - no linked session / inert ledger (lifecycle-only) / kill switch
+//     COOP_VC_LEDGER_REPLAY=0 -> legacy host fallback (back-compat).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+function mkApp(t) {
+  const created = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof created.close === 'function') await created.close().catch(() => {});
+  });
+  return created;
+}
+
+async function setupCoopAtCombat(app) {
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'Host', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  r = await request(app).post('/api/lobby/join').send({ code, player_name: 'A' });
+  const playerId = r.body.player_id;
+  const playerToken = r.body.player_token;
+  r = await request(app)
+    .post('/api/coop/run/start')
+    .send({ code, host_token: hostToken, scenario_stack: ['enc_demo_01'] });
+  const runId = r.body.run_id;
+  await request(app).post('/api/coop/character/create').send({
+    code,
+    player_id: playerId,
+    player_token: playerToken,
+    name: 'A',
+    form_id: 'istj',
+    species_id: 'x',
+    job_id: 'guerriero',
+  });
+  await request(app)
+    .post('/api/coop/world/confirm')
+    .send({ code, host_token: hostToken, scenario_id: 'enc_demo_01' });
+  return { code, hostToken, runId };
+}
+
+// Start a server combat session linked to the coop run (campaign_id == run.id
+// -> coopStore.linkSession -> orch.sessionId).
+async function startLinkedSession(app, runId) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const startRes = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, campaign_id: runId });
+  return startRes.body.session_id;
+}
+
+// Generate real attributed combat events on the server ledger.
+async function fightOneRound(app, sid) {
+  const res = await request(app)
+    .post('/api/session/round/execute')
+    .send({
+      session_id: sid,
+      player_intents: [{ actor_id: 'p_scout', action: { type: 'attack', target_id: 'e_nomad_1' } }],
+      ai_auto: false,
+    });
+  assert.equal(res.status, 200, `round/execute ok: ${JSON.stringify(res.body).slice(0, 200)}`);
+}
+
+const BOGUS_HOST_PAYLOAD = {
+  per_actor: {
+    spoofed_unit: {
+      sentience_tier: 'T6',
+      conviction_axis: { utility: 99, liberty: 99, morality: 99 },
+      ennea_archetype: 'Riformatore',
+    },
+  },
+};
+
+test('D3 wire: linked fought session -> run.debrief rebuilt from server ledger (no host payload)', async (t) => {
+  const { app, coopStore } = mkApp(t);
+  const { code, hostToken, runId } = await setupCoopAtCombat(app);
+  const sid = await startLinkedSession(app, runId);
+  await fightOneRound(app, sid);
+
+  const res = await request(app)
+    .post('/api/coop/combat/end')
+    .send({ code, host_token: hostToken, outcome: 'victory' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.debrief_source, 'ledger_replay');
+
+  const orch = coopStore.get(code);
+  assert.ok(orch.run.debrief, 'run.debrief populated server-side from the ledger replay');
+  assert.ok(
+    orch.run.debrief.per_actor && typeof orch.run.debrief.per_actor === 'object',
+    'pinned shape per_actor',
+  );
+  // Real roster ids (tutorial scenario), not host-invented ones.
+  assert.ok(
+    Object.keys(orch.run.debrief.per_actor).length > 0,
+    'per_actor carries the server roster actors',
+  );
+});
+
+test('D3 parity contract coop<->single: replay debrief == GET /:id/vc debrief_payload (same ledger)', async (t) => {
+  const { app, coopStore } = mkApp(t);
+  const { code, hostToken, runId } = await setupCoopAtCombat(app);
+  const sid = await startLinkedSession(app, runId);
+  await fightOneRound(app, sid);
+
+  // Single-flow surface on the same ledger (session still alive, GET is
+  // non-destructive).
+  const vcRes = await request(app).get(`/api/session/${sid}/vc`);
+  assert.equal(vcRes.status, 200);
+  const singlePayload = vcRes.body.debrief_payload;
+  assert.ok(singlePayload && singlePayload.per_actor, 'single-flow debrief_payload present');
+
+  const res = await request(app)
+    .post('/api/coop/combat/end')
+    .send({ code, host_token: hostToken, outcome: 'victory' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.debrief_source, 'ledger_replay');
+
+  const coopPayload = coopStore.get(code).run.debrief;
+  // THE parity contract (Godot #371 pattern, Node side): same event ledger ->
+  // byte-identical debrief payload across the coop and single flows.
+  assert.deepEqual(coopPayload, singlePayload);
+});
+
+test('D3 wire: bogus host payload IGNORED when ledger replay available (+divergence surfaced)', async (t) => {
+  const { app, coopStore } = mkApp(t);
+  const { code, hostToken, runId } = await setupCoopAtCombat(app);
+  const sid = await startLinkedSession(app, runId);
+  await fightOneRound(app, sid);
+
+  const res = await request(app).post('/api/coop/combat/end').send({
+    code,
+    host_token: hostToken,
+    outcome: 'victory',
+    debrief_payload: BOGUS_HOST_PAYLOAD,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.debrief_source, 'ledger_replay');
+  assert.equal(res.body.host_payload_divergent, true);
+
+  const orch = coopStore.get(code);
+  assert.equal(
+    'spoofed_unit' in orch.run.debrief.per_actor,
+    false,
+    'host-invented actor must NOT survive the server replay',
+  );
+});
+
+test('D3 back-compat: no linked session -> legacy host passthrough', async (t) => {
+  const { app, coopStore } = mkApp(t);
+  const { code, hostToken } = await setupCoopAtCombat(app);
+
+  const res = await request(app).post('/api/coop/combat/end').send({
+    code,
+    host_token: hostToken,
+    outcome: 'victory',
+    debrief_payload: BOGUS_HOST_PAYLOAD,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.debrief_source, 'host');
+  assert.deepEqual(coopStore.get(code).run.debrief, BOGUS_HOST_PAYLOAD);
+});
+
+test('D3 back-compat: inert ledger (session_start only, no actor events) -> host fallback', async (t) => {
+  const { app, coopStore } = mkApp(t);
+  const { code, hostToken, runId } = await setupCoopAtCombat(app);
+  await startLinkedSession(app, runId); // linked but NEVER fought server-side
+
+  const res = await request(app).post('/api/coop/combat/end').send({
+    code,
+    host_token: hostToken,
+    outcome: 'victory',
+    debrief_payload: BOGUS_HOST_PAYLOAD,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.debrief_source, 'host');
+  assert.deepEqual(coopStore.get(code).run.debrief, BOGUS_HOST_PAYLOAD);
+});
+
+test('D3 kill switch: COOP_VC_LEDGER_REPLAY=0 -> legacy host passthrough even with fought ledger', async (t) => {
+  const prev = process.env.COOP_VC_LEDGER_REPLAY;
+  process.env.COOP_VC_LEDGER_REPLAY = '0';
+  t.after(() => {
+    if (prev === undefined) delete process.env.COOP_VC_LEDGER_REPLAY;
+    else process.env.COOP_VC_LEDGER_REPLAY = prev;
+  });
+
+  const { app, coopStore } = mkApp(t);
+  const { code, hostToken, runId } = await setupCoopAtCombat(app);
+  const sid = await startLinkedSession(app, runId);
+  await fightOneRound(app, sid);
+
+  const res = await request(app).post('/api/coop/combat/end').send({
+    code,
+    host_token: hostToken,
+    outcome: 'victory',
+    debrief_payload: BOGUS_HOST_PAYLOAD,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.debrief_source, 'host');
+  assert.deepEqual(coopStore.get(code).run.debrief, BOGUS_HOST_PAYLOAD);
+});
+
+test('D3 FP plumb: replay path asks coopStore.getFormPulses(run_id) (SPEC-M parity with /end)', async (t) => {
+  const { app, coopStore } = mkApp(t);
+  const { code, hostToken, runId } = await setupCoopAtCombat(app);
+  const sid = await startLinkedSession(app, runId);
+  await fightOneRound(app, sid);
+
+  const calls = [];
+  const origGetFormPulses = coopStore.getFormPulses;
+  coopStore.getFormPulses = (cid) => {
+    calls.push(cid);
+    return origGetFormPulses(cid);
+  };
+  t.after(() => {
+    coopStore.getFormPulses = origGetFormPulses;
+  });
+
+  const res = await request(app)
+    .post('/api/coop/combat/end')
+    .send({ code, host_token: hostToken, outcome: 'victory' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.debrief_source, 'ledger_replay');
+  assert.ok(calls.includes(runId), `getFormPulses called with run_id; got: ${calls}`);
+});

--- a/tests/services/coop/vcLedgerReplay.test.js
+++ b/tests/services/coop/vcLedgerReplay.test.js
@@ -1,0 +1,225 @@
+// OD-058 D3 -- coop vcSnapshot server-side replay (issue #2531, box D3.1).
+//
+// services/coop/vcLedgerReplay.js rebuilds the vcSnapshot + debrief_payload
+// from the server-side event ledger (session.events) of the combat session
+// linked to a coop run (coopStore.linkSession). The coop debrief stops being
+// trust-the-host: /coop/combat/end derives the payload from the server's own
+// ledger via the SAME vcScoring path used by the single-player flow
+// (buildVcSnapshot -> vcSnapshotToDebriefPayload), so parity is by
+// construction. Mirror of the Godot parity-contract pattern (#371), Node side.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const {
+  loadTelemetryConfig,
+  buildVcSnapshot,
+} = require('../../../apps/backend/services/vcScoring');
+const {
+  vcSnapshotToDebriefPayload,
+} = require('../../../apps/backend/services/coop/vcSnapshotToDebriefPayload');
+const { PROPOSED_FP_VC_MAPPING } = require('../../../apps/backend/services/formPulseVc');
+const {
+  replayVcSnapshotFromLedger,
+  replayDebriefFromLedger,
+  unitStatsById,
+  isLedgerReplayEnabled,
+} = require('../../../apps/backend/services/coop/vcLedgerReplay');
+
+const CONFIG_PATH = path.resolve(__dirname, '..', '..', '..', 'data', 'core', 'telemetry.yaml');
+const cfg = loadTelemetryConfig(CONFIG_PATH, { log: () => {}, warn: () => {} });
+
+// buildVcSnapshot stamps meta.generated_at = now -> strip the volatile field
+// before deepEqual (two builds milliseconds apart must still be "the same").
+function stripVolatile(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return snapshot;
+  const out = { ...snapshot };
+  if (out.meta && typeof out.meta === 'object') {
+    const meta = { ...out.meta };
+    delete meta.generated_at;
+    out.meta = meta;
+  }
+  return out;
+}
+
+function mkSession({ events, formPulses } = {}) {
+  const evts =
+    events ||
+    Array.from({ length: 12 }, (_, i) => ({
+      turn: i + 1,
+      action_type: 'attack',
+      actor_id: 'unit_1',
+      target_id: 'unit_2',
+      position_from: { x: 2, y: 2 },
+      target_position_at_attack: { x: 3, y: 2 },
+      result: 'hit',
+      damage_dealt: 2,
+      mos: 3,
+      target_hp_before: 10,
+      target_hp_after: 8,
+    }));
+  const session = {
+    session_id: 'ledger-replay-test',
+    turn: 1,
+    units: [
+      {
+        id: 'unit_1',
+        controlled_by: 'player',
+        hp: 10,
+        max_hp: 10,
+        speed: 4,
+        position: { x: 0, y: 0 },
+      },
+      { id: 'unit_2', controlled_by: 'sistema', hp: 10, max_hp: 10, position: { x: 5, y: 5 } },
+    ],
+    events: evts,
+    grid: { width: 6, height: 6 },
+  };
+  if (formPulses) session.formPulses = formPulses;
+  return session;
+}
+
+// ---------------------------------------------------------------------------
+// replayVcSnapshotFromLedger
+// ---------------------------------------------------------------------------
+
+test('replay: snapshot deepEqual buildVcSnapshot on the same ledger (parity by construction)', () => {
+  const session = mkSession();
+  const direct = buildVcSnapshot(session, cfg);
+  const replayed = replayVcSnapshotFromLedger(session, { telemetryConfig: cfg });
+  assert.deepEqual(stripVolatile(replayed), stripVolatile(direct));
+});
+
+test('replay: null/invalid session -> null (never throws)', () => {
+  assert.equal(replayVcSnapshotFromLedger(null, { telemetryConfig: cfg }), null);
+  assert.equal(replayVcSnapshotFromLedger(undefined, { telemetryConfig: cfg }), null);
+  assert.equal(replayVcSnapshotFromLedger(42, { telemetryConfig: cfg }), null);
+});
+
+test('replay: formPulses option hydrates the snapshot WITHOUT mutating the session', () => {
+  const [fpKey] = Object.entries(PROPOSED_FP_VC_MAPPING)[0];
+  const fp = new Map([
+    ['p1', { axes: { [fpKey]: 1 } }],
+    ['p2', { axes: { [fpKey]: 1 } }],
+  ]);
+  const session = mkSession();
+  const expected = buildVcSnapshot(Object.assign({}, session, { formPulses: fp }), cfg);
+  const replayed = replayVcSnapshotFromLedger(session, { telemetryConfig: cfg, formPulses: fp });
+  assert.deepEqual(stripVolatile(replayed), stripVolatile(expected));
+  // /end-path parity (session.js:3622): hydration is read-only on the session.
+  assert.equal('formPulses' in session, false, 'session must NOT be mutated by replay');
+});
+
+test('replay: session.formPulses wins over the option (mirror /end !session.formPulses guard)', () => {
+  const [fpKey] = Object.entries(PROPOSED_FP_VC_MAPPING)[0];
+  const own = new Map([['p1', { axes: { [fpKey]: 1 } }]]);
+  const other = new Map([
+    ['p1', { axes: { [fpKey]: -1 } }],
+    ['p2', { axes: { [fpKey]: -1 } }],
+  ]);
+  const session = mkSession({ formPulses: own });
+  const expected = buildVcSnapshot(session, cfg);
+  const replayed = replayVcSnapshotFromLedger(session, { telemetryConfig: cfg, formPulses: other });
+  assert.deepEqual(stripVolatile(replayed), stripVolatile(expected));
+});
+
+// ---------------------------------------------------------------------------
+// replayDebriefFromLedger
+// ---------------------------------------------------------------------------
+
+test('replayDebrief: debrief_payload == serializer(snapshot, unitStatsById) + events_count', () => {
+  const session = mkSession();
+  const out = replayDebriefFromLedger(session, { telemetryConfig: cfg });
+  assert.ok(out && typeof out === 'object');
+  assert.equal(out.events_count, session.events.length);
+  assert.equal(out.actor_events_count, session.events.length);
+  assert.deepEqual(stripVolatile(out.vc_snapshot), stripVolatile(buildVcSnapshot(session, cfg)));
+  assert.deepEqual(
+    out.debrief_payload,
+    vcSnapshotToDebriefPayload(out.vc_snapshot, unitStatsById(session)),
+  );
+  // Pinned Godot #276 shape: per_actor present.
+  assert.ok(out.debrief_payload.per_actor && typeof out.debrief_payload.per_actor === 'object');
+});
+
+test('replayDebrief: empty ledger -> events_count 0 (caller decides the host fallback)', () => {
+  const out = replayDebriefFromLedger(mkSession({ events: [] }), { telemetryConfig: cfg });
+  assert.ok(out);
+  assert.equal(out.events_count, 0);
+  assert.equal(out.actor_events_count, 0);
+});
+
+test('replayDebrief: lifecycle-only ledger (session_start, actor null) -> actor_events_count 0', () => {
+  // /session/start seeds a session_start event (turn 0, actor_id null): a
+  // linked-but-never-fought-server-side session must NOT count as a
+  // replayable ledger (Godot client-side combat keeps host fallback).
+  const out = replayDebriefFromLedger(
+    mkSession({
+      events: [
+        {
+          action_type: 'session_start',
+          turn: 0,
+          actor_id: null,
+          target_id: null,
+          damage_dealt: 0,
+          result: 'ok',
+          position_from: null,
+          position_to: null,
+        },
+      ],
+    }),
+    { telemetryConfig: cfg },
+  );
+  assert.ok(out);
+  assert.equal(out.events_count, 1);
+  assert.equal(out.actor_events_count, 0);
+});
+
+test('replayDebrief: null session -> null', () => {
+  assert.equal(replayDebriefFromLedger(null, { telemetryConfig: cfg }), null);
+});
+
+// ---------------------------------------------------------------------------
+// unitStatsById (moved from routes/session.js closure -- #2679 Q2-bis semantics)
+// ---------------------------------------------------------------------------
+
+test('unitStatsById: extracts speed + max_hp->hp_max, guards null/undefined', () => {
+  const stats = unitStatsById({
+    units: [
+      { id: 'u1', speed: 4, max_hp: 12 },
+      { id: 'u2', speed: null, max_hp: undefined },
+      { id: 'u3', speed: 'fast', max_hp: 8 },
+      { id: null, speed: 1, max_hp: 1 },
+    ],
+  });
+  assert.deepEqual(stats, { u1: { speed: 4, hp_max: 12 }, u3: { hp_max: 8 } });
+});
+
+test('unitStatsById: no units -> empty object', () => {
+  assert.deepEqual(unitStatsById(null), {});
+  assert.deepEqual(unitStatsById({}), {});
+});
+
+// ---------------------------------------------------------------------------
+// isLedgerReplayEnabled (kill switch COOP_VC_LEDGER_REPLAY, default ON)
+// ---------------------------------------------------------------------------
+
+test('isLedgerReplayEnabled: default ON, env 0/false/off -> OFF', () => {
+  const prev = process.env.COOP_VC_LEDGER_REPLAY;
+  try {
+    delete process.env.COOP_VC_LEDGER_REPLAY;
+    assert.equal(isLedgerReplayEnabled(), true);
+    for (const off of ['0', 'false', 'off']) {
+      process.env.COOP_VC_LEDGER_REPLAY = off;
+      assert.equal(isLedgerReplayEnabled(), false, `expected OFF for "${off}"`);
+    }
+    process.env.COOP_VC_LEDGER_REPLAY = '1';
+    assert.equal(isLedgerReplayEnabled(), true);
+  } finally {
+    if (prev === undefined) delete process.env.COOP_VC_LEDGER_REPLAY;
+    else process.env.COOP_VC_LEDGER_REPLAY = prev;
+  }
+});


### PR DESCRIPTION
## OD-058 D3 -- coop vcSnapshot server-side (ledger replay) -- ULTIMO blocco tracker #2531

Il debrief coop era trust-the-host: `POST /coop/combat/end` accettava un `debrief_payload` host-authored (Bundle C 2026-05-15). Ora il server ricostruisce vcSnapshot + debrief_payload dal PROPRIO event ledger (la sessione combat linkata via `coopStore.linkSession`), stesso path vcScoring del flusso single.

### 3 box D3 (issue #2531)

1. **Ricostruzione vcSnapshot server-side dal ledger coop** -- nuovo `apps/backend/services/coop/vcLedgerReplay.js`: `replayVcSnapshotFromLedger` / `replayDebriefFromLedger` (replay-from-event-log su `session.events`, idratazione Form Pulse parity con `/end`, sessione mai mutata, `actor_events_count` per la soglia di replayabilita'). Seam: `sessionRouter.getSessionById` (read-only) -> `createCoopRouter({ getCombatSession })`.
2. **`vcSnapshotToDebriefPayload` non piu' orphan nel path coop** -- prodotto dal replay in `/coop/combat/end` (`buildVcSnapshot -> vcSnapshotToDebriefPayload(snapshot, unitStatsById)`), non solo dal flusso `/end` host-driven. `unitStatsById` spostata nel modulo condiviso (impl canonical unica, semantica verdetto #2679 Q2-bis preservata).
3. **Parity-check coop<->single** -- `tests/api/coopVcLedgerReplay.test.js`: contract `run.debrief` (replay coop) `deepEqual` `GET /:id/vc debrief_payload` (single) sullo stesso ledger. Versione Node di `test_combat_engine_parity_contract.gd` (Godot #371).

### Policy fallback (Opzione 2: combat resolution resta client-side)

| Caso | Esito |
| --- | --- |
| Sessione linkata + eventi attribuiti | replay AUTHORITATIVE (`debrief_source: 'ledger_replay'`); host payload ignorato, divergenza -> `host_payload_divergent: true` + warn log |
| Nessuna sessione linkata | legacy host passthrough (`'host'`) |
| Ledger inerte (solo `session_start`, combat client-side Godot) | host fallback |
| `COOP_VC_LEDGER_REPLAY=0\|false\|off` | kill switch -> legacy |

Outcome/survivors/xp restano host-reported (D3 sposta SOLO la derivazione VC). Campi response additive (`debrief_source`, `host_payload_divergent`); `run.debrief` resta shape PINNED Godot #276 -- nessun campo nuovo nel payload broadcast.

### Evidence (TDD)

- RED verificato: 3 unit fail + 7/7 API fail PRIMA del wire.
- GREEN: unit 11/11 (`tests/services/coop/vcLedgerReplay.test.js`) + API 7/7 (incl. spoof-rejection: actor host-inventato non sopravvive al replay).
- Area regression 56/56 (sessionVcDebriefPayload / vcSnapshotToDebriefPayload / coopBroadcastDebriefPayload / coop-recruit-candidates / coopDebrief / coopRoutes) -- i test coop esistenti non linkano sessioni -> path legacy INVARIATO.
- **Full `tests/api`: 1558 pass / 0 fail** (1 skip pre-esistente) -- tests/services area 175/175 -- tests/ai 502/502.
- Governance: `errors=0` (registry entry stessa PR); prettier clean.
- Evidence doc: `docs/reports/2026-06-10-od058-d3-vcsnapshot-replay-evidence.md`.

### Vincoli

- Raw event schema INVARIATO (replay = read-only). `packages/contracts/` non toccato. Nessuna dipendenza nuova. Forbidden paths: zero. Codice produzione solo sotto `apps/backend/` (fuori: solo test + docs).

### Rollback (03A)

Kill switch runtime: `COOP_VC_LEDGER_REPLAY=0` ripristina il trust-the-host SENZA deploy. Rollback completo: revert del commit (modulo nuovo + wire additive, zero migrazioni).

### Changelog

- feat(combat): debrief coop server-authoritative via ledger replay (OD-058 D3); kill switch `COOP_VC_LEDGER_REPLAY`.

### Caveat (DD, non bloccante)

Ledger sparso Godot futuro (client streama pochi device-events attribuiti senza combat completo): replay diventerebbe authoritative su ledger parziale. Mitigazione = soglia `actor_events_count > 0` + kill switch; knob da rivedere quando il flusso streaming Godot sara' definito (oggi quel path non linka sessioni -> fallback host pulito).
