### PR TITLE
chore(governance): non-living statuses skip stale check (-17 warnings)

### DIFF
--- a/tests/test_check_docs_governance.py
+++ b/tests/test_check_docs_governance.py
@@ -307,6 +307,21 @@ class TestValidateRegistry:
         stale = next(i for i in issues if i.code == "stale_document")
         assert stale.level == "warning"
 
+    @pytest.mark.parametrize(
+        "status",
+        ["superseded", "deprecated", "archived", "historical_ref", "generated"],
+    )
+    def test_non_living_status_skips_stale(self, tmp_path: Path, status: str):
+        # Statuti non-living (record datati / autogenerati) non vanno mai flaggati
+        # stale, anche con last_verified ben oltre il review_cycle.
+        old_date = (date.today() - timedelta(days=365)).isoformat()
+        entry = make_valid_entry(
+            last_verified=old_date, review_cycle_days=14, doc_status=status
+        )
+        setup_repo(tmp_path, entries=[entry])
+        issues = validator.validate_registry(tmp_path, make_valid_registry(entries=[entry]))
+        assert "stale_document" not in issue_codes(issues)
+
     def test_path_missing_raises_error(self, tmp_path: Path):
         entry = make_valid_entry(path="docs/missing.md")
         registry = make_valid_registry(

--- a/tools/check_docs_governance.py
+++ b/tools/check_docs_governance.py
@@ -232,7 +232,19 @@ def validate_registry(repo_root: Path, registry: dict[str, Any]) -> list[Issue]:
                 issues.append(Issue("error", "invalid_review_cycle", rel_path, f"review_cycle_days invalido: {cycle}"))
             else:
                 due = lv_date + timedelta(days=cycle)
-                _retired_statuses = {"superseded", "deprecated", "archived"}
+                # Statuti non-living: documenti che per definizione NON sono
+                # soggetti a re-verifica periodica umana, quindi non vanno mai
+                # flaggati stale (allinea historical_ref/generated alla semantica
+                # gia' applicata a superseded/deprecated/archived).
+                #   - historical_ref: record datato (snapshot/riferimento storico)
+                #   - generated: autogenerato (mai rivisto a mano)
+                _retired_statuses = {
+                    "superseded",
+                    "deprecated",
+                    "archived",
+                    "historical_ref",
+                    "generated",
+                }
                 if due < today and entry.get("doc_status") not in _retired_statuses:
                     issues.append(Issue("warning", "stale_document", rel_path, f"Documento stale: revisione scaduta il {due.isoformat()}"))
 


### PR DESCRIPTION
## Sintesi

Stale burn-down (parte governance): `historical_ref` (record datato) e `generated` (autogenerato) **non sono soggetti a re-verifica periodica umana** -> non vanno mai flaggati `stale_document`, esattamente come gia' `superseded`/`deprecated`/`archived`. Allinea la semantica dello skip-set.

## Effetto
- Stale warnings **367 -> 350** (-17: 14 historical_ref + 3 generated), errors=0.
- I 350 residui = living-doc reali (206 active + 143 draft + 1 legacy_active) -> burn-down per-doc review separato (vedi BACKLOG TKT-STALE-B2).

## Verify
- TDD: `test_non_living_status_skips_stale` parametrizzato sui 5 statuti non-living.
- `pytest tests/test_check_docs_governance.py` -> **68 passed**.

## Rollback
1-riga sul set + test. Revert pulito. `tools/` non e' forbidden-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)