### PR TITLE
fix(meta): store globale null usa findFirst su unique nullable (#2746 G4)

### DIFF
--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -740,24 +740,43 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
   const usePrisma = prismaSupportsMeta(prisma);
   const fallback = usePrisma ? null : createMetaTracker();
 
+  // G4 #2746 Codex P2 — Postgres unique on nullable campaign_id does NOT
+  // reject a second NULL row, so the global-store findFirst+create race can
+  // produce duplicates (unlike the non-null findUnique+create race, which
+  // fails loudly with P2002). Mitigation: serialize first-creation in-process
+  // (single backend process serves these routes) and order reads by createdAt
+  // so any stray duplicate is never read again (oldest row = canonical).
+  const GLOBAL_ROW_ORDER = [{ createdAt: 'asc' }, { id: 'asc' }];
+  const _globalRelCreate = new Map(); // npcId → in-flight create promise
+  let _globalNestCreate = null;
+
   async function getOrCreateRelation(npcId) {
     if (!usePrisma) return null;
+    if (campaignId !== null) {
+      const existing = await prisma.npcRelation.findUnique({
+        where: { campaignId_npcId: { campaignId, npcId } },
+      });
+      if (existing) return existing;
+      return prisma.npcRelation.create({
+        data: { campaignId, npcId },
+      });
+    }
     // G4 #2746 — compound unique (campaignId, npcId) has campaignId String?:
     // the real Prisma client rejects findUnique with a null member
-    // (PrismaClientValidationError). Global store (campaignId null) must use
-    // findFirst; in Postgres NULL never collides on the unique index, so
-    // findFirst is the correct "the global row" lookup. The findFirst+create
-    // race is the same as the pre-existing findUnique+create one.
-    const existing =
-      campaignId === null
-        ? await prisma.npcRelation.findFirst({ where: { campaignId: null, npcId } })
-        : await prisma.npcRelation.findUnique({
-            where: { campaignId_npcId: { campaignId, npcId } },
-          });
-    if (existing) return existing;
-    return prisma.npcRelation.create({
-      data: { campaignId, npcId },
+    // (PrismaClientValidationError). Global store must use findFirst.
+    const existing = await prisma.npcRelation.findFirst({
+      where: { campaignId: null, npcId },
+      orderBy: GLOBAL_ROW_ORDER,
     });
+    if (existing) return existing;
+    let pending = _globalRelCreate.get(npcId);
+    if (!pending) {
+      pending = prisma.npcRelation
+        .create({ data: { campaignId: null, npcId } })
+        .finally(() => _globalRelCreate.delete(npcId));
+      _globalRelCreate.set(npcId, pending);
+    }
+    return pending;
   }
 
   function toNpcShape(relation) {
@@ -827,16 +846,29 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
 
   async function getNestRecord() {
     if (!usePrisma) return null;
+    if (campaignId !== null) {
+      const existing = await prisma.nestState.findUnique({ where: { campaignId } });
+      if (existing) return existing;
+      return prisma.nestState.create({
+        data: { campaignId, level: 0, biome: null, requirementsMet: false },
+      });
+    }
     // G4 #2746 — NestState.campaignId is String? @unique: real client rejects
-    // findUnique({ where: { campaignId: null } }). See getOrCreateRelation.
-    const existing =
-      campaignId === null
-        ? await prisma.nestState.findFirst({ where: { campaignId: null } })
-        : await prisma.nestState.findUnique({ where: { campaignId } });
-    if (existing) return existing;
-    return prisma.nestState.create({
-      data: { campaignId, level: 0, biome: null, requirementsMet: false },
+    // findUnique({ where: { campaignId: null } }). See getOrCreateRelation for
+    // the null-row duplicate rationale (Codex P2).
+    const existing = await prisma.nestState.findFirst({
+      where: { campaignId: null },
+      orderBy: GLOBAL_ROW_ORDER,
     });
+    if (existing) return existing;
+    if (!_globalNestCreate) {
+      _globalNestCreate = prisma.nestState
+        .create({ data: { campaignId: null, level: 0, biome: null, requirementsMet: false } })
+        .finally(() => {
+          _globalNestCreate = null;
+        });
+    }
+    return _globalNestCreate;
   }
 
   async function canMate(npcId) {

--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -742,9 +742,18 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
 
   async function getOrCreateRelation(npcId) {
     if (!usePrisma) return null;
-    const existing = await prisma.npcRelation.findUnique({
-      where: { campaignId_npcId: { campaignId, npcId } },
-    });
+    // G4 #2746 — compound unique (campaignId, npcId) has campaignId String?:
+    // the real Prisma client rejects findUnique with a null member
+    // (PrismaClientValidationError). Global store (campaignId null) must use
+    // findFirst; in Postgres NULL never collides on the unique index, so
+    // findFirst is the correct "the global row" lookup. The findFirst+create
+    // race is the same as the pre-existing findUnique+create one.
+    const existing =
+      campaignId === null
+        ? await prisma.npcRelation.findFirst({ where: { campaignId: null, npcId } })
+        : await prisma.npcRelation.findUnique({
+            where: { campaignId_npcId: { campaignId, npcId } },
+          });
     if (existing) return existing;
     return prisma.npcRelation.create({
       data: { campaignId, npcId },
@@ -818,7 +827,12 @@ function createMetaStore({ prisma, campaignId = null } = {}) {
 
   async function getNestRecord() {
     if (!usePrisma) return null;
-    const existing = await prisma.nestState.findUnique({ where: { campaignId } });
+    // G4 #2746 — NestState.campaignId is String? @unique: real client rejects
+    // findUnique({ where: { campaignId: null } }). See getOrCreateRelation.
+    const existing =
+      campaignId === null
+        ? await prisma.nestState.findFirst({ where: { campaignId: null } })
+        : await prisma.nestState.findUnique({ where: { campaignId } });
     if (existing) return existing;
     return prisma.nestState.create({
       data: { campaignId, level: 0, biome: null, requirementsMet: false },

--- a/tests/ai/metaProgression.test.js
+++ b/tests/ai/metaProgression.test.js
@@ -447,3 +447,50 @@ test('adapter recruit without speciesId: species_id stays undefined in shape', a
   assert.equal(result.success, true);
   assert.equal(result.npc.species_id, undefined);
 });
+
+// ─── G4 #2746 — global store (campaignId null) vs real Prisma semantics ─────
+// Real client rejects findUnique with null unique-key members
+// (PrismaClientValidationError). The strict mock reproduces that; before the
+// fix these tests blow up exactly like GET /api/meta/npg and /api/v1/meta/nest
+// did against Prisma+Postgres.
+
+const { makeStrictMetaPrisma } = require('../helpers/strictMetaPrisma');
+
+test('G4 #2746: global store getNest() works under real-client null semantics', async () => {
+  const prisma = makeStrictMetaPrisma();
+  const store = createMetaStore({ prisma, campaignId: null });
+  const nest = await store.getNest();
+  assert.deepEqual(nest, { level: 0, biome: null, requirements_met: false });
+  // Null scope must never hit the unique lookup (real client would throw).
+  assert.equal(prisma._calls.nestFindUnique, 0);
+});
+
+test('G4 #2746: global store getNest() reuses the single global row', async () => {
+  const prisma = makeStrictMetaPrisma();
+  const store = createMetaStore({ prisma, campaignId: null });
+  await store.getNest();
+  await store.getNest();
+  assert.equal(prisma._rows.nests.length, 1);
+  assert.equal(prisma._rows.nests[0].campaignId, null);
+});
+
+test('G4 #2746: global store mutation (updateAffinity) does not throw', async () => {
+  const prisma = makeStrictMetaPrisma();
+  const store = createMetaStore({ prisma, campaignId: null });
+  const npc = await store.updateAffinity('npc_g4', 1);
+  assert.equal(npc.npc_id, 'npc_g4');
+  assert.equal(npc.affinity, 1);
+  assert.equal(prisma._calls.npcFindUnique, 0);
+});
+
+test('G4 #2746 regression: per-campaign store keeps the findUnique path', async () => {
+  const prisma = makeStrictMetaPrisma();
+  const store = createMetaStore({ prisma, campaignId: 'camp-1' });
+  await store.updateAffinity('npc_a', 1);
+  const nest = await store.getNest();
+  assert.equal(nest.level, 0);
+  assert.ok(prisma._calls.npcFindUnique >= 1);
+  assert.ok(prisma._calls.nestFindUnique >= 1);
+  assert.equal(prisma._calls.npcFindFirst, 0);
+  assert.equal(prisma._calls.nestFindFirst, 0);
+});

--- a/tests/ai/metaProgression.test.js
+++ b/tests/ai/metaProgression.test.js
@@ -494,3 +494,49 @@ test('G4 #2746 regression: per-campaign store keeps the findUnique path', async 
   assert.equal(prisma._calls.npcFindFirst, 0);
   assert.equal(prisma._calls.nestFindFirst, 0);
 });
+
+// Codex P2 (PR #2748): Postgres unique on nullable campaign_id does NOT
+// reject a second NULL row → concurrent first reads could create duplicate
+// global rows, and findFirst without ordering reads an arbitrary one.
+
+test('G4 #2746 P2: concurrent first getNest() creates a single global row', async () => {
+  const prisma = makeStrictMetaPrisma();
+  const store = createMetaStore({ prisma, campaignId: null });
+  await Promise.all([store.getNest(), store.getNest(), store.getNest()]);
+  assert.equal(prisma._rows.nests.length, 1);
+});
+
+test('G4 #2746 P2: stray duplicate global nest rows → reads converge on oldest', async () => {
+  const prisma = makeStrictMetaPrisma();
+  // Seed duplicates out of order: newer row first in insertion order.
+  await prisma.nestState.create({
+    data: { campaignId: null, level: 2, biome: 'tundra', createdAt: new Date('2026-02-02') },
+  });
+  await prisma.nestState.create({
+    data: { campaignId: null, level: 1, biome: 'savana', createdAt: new Date('2026-01-01') },
+  });
+  const store = createMetaStore({ prisma, campaignId: null });
+  const nest = await store.getNest();
+  assert.equal(nest.biome, 'savana'); // oldest = canonical
+  assert.equal(nest.level, 1);
+});
+
+test('G4 #2746 P2: concurrent first relation access creates a single row per npc', async () => {
+  const prisma = makeStrictMetaPrisma();
+  const store = createMetaStore({ prisma, campaignId: null });
+  await Promise.all([store.canRecruit('npc_dup'), store.canRecruit('npc_dup')]);
+  assert.equal(prisma._rows.relations.filter((r) => r.npcId === 'npc_dup').length, 1);
+});
+
+test('G4 #2746 P2: stray duplicate global relation rows → reads converge on oldest', async () => {
+  const prisma = makeStrictMetaPrisma();
+  await prisma.npcRelation.create({
+    data: { campaignId: null, npcId: 'npc_c', affinity: 2, createdAt: new Date('2026-02-02') },
+  });
+  await prisma.npcRelation.create({
+    data: { campaignId: null, npcId: 'npc_c', affinity: 0, createdAt: new Date('2026-01-01') },
+  });
+  const store = createMetaStore({ prisma, campaignId: null });
+  const npc = await store.updateAffinity('npc_c', 1);
+  assert.equal(npc.affinity, 1); // oldest row (affinity 0) +1, not newer (2)+1
+});

--- a/tests/api/metaRoutes.test.js
+++ b/tests/api/metaRoutes.test.js
@@ -117,3 +117,28 @@ test('adapter mode falls back to in-memory when no DATABASE_URL', async () => {
   const npc = await store.updateAffinity('npc_fallback_01', 1);
   assert.equal(npc.affinity, 1);
 });
+
+// ─── G4 #2746 — prisma-backed GLOBAL store (campaignId null) ───────────────
+// With Prisma+Postgres the real client rejects findUnique on null unique-key
+// members → GET /api/meta/npg and GET /api/v1/meta/nest answered 500
+// PrismaClientValidationError. Strict mock reproduces real-client semantics
+// (see tests/helpers/strictMetaPrisma.js).
+
+test('G4 #2746: GET /npg + /nest return 200 with prisma-backed global store', async () => {
+  const express = require('express');
+  const { createMetaRouter } = require('../../apps/backend/routes/meta');
+  const { makeStrictMetaPrisma } = require('../helpers/strictMetaPrisma');
+
+  const prisma = makeStrictMetaPrisma();
+  const app = express();
+  app.use(express.json());
+  app.use('/api/meta', createMetaRouter({ prisma, campaignId: null }));
+
+  const npg = await request(app).get('/api/meta/npg').expect(200);
+  assert.ok(Array.isArray(npg.body.npcs));
+  assert.equal(npg.body.nest.level, 0);
+  assert.equal(npg.body.nest.requirements_met, false);
+
+  const nest = await request(app).get('/api/meta/nest').expect(200);
+  assert.deepEqual(nest.body, { level: 0, biome: null, requirements_met: false });
+});

--- a/tests/helpers/strictMetaPrisma.js
+++ b/tests/helpers/strictMetaPrisma.js
@@ -16,6 +16,19 @@ function prismaValidationError(message) {
   return err;
 }
 
+function applyOrderBy(rows, orderBy) {
+  if (!orderBy) return rows;
+  const specs = Array.isArray(orderBy) ? orderBy : [orderBy];
+  return [...rows].sort((a, b) => {
+    for (const spec of specs) {
+      const [field, dir] = Object.entries(spec)[0];
+      if (a[field] < b[field]) return dir === 'desc' ? 1 : -1;
+      if (a[field] > b[field]) return dir === 'desc' ? -1 : 1;
+    }
+    return 0;
+  });
+}
+
 function makeStrictMetaPrisma() {
   const relations = [];
   const nests = [];
@@ -26,6 +39,8 @@ function makeStrictMetaPrisma() {
     nestFindUnique: 0,
     nestFindFirst: 0,
   };
+  // Monotonic createdAt so orderBy createdAt is deterministic in tests.
+  const nextCreatedAt = () => new Date(Date.UTC(2026, 0, 1, 0, 0, 0, seq));
 
   return {
     _rows: { relations, nests },
@@ -43,16 +58,15 @@ function makeStrictMetaPrisma() {
           relations.find((r) => r.campaignId === key.campaignId && r.npcId === key.npcId) || null
         );
       },
-      findFirst: async ({ where } = {}) => {
+      findFirst: async ({ where, orderBy } = {}) => {
         calls.npcFindFirst += 1;
         const w = where || {};
-        return (
-          relations.find(
-            (r) =>
-              (!('campaignId' in w) || r.campaignId === w.campaignId) &&
-              (!('npcId' in w) || r.npcId === w.npcId),
-          ) || null
+        const matches = relations.filter(
+          (r) =>
+            (!('campaignId' in w) || r.campaignId === w.campaignId) &&
+            (!('npcId' in w) || r.npcId === w.npcId),
         );
+        return applyOrderBy(matches, orderBy)[0] || null;
       },
       findMany: async ({ where } = {}) => {
         const w = where || {};
@@ -60,7 +74,8 @@ function makeStrictMetaPrisma() {
       },
       create: async ({ data }) => {
         const row = {
-          id: `rel_${seq++}`,
+          id: `rel_${seq}`,
+          createdAt: nextCreatedAt(),
           affinity: 0,
           trust: 0,
           recruited: false,
@@ -71,6 +86,7 @@ function makeStrictMetaPrisma() {
           mbtiType: null,
           ...data,
         };
+        seq += 1;
         relations.push(row);
         return row;
       },
@@ -97,19 +113,22 @@ function makeStrictMetaPrisma() {
         calls.nestFindUnique += 1;
         return nests.find((n) => n.campaignId === where.campaignId) || null;
       },
-      findFirst: async ({ where } = {}) => {
+      findFirst: async ({ where, orderBy } = {}) => {
         calls.nestFindFirst += 1;
         const w = where || {};
-        return nests.find((n) => !('campaignId' in w) || n.campaignId === w.campaignId) || null;
+        const matches = nests.filter((n) => !('campaignId' in w) || n.campaignId === w.campaignId);
+        return applyOrderBy(matches, orderBy)[0] || null;
       },
       create: async ({ data }) => {
         const row = {
-          id: `nest_${seq++}`,
+          id: `nest_${seq}`,
+          createdAt: nextCreatedAt(),
           level: 0,
           biome: null,
           requirementsMet: false,
           ...data,
         };
+        seq += 1;
         nests.push(row);
         return row;
       },

--- a/tests/helpers/strictMetaPrisma.js
+++ b/tests/helpers/strictMetaPrisma.js
@@ -1,0 +1,126 @@
+// G4 #2746 — faithful Prisma mock for meta-progression tests.
+//
+// The real Prisma client REJECTS `findUnique` when a unique-key member is
+// null (NestState.campaignId String? @unique; NpcRelation
+// @@unique([campaignId, npcId]) with campaignId String?). The lenient mocks
+// used before this fix accepted null and hid the 500
+// PrismaClientValidationError on the global store (campaignId null).
+// This mock reproduces the real-client semantics: findUnique throws on null
+// unique-key members, findFirst accepts null in `where` (IS NULL filter).
+
+'use strict';
+
+function prismaValidationError(message) {
+  const err = new Error(message);
+  err.name = 'PrismaClientValidationError';
+  return err;
+}
+
+function makeStrictMetaPrisma() {
+  const relations = [];
+  const nests = [];
+  let seq = 1;
+  const calls = {
+    npcFindUnique: 0,
+    npcFindFirst: 0,
+    nestFindUnique: 0,
+    nestFindFirst: 0,
+  };
+
+  return {
+    _rows: { relations, nests },
+    _calls: calls,
+    npcRelation: {
+      findUnique: async ({ where } = {}) => {
+        const key = where && where.campaignId_npcId;
+        if (!key || key.campaignId == null || key.npcId == null) {
+          throw prismaValidationError(
+            'Argument `campaignId`: Invalid value provided. Expected String, provided null. (npcRelation.findUnique)',
+          );
+        }
+        calls.npcFindUnique += 1;
+        return (
+          relations.find((r) => r.campaignId === key.campaignId && r.npcId === key.npcId) || null
+        );
+      },
+      findFirst: async ({ where } = {}) => {
+        calls.npcFindFirst += 1;
+        const w = where || {};
+        return (
+          relations.find(
+            (r) =>
+              (!('campaignId' in w) || r.campaignId === w.campaignId) &&
+              (!('npcId' in w) || r.npcId === w.npcId),
+          ) || null
+        );
+      },
+      findMany: async ({ where } = {}) => {
+        const w = where || {};
+        return relations.filter((r) => !('campaignId' in w) || r.campaignId === w.campaignId);
+      },
+      create: async ({ data }) => {
+        const row = {
+          id: `rel_${seq++}`,
+          affinity: 0,
+          trust: 0,
+          recruited: false,
+          mated: false,
+          matingCooldown: 0,
+          traitIds: '[]',
+          speciesId: null,
+          mbtiType: null,
+          ...data,
+        };
+        relations.push(row);
+        return row;
+      },
+      update: async ({ where, data }) => {
+        const row = relations.find((r) => r.id === where.id);
+        if (!row) throw new Error(`npcRelation.update: no row ${where.id}`);
+        // Strip nested-write blocks (affinityLogs/trustLogs/matingEvents create).
+        const { affinityLogs, trustLogs, matingEvents, ...scalar } = data;
+        Object.assign(row, scalar);
+        return row;
+      },
+      updateMany: async () => ({ count: 0 }),
+      upsert: async () => {
+        throw new Error('npcRelation.upsert: not exercised by these tests');
+      },
+    },
+    nestState: {
+      findUnique: async ({ where } = {}) => {
+        if (!where || where.campaignId == null) {
+          throw prismaValidationError(
+            'Argument `campaignId`: Invalid value provided. Expected String, provided null. (nestState.findUnique)',
+          );
+        }
+        calls.nestFindUnique += 1;
+        return nests.find((n) => n.campaignId === where.campaignId) || null;
+      },
+      findFirst: async ({ where } = {}) => {
+        calls.nestFindFirst += 1;
+        const w = where || {};
+        return nests.find((n) => !('campaignId' in w) || n.campaignId === w.campaignId) || null;
+      },
+      create: async ({ data }) => {
+        const row = {
+          id: `nest_${seq++}`,
+          level: 0,
+          biome: null,
+          requirementsMet: false,
+          ...data,
+        };
+        nests.push(row);
+        return row;
+      },
+      update: async ({ where, data }) => {
+        const row = nests.find((n) => n.id === where.id);
+        if (!row) throw new Error(`nestState.update: no row ${where.id}`);
+        Object.assign(row, data);
+        return row;
+      },
+    },
+  };
+}
+
+module.exports = { makeStrictMetaPrisma };


### PR DESCRIPTION
## Riferimento

Issue #2746 **voce G4** (SOLO G4 — G1/G2/G3/G5 restano aperte nella issue, NON chiudere). Trovato dal playtest AI GGv2 item-5 (report `Game-Godot-v2/docs/godot-v2/qa/2026-06-12-item5-item6-ai-playtest.md`): bloccava l'assert B3 "Nido mirror" affinity-half sul phone Godot.

## Root cause

Con Prisma+Postgres reale e store meta-progression **globale** (`campaignId = null`), `apps/backend/services/metaProgression.js` chiamava `findUnique` con membro null su unique key — il client reale rigetta con `PrismaClientValidationError`:

1. `getNestRecord()`: `prisma.nestState.findUnique({ where: { campaignId } })` con `NestState.campaignId String? @unique` → `getNest()` 500 su `GET /api/v1/meta/nest`; e `GET /api/meta/npg` fa `Promise.all([listNpcs(), getNest()])` → 500 anche lì.
2. `getOrCreateRelation(npcId)`: `findUnique({ where: { campaignId_npcId: { campaignId, npcId } } })` con `@@unique([campaignId, npcId])` e `campaignId String?` → stessa eccezione su ogni mutazione dello store globale (affinity/trust/recruit/mating).

Passato inosservato perché i mock di test accettavano null su `findUnique` (il client reale no).

## Fix (minimale, nessuna migration)

Branch sul caso null → `findFirst` (in Postgres NULL non collide sull'indice unique, quindi `findFirst` è la query corretta per "la riga globale"). Store per-campaign continua a usare `findUnique` (nessuna regressione, asserito da test).

**Codex P2 (accolto, commit `dbb77574`)**: la race `findFirst+create` sul path null NON è equivalente alla pre-esistente `findUnique+create` — quella non-null fallisce loud (P2002), quella null creava duplicati silenziosi (unique Postgres non rigetta un secondo NULL). Mitigazione two-layer senza migration: (1) create serializzato in-process (promise memoizzata; `Map` per npcId), (2) read null-path con `orderBy: [{createdAt: asc}, {id: asc}]` → riga più vecchia = canonica, eventuale dup residuo cross-process mai più letto/aggiornato. Fix completo (partial unique index `WHERE campaign_id IS NULL`) richiederebbe migration = fuori scope G4.

## Test (TDD — rosso verificato prima del fix)

- Nuovo `tests/helpers/strictMetaPrisma.js`: mock **fedele al client reale** — `findUnique` throwa `PrismaClientValidationError` su membro null della unique key; `findFirst` accetta null nel `where`.
- `tests/ai/metaProgression.test.js` +4: store globale `getNest()` shape `{level, biome, requirements_met}` senza throw + riusa singola riga globale + `updateAffinity` senza throw + **regressione per-campaign** (findUnique usato, findFirst mai).
- `tests/api/metaRoutes.test.js` +1: `GET /npg` + `GET /nest` → 200 via router con store globale prisma-backed.
- RED verificato pre-fix: 4 test rossi con `PrismaClientValidationError` esattamente alle righe bug (`metaProgression.js:821`, `:745`).
- **Codex P2** (`dbb77574`) +4 test (rossi pre-fix): first-read concorrente → 1 sola riga globale (nest + relation); duplicati seminati → read converge sulla più vecchia (nest + relation). Mock esteso: `findFirst` onora `orderBy`, `createdAt` monotono.

```
tests/ai/metaProgression.test.js   50/50 pass
tests/api/metaRoutes.test.js        8/8  pass
consumer meta (epigenome*, hybridFusion, meta.lineage, complexityBudget,
  metaRecruitRoster, computeMatingEligibles)  56/56 pass
tests/ai/*.test.js (DoD baseline)  510/510 pass
prettier --check (file toccati)    clean
```

## Changelog

- fix(meta): store globale (`campaignId null`) usa `findFirst` su unique nullable — `GET /api/meta/npg` e `GET /api/v1/meta/nest` non rispondono più 500 con Prisma+Postgres reale (#2746 G4).

## Rollback plan (03A)

Revert dei 2 commit (`git revert dbb77574 b3482696`): nessuna migration, nessun cambio schema/contracts, superficie = 1 servizio backend + test. Comportamento in-memory fallback intoccato.

## Follow-up cross-repo (post-merge)

Sbloccare il re-check **GGv2 item-5 B3 affinity-half** (lane Lenovo, ~15 min, istruzioni già nel report qa `2026-06-12-item5-item6-ai-playtest.md`).

## Note governance

- Test estesi fuori `apps/backend/` (~190 righe in `tests/` + helper): richiesti esplicitamente dalla issue (sezione TEST obbligatoria).
- Merge = Eduardo only. Dopo merge: commento sulla issue #2746 spuntando G4 con link PR.

