### PR TITLE
chore(format): prettier su apps/play/src/main.js (drift post-merge)

### DIFF
--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -1555,11 +1555,7 @@ async function startNewSession() {
           `🗺 Campagna ${summary?.id || lobbyBridge.session.campaign_id} avviata (live-mirror ON)`,
         );
       } else {
-        appendLog(
-          logEl,
-          `✖ campagna bootstrap: ${campRes.data?.error || campRes.status}`,
-          'error',
-        );
+        appendLog(logEl, `✖ campagna bootstrap: ${campRes.data?.error || campRes.status}`, 'error');
       }
     } catch (err) {
       appendLog(logEl, `✖ campagna bootstrap: ${err?.message || err}`, 'error');


### PR DESCRIPTION
Health-sweep post chip-round (2026-06-10 notte): unico file non prettier-clean su main (drift dal merge #2727). `npm run format:check` torna verde. Doc-zero, logic-zero.

Sweep completo eseguito: full tests/api **1563/1564** (1 skip) · AI 502/502 · services 1264/1264 · sim+play+scripts 598/598 · governance errors=0 (stale 362). Catch ambiente: npm ci parziale (114 pkg) da reparse rotti -> reinstall pulito; 655 file working-tree cancellati da worktree-remove --force su junction rotte -> restored da HEAD (zero perdita, tutto tracked).

## Rollback plan (03A)
Revert: formato-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)