### PR TITLE
fix(combat): spawner position format drift array vs {x,y} (#2724)

### DIFF
--- a/apps/backend/services/combat/reinforcementSpawner.js
+++ b/apps/backend/services/combat/reinforcementSpawner.js
@@ -36,8 +36,23 @@ const biomePopulation = require('../worldgen/biomePopulation');
 const DEFAULT_MIN_DISTANCE_FROM_PG = 3; // Manhattan
 const TIER_LABEL_ORDER = ['Calm', 'Alert', 'Escalated', 'Critical', 'Apex'];
 
+// #2724 -- position format drift: authored tiles are arrays [x,y], runtime
+// round-model units carry {x,y} objects. Normalize both; unknown -> null.
+function coordOf(p) {
+  if (Array.isArray(p) && p.length >= 2) return [Number(p[0]), Number(p[1])];
+  if (p && typeof p === 'object' && Number.isFinite(Number(p.x)) && Number.isFinite(Number(p.y))) {
+    return [Number(p.x), Number(p.y)];
+  }
+  return null;
+}
+
 function manhattanDistance(a, b) {
-  return Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]);
+  const ca = coordOf(a);
+  const cb = coordOf(b);
+  // unknown coords -> Infinity (= "far"): mirrors the pre-existing permissive
+  // `!pg.position` branch in farFromAllPG (absent position never blocks a tile).
+  if (!ca || !cb) return Infinity;
+  return Math.abs(ca[0] - cb[0]) + Math.abs(ca[1] - cb[1]);
 }
 
 function tierMeetsMin(currentLabel, minLabel) {
@@ -51,9 +66,11 @@ function isWalkable(tile, session) {
   const [x, y] = tile;
   const grid = session.grid || { width: 10, height: 10 };
   if (x < 0 || y < 0 || x >= grid.width || y >= grid.height) return false;
-  const occupied = (session.units || []).some(
-    (u) => (u.hp ?? 0) > 0 && u.position && u.position[0] === x && u.position[1] === y,
-  );
+  const occupied = (session.units || []).some((u) => {
+    if ((u.hp ?? 0) <= 0) return false;
+    const c = coordOf(u.position);
+    return !!c && c[0] === x && c[1] === y;
+  });
   return !occupied;
 }
 
@@ -307,7 +324,11 @@ function tick(session, encounter, opts = {}) {
       // real creature instead of the archetype label.
       species_id: entry.species_id || '',
       controlled_by: 'sistema',
-      position: tile,
+      // #2724: spawn in the SESSION's position format (object when the round
+      // model is live) so downstream distance/attack math stays coherent.
+      position: (session.units || []).some((u) => u && u.position && !Array.isArray(u.position))
+        ? { x: tile[0], y: tile[1] }
+        : tile,
       hp: Number(entry.hp) || 8,
       hp_max: Number(entry.hp) || 8,
       ap: 2,

--- a/tests/services/reinforcementSpawner.test.js
+++ b/tests/services/reinforcementSpawner.test.js
@@ -461,3 +461,45 @@ test('GAP-A: no biome_id -> filter passthrough (no_biome)', () => {
   assert.equal(res.foodweb_filter.reason, 'no_biome');
   assert.ok(res.spawned.length > 0);
 });
+
+// #2724 -- position format drift: il round model porta position {x,y} (object),
+// lo spawner leggeva SOLO array -> manhattanDistance NaN -> farFromAllPG false
+// per ogni tile con un PG vivo -> rinforzi MAI spawnati in partita reale.
+test('#2724: spawns with object-format {x,y} PG positions (round model)', () => {
+  const session = mockSession({
+    units: [
+      { id: 'p1', controlled_by: 'player', position: { x: 0, y: 0 }, hp: 10 },
+      { id: 'p2', controlled_by: 'player', position: { x: 1, y: 0 }, hp: 10 },
+    ],
+  });
+  const res = tick(session, mockEncounter(), { rng: () => 0.5 });
+  assert.ok(!res.reason || res.reason === 'spawned', `expected spawn, got skip: ${res.reason}`);
+  assert.equal(res.spawned.length, 1, 'Alert budget 1 -> one spawn');
+});
+
+test('#2724: occupied tile detected with object-format positions', () => {
+  const session = mockSession({
+    units: [
+      // un'unit object-position SOPRA l'entry tile [9,9] -> tile occupato
+      { id: 'p1', controlled_by: 'player', position: { x: 0, y: 0 }, hp: 10 },
+      { id: 'blocker', controlled_by: 'sistema', position: { x: 9, y: 9 }, hp: 5 },
+    ],
+  });
+  const enc = mockEncounter({ reinforcement_entry_tiles: [[9, 9]] });
+  const res = tick(session, enc, { rng: () => 0.5 });
+  assert.equal(res.spawned.length, 0, 'only tile is occupied -> no spawn');
+});
+
+test('#2724: spawned unit position matches the session format (object when PGs are objects)', () => {
+  const session = mockSession({
+    units: [{ id: 'p1', controlled_by: 'player', position: { x: 0, y: 0 }, hp: 10 }],
+  });
+  const res = tick(session, mockEncounter(), { rng: () => 0.5 });
+  assert.equal(res.spawned.length, 1);
+  const spawned = session.units.find((u) => u.id === res.spawned[0].spawned_unit_id);
+  assert.ok(spawned, 'unit added to session');
+  assert.ok(
+    spawned.position && typeof spawned.position === 'object' && !Array.isArray(spawned.position),
+    `expected {x,y} position, got ${JSON.stringify(spawned.position)}`,
+  );
+});


### PR DESCRIPTION
## Summary

Health-check del lavoro Ryzen: **#2724 era stata chiusa senza fix nel codice** (riaperta). Il bug e' serio: i rinforzi del round model non spawnano MAI con un PG vivo (`manhattanDistance` legge `a[0]`/`b[0]`, le unit runtime portano `{x,y}` -> NaN -> ogni tile scartato). Feature reinforcement di fatto morta in partita reale, mascherata dai test (mock con position array).

## Fix (3 punti, normalizzatore unico)

- `coordOf(p)`: array `[x,y]` E oggetto `{x,y}` -> coppia numerica; unknown -> `null`.
- `manhattanDistance`: normalizza entrambi i lati; unknown -> `Infinity` (permissive, mirror del branch `!pg.position` esistente).
- occupied-check (`isWalkable`): era CIECO alle unit object-position (tile occupato risultava libero) -> normalizzato.
- spawn `position`: emessa nel FORMATO della sessione (oggetto quando il round model e' live) -- prima la unit spawnata nasceva con array in una sessione object = NaN downstream su di lei.

## Test (TDD, RED verificato)

3 nuovi (#2724): spawn con PG `{x,y}` (riproduce il bug), occupazione object-position, formato spawn coerente. Spawner **29/29** · AI baseline **502/502** · array-format legacy intatto (mock esistenti verdi).

## Sblocca

Re-run N=40 dell'effetto overrun ER6 (`OVERRUN_BUDGET_BONUS` PROPOSED -- era strutturalmente no-op proprio per questo bug; ratifica master-dd post-evidence).

Closes #2724

## Rollback plan (03A)

Revert singolo commit: normalizzatore additivo, semantica array invariata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)