### PR TITLE
fix(taxonomy): align filamenti_digestivi_compattanti to canonical label

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -2604,7 +2604,7 @@
       "description_en": "Predatory psycho-physical state increasing aggression and offensive power under stress; favors consecutive multi-attacks."
     },
     "filamenti_digestivi_compattanti": {
-      "label_it": "Filamento materiali digeriti",
+      "label_it": "Filamenti Digestivi Compattanti",
       "label_en": "Digestive Compaction Filaments",
       "description_it": "Filamenti digestivi che compattano scarti e liberano spazio vitale.",
       "description_en": "Digestive filaments compact waste to free vital space."

--- a/packs/evo_tactics_pack/docs/catalog/trait_glossary.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_glossary.json
@@ -576,7 +576,7 @@
       "description_en": "Epitelio Fosforescente allow squads to synchronise allied organisms and mutualistic flows within reef luminescente."
     },
     "filamenti_digestivi_compattanti": {
-      "label_it": "Filamento materiali digeriti",
+      "label_it": "Filamenti Digestivi Compattanti",
       "label_en": "Digestive Compaction Filaments",
       "description_it": "Filamenti digestivi che compattano scarti e liberano spazio vitale.",
       "description_en": "Digestive filaments compact waste to free vital space."

--- a/packs/evo_tactics_pack/docs/catalog/trait_reference.json
+++ b/packs/evo_tactics_pack/docs/catalog/trait_reference.json
@@ -4148,7 +4148,7 @@
       }
     },
     "filamenti_digestivi_compattanti": {
-      "label": "Filamento materiali digeriti",
+      "label": "Filamenti Digestivi Compattanti",
       "famiglia_tipologia": "Digestivo/Escretorio",
       "fattore_mantenimento_energetico": "Basso (Passivo)",
       "tier": "T2",

--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,7 +1,7 @@
 # QA export changelog
 
-Generato: 2026-06-13T22:08:23.387724Z
-Baseline precedente: 2026-06-12T00:11:09.302609Z
+Generato: 2026-06-13T22:24:21.724133Z
+Baseline precedente: 2026-06-13T22:08:23.387724Z
 
 ## Metriche baseline
 - Tratti totali: 254 (0 vs precedente)

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-13T22:08:23.387724Z",
+  "generated_at": "2026-06-13T22:24:21.724133Z",
   "summary": {
     "total_traits": 254,
     "glossary_ok": 254,
@@ -14942,7 +14942,7 @@
     },
     {
       "id": "filamenti_digestivi_compattanti",
-      "label": "Filamento materiali digeriti",
+      "label": "Filamenti Digestivi Compattanti",
       "tier": "T2",
       "coverage": {
         "core": 8,


### PR DESCRIPTION
## Summary
- Resolves the Codex P2 on #2750 (post-merge): trait_reference's label 'Filamento materiali digeriti' for filamenti_digestivi_compattanti disagreed with the canonical catalog (data/traits/index.json + external aggregate), both of which use 'Filamenti Digestivi Compattanti'. The #2750 glossary export had propagated the reference label into the glossary, making the same trait show two names depending on the artifact read.
- Aligns the it-label in trait_reference.json + pack/core glossary to the canonical 'Filamenti Digestivi Compattanti' (label_en 'Digestive Compaction Filaments' kept). All canonical artifacts now agree; the next evo:import propagates the value to Game-Database (glossary now wins editorial precedence with a real label). QA baselines regenerated.
- 3 source files (1 line each) + QA. docs/public trait-glossary/trait-reference MIRRORS carry pre-existing staleness (unrelated, would add ~7k-line churn) and are deliberately NOT regenerated here -- flagged for a separate mirror-resync cleanup.

## Test plan
- [ ] evo-import-gate (round-trip) green.
- [ ] QA baselines gate green.
- [x] Diff = the single canonical label across the 3 source artifacts; UTF-8 preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)