### PR TITLE
fix(coop): phase_change broadcast versionato per client Godot (#2746 G1)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -78,10 +78,18 @@ function createCoopRouter({
 
   function broadcastCoopState(room, orch) {
     if (!room || typeof room.broadcast !== 'function') return;
-    room.broadcast({
-      type: 'phase_change',
-      payload: buildPhaseChangePayload(orch),
-    });
+    // G1 #2746 — route phase_change through the VERSIONED publisher so the
+    // Godot phone accepts the frame (raw broadcast had no `version` key and
+    // was dropped as unknown_type -> blank screen). publishEvent version-stamps
+    // + ledger-records while broadcasting the same rich payload. Fallback to a
+    // raw broadcast only if the room lacks publishEvent (defensive; real Room
+    // always has it).
+    const phasePayload = buildPhaseChangePayload(orch);
+    if (typeof room.publishEvent === 'function') {
+      room.publishEvent('phase_change', phasePayload);
+    } else {
+      room.broadcast({ type: 'phase_change', payload: phasePayload });
+    }
     room.broadcast({
       type: 'character_ready_list',
       payload: orch.characterReadyList(quorumPids(room, orch, null)),

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -999,8 +999,13 @@ function sendCoopSnapshotToPlayer(room, orch, playerId) {
       // best-effort
     }
   };
+  // G1 #2746 — stamp the current stateVersion on the per-socket connect
+  // snapshot so the Godot phone accepts the phase_change frame (unversioned
+  // frames were dropped as unknown_type). This is a targeted replay, not a
+  // new event: it reflects the room's current version without bumping it.
   send({
     type: 'phase_change',
+    version: room.stateVersion ?? 0,
     payload: buildPhaseChangePayload(orch, { reason: 'reconnect' }),
   });
   if (typeof orch.characterReadyList === 'function') {
@@ -1053,10 +1058,15 @@ function rebroadcastCoopState(room, orch) {
   const connectedIds = Array.from(room.players.values())
     .filter((p) => p.id !== room.hostId && p.role !== 'host' && p.connected)
     .map((p) => p.id);
-  room.broadcast({
-    type: 'phase_change',
-    payload: buildPhaseChangePayload(orch, { reason: 'host_transferred' }),
-  });
+  // G1 #2746 — versioned publish so the Godot phone accepts the host-transfer
+  // phase_change (raw frames were dropped as unknown_type). Fallback to raw
+  // broadcast only if the room lacks publishEvent (defensive).
+  const htPayload = buildPhaseChangePayload(orch, { reason: 'host_transferred' });
+  if (typeof room.publishEvent === 'function') {
+    room.publishEvent('phase_change', htPayload);
+  } else {
+    room.broadcast({ type: 'phase_change', payload: htPayload });
+  }
   if (typeof orch.characterReadyList === 'function') {
     room.broadcast({
       type: 'character_ready_list',

--- a/tests/api/coopPhaseChangeVersioned.test.js
+++ b/tests/api/coopPhaseChangeVersioned.test.js
@@ -1,0 +1,132 @@
+// G1 #2746 — coop phase_change broadcast must be VERSIONED.
+//
+// broadcastCoopState (routes/coop.js) emitted phase_change via raw
+// room.broadcast (no `version` key). The Godot phone client drops
+// unversioned frames as unknown_type -> phone stuck on a blank screen
+// (root cause of item-3 finding-1, deterministic not flaky). Fix routes
+// the broadcast through room.publishEvent('phase_change', ...) which
+// version-stamps + ledger-records while preserving the rich payload
+// (phase/round/scenario/session_id/campaign_id from buildPhaseChangePayload).
+//
+// Ref: MasterDD-L34D/Game#2746 voce G1.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  // Capture all broadcasts emitted to rooms via LobbyService. publishEvent
+  // delegates to room.broadcast internally, so wrapping broadcast captures
+  // both raw and versioned frames (with the `version` field when present).
+  const broadcasts = [];
+  const origGetRoom = lobby.getRoom.bind(lobby);
+  lobby.getRoom = function (code) {
+    const room = origGetRoom(code);
+    if (room && !room.__broadcastWrapped) {
+      const origBroadcast = room.broadcast.bind(room);
+      room.broadcast = function (msg) {
+        broadcasts.push({ code, msg });
+        return origBroadcast(msg);
+      };
+      room.__broadcastWrapped = true;
+    }
+    return room;
+  };
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app, lobby, coopStore, broadcasts };
+}
+
+async function startRun(app) {
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'Host', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  r = await request(app).post('/api/lobby/join').send({ code, player_name: 'A' });
+  const playerId = r.body.player_id;
+  const playerToken = r.body.player_token;
+  await request(app)
+    .post('/api/coop/run/start')
+    .send({ code, host_token: hostToken, scenario_stack: ['enc_demo_01'] });
+  return { code, hostToken, playerId, playerToken };
+}
+
+function phaseChanges(broadcasts) {
+  return broadcasts.filter((b) => b.msg.type === 'phase_change').map((b) => b.msg);
+}
+
+test('G1: REST broadcastCoopState emits phase_change WITH version', async () => {
+  const { app, broadcasts } = buildApp();
+  await startRun(app);
+  const pcs = phaseChanges(broadcasts);
+  assert.ok(pcs.length >= 1, `expected at least one phase_change broadcast, got ${pcs.length}`);
+  for (const pc of pcs) {
+    assert.equal(
+      typeof pc.version,
+      'number',
+      `phase_change missing numeric version: ${JSON.stringify(pc)}`,
+    );
+    assert.ok(pc.version >= 1, `phase_change version must be >= 1, got ${pc.version}`);
+  }
+});
+
+test('G1: versioned phase_change preserves the rich payload (no regression)', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken, playerId, playerToken } = await startRun(app);
+  broadcasts.length = 0;
+  await request(app).post('/api/coop/character/create').send({
+    code,
+    player_id: playerId,
+    player_token: playerToken,
+    name: 'A',
+    form_id: 'istj',
+    species_id: 'x',
+    job_id: 'guerriero',
+  });
+  const pcs = phaseChanges(broadcasts);
+  assert.ok(pcs.length >= 1, 'expected a phase_change after character/create');
+  const pc = pcs[pcs.length - 1];
+  // Rich payload fields from buildPhaseChangePayload must survive the switch.
+  assert.equal(typeof pc.version, 'number');
+  assert.ok('phase' in pc.payload, 'payload.phase missing');
+  assert.ok('round' in pc.payload, 'payload.round missing (rich payload lost)');
+  assert.ok('scenario' in pc.payload, 'payload.scenario missing (rich payload lost)');
+  assert.ok('campaign_id' in pc.payload, 'payload.campaign_id missing');
+  assert.ok('session_id' in pc.payload, 'payload.session_id missing');
+});
+
+test('G1: phase_change version is monotonic across REST broadcasts', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken, playerId, playerToken } = await startRun(app);
+  await request(app).post('/api/coop/character/create').send({
+    code,
+    player_id: playerId,
+    player_token: playerToken,
+    name: 'A',
+    form_id: 'istj',
+    species_id: 'x',
+    job_id: 'guerriero',
+  });
+  await request(app)
+    .post('/api/coop/world/confirm')
+    .send({ code, host_token: hostToken, scenario_id: 'enc_demo_01' });
+  const versions = phaseChanges(broadcasts).map((m) => m.version);
+  assert.ok(versions.length >= 2, `expected >=2 versioned phase_change, got ${versions.length}`);
+  for (let i = 1; i < versions.length; i += 1) {
+    assert.ok(
+      versions[i] >= versions[i - 1],
+      `version non-monotonic: v[${i}]=${versions[i]} < v[${i - 1}]=${versions[i - 1]}`,
+    );
+  }
+});

--- a/tests/api/coopWsRebroadcast.test.js
+++ b/tests/api/coopWsRebroadcast.test.js
@@ -126,6 +126,13 @@ test('F-1: host transfer after drop rebroadcasts coop phase_change to survivors'
       2000,
     );
     assert.equal(phaseMsg.payload.phase, 'world_setup');
+    // G1 #2746 — host-transfer rebroadcast must be versioned so the Godot
+    // phone accepts it (raw broadcast frames were dropped as unknown_type).
+    assert.equal(
+      typeof phaseMsg.version,
+      'number',
+      'host-transfer phase_change must carry version',
+    );
     // Also should receive character_ready_list snapshot.
     const readyMsg = await waitForMessage(p1Ws, (m) => m.type === 'character_ready_list', 2000);
     assert.ok(Array.isArray(readyMsg.payload));
@@ -164,6 +171,54 @@ test('F-1: host transfer without coopStore is no-op (backward compat)', async ()
     // Wait past grace window and ensure room did not close unexpectedly.
     await new Promise((resolve) => setTimeout(resolve, 250));
     assert.equal(lobby.getRoom(room.code)?.hostId, p1.player_id);
+
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('G1 #2746: fresh-join coop snapshot phase_change carries version', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    // Drive orchestrator into world_setup so the per-socket connect snapshot
+    // emits a phase_change frame (reason: 'reconnect').
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    orch.submitCharacter(
+      p1.player_id,
+      { name: 'Bobby', form_id: 'istj_custode' },
+      { allPlayerIds: [p1.player_id] },
+    );
+    assert.equal(orch.phase, 'world_setup');
+
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await waitOpen(p1Ws);
+    // Snapshot phase_change is pushed right after hello on connect.
+    const snap = await waitForMessage(
+      p1Ws,
+      (m) => m.type === 'phase_change' && m.payload?.reason === 'reconnect',
+      2000,
+    );
+    assert.equal(snap.payload.phase, 'world_setup');
+    assert.equal(
+      typeof snap.version,
+      'number',
+      'fresh-join snapshot phase_change must carry version',
+    );
 
     p1Ws.close();
   } finally {


### PR DESCRIPTION
## Riferimento

Issue #2746 **voce G1** [P1] (SOLO G1 — G2/G3/G5 restano aperte nella issue, NON chiudere). Root cause deterministica del finding-1 di item-3 (creduto flaky): il phone Godot resta su schermo vuoto.

## Root cause

Tre emitter di `phase_change` sul canale coop-WS usavano `room.broadcast` **raw**, senza chiave `version`. Il client phone Godot (pre-GGv2 #471) scartava i frame non versionati come `unknown_type` → phone bloccato:

1. `broadcastCoopState` (`routes/coop.js`) — chiamato da tutti i path REST (`/coop/run/start`, `/coop/character/create`, `/coop/world/*`, `/coop/combat/end`, `/coop/debrief/choice`, `/coop/run/force-advance`, ...).
2. `rebroadcastCoopState` (`wsSession.js`) — host-transfer rebroadcast.
3. snapshot per-socket sul fresh-join (`wsSession.js` `sendCoopSnapshotToPlayer`).

## Fix (minimale, nessuna migration)

- **#1 + #2** (room broadcast → versionato): `room.publishEvent('phase_change', payload)` invece di `room.broadcast({type:'phase_change', payload})`. `publishEvent` version-stampa (`stateVersion += 1`) + ledger-records (resume replay) e fa il broadcast con lo **stesso payload ricco** (`buildPhaseChangePayload`: phase/round/scenario/session_id/campaign_id). `phase_change` non è reserved (`publishPhaseChange` stesso lo usa). Fallback `room.broadcast` raw difensivo se la room non ha `publishEvent`.
- **#3** (snapshot per-socket = `send` targetato): aggiunto `version: room.stateVersion ?? 0`. È un replay mirato sul socket che si connette, **non** un evento nuovo → riflette la versione corrente senza bump.

Scelta vs `publishPhaseChange`: scartata perché ha payload LEAN (no round/scenario), setta `room.phase` e ha gate `KNOWN_PHASES` — side-effect non voluti per il broadcast di stato. `publishEvent` versiona preservando il payload ricco, zero side-effect.

`character_ready_list`/`world_tally`/`route_choice` lasciati raw: l'issue G1 flagga solo `phase_change` come blocker.

## Test (TDD — rosso verificato prima del fix)

- **Nuovo** `tests/api/coopPhaseChangeVersioned.test.js` (+3): REST `broadcastCoopState` → `phase_change` con `version` numerico ≥1; payload ricco preservato (phase/round/scenario/campaign_id/session_id); version monotona su broadcast multipli. Harness = wrap di `room.broadcast` (cattura il frame interno di `publishEvent`).
- `tests/api/coopWsRebroadcast.test.js` (+2): host-transfer rebroadcast porta `version`; fresh-join snapshot porta `version`.
- RED pre-fix: 5 test rossi (no `version`).

```
tests/api/coopPhaseChangeVersioned.test.js   3/3  pass
tests/api/coopWsRebroadcast.test.js          3/3  pass
coop + WS + phase_change cluster            185/185 pass
tests/services/network/*.test.js             91/91 pass
tests/ai/*.test.js (DoD baseline)           510/510 pass
prettier --check (file toccati)              clean
```

## Changelog

- fix(coop): `phase_change` coop-WS broadcast versionato (broadcastCoopState + host-transfer rebroadcast + fresh-join snapshot) — il phone Godot non resta più su schermo vuoto per frame `unknown_type` (#2746 G1).

## Rollback plan (03A)

Revert del singolo commit (`git revert 3b9d2d90`): nessuna migration, nessun cambio schema/contracts. Superficie = 2 file backend (1 route + 1 service). Il fallback raw-broadcast preserva il comportamento legacy se `publishEvent` assente.

## Note governance

- `wsSession.js` non è in forbidden-path; tocca il canale coop-WS (sensibile) → girata la suite coop+WS completa (185+91 verde).
- Merge = Eduardo only. Dopo merge: commento su #2746 spuntando G1. G2/G3/G5 restano (PR successive).
