### PR TITLE
fix(balance): re-ratify hc06 post-#2719 + per-PR combat oracle gate

### DIFF
--- a/.github/workflows/combat-balance-gate.yml
+++ b/.github/workflows/combat-balance-gate.yml
@@ -1,0 +1,124 @@
+name: Combat Balance Gate
+
+# Per-PR canonical balance-oracle gate (the missing guardrail behind #2719).
+#
+# WHY: docs/process/CANONICAL-AI-PLAYTEST.md sec 5 declares the merge gate as
+# "touched-scenario WR in-band @ N=40", but it was never wired per-PR -- only
+# the weekly playtest-2 sweep existed. So PR #2719 (a CORRECT channel-routing
+# fix) silently pushed canonical oracle hardcore_06 from 17% to 53% WR and sat
+# undetected for days (caught later by a forensic N=100 sweep + git-bisect).
+# With the reconstruction suite (SPEC A..Q) shipping combat changes ~daily,
+# this WILL recur. This gate re-runs the canonical oracles on combat-touching
+# PRs and surfaces any band drift before merge.
+#
+# Determinism: the canonical runner pins seed 424242 and splits it across
+# --shards 4 (per-shard seed offsets). CI MUST use the SAME shards count + seed
+# as ratification, else the sampled runs differ. Do not change --shards here
+# without re-ratifying the bands. host 127.0.0.1 + LOBBY_WS_ENABLED=false +
+# DAMAGE_CURVES_PATH are all handled inside playtest_canonical.py.
+#
+# PHASE 1 (current): warn-only. The job carries `continue-on-error: true` and
+# the verdict step emits a ::warning:: (never blocks merge). Reason: hc07 is
+# still marginally OOB (52% vs [30-50], #2719-independent, un-bisected) so a
+# blocking gate would freeze merges on a pre-existing issue.
+# PHASE 2 (flip once hc07 is in-band): remove `continue-on-error` and change the
+# verdict step's ::warning:: -> ::error:: + `exit 1`. Then register this as a
+# required status check in branch protection.
+#
+# Band-invalidation protocol (correct-fix shifts a band): see
+# docs/process/CANONICAL-AI-PLAYTEST.md sec 9 -- block + human re-ratify, never
+# auto-update target_band.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/backend/services/combat/**'
+      - 'apps/backend/routes/session*.js'
+      - 'apps/backend/services/ai/**'
+      - 'apps/backend/services/hardcoreScenario.js'
+      - 'apps/backend/services/tutorialScenario.js'
+      - 'data/core/balance/**'
+      - 'data/core/traits/active_effects.yaml'
+      - 'packs/evo_tactics_pack/data/balance/**'
+      - 'tools/py/batch_calibrate_hardcore*.py'
+      - 'tools/py/calibrate_parallel.py'
+      - 'tools/py/playtest_canonical.py'
+      - 'docs/playtest/canonical-suite.yaml'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  combat-oracle:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 25
+    continue-on-error: true # PHASE 1 warn-only. Remove for phase-2 blocking.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-pyyaml
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml
+
+      - name: Run canonical balance oracles (N=40, seed 424242, shards 4)
+        id: oracle
+        continue-on-error: true
+        env:
+          LOBBY_WS_ENABLED: 'false'
+          ORCHESTRATOR_AUTOCLOSE_MS: '2000'
+        run: |
+          mkdir -p /tmp/oracle
+          set +e
+          python tools/py/playtest_canonical.py \
+            --n 40 --shards 4 --base-port 3360 \
+            --label ci-${{ github.run_id }} \
+            --out-dir /tmp/oracle
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Write step summary
+        if: always()
+        run: |
+          echo "## Combat balance oracle (N=40, seed 424242)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/oracle/ci-${{ github.run_id }}-canonical-suite.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
+            || echo "(no report produced -- the oracle run failed before writing; see job log)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload oracle report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: combat-oracle-${{ github.run_id }}
+          path: /tmp/oracle/
+          retention-days: 14
+
+      - name: Verdict (phase 1 = warn-only)
+        if: always()
+        run: |
+          if [ "${{ steps.oracle.outputs.exit_code }}" != "0" ]; then
+            echo "::warning title=Combat balance oracle out-of-band::A canonical oracle WR left its ratified band (see step summary). If this PR is a correct combat fix, follow the band re-ratify protocol: docs/process/CANONICAL-AI-PLAYTEST.md sec 9. PHASE 1 = warn-only, not blocking."
+          else
+            echo "All canonical oracles in-band."
+          fi

--- a/data/core/balance/damage_curves.yaml
+++ b/data/core/balance/damage_curves.yaml
@@ -250,15 +250,23 @@ player_classes:
 
 scenario_overrides:
   enc_tutorial_06_hardcore:
-    # iter5 OPTUNA REJECTED (2026-05-21): Method A TPE 3-trial converged
-    # boss 0.866 + limit 31 → N=20 WR 15% BUT N=40 ratify → WR 30% OOB-high.
-    # L-073 META-LESSON: Optuna optimized on N=20 objective = converged to
-    # noise (trial 1 lucky-low 3/20). Optimizer inherited L-069 flaw.
-    # Rollback iter5. iter2 (boss 0.65 alone) restored = N=40 WR 15% confirmed.
-    # FUTURE: Optuna n_per_trial MUST be >=40 OR converges to noise.
-    # Vedi docs/playtest/2026-05-21-optuna-l073-noise-convergence.md
-    boss_hp_multiplier: 0.65
-    rationale: 'iter2 N=40 WR 15% in-band primary RESTORED. iter5 Optuna (boss 0.866 + limit 31) REJECTED N=40 WR 30% OOB-high (L-073 optimizer-on-noise). Secondary metrics (defeat 85%) deferred Sprint M14 N=40-objective Optuna OR MAP-Elites.'
+    # RE-RATIFY 2026-06-14 (post-#2719): boss_hp_multiplier 0.65 -> 1.04.
+    # git-bisect proved #2719 f5387e66 (channel-routing fix: /round/execute now
+    # honors action.channel) flipped hc06 17% (parent #2717) -> 51% OOB. The
+    # greedy policy's `psionico` exploit vs the corazzato boss/elites was a no-op
+    # under the prior bug (every round attack was physical); the fix unlocked it
+    # -> 0.65 too weak. The 15-25% band had been ratified UNDER the bug. Forensic
+    # N=100 @ canonical seed 424242: boss 1.04 -> WR 22% (def 78%, timeout 0%) =
+    # all 3 class bands met. Lever is STEEP near band (1.0->27%, 1.05->12.5% N=40)
+    # -> the combat-balance CI gate + band-invalidation protocol
+    # (docs/process/CANONICAL-AI-PLAYTEST.md sec 9) guard recurrence.
+    # Evidence: docs/playtest/2026-06-14-canonical-forensic-n100.md
+    # --- HISTORY (pre-#2719, channel-bug era; band measured under the bug) ---
+    # iter5 OPTUNA REJECTED (2026-05-21): boss 0.866+limit 31 -> N=40 WR 30% OOB
+    # (L-073 optimizer-on-N=20-noise). iter2 (boss 0.65) = N=40 WR 15% confirmed
+    # BUT under the channel bug. docs/playtest/2026-05-21-optuna-l073-noise-convergence.md
+    boss_hp_multiplier: 1.04
+    rationale: 'RE-RATIFIED 2026-06-14 post-#2719 (channel-routing fix): boss_hp_multiplier 0.65 -> 1.04. git-bisect root-caused the 0.65 -> 53% drift to #2719 unlocking the greedy psionico exploit (band was ratified under the channel bug). Forensic N=100 seed 424242: WR 22% in-band [15-25], defeat 78% [75-85], timeout 0% [0-5]. Steep lever near band; CI gate guards recurrence. Pre-#2719 history: iter2 boss 0.65 = WR 15% (measured under the bug).'
 
   enc_tutorial_07_hardcore_pod_rush:
     # 3A iter2 (2026-05-21): enemy_damage_multiplier_override 2.2 (REPLACES

--- a/docs/playtest/2026-06-14-canonical-forensic-n100.md
+++ b/docs/playtest/2026-06-14-canonical-forensic-n100.md
@@ -2,12 +2,13 @@
 
 > Date: 2026-06-14 | PC: Lenovo (edusc) | Commit: `eb78814d` (origin/main) | Worktree: `Game-forensic` (clean)
 > Method: canonical suite-runner `playtest_canonical.py --n 100 --shards 4` (forensic tier, L-073), seed `424242` (pinned, reproducible).
-> Verdict: **BOTH OUT-OF-BAND (high)**. hc06 = **hard regression** (53% vs 15-25%). hc07 = **marginal** (52% vs 30-50%, within CI of ceiling). Difficulty ladder **collapsed/flattened**.
-> Action: **diagnosis + flag only — NO knob applied** (L-070/L-073: tuning is master-dd's). Re-tune/re-ratify gated on master-dd.
+> Verdict: **BOTH OUT-OF-BAND (high)**. hc06 = **53% vs 15-25%**. hc07 = **52% vs 30-50%** (marginal, within CI of ceiling). Difficulty ladder **flattened**.
+> Root cause: **CONFIRMED by git-bisect = #2719 `f5387e66`** (channel-routing fix). Parent #2717 = 17% in-band → #2719 = 51% OOB. The fix is correct; the band was ratified under the prior bug. **#2725 ER1 = REFUTED** (A/B inert).
+> Action: **diagnosis only — NO knob applied** (L-070/L-073: tuning is master-dd's). Recommended = **re-tune + re-ratify hc06 at N=40** against post-#2719 combat. Do NOT revert #2719.
 
 ## TL;DR
 
-Forensic N=100 of the two canonical `balance_oracle` scenarios on current `origin/main` shows **both scenarios sit at a ~52-53% coin-flip win rate**, well above their ratified bands. The intended difficulty ladder (hc06 should be the _hardest_ scenario at 15-25%, hc07 easier at 30-50%) has **inverted/flattened**: hc06 ≈ hc07 ≈ coin-flip. The uniform upward shift (large on the elimination scenario, small on the timer scenario) points to a **global combat-power change since the ratify dates (~2026-05-26)** rather than a per-scenario knob drift. This is a metric-first diagnosis; root-cause confirmation + any tuning is deferred to master-dd.
+Forensic N=100 of the two canonical `balance_oracle` scenarios on current `origin/main` shows **both scenarios sit at a ~52-53% coin-flip win rate**, well above their ratified bands. The intended difficulty ladder (hc06 should be the _hardest_ scenario at 15-25%, hc07 easier at 30-50%) has **inverted/flattened**: hc06 ≈ hc07 ≈ coin-flip. The uniform upward shift (large on the elimination scenario, small on the timer scenario) pointed to a global combat change; **git-bisect confirms it = a single commit, #2719 (`f5387e66`), a channel-routing _bug fix_** that unlocked the hc06 policy's `psionico` exploit against the armored boss/elites (parent #2717 = 17% in-band → #2719 = 51% OOB at N=100). The band was ratified under the prior bug, so it is now stale. Any tuning/re-ratify is deferred to master-dd.
 
 ## Results (N=100, seed 424242, greedy policy)
 
@@ -52,21 +53,25 @@ Composite metric (`0.50·WR + 0.25·KD + 0.25·PE`, anti false-balanced):
 - The ladder no longer discriminates difficulty: the scenario meant to be the _punishing_ one (hc06) is now **as winnable as the easier one**. hc06 has lost its identity.
 - The **asymmetry is itself diagnostic**: a global player-buff / enemy-nerf differentially inflates an _elimination_ scenario (hc06, kill-gated → +28pp) far more than a _timer_ scenario (hc07, clock-gated → +2pp). This is the signature of a **combat-power shift**, not two independent per-scenario config drifts.
 
-## Root-cause hypotheses (FLAG for master-dd — NOT confirmed, NOT bisected)
+## Root cause — CONFIRMED by git-bisect (`a81fe108`..`eb78814d`, 281 commits)
 
-The regression is on `eb78814d` vs the ratify state (hc06 #2381, ~2026-05-26). Combat-touching commits landed since then; the uniform-upward-shift signature points at a **global** change. Top candidates to investigate first (highest blast-radius on raw combat power):
+Bisected with the identical harness (seed 424242, greedy, N=40/step → N=100 confirm on the boundary pair). Exact flip pinpointed at **one commit**:
 
-1. **#2725 `28690f9b` — "SPEC-I ER1/ER6 N=40 gates PASSED — role-aware harness + flip default ON"**: an ER1 _role-gap_ combat effect was **flipped from default-OFF to default-ON**. A combat modifier newly active in every fight is the strongest single suspect for a uniform WR lift. _(Cross-check: was the N=40 gate that flipped it run against the canonical hardcore oracles, or only its own SPEC-I harness? If the latter, hc06/hc07 were never re-checked post-flip.)_
-2. **#2720 `e1064339` / #2714 / #2535 — OD-058 wound system cutover (flip ON)**: location→stat-malus. If wounds land asymmetrically (or the cutover changed enemy effectiveness), it shifts combat power.
-3. **#2698 `c81d1ec8` — data-derived `agile_robust` / base-stats bounds**: touches the stat source (hp/speed) feeding units.
-4. **#2719 `f5387e66` — trait resistances mirror + channel-routing round path**: changes how channel/resistance routing resolves damage.
+| Commit                                                                                        | hc06 WR (N=100) | Band 15-25% |
+| --------------------------------------------------------------------------------------------- | --------------- | ----------- |
+| `a81fe108` (2026-05-30 baseline)                                                              | 16.0%           | in-band ✓   |
+| `7f39b3bd` (#2717, parent of culprit)                                                         | **17.0%**       | in-band ✓   |
+| **`f5387e66` (#2719)** — `fix(combat): trait resistances mirror + channel routing round path` | **51.0%**       | **OOB ✗**   |
 
-Lower-prior (claimed band-neutral at ship, but worth a sanity re-check now): economy gates #2557/#2555, PHASEC perks, A13/ER read-side eco effects.
+**Mechanism** (from the #2719 commit body + the hc06 policy): #2719's "Root-cause 2" fixed `/round/execute`, which **was not passing `action.channel` to `handleLegacyAttackViaRound` → every round attack resolved as `fisico` (physical)**. The hc06 batch policy (`CHANNEL_EXPLOIT_MAP`) attacks the boss + elite hunters with **`psionico`** to exploit their `corazzato` (armored) weakness. Under the bug those attacks were silently downgraded to physical → armor resisted → scenario hard (17%). Post-fix the psionico exploit lands → boss/elites melt → scenario easy (51%).
 
-> **Recommended first step (master-dd):** before any re-tune, confirm whether the global combat shift is _intended_ (e.g., ER1-ON is a deliberate new baseline) or _accidental_. The fix differs:
->
-> - **Accidental** → identify/correct the offending change; re-run this N=100 to confirm the bands return.
-> - **Intended/permanent** → the ratified bands are stale; **re-ratify** the scenario knobs at N=40 against the new baseline.
+**This is a legitimate bug fix, NOT a break — do not revert #2719.** The consequence is that the hc06 band (15-25%) was **ratified under the channel-routing bug** (all-physical round combat) and is now stale. Correct action = **re-tune + re-ratify** hc06 against post-#2719 (correct) channel routing.
+
+**REFUTED suspects** (tested, ruled out — not hand-waved):
+
+- **#2725 ER1 role-gap (default-ON flip)** — A/B with `ERMES_ROLE_GAP_ENABLED=false` gave **byte-identical** results (0/100 runs changed). ER1 (`session.js:1844`) only fires inside the biome-eco path: it needs a `biome_id` **and** party `job`s in `BIOME_ROLE_DEMANDS`; the hc06 batch passes neither → inert. That same biome-gated block makes **#2720 wound-cutover / #2535 / A13 / ER2** almost certainly inert for hc06 too (no `biome_id` in the batch).
+
+> ⚠️ **Broader flag:** the channel-routing bug was live through an entire calibration era (until #2719, 2026-06-10). Any balance band ratified before that date — measured under all-physical round combat — may be **stale** wherever the player/AI policy relied on channel exploits. hc07 (+2pp, timer-gated) is only marginally affected; re-check any other oracle the same way.
 
 ## Proposed knobs — _diagnosis-derived directions, NOT applied_ (tuning = master-dd, L-070/L-073)
 

--- a/docs/playtest/2026-06-14-canonical-forensic-n100.md
+++ b/docs/playtest/2026-06-14-canonical-forensic-n100.md
@@ -1,0 +1,86 @@
+# Canonical AI-driven playtest — Forensic N=100 sweep (hardcore_06 + hardcore_07)
+
+> Date: 2026-06-14 | PC: Lenovo (edusc) | Commit: `eb78814d` (origin/main) | Worktree: `Game-forensic` (clean)
+> Method: canonical suite-runner `playtest_canonical.py --n 100 --shards 4` (forensic tier, L-073), seed `424242` (pinned, reproducible).
+> Verdict: **BOTH OUT-OF-BAND (high)**. hc06 = **hard regression** (53% vs 15-25%). hc07 = **marginal** (52% vs 30-50%, within CI of ceiling). Difficulty ladder **collapsed/flattened**.
+> Action: **diagnosis + flag only — NO knob applied** (L-070/L-073: tuning is master-dd's). Re-tune/re-ratify gated on master-dd.
+
+## TL;DR
+
+Forensic N=100 of the two canonical `balance_oracle` scenarios on current `origin/main` shows **both scenarios sit at a ~52-53% coin-flip win rate**, well above their ratified bands. The intended difficulty ladder (hc06 should be the _hardest_ scenario at 15-25%, hc07 easier at 30-50%) has **inverted/flattened**: hc06 ≈ hc07 ≈ coin-flip. The uniform upward shift (large on the elimination scenario, small on the timer scenario) points to a **global combat-power change since the ratify dates (~2026-05-26)** rather than a per-scenario knob drift. This is a metric-first diagnosis; root-cause confirmation + any tuning is deferred to master-dd.
+
+## Results (N=100, seed 424242, greedy policy)
+
+| Scenario                            | Role           | Target band | WR (N=100) | CI95 (±10pp)            | In-band                     | Ratified knob                           |
+| ----------------------------------- | -------------- | ----------- | ---------- | ----------------------- | --------------------------- | --------------------------------------- |
+| `enc_tutorial_06_hardcore`          | balance_oracle | **15-25%**  | **53.0%**  | ±9.8pp → [43.2%, 62.8%] | **NO** (+28pp over ceiling) | `boss_hp_multiplier: 0.65`              |
+| `enc_tutorial_07_hardcore_pod_rush` | balance_oracle | **30-50%**  | **52.0%**  | ±9.8pp → [42.2%, 61.8%] | **NO** (+2pp over ceiling)  | `enemy_damage_multiplier_override: 2.1` |
+
+- **hc06**: CI95 lower bound (43.2%) is **18pp above the band ceiling (25%)** → robust, unambiguous regression, not a sampling fluke.
+- **hc07**: CI95 [42.2%, 61.8%] **straddles the 50% ceiling** → only marginally out; statistically consistent with sitting _at_ its ceiling. Mild upward lean, not a catastrophe.
+
+Composite metric (`0.50·WR + 0.25·KD + 0.25·PE`, anti false-balanced):
+
+| Scenario | WR   | KD_avg                               | PE (party-survive proxy) | Reading                                                         |
+| -------- | ---- | ------------------------------------ | ------------------------ | --------------------------------------------------------------- |
+| hc06     | 0.53 | 2.98                                 | 0.72 (5.8/8 alive)       | All three axes high → genuinely **too easy**, not a WR artifact |
+| hc07     | 0.52 | n/a (objective scenario, no elim KD) | 0.37                     | WR/timer-gated; KD/PE not elimination-meaningful                |
+
+## Metric-first diagnosis (SoT §1.3 — _before_ touching any knob)
+
+### hardcore_06 — elimination, HARD regression
+
+- timeout **0%** (band 0-5% ✓) → **not a timer problem**; `turn_limit_defeat=25` is firing correctly (losses cap at turn 25, wins resolve ~turn 20).
+- defeat 47% / victory 53%; turns med 25 (loss) vs ~20 (win).
+- `dmg_taken_avg = 24.1` of a **90-HP party pool** (only 27% chipped); `players_alive_on_win = 6/8`; `kd_avg = 2.98` (party kills ~3× more than it loses).
+- `boss_hp_remaining`: **0 on win** (boss cleared), 9.3 on loss (~55% of eff-HP ~16.9 = 26×0.65).
+- **SoT §1.3 match**: _"WR alto + boss residual <10% → DPR insufficiente nemico → enemy_damage_multiplier"_. On wins the boss residual is 0; the party survives near-untouched and grinds the roster down. → **Enemies under-pressure the party / party over-survives.** The scenario lost its lethality.
+
+### hardcore_07 — pod-rush timer, marginal
+
+- defeat **0%**, **timeout 48%**, victory 52%; turns max 15 (mission timer); elimination metrics (KD/dmg) not emitted (objective scenario).
+- **SoT §1.3 match**: _"Timeout high + turns=max → timer"_. This is a **timer race**: 52% reach the objective inside 15 turns, 48% time out. WR is gated by the clock, not by kills — which is exactly why a global combat-power buff barely moves it (+2pp) while it swings hc06 hard (+28pp).
+
+## Cross-scenario fairness / metagame-lock
+
+|                | Designed              | Observed (N=100)                     |
+| -------------- | --------------------- | ------------------------------------ |
+| hc06 (hardest) | 15-25%                | **53%**                              |
+| hc07 (easier)  | 30-50%                | **52%**                              |
+| Ordering       | hc06_WR **<** hc07_WR | hc06 ≈ hc07 (**flattened/inverted**) |
+
+- The ladder no longer discriminates difficulty: the scenario meant to be the _punishing_ one (hc06) is now **as winnable as the easier one**. hc06 has lost its identity.
+- The **asymmetry is itself diagnostic**: a global player-buff / enemy-nerf differentially inflates an _elimination_ scenario (hc06, kill-gated → +28pp) far more than a _timer_ scenario (hc07, clock-gated → +2pp). This is the signature of a **combat-power shift**, not two independent per-scenario config drifts.
+
+## Root-cause hypotheses (FLAG for master-dd — NOT confirmed, NOT bisected)
+
+The regression is on `eb78814d` vs the ratify state (hc06 #2381, ~2026-05-26). Combat-touching commits landed since then; the uniform-upward-shift signature points at a **global** change. Top candidates to investigate first (highest blast-radius on raw combat power):
+
+1. **#2725 `28690f9b` — "SPEC-I ER1/ER6 N=40 gates PASSED — role-aware harness + flip default ON"**: an ER1 _role-gap_ combat effect was **flipped from default-OFF to default-ON**. A combat modifier newly active in every fight is the strongest single suspect for a uniform WR lift. _(Cross-check: was the N=40 gate that flipped it run against the canonical hardcore oracles, or only its own SPEC-I harness? If the latter, hc06/hc07 were never re-checked post-flip.)_
+2. **#2720 `e1064339` / #2714 / #2535 — OD-058 wound system cutover (flip ON)**: location→stat-malus. If wounds land asymmetrically (or the cutover changed enemy effectiveness), it shifts combat power.
+3. **#2698 `c81d1ec8` — data-derived `agile_robust` / base-stats bounds**: touches the stat source (hp/speed) feeding units.
+4. **#2719 `f5387e66` — trait resistances mirror + channel-routing round path**: changes how channel/resistance routing resolves damage.
+
+Lower-prior (claimed band-neutral at ship, but worth a sanity re-check now): economy gates #2557/#2555, PHASEC perks, A13/ER read-side eco effects.
+
+> **Recommended first step (master-dd):** before any re-tune, confirm whether the global combat shift is _intended_ (e.g., ER1-ON is a deliberate new baseline) or _accidental_. The fix differs:
+>
+> - **Accidental** → identify/correct the offending change; re-run this N=100 to confirm the bands return.
+> - **Intended/permanent** → the ratified bands are stale; **re-ratify** the scenario knobs at N=40 against the new baseline.
+
+## Proposed knobs — _diagnosis-derived directions, NOT applied_ (tuning = master-dd, L-070/L-073)
+
+- **hc06**: raise enemy pressure to restore lethality — e.g. add an `enemy_damage_multiplier_override` for `enc_tutorial_06_hardcore` (currently none; inherits class), and/or revisit `boss_hp_multiplier` 0.65 upward. **Multi-knob discipline (L-070):** do NOT move two knobs together without an N=10 probe between them (the iter3 `turn_limit null` overshoot to 85% is the cautionary precedent). Prefer single-knob bisection.
+- **hc07**: **no action recommended on this evidence** — +2pp over ceiling is within CI95 of the band edge. If tightened later, it is timer-gated (tune `mission_timer`/`turn_limit` or enemy pressure), but re-probe at N=40 first; do not tune on a marginal forensic.
+
+## Reproducibility contract (SoT §3)
+
+- Command: `python tools/py/playtest_canonical.py --n 100 --shards 4 --base-port 3341 --label forensic-n100`
+- Commit `eb78814d`; seed `424242` (manifest `seed_pinned: true`); host `127.0.0.1`; `LOBBY_WS_ENABLED=false`; `DAMAGE_CURVES_PATH` pinned to `data/core/balance/damage_curves.yaml` (knobs verified present: hc06 `boss_hp_multiplier: 0.65` L260, hc07 `enemy_damage_multiplier_override: 2.1` L269).
+- pre-batch gate run: predictCombat sanity (player→enemy hit 45-65% exp_dmg ~1.0-1.55/hit; enemy→player hit 50-60%; party DPR ~8.6/round vs enemy eff-HP ~47 → config non-degenerate) + live N=2 chain smoke (0 failures, deterministic: seed-424242 run = defeat boss_hp 6, reproduced exactly in the N=100 sweep).
+- Evidence: `docs/playtest/_canonical-work-forensic-n100/parallel-hardcore_0{6,7}-forensic-n100-merged.json` (100 runs each) + `docs/playtest/forensic-n100-canonical-suite.{md,json}`.
+
+## Method caveats
+
+- **Single-policy (greedy):** the canonical suite-runner drives the **greedy** player policy only (the bands were ratified the same way). The multi-policy triangulation band (random/lookahead2/utility, SoT §1.1) is a **separate tool** (`--policy all`) and was **not** run here. The numbers above are the greedy/ceiling-local proxy. A full per-policy band is a useful follow-up if master-dd wants the skill-vs-luck spread.
+- **Data-integrity note:** an initial run accidentally double-wrote hc06's append-mode JSONL (label reuse → 200 dup runs; WR ratio unchanged but CI understated). The reported figures are from a **clean re-run** (work dir cleared first) verified at exactly n=100 per scenario.

--- a/docs/playtest/2026-06-14-canonical-forensic-n100.md
+++ b/docs/playtest/2026-06-14-canonical-forensic-n100.md
@@ -4,11 +4,11 @@
 > Method: canonical suite-runner `playtest_canonical.py --n 100 --shards 4` (forensic tier, L-073), seed `424242` (pinned, reproducible).
 > Verdict: **BOTH OUT-OF-BAND (high)**. hc06 = **53% vs 15-25%**. hc07 = **52% vs 30-50%** (marginal, within CI of ceiling). Difficulty ladder **flattened**.
 > Root cause: **CONFIRMED by git-bisect = #2719 `f5387e66`** (channel-routing fix). Parent #2717 = 17% in-band → #2719 = 51% OOB. The fix is correct; the band was ratified under the prior bug. **#2725 ER1 = REFUTED** (A/B inert).
-> Action: **diagnosis only — NO knob applied** (L-070/L-073: tuning is master-dd's). Recommended = **re-tune + re-ratify hc06 at N=40** against post-#2719 combat. Do NOT revert #2719.
+> Resolution (this PR): hc06 re-tuned **`boss_hp_multiplier` 0.65 -> 1.04** (forensic N=100 WR **22%**, def 78%, timeout 0% — all 3 class bands) + per-PR **CI balance gate** (`.github/workflows/combat-balance-gate.yml`, phase-1 warn) + band-invalidation protocol (SoT §9). hc07 = marginal, #2719-independent (separate follow-up). **Do NOT revert #2719.** Knob value calibrated at N≥40 / ratified N=100 (L-073), not chosen blindly.
 
 ## TL;DR
 
-Forensic N=100 of the two canonical `balance_oracle` scenarios on current `origin/main` shows **both scenarios sit at a ~52-53% coin-flip win rate**, well above their ratified bands. The intended difficulty ladder (hc06 should be the _hardest_ scenario at 15-25%, hc07 easier at 30-50%) has **inverted/flattened**: hc06 ≈ hc07 ≈ coin-flip. The uniform upward shift (large on the elimination scenario, small on the timer scenario) pointed to a global combat change; **git-bisect confirms it = a single commit, #2719 (`f5387e66`), a channel-routing _bug fix_** that unlocked the hc06 policy's `psionico` exploit against the armored boss/elites (parent #2717 = 17% in-band → #2719 = 51% OOB at N=100). The band was ratified under the prior bug, so it is now stale. Any tuning/re-ratify is deferred to master-dd.
+Forensic N=100 of the two canonical `balance_oracle` scenarios on current `origin/main` shows **both scenarios sit at a ~52-53% coin-flip win rate**, well above their ratified bands. The intended difficulty ladder (hc06 should be the _hardest_ scenario at 15-25%, hc07 easier at 30-50%) has **inverted/flattened**: hc06 ≈ hc07 ≈ coin-flip. The uniform upward shift (large on the elimination scenario, small on the timer scenario) pointed to a global combat change; **git-bisect confirms it = a single commit, #2719 (`f5387e66`), a channel-routing _bug fix_** that unlocked the hc06 policy's `psionico` exploit against the armored boss/elites (parent #2717 = 17% in-band → #2719 = 51% OOB at N=100). The band was ratified under the prior bug, so it was stale. **Resolved in this PR** — hc06 re-tuned (`boss_hp_multiplier` 0.65 -> 1.04, N=100 WR 22%) + a per-PR CI balance gate so this can't silently recur (see Resolution). Merge = master-dd.
 
 ## Results (N=100, seed 424242, greedy policy)
 
@@ -65,7 +65,7 @@ Bisected with the identical harness (seed 424242, greedy, N=40/step → N=100 co
 
 **Mechanism** (from the #2719 commit body + the hc06 policy): #2719's "Root-cause 2" fixed `/round/execute`, which **was not passing `action.channel` to `handleLegacyAttackViaRound` → every round attack resolved as `fisico` (physical)**. The hc06 batch policy (`CHANNEL_EXPLOIT_MAP`) attacks the boss + elite hunters with **`psionico`** to exploit their `corazzato` (armored) weakness. Under the bug those attacks were silently downgraded to physical → armor resisted → scenario hard (17%). Post-fix the psionico exploit lands → boss/elites melt → scenario easy (51%).
 
-**This is a legitimate bug fix, NOT a break — do not revert #2719.** The consequence is that the hc06 band (15-25%) was **ratified under the channel-routing bug** (all-physical round combat) and is now stale. Correct action = **re-tune + re-ratify** hc06 against post-#2719 (correct) channel routing.
+**This is a legitimate bug fix, NOT a break — do not revert #2719.** The consequence is that the hc06 band (15-25%) was **ratified under the channel-routing bug** (all-physical round combat) and is now stale. Correct action = **re-tune + re-ratify** hc06 against post-#2719 (correct) channel routing — **done in this PR** (see Resolution).
 
 **REFUTED suspects** (tested, ruled out — not hand-waved):
 
@@ -77,6 +77,37 @@ Bisected with the identical harness (seed 424242, greedy, N=40/step → N=100 co
 
 - **hc06**: raise enemy pressure to restore lethality — e.g. add an `enemy_damage_multiplier_override` for `enc_tutorial_06_hardcore` (currently none; inherits class), and/or revisit `boss_hp_multiplier` 0.65 upward. **Multi-knob discipline (L-070):** do NOT move two knobs together without an N=10 probe between them (the iter3 `turn_limit null` overshoot to 85% is the cautionary precedent). Prefer single-knob bisection.
 - **hc07**: **no action recommended on this evidence** — +2pp over ceiling is within CI95 of the band edge. If tightened later, it is timer-gated (tune `mission_timer`/`turn_limit` or enemy pressure), but re-probe at N=40 first; do not tune on a marginal forensic.
+
+## Resolution (this PR)
+
+### 1. hc06 re-tuned (evidence, not blind)
+
+`boss_hp_multiplier 0.65 -> 1.04` in `data/core/balance/damage_curves.yaml`, calibrated against post-#2719 (correct) combat:
+
+| boss_hp_multiplier | WR (N=40) | WR (N=100) | verdict                                               |
+| ------------------ | --------- | ---------- | ----------------------------------------------------- |
+| 0.65 (old)         | —         | 53%        | OOB-high                                              |
+| 1.0                | 20%       | 27%        | edge / OOB-high                                       |
+| **1.04 (new)**     | **20%**   | **22%**    | **in-band** (def 78%, timeout 0% — all 3 class bands) |
+| 1.05               | 12.5%     | —          | OOB-low                                               |
+
+The lever is **steep** near the band (1.0->27%, 1.05->12.5%), so the value was chosen at the band centre (22% @ N=100) for maximum margin. L-073 respected: candidate picked at N>=40, ratified at N=100, never N<=20. `canonical-suite.yaml` updated (`ratified_knob` + `last_wr_n40` + `status`).
+
+### 2. Systemic guardrail (so it doesn't recur)
+
+Root gap: the SoT (§5) declared a merge gate but it was **never wired per-PR** (only a weekly playtest-2 sweep existed). With SPEC A..Q churning combat ~daily, silent band-invalidation recurs by default. Added:
+
+- **`.github/workflows/combat-balance-gate.yml`** — per-PR gate, path-filtered to combat code/data, runs the canonical oracles (N=40, seed 424242, **shards 4 = same as ratification = deterministic**). **Phase 1 = warn-only** (`continue-on-error`) because hc07 is still marginally OOB; flip to blocking once hc07 is in-band.
+- **Band-invalidation protocol** (`CANONICAL-AI-PLAYTEST.md` §9): a correct fix that shifts a band ⇒ block + human re-ratify, **never** auto-update the band (Stockfish-fishtest discipline).
+- **Follow-up (documented, not built)**: also gate a `random`-policy band (mechanic-robust, already in `--policy all`) so a single-mechanic fix can't silently move the oracle — hc06's fragility came from the greedy policy hardcoding the channel exploit (`CHANNEL_EXPLOIT_MAP`).
+
+### hc07 status
+
+52% (band 30-50%), CI95 [42,62] straddling the ceiling. Policy is `fisico`-only (no channel exploit) → **#2719-independent**; drifted from ~40% for an un-bisected reason. Marginal (+2pp), low priority → separate follow-up; the gate stays warn-only until it is resolved or re-ratified.
+
+### ⚠️ Forbidden-path flag
+
+This PR touches `.github/workflows/` (the CI guardrail) — a guarded path per repo policy — so it is **not auto-mergeable** and is surfaced for explicit review. The balance ratification (`damage_curves.yaml`) is also a master-dd merge gate. Review + merge = master-dd.
 
 ## Reproducibility contract (SoT §3)
 

--- a/docs/playtest/_canonical-work-forensic-n100/parallel-hardcore_06-forensic-n100-merged.json
+++ b/docs/playtest/_canonical-work-forensic-n100/parallel-hardcore_06-forensic-n100-merged.json
@@ -1,0 +1,3647 @@
+{
+  "scenario": "hardcore_06",
+  "scenario_id": "enc_tutorial_06_hardcore",
+  "target_band": [0.15, 0.25],
+  "total_n": 100,
+  "seed": 424242,
+  "shards": 4,
+  "n_per_shard": [25, 25, 25, 25],
+  "hosts": [
+    "http://127.0.0.1:3341",
+    "http://127.0.0.1:3342",
+    "http://127.0.0.1:3343",
+    "http://127.0.0.1:3344"
+  ],
+  "parallel_elapsed_sec": 21.264872074127197,
+  "serial_estimated_sec": 85.05948829650879,
+  "speedup_x": 4,
+  "method": "C-parallel-shards",
+  "method_ref": "docs/research/2026-05-20-calibration-knob-patterns-industry.md",
+  "aggregate": {
+    "N": 100,
+    "encounter_class": "hardcore",
+    "target_bands": {
+      "win_rate": [0.15, 0.25],
+      "defeat_rate": [0.75, 0.85],
+      "timeout_rate": [0.0, 0.05]
+    },
+    "verdict": "RED",
+    "verdict_reasons": [
+      "win_rate=0.53 out of band [0.15,0.25] (red)",
+      "defeat_rate=0.47 out of band [0.75,0.85] (red)"
+    ],
+    "win_rate": 0.53,
+    "defeat_rate": 0.47,
+    "timeout_rate": 0.0,
+    "win_count": 53,
+    "loss_count": 47,
+    "timeout_count": 0,
+    "turns_avg": 22.33,
+    "turns_median": 25.0,
+    "turns_stdev": 3.530028328498229,
+    "turns_min": 13,
+    "turns_max": 25,
+    "turns_hist": {
+      "1-5": 0,
+      "6-10": 0,
+      "11-15": 5,
+      "16-20": 26,
+      "21-30": 69,
+      "31-40": 0,
+      "41+": 0
+    },
+    "kd_avg": 2.9778333333333333,
+    "kd_median": 2.5,
+    "dmg_dealt_avg": 51.65,
+    "dmg_taken_avg": 24.14,
+    "boss_hp_remaining_avg_on_loss": 9.25531914893617,
+    "players_alive_avg_on_win": 6,
+    "ai_intent_distribution": {
+      "Critical|move": 476,
+      "Critical|unknown": 206,
+      "Critical|attack": 76,
+      "Apex|move": 760,
+      "Apex|attack": 1253,
+      "Apex|unknown": 250
+    },
+    "player_action_distribution": {
+      "move": 4922,
+      "unknown": 8775,
+      "attack": 3902,
+      "skip": 38
+    },
+    "trait_used_distribution": {
+      "zampe_a_molla": 26,
+      "status:wound": 66,
+      "status:slow_down": 96
+    }
+  },
+  "runs": [
+    {
+      "run": 0,
+      "seed": 424242,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 50,
+      "dmg_taken_player": 46,
+      "boss_hp_remaining": 6,
+      "pressure_final": 80,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Critical|attack": 8,
+        "Apex|move": 8,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 42,
+        "unknown": 99,
+        "attack": 36,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 1,
+      "seed": 424243,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 50,
+      "dmg_taken_player": 11,
+      "boss_hp_remaining": 6,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 11,
+        "Apex|move": 8
+      },
+      "player_action_tally": {
+        "move": 61,
+        "unknown": 129,
+        "attack": 41
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 2,
+      "seed": 424244,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 2,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 29,
+        "unknown": 57,
+        "attack": 50
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 3,
+      "seed": 424245,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 19,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 21,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Critical|attack": 2,
+        "Apex|attack": 12,
+        "Apex|move": 4,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 38,
+        "unknown": 68,
+        "attack": 35
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 4,
+      "seed": 424246,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 21,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 35,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 8,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 12,
+        "Apex|move": 6,
+        "Critical|attack": 4
+      },
+      "player_action_tally": {
+        "move": 64,
+        "unknown": 64,
+        "attack": 19
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 3
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 5,
+      "seed": 424247,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 22,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|unknown": 5,
+        "Apex|attack": 15,
+        "Apex|move": 4
+      },
+      "player_action_tally": {
+        "move": 43,
+        "unknown": 78,
+        "attack": 49
+      },
+      "trait_used_tally": {
+        "status:wound": 4,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 6,
+      "seed": 424248,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 44,
+      "dmg_taken_player": 35,
+      "boss_hp_remaining": 12,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Apex|move": 7,
+        "Apex|attack": 16,
+        "Critical|attack": 3,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 40,
+        "unknown": 91,
+        "attack": 40,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 7,
+      "seed": 424249,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 17,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 10,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 23,
+        "unknown": 101,
+        "attack": 44
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 8,
+      "seed": 424250,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 50,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 6,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 15,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 55,
+        "unknown": 111,
+        "attack": 42
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 3
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 9,
+      "seed": 424251,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 24,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 29,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 16,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 62,
+        "unknown": 71,
+        "attack": 42
+      },
+      "trait_used_tally": {
+        "status:wound": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 10,
+      "seed": 424252,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 50,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 6,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 12,
+        "Apex|attack": 8,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 77,
+        "unknown": 109,
+        "attack": 36
+      },
+      "trait_used_tally": {
+        "status:wound": 1,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 11,
+      "seed": 424253,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 9,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 11,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 49,
+        "unknown": 116,
+        "attack": 50
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 12,
+      "seed": 424254,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 15,
+      "players_alive": 8,
+      "players_dead": 0,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 7,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 8,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 25,
+        "unknown": 60,
+        "attack": 36
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 13,
+      "seed": 424255,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 48,
+      "dmg_taken_player": 43,
+      "boss_hp_remaining": 8,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 11,
+        "Apex|attack": 20,
+        "Critical|attack": 2,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 43,
+        "unknown": 95,
+        "attack": 39,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1,
+        "zampe_a_molla": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 14,
+      "seed": 424256,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 5,
+        "Apex|attack": 12,
+        "Apex|unknown": 3,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 26,
+        "unknown": 61,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1,
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 15,
+      "seed": 424257,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 53,
+      "dmg_taken_player": 39,
+      "boss_hp_remaining": 3,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 9,
+        "Apex|attack": 21,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 40,
+        "unknown": 88,
+        "attack": 43,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:wound": 3,
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 16,
+      "seed": 424258,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 24,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 9,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 10,
+        "Apex|unknown": 2,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 49,
+        "unknown": 117,
+        "attack": 48
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 17,
+      "seed": 424259,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 52,
+      "dmg_taken_player": 16,
+      "boss_hp_remaining": 4,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 9,
+        "Apex|attack": 9,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 60,
+        "unknown": 117,
+        "attack": 44
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 18,
+      "seed": 424260,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 48,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 8,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 11,
+        "Apex|attack": 15,
+        "Apex|unknown": 4
+      },
+      "player_action_tally": {
+        "move": 65,
+        "unknown": 84,
+        "attack": 47
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 19,
+      "seed": 424261,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 17,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 15,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 23,
+        "unknown": 60,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 20,
+      "seed": 424262,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 42,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 14,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|unknown": 4,
+        "Apex|attack": 12,
+        "Apex|move": 12
+      },
+      "player_action_tally": {
+        "move": 86,
+        "unknown": 87,
+        "attack": 30
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1,
+        "status:wound": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 21,
+      "seed": 424263,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 17,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 2,
+        "Apex|attack": 9,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 24,
+        "unknown": 88,
+        "attack": 39
+      },
+      "trait_used_tally": {
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 22,
+      "seed": 424264,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 16,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 8,
+        "Apex|unknown": 2,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 23,
+        "unknown": 87,
+        "attack": 39
+      },
+      "trait_used_tally": {
+        "status:wound": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 23,
+      "seed": 424265,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 46,
+      "dmg_taken_player": 21,
+      "boss_hp_remaining": 10,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 10,
+        "Apex|move": 13
+      },
+      "player_action_tally": {
+        "move": 82,
+        "unknown": 74,
+        "attack": 36,
+        "skip": 1
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 24,
+      "seed": 424266,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 40,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 16,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|unknown": 3,
+        "Apex|attack": 13,
+        "Apex|move": 17
+      },
+      "player_action_tally": {
+        "move": 59,
+        "unknown": 93,
+        "attack": 41
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 25,
+      "seed": 424267,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 48,
+      "dmg_taken_player": 22,
+      "boss_hp_remaining": 8,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|attack": 10,
+        "Apex|unknown": 3,
+        "Apex|move": 12
+      },
+      "player_action_tally": {
+        "move": 77,
+        "unknown": 92,
+        "attack": 35
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 26,
+      "seed": 424268,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 20,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 22,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 3,
+        "Apex|attack": 9,
+        "Apex|move": 5,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 47,
+        "unknown": 68,
+        "attack": 40,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 27,
+      "seed": 424269,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 47,
+      "dmg_taken_player": 40,
+      "boss_hp_remaining": 9,
+      "pressure_final": 80,
+      "ai_intent_tally": {
+        "Critical|move": 7,
+        "Critical|unknown": 2,
+        "Apex|move": 8,
+        "Apex|attack": 18,
+        "Apex|unknown": 2,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 69,
+        "unknown": 75,
+        "attack": 36,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:wound": 1,
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 28,
+      "seed": 424270,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 44,
+      "dmg_taken_player": 41,
+      "boss_hp_remaining": 12,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|attack": 17,
+        "Apex|move": 10,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 46,
+        "unknown": 89,
+        "attack": 34
+      },
+      "trait_used_tally": {
+        "status:wound": 2,
+        "status:slow_down": 1,
+        "zampe_a_molla": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 29,
+      "seed": 424271,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 10,
+        "Apex|unknown": 2,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 23,
+        "unknown": 100,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 30,
+      "seed": 424272,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 14,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 20,
+        "unknown": 94,
+        "attack": 41
+      },
+      "trait_used_tally": {
+        "status:wound": 1,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 31,
+      "seed": 424273,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 24,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 8,
+        "Apex|attack": 18,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 52,
+        "unknown": 105,
+        "attack": 36
+      },
+      "trait_used_tally": {
+        "status:wound": 6,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 32,
+      "seed": 424274,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 55,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 1,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|move": 17,
+        "Apex|attack": 15,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 52,
+        "unknown": 110,
+        "attack": 45
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 33,
+      "seed": 424275,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 39,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 17,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 10,
+        "Apex|attack": 10,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 60,
+        "unknown": 149,
+        "attack": 29
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 34,
+      "seed": 424276,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 33,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 6,
+        "Apex|attack": 13,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 34,
+        "unknown": 60,
+        "attack": 38,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:wound": 1,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 35,
+      "seed": 424277,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 29,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 4,
+        "Apex|attack": 13,
+        "Apex|move": 2
+      },
+      "player_action_tally": {
+        "move": 31,
+        "unknown": 74,
+        "attack": 39
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3,
+        "zampe_a_molla": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 36,
+      "seed": 424278,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 48,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 8,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 11,
+        "Apex|attack": 8,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 67,
+        "unknown": 103,
+        "attack": 33
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 37,
+      "seed": 424279,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 23,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 5,
+        "Apex|attack": 15,
+        "Apex|move": 9
+      },
+      "player_action_tally": {
+        "move": 60,
+        "unknown": 75,
+        "attack": 37,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1,
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 38,
+      "seed": 424280,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 15,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 4,
+        "Apex|attack": 8
+      },
+      "player_action_tally": {
+        "move": 23,
+        "unknown": 87,
+        "attack": 34
+      },
+      "trait_used_tally": {
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 39,
+      "seed": 424281,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 55,
+      "dmg_taken_player": 44,
+      "boss_hp_remaining": 1,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Apex|move": 11,
+        "Apex|attack": 18,
+        "Apex|unknown": 2,
+        "Critical|attack": 2
+      },
+      "player_action_tally": {
+        "move": 65,
+        "unknown": 71,
+        "attack": 33,
+        "skip": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 40,
+      "seed": 424282,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 17,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 22,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 5,
+        "Apex|attack": 11,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 33,
+        "unknown": 57,
+        "attack": 34
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 41,
+      "seed": 424283,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 53,
+      "dmg_taken_player": 36,
+      "boss_hp_remaining": 3,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 3,
+        "Apex|move": 10,
+        "Apex|attack": 16,
+        "Apex|unknown": 1,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 64,
+        "unknown": 65,
+        "attack": 38,
+        "skip": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 42,
+      "seed": 424284,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 13,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 6
+      },
+      "player_action_tally": {
+        "move": 23,
+        "unknown": 69,
+        "attack": 27
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 43,
+      "seed": 424285,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 31,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 18,
+        "Apex|move": 10
+      },
+      "player_action_tally": {
+        "move": 64,
+        "unknown": 71,
+        "attack": 36,
+        "skip": 2
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 44,
+      "seed": 424286,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 23,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 14,
+        "Apex|move": 8,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 41,
+        "unknown": 85,
+        "attack": 39,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 45,
+      "seed": 424287,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 45,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 11,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|unknown": 3,
+        "Apex|attack": 10,
+        "Apex|move": 11
+      },
+      "player_action_tally": {
+        "move": 78,
+        "unknown": 96,
+        "attack": 30
+      },
+      "trait_used_tally": {
+        "status:wound": 3
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 46,
+      "seed": 424288,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 20,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 9,
+        "Apex|unknown": 3,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 24,
+        "unknown": 100,
+        "attack": 48
+      },
+      "trait_used_tally": {
+        "status:wound": 1,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 47,
+      "seed": 424289,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 37,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 19,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 7,
+        "Critical|unknown": 2,
+        "Critical|attack": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 12,
+        "Apex|move": 3
+      },
+      "player_action_tally": {
+        "move": 38,
+        "unknown": 136,
+        "attack": 40
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 48,
+      "seed": 424290,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 22,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 5,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 41,
+        "unknown": 52,
+        "attack": 44,
+        "skip": 1
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 49,
+      "seed": 424291,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 47,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 9,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 11,
+        "Apex|attack": 9,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 69,
+        "unknown": 97,
+        "attack": 36
+      },
+      "trait_used_tally": {
+        "status:wound": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 50,
+      "seed": 424292,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 16,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 2,
+        "Apex|attack": 10,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 29,
+        "unknown": 38,
+        "attack": 44
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1,
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 51,
+      "seed": 424293,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 23,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 21,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 11,
+        "Apex|attack": 16,
+        "Apex|unknown": 4
+      },
+      "player_action_tally": {
+        "move": 61,
+        "unknown": 76,
+        "attack": 50
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 52,
+      "seed": 424294,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 45,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 11,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 11,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 69,
+        "unknown": 81,
+        "attack": 42
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 53,
+      "seed": 424295,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 49,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 7,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 9,
+        "Apex|attack": 10,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 34,
+        "unknown": 129,
+        "attack": 34,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 54,
+      "seed": 424296,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 23,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|move": 5,
+        "Apex|attack": 13,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 29,
+        "unknown": 64,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "status:wound": 2,
+        "zampe_a_molla": 1,
+        "status:slow_down": 3
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 55,
+      "seed": 424297,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 50,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 6,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 9,
+        "Apex|attack": 11,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 61,
+        "unknown": 130,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 56,
+      "seed": 424298,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 44,
+      "dmg_taken_player": 41,
+      "boss_hp_remaining": 12,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 8,
+        "Critical|unknown": 2,
+        "Critical|attack": 4,
+        "Apex|attack": 17,
+        "Apex|move": 7,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 71,
+        "unknown": 70,
+        "attack": 30,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2,
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 57,
+      "seed": 424299,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 24,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 9,
+        "Critical|unknown": 3,
+        "Apex|unknown": 3,
+        "Apex|attack": 8,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 49,
+        "unknown": 110,
+        "attack": 41
+      },
+      "trait_used_tally": {
+        "status:wound": 1,
+        "status:slow_down": 3
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 58,
+      "seed": 424300,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 24,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|unknown": 3,
+        "Apex|attack": 13,
+        "Apex|move": 9
+      },
+      "player_action_tally": {
+        "move": 56,
+        "unknown": 76,
+        "attack": 37,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1,
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 59,
+      "seed": 424301,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 48,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 8,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|attack": 12,
+        "Apex|unknown": 3,
+        "Apex|move": 8
+      },
+      "player_action_tally": {
+        "move": 62,
+        "unknown": 101,
+        "attack": 44
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1,
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 60,
+      "seed": 424302,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 20,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 2,
+        "Apex|attack": 12,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 24,
+        "unknown": 96,
+        "attack": 50
+      },
+      "trait_used_tally": {
+        "status:wound": 3
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 61,
+      "seed": 424303,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 55,
+      "dmg_taken_player": 37,
+      "boss_hp_remaining": 1,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 9,
+        "Apex|attack": 14,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 51,
+        "unknown": 95,
+        "attack": 39,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:wound": 3,
+        "status:slow_down": 2,
+        "zampe_a_molla": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 62,
+      "seed": 424304,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 24,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 29,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Apex|move": 12,
+        "Apex|attack": 14,
+        "Critical|attack": 1,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 61,
+        "unknown": 76,
+        "attack": 44,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 63,
+      "seed": 424305,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 25,
+      "players_alive": 3,
+      "players_dead": 5,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 51,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 3,
+        "Apex|move": 8,
+        "Apex|attack": 18,
+        "Apex|unknown": 2,
+        "Critical|attack": 3
+      },
+      "player_action_tally": {
+        "move": 58,
+        "unknown": 65,
+        "attack": 36,
+        "skip": 4
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 64,
+      "seed": 424306,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 17,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 28,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 5,
+        "Apex|attack": 14,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 25,
+        "unknown": 61,
+        "attack": 43
+      },
+      "trait_used_tally": {
+        "status:wound": 4,
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 65,
+      "seed": 424307,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 20,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 23,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 6,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 37,
+        "unknown": 67,
+        "attack": 47
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 66,
+      "seed": 424308,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 44,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 12,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 14,
+        "Apex|attack": 10,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 75,
+        "unknown": 125,
+        "attack": 27
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 67,
+      "seed": 424309,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 30,
+      "dmg_taken_player": 40,
+      "boss_hp_remaining": 26,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|attack": 19,
+        "Apex|move": 17,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 62,
+        "unknown": 96,
+        "attack": 21,
+        "skip": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 68,
+      "seed": 424310,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 47,
+      "dmg_taken_player": 40,
+      "boss_hp_remaining": 9,
+      "pressure_final": 80,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Apex|move": 7,
+        "Apex|attack": 16,
+        "Critical|attack": 2,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 39,
+        "unknown": 88,
+        "attack": 45,
+        "skip": 1
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 69,
+      "seed": 424311,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 49,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 7,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 14,
+        "Apex|attack": 7,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 84,
+        "unknown": 88,
+        "attack": 26
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 70,
+      "seed": 424312,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 24,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 24,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 10,
+        "Apex|attack": 17,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 52,
+        "unknown": 91,
+        "attack": 43
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 71,
+      "seed": 424313,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 6,
+        "Apex|attack": 14,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 46,
+        "unknown": 110,
+        "attack": 49
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 72,
+      "seed": 424314,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 50,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 6,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 15,
+        "Apex|attack": 8,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 92,
+        "unknown": 76,
+        "attack": 27
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 73,
+      "seed": 424315,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 43,
+      "dmg_taken_player": 37,
+      "boss_hp_remaining": 13,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 3,
+        "Apex|move": 12,
+        "Apex|attack": 17,
+        "Apex|unknown": 2,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 76,
+        "unknown": 67,
+        "attack": 29,
+        "skip": 1
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 74,
+      "seed": 424316,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 19,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 7,
+        "Apex|attack": 13,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 38,
+        "unknown": 66,
+        "attack": 40
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3,
+        "zampe_a_molla": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 75,
+      "seed": 424317,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 42,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 14,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 14,
+        "Apex|attack": 8,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 36,
+        "unknown": 125,
+        "attack": 30,
+        "skip": 1
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 76,
+      "seed": 424318,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 21,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 18,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 8,
+        "Apex|attack": 11,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 57,
+        "unknown": 81,
+        "attack": 31
+      },
+      "trait_used_tally": {
+        "status:wound": 2,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 77,
+      "seed": 424319,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 22,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 7,
+        "Apex|attack": 12,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 46,
+        "unknown": 97,
+        "attack": 42
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 78,
+      "seed": 424320,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 37,
+      "dmg_taken_player": 38,
+      "boss_hp_remaining": 19,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Apex|move": 7,
+        "Apex|attack": 17,
+        "Critical|attack": 3,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 40,
+        "unknown": 98,
+        "attack": 35,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 79,
+      "seed": 424321,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 21,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 17,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 14,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 23,
+        "unknown": 116,
+        "attack": 53
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2,
+        "status:wound": 4
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 80,
+      "seed": 424322,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 13,
+        "Apex|move": 10
+      },
+      "player_action_tally": {
+        "move": 53,
+        "unknown": 86,
+        "attack": 53
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 81,
+      "seed": 424323,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 47,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 9,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 3,
+        "Apex|move": 13,
+        "Apex|attack": 10,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 82,
+        "unknown": 87,
+        "attack": 36
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 82,
+      "seed": 424324,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 55,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 1,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|attack": 13,
+        "Apex|move": 11,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 79,
+        "unknown": 86,
+        "attack": 35
+      },
+      "trait_used_tally": {
+        "status:wound": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 83,
+      "seed": 424325,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 35,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 21,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 13,
+        "Apex|attack": 12,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 40,
+        "unknown": 134,
+        "attack": 33,
+        "skip": 1
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 84,
+      "seed": 424326,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 19,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 29,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 3,
+        "Apex|attack": 14,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 32,
+        "unknown": 63,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "status:wound": 2,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 85,
+      "seed": 424327,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 4,
+      "players_dead": 4,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 48,
+      "dmg_taken_player": 40,
+      "boss_hp_remaining": 8,
+      "pressure_final": 80,
+      "ai_intent_tally": {
+        "Critical|move": 7,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 13,
+        "Apex|move": 15,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 83,
+        "unknown": 65,
+        "attack": 33
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 86,
+      "seed": 424328,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 22,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 2,
+        "Apex|attack": 14,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 26,
+        "unknown": 60,
+        "attack": 51
+      },
+      "trait_used_tally": {
+        "status:slow_down": 4
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 87,
+      "seed": 424329,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 15,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 8,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 26,
+        "unknown": 51,
+        "attack": 40
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 88,
+      "seed": 424330,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 18,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 5,
+        "Critical|unknown": 2,
+        "Critical|attack": 1,
+        "Apex|attack": 12,
+        "Apex|unknown": 4,
+        "Apex|move": 4
+      },
+      "player_action_tally": {
+        "move": 40,
+        "unknown": 69,
+        "attack": 36
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 89,
+      "seed": 424331,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 55,
+      "dmg_taken_player": 36,
+      "boss_hp_remaining": 1,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 6,
+        "Critical|unknown": 2,
+        "Critical|attack": 3,
+        "Apex|attack": 19,
+        "Apex|unknown": 3,
+        "Apex|move": 11
+      },
+      "player_action_tally": {
+        "move": 63,
+        "unknown": 82,
+        "attack": 41
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 90,
+      "seed": 424332,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 17,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 13,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 13,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 20,
+        "unknown": 85,
+        "attack": 44
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 91,
+      "seed": 424333,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 50,
+      "dmg_taken_player": 36,
+      "boss_hp_remaining": 6,
+      "pressure_final": 80,
+      "ai_intent_tally": {
+        "Critical|move": 8,
+        "Critical|unknown": 2,
+        "Apex|move": 7,
+        "Apex|attack": 11,
+        "Apex|unknown": 3,
+        "Critical|attack": 5
+      },
+      "player_action_tally": {
+        "move": 62,
+        "unknown": 75,
+        "attack": 37
+      },
+      "trait_used_tally": {
+        "status:wound": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 92,
+      "seed": 424334,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 28,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 12,
+        "Apex|attack": 14,
+        "Apex|unknown": 4
+      },
+      "player_action_tally": {
+        "move": 45,
+        "unknown": 103,
+        "attack": 45,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 93,
+      "seed": 424335,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 30,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 26,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 7,
+        "Critical|unknown": 4,
+        "Apex|move": 12,
+        "Apex|attack": 17,
+        "Apex|unknown": 1,
+        "Critical|attack": 1
+      },
+      "player_action_tally": {
+        "move": 69,
+        "unknown": 81,
+        "attack": 29,
+        "skip": 3
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 94,
+      "seed": 424336,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 48,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 8,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 12,
+        "Apex|attack": 7,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 73,
+        "unknown": 101,
+        "attack": 29
+      },
+      "trait_used_tally": {},
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 95,
+      "seed": 424337,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 55,
+      "dmg_taken_player": 13,
+      "boss_hp_remaining": 1,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 9,
+        "Apex|attack": 11,
+        "Apex|unknown": 1
+      },
+      "player_action_tally": {
+        "move": 61,
+        "unknown": 128,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 96,
+      "seed": 424338,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 24,
+      "players_alive": 6,
+      "players_dead": 2,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 20,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 6,
+        "Apex|attack": 9,
+        "Apex|unknown": 3
+      },
+      "player_action_tally": {
+        "move": 46,
+        "unknown": 109,
+        "attack": 43
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 97,
+      "seed": 424339,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 17,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 1,
+        "Apex|attack": 10,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 23,
+        "unknown": 99,
+        "attack": 42
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 98,
+      "seed": 424340,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 14,
+      "players_alive": 7,
+      "players_dead": 1,
+      "enemies_alive": 0,
+      "enemies_dead": 6,
+      "dmg_dealt_player": 56,
+      "dmg_taken_player": 10,
+      "boss_hp_remaining": 0,
+      "pressure_final": 100,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|move": 2,
+        "Apex|attack": 6,
+        "Apex|unknown": 2
+      },
+      "player_action_tally": {
+        "move": 24,
+        "unknown": 75,
+        "attack": 30
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2,
+        "status:wound": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    },
+    {
+      "run": 99,
+      "seed": 424341,
+      "policy": "greedy",
+      "outcome": "defeat",
+      "rounds": 25,
+      "players_alive": 5,
+      "players_dead": 3,
+      "enemies_alive": 1,
+      "enemies_dead": 5,
+      "dmg_dealt_player": 50,
+      "dmg_taken_player": 30,
+      "boss_hp_remaining": 6,
+      "pressure_final": 90,
+      "ai_intent_tally": {
+        "Critical|move": 4,
+        "Critical|unknown": 2,
+        "Apex|unknown": 3,
+        "Apex|attack": 15,
+        "Apex|move": 12
+      },
+      "player_action_tally": {
+        "move": 43,
+        "unknown": 92,
+        "attack": 39,
+        "skip": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      },
+      "vc": {
+        "mbti": null,
+        "ennea": null,
+        "aggregate": null
+      }
+    }
+  ]
+}

--- a/docs/playtest/_canonical-work-forensic-n100/parallel-hardcore_07-forensic-n100-merged.json
+++ b/docs/playtest/_canonical-work-forensic-n100/parallel-hardcore_07-forensic-n100-merged.json
@@ -1,0 +1,2116 @@
+{
+  "scenario": "hardcore_07",
+  "scenario_id": "enc_tutorial_07_hardcore_pod_rush",
+  "target_band": [0.3, 0.5],
+  "total_n": 100,
+  "seed": 424242,
+  "shards": 4,
+  "n_per_shard": [25, 25, 25, 25],
+  "hosts": [
+    "http://127.0.0.1:3341",
+    "http://127.0.0.1:3342",
+    "http://127.0.0.1:3343",
+    "http://127.0.0.1:3344"
+  ],
+  "parallel_elapsed_sec": 20.50495481491089,
+  "serial_estimated_sec": 82.01981925964355,
+  "speedup_x": 4,
+  "method": "C-parallel-shards",
+  "method_ref": "docs/research/2026-05-20-calibration-knob-patterns-industry.md",
+  "aggregate": {
+    "n": 100,
+    "win_rate": 52.0,
+    "win_rate_ci95": [42.0, 62.0],
+    "defeat_rate": 0.0,
+    "defeat_rate_ci95": [0, 0],
+    "timeout_rate": 48.0,
+    "timeout_rate_ci95": [38.0, 58.0],
+    "timer_expire_rate": 0.0,
+    "rounds_avg": 13.1,
+    "rounds_ci95": [12.67, 13.53],
+    "rounds_median": 15.0,
+    "kd_avg": 3.12,
+    "kd_ci95": [2.92, 3.31],
+    "target_band": "win 30-50%",
+    "in_band": false,
+    "player_action_distribution": {
+      "move": 500,
+      "attack": 3903,
+      "unknown": 122
+    },
+    "trait_used_distribution": {
+      "zampe_a_molla": 44,
+      "status:wound": 19,
+      "status:slow_down": 116
+    }
+  },
+  "runs": [
+    {
+      "run": 0,
+      "seed": 424242,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 14,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 41,
+        "unknown": 3
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 1,
+      "seed": 424243,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 2,
+      "seed": 424244,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 3
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:wound": 1,
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 3,
+      "seed": 424245,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 4,
+      "seed": 424246,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 31,
+        "unknown": 3
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:wound": 2,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 5,
+      "seed": 424247,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 6,
+      "seed": 424248,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 36,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 7,
+      "seed": 424249,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 31,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 8,
+      "seed": 424250,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 35,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 9,
+      "seed": 424251,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 10,
+      "seed": 424252,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 11,
+      "seed": 424253,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 47
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 12,
+      "seed": 424254,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 13,
+      "seed": 424255,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 40
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 14,
+      "seed": 424256,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 43,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 15,
+      "seed": 424257,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 36,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 16,
+      "seed": 424258,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 38,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 17,
+      "seed": 424259,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 18,
+      "seed": 424260,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 19,
+      "seed": 424261,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 14,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 41,
+        "unknown": 3
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 20,
+      "seed": 424262,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 33,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 21,
+      "seed": 424263,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 5
+      }
+    },
+    {
+      "run": 22,
+      "seed": 424264,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 23,
+      "seed": 424265,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 10,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 29,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 24,
+      "seed": 424266,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 25,
+      "seed": 424267,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 10,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 30,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 26,
+      "seed": 424268,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 27,
+      "seed": 424269,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 28,
+      "seed": 424270,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 36,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:wound": 2
+      }
+    },
+    {
+      "run": 29,
+      "seed": 424271,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 30,
+      "seed": 424272,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 33,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 31,
+      "seed": 424273,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 32,
+      "seed": 424274,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 33,
+      "seed": 424275,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 2,
+      "enemies_alive": 3,
+      "kills": 1,
+      "losses": 2,
+      "kd": 0.5,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 40
+      },
+      "trait_used_tally": {
+        "status:wound": 1
+      }
+    },
+    {
+      "run": 34,
+      "seed": 424276,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 39,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1,
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 35,
+      "seed": 424277,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:wound": 1
+      }
+    },
+    {
+      "run": 36,
+      "seed": 424278,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 27,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 37,
+      "seed": 424279,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 38,
+      "seed": 424280,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 36,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:wound": 2
+      }
+    },
+    {
+      "run": 39,
+      "seed": 424281,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 31,
+        "unknown": 4
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 40,
+      "seed": 424282,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 41,
+      "seed": 424283,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 26,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 42,
+      "seed": 424284,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 35,
+        "unknown": 4
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 43,
+      "seed": 424285,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 34,
+        "unknown": 3
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 44,
+      "seed": 424286,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 45,
+      "seed": 424287,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 33,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 46,
+      "seed": 424288,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "status:wound": 1
+      }
+    },
+    {
+      "run": 47,
+      "seed": 424289,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 47
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 48,
+      "seed": 424290,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 35,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3,
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 49,
+      "seed": 424291,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 14,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 39,
+        "unknown": 4
+      },
+      "trait_used_tally": {
+        "status:wound": 2,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 50,
+      "seed": 424292,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 10,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 28,
+        "unknown": 3
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2,
+        "zampe_a_molla": 1,
+        "status:wound": 1
+      }
+    },
+    {
+      "run": 51,
+      "seed": 424293,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 47
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 52,
+      "seed": 424294,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 31,
+        "unknown": 3
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 53,
+      "seed": 424295,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 14,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 42,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 54,
+      "seed": 424296,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 34,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 55,
+      "seed": 424297,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 2
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 56,
+      "seed": 424298,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 26,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 57,
+      "seed": 424299,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 10,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 30,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 58,
+      "seed": 424300,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 34
+      },
+      "trait_used_tally": {
+        "status:slow_down": 4
+      }
+    },
+    {
+      "run": 59,
+      "seed": 424301,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 3
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 60,
+      "seed": 424302,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 61,
+      "seed": 424303,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 35,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 62,
+      "seed": 424304,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:wound": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 63,
+      "seed": 424305,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 35,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 64,
+      "seed": 424306,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 47
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 65,
+      "seed": 424307,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 66,
+      "seed": 424308,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "status:wound": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 67,
+      "seed": 424309,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 68,
+      "seed": 424310,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 69,
+      "seed": 424311,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 8,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 26
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 70,
+      "seed": 424312,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 71,
+      "seed": 424313,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "status:wound": 1
+      }
+    },
+    {
+      "run": 72,
+      "seed": 424314,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 73,
+      "seed": 424315,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 38,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "status:wound": 2,
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 74,
+      "seed": 424316,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 75,
+      "seed": 424317,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 14,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 42,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 76,
+      "seed": 424318,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 8,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 23,
+        "unknown": 3
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 77,
+      "seed": 424319,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {
+        "status:wound": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 78,
+      "seed": 424320,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 8,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 23,
+        "unknown": 3
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 79,
+      "seed": 424321,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 80,
+      "seed": 424322,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 81,
+      "seed": 424323,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 2
+      }
+    },
+    {
+      "run": 82,
+      "seed": 424324,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 36,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2,
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 83,
+      "seed": 424325,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 13,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 40,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 84,
+      "seed": 424326,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 27,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 85,
+      "seed": 424327,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 7,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 21,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 86,
+      "seed": 424328,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 43,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 87,
+      "seed": 424329,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 26,
+        "unknown": 2
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 88,
+      "seed": 424330,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 12,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 35,
+        "unknown": 2
+      },
+      "trait_used_tally": {
+        "status:slow_down": 4
+      }
+    },
+    {
+      "run": 89,
+      "seed": 424331,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 90,
+      "seed": 424332,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 44
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 91,
+      "seed": 424333,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 14,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 42,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1,
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 92,
+      "seed": 424334,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 93,
+      "seed": 424335,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 46,
+        "unknown": 1
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 94,
+      "seed": 424336,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 8,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 25,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 2,
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 95,
+      "seed": 424337,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 29
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    },
+    {
+      "run": 96,
+      "seed": 424338,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 2,
+      "kills": 2,
+      "losses": 1,
+      "kd": 2.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45
+      },
+      "trait_used_tally": {}
+    },
+    {
+      "run": 97,
+      "seed": 424339,
+      "policy": "greedy",
+      "outcome": "timeout",
+      "rounds": 15,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 1,
+      "kills": 3,
+      "losses": 1,
+      "kd": 3.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 45,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "status:slow_down": 3
+      }
+    },
+    {
+      "run": 98,
+      "seed": 424340,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 9,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 28,
+        "unknown": 1
+      },
+      "trait_used_tally": {
+        "zampe_a_molla": 1
+      }
+    },
+    {
+      "run": 99,
+      "seed": 424341,
+      "policy": "greedy",
+      "outcome": "victory",
+      "rounds": 11,
+      "timer_expired": false,
+      "players_alive": 3,
+      "enemies_alive": 0,
+      "kills": 4,
+      "losses": 1,
+      "kd": 4.0,
+      "player_action_tally": {
+        "move": 5,
+        "attack": 31,
+        "unknown": 4
+      },
+      "trait_used_tally": {
+        "status:slow_down": 1
+      }
+    }
+  ]
+}

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -3,7 +3,7 @@
 # Machine-readable list of canonical scenarios + ratified bands + run config.
 # Paradigm (2026-05-29): AI-driven multi-policy = gate/oracle; human = optional.
 version: 1
-last_verified: '2026-05-29'
+last_verified: '2026-06-14'
 
 # N-ladder (L-069/L-073): 10 probe (+-30pp) / 40 ratify (+-15pp) / 100 forensic (+-10pp)
 n_ladder:
@@ -32,22 +32,22 @@ scenarios:
   - id: enc_tutorial_06_hardcore
     role: balance_oracle
     target_band: [0.15, 0.25]
-    ratified_knob: { boss_hp_multiplier: 0.65 }
-    last_wr_n40: '0.15-0.25'
+    ratified_knob: { boss_hp_multiplier: 1.04 }
+    last_wr_n40: '0.22 (N=100 2026-06-14, seed 424242)'
     status: ratified
     tool: tools/py/batch_calibrate_hardcore06.py
     port: 3340
-    note: 'iter3 turn_limit_defeat null = overshoot WR 0.85 REJECTED. Source #2381 ratify.'
+    note: 'RE-RATIFIED 2026-06-14 post-#2719 channel-routing fix: boss_hp_multiplier 0.65->1.04 (N=100 WR 22%, def 78%, timeout 0%). git-bisect proved #2719 (f5387e66) unlocked the greedy psionico exploit -> the old 0.65 band was measured under the channel bug. Evidence docs/playtest/2026-06-14-canonical-forensic-n100.md. iter3 turn_limit null overshoot 0.85 still REJECTED.'
 
   - id: enc_tutorial_07_hardcore_pod_rush
     role: balance_oracle
     target_band: [0.30, 0.50]
     ratified_knob: { enemy_damage_multiplier_override: 2.1 } # REPLACES class 1.8, not stack
-    last_wr_n40: '0.30-0.40'
-    status: in_band
+    last_wr_n40: '0.52 (N=100 2026-06-14, marginal +2pp over ceiling)'
+    status: review_needed
     tool: tools/py/batch_calibrate_hardcore07.py
     port: 3334
-    note: 'post wave 5-7 nerf (6 traits cost_ap 1->2) = -40-60pp WR. Timer-driven scenario.'
+    note: 'Timer/objective scenario, fisico-only policy (NO channel exploit) -> #2719-INDEPENDENT. Forensic N=100 2026-06-14 = WR 52% vs band [30-50], CI95 [42,62] straddles ceiling. Drift from ~40% is NOT #2719; cause un-bisected = separate low-priority follow-up. Original: post wave 5-7 nerf 6 traits cost_ap 1->2.'
 
   - id: enc_tutorial_01_05
     role: designed_winnable_ladder
@@ -66,4 +66,6 @@ run_canonical: |
 
 gate:
   merge: 'AI regression tests/ai/*.test.js green AND touched-scenario WR in-band @ N=40 AND no crash/contract-ripple'
+  ci_workflow: '.github/workflows/combat-balance-gate.yml (phase 1 = warn-only; flip to blocking once hc07 in-band)'
+  band_invalidation_protocol: 'docs/process/CANONICAL-AI-PLAYTEST.md sec 9 -- a correct combat fix that shifts a band = block + human re-ratify, NEVER auto-update target_band'
   human_playtest: 'OPTIONAL confirmation, never blocking'

--- a/docs/playtest/forensic-n100-canonical-suite.json
+++ b/docs/playtest/forensic-n100-canonical-suite.json
@@ -1,0 +1,48 @@
+{
+  "suite": "canonical-ai-playtest",
+  "label": "forensic-n100",
+  "manifest": "C:\\dev\\Game-forensic\\docs\\playtest\\canonical-suite.yaml",
+  "n": 100,
+  "seed": 424242,
+  "ladder_role": "ratify",
+  "all_in_band": false,
+  "repro": {
+    "host": "http://127.0.0.1",
+    "lobby_ws_enabled": false,
+    "damage_curves_path_required": true,
+    "seed_pinned": true,
+    "canonical_seed": 424242,
+    "config_source": "data/core/balance/damage_curves.yaml",
+    "scenario_spawn_source": "apps/backend/services/hardcoreScenario.js"
+  },
+  "scenarios": [
+    {
+      "id": "enc_tutorial_06_hardcore",
+      "parallel_key": "hardcore_06",
+      "target_band": [0.15, 0.25],
+      "ratified_knob": {
+        "boss_hp_multiplier": 0.65
+      },
+      "status": "ok",
+      "n_runs": 100,
+      "win_rate": 0.53,
+      "in_band": false,
+      "elapsed_sec": 21.264872074127197,
+      "merged_path": "C:\\dev\\Game-forensic\\docs\\playtest\\_canonical-work-forensic-n100\\parallel-hardcore_06-forensic-n100-merged.json"
+    },
+    {
+      "id": "enc_tutorial_07_hardcore_pod_rush",
+      "parallel_key": "hardcore_07",
+      "target_band": [0.3, 0.5],
+      "ratified_knob": {
+        "enemy_damage_multiplier_override": 2.1
+      },
+      "status": "ok",
+      "n_runs": 100,
+      "win_rate": 0.52,
+      "in_band": false,
+      "elapsed_sec": 20.50495481491089,
+      "merged_path": "C:\\dev\\Game-forensic\\docs\\playtest\\_canonical-work-forensic-n100\\parallel-hardcore_07-forensic-n100-merged.json"
+    }
+  ]
+}

--- a/docs/playtest/forensic-n100-canonical-suite.md
+++ b/docs/playtest/forensic-n100-canonical-suite.md
@@ -1,0 +1,10 @@
+# Canonical AI-driven playtest suite -- forensic-n100
+
+Manifest: `C:\dev\Game-forensic\docs\playtest\canonical-suite.yaml` | N=100 (ratify) | all_in_band: **False**
+
+| scenario                          | key         | band       | WR (N)      | in-band | knob                                        |
+| --------------------------------- | ----------- | ---------- | ----------- | ------- | ------------------------------------------- |
+| enc_tutorial_06_hardcore          | hardcore_06 | [15%, 25%] | 53.0% (100) | NO      | `{"boss_hp_multiplier": 0.65}`              |
+| enc_tutorial_07_hardcore_pod_rush | hardcore_07 | [30%, 50%] | 52.0% (100) | NO      | `{"enemy_damage_multiplier_override": 2.1}` |
+
+Method SoT: `docs/process/CANONICAL-AI-PLAYTEST.md`. Repro: host 127.0.0.1, LOBBY_WS_ENABLED=false, DAMAGE_CURVES_PATH pinned.

--- a/docs/process/CANONICAL-AI-PLAYTEST.md
+++ b/docs/process/CANONICAL-AI-PLAYTEST.md
@@ -178,6 +178,41 @@ Questi riferimenti al playtest umano come gate/oracolo sono **declassati a opzio
 - `CLAUDE.md` / `COMPACT_CONTEXT.md` (Game) sprint-context "4 amici" gate — flag: vedi questo doc
 - `docs/planning/EVO_FINAL_DESIGN_MILESTONES_AND_GATES.md` G7 RC sign-off — resta milestone RC, NON gate-dev
 
+## 9. Band invalidation da correct-fix (protocollo, 2026-06-14)
+
+**Caso #2719** (2026-06-10): un bug-fix CORRETTO (channel routing -- `/round/execute`
+ora passa `action.channel`; prima ogni attacco di round era `fisico`) ha sbloccato
+l'exploit `psionico` della policy hc06 contro boss/elite corazzati -> hc06 da 17%
+(padre #2717) a 51% OOB. La banda 15-25% era stata ratificata SOTTO il bug. NON e'
+una regressione da revertare -- e' la banda a essere stale. git-bisect + forensic
+N=100: `docs/playtest/2026-06-14-canonical-forensic-n100.md`. Gate mancante: la
+SoT (sez. 5) dichiarava il merge-gate ma non era wired per-PR -> #2719 e' passato.
+
+**Regola** (mirror Stockfish fishtest: la soglia e' decisione UMANA, mai auto-derivata).
+Quando un PR di combat porta un oracolo fuori banda:
+
+1. Il gate CI `.github/workflows/combat-balance-gate.yml` segnala (phase 1 = warn;
+   phase 2 = block).
+2. Classifica: e' un BUG (-> fixa/reverta, la banda resta giusta) o un FIX corretto
+   che sposta la banda (-> ri-taratura)? Usa git-bisect per la ground-truth.
+3. Se fix corretto: ri-tara il knob a **N>=40** (L-073: MAI scegliere il valore da
+   N<=20) e ri-ratifica a **N=100** forensic; se il lever e' steep, N=100 obbligatorio.
+4. Aggiorna `canonical-suite.yaml` (`ratified_knob` + `last_wr_n40` + `note`) **e** il
+   knob in `data/core/balance/` atomicamente. Documenta vecchia banda / nuova / perche'.
+5. **MAI auto-aggiornare `target_band` in CI.** Bande = human-ratified, machine-verified.
+6. Approvazione master-dd esplicita prima del merge.
+
+**Caveat storico**: qualunque banda ratificata PRIMA di #2719 (2026-06-10) e' stata
+misurata sotto il channel-bug (tutto-fisico) -> potenzialmente stale dove la policy
+usa channel-exploit. hc06 ri-ratificato (boss_hp_multiplier 0.65 -> 1.04, N=100 WR 22%).
+hc07 = fisico-only, **#2719-INDEPENDENT** (resta marginale 52%, follow-up separato).
+
+**Robustezza oracolo (follow-up)**: hc06 e' fragile perche' la policy greedy hardcoda
+l'exploit di canale (`CHANNEL_EXPLOIT_MAP`). Un gate secondario su policy `random`
+(mechanic-robust, gia' in `--policy all`) misurerebbe la difficolta' dell'encounter
+indipendente dallo skill = piu' diagnostico. Richiede ratificare `random_target_band`
+a N=40 per oracolo.
+
 ## Riferimenti
 
 - Metodologia: `.claude/agents/balance-illuminator.md` (calibration + research) + `docs/research/2026-05-20-calibration-knob-patterns-industry.md`

--- a/tests/api/hardcoreScenario.test.js
+++ b/tests/api/hardcoreScenario.test.js
@@ -25,12 +25,14 @@ test('GET /api/tutorial/enc_tutorial_06_hardcore returns 14 units + recommended 
     assert.equal(enemies.length, 6);
     const boss = enemies.find((u) => u.id === 'e_apex_boss');
     assert.ok(boss);
-    // 2026-05-20 L-069 iter2 SHIPPED: scenario_overrides.boss_hp_multiplier 0.65
-    // applies at build time. HP 40 (raw scenario) → 26 (post override).
-    // _hp_base preserves raw scenario value, _hp_scenario_multiplier audits factor.
-    assert.equal(boss.hp, 26); // iter 2 base 40 × 0.65 = 26
+    // RE-RATIFY 2026-06-14 (PR #2753, post-#2719): scenario_overrides
+    // boss_hp_multiplier 0.65 -> 1.04, applied at build time. HP 40 (raw) ->
+    // 42 (post override, round(40*1.04)). The old 0.65/26 band was ratified
+    // UNDER the #2719 channel-routing bug (git-bisect); re-ratified at N=100
+    // WR 22%. See docs/playtest/2026-06-14-canonical-forensic-n100.md.
+    assert.equal(boss.hp, 42); // re-ratify: round(base 40 * 1.04) = 42
     assert.equal(boss._hp_base, 40, 'override preserves raw HP audit trail');
-    assert.equal(boss._hp_scenario_multiplier, 0.65, 'override factor logged');
+    assert.equal(boss._hp_scenario_multiplier, 1.04, 'override factor logged');
     assert.equal(boss.mod, 3); // iter 4 (M14-C): 5→3 per compensare elevation +30%
     assert.equal(boss.guardia, 4); // iter 2: 3→4
     assert.equal(boss.attack_range, 3); // iter 2: 2→3


### PR DESCRIPTION
Resolves the canonical balance-oracle regression found by a forensic N=100 sweep. **Diagnosis + root cause + fix + systemic guardrail**, all evidence-backed. Touches a guarded path (CI) → master-dd review/merge.

## Problem (forensic N=100, seed 424242)

| Scenario | Band | WR | |
|---|---|---|---|
| `hardcore_06` (elim, *hardest*) | 15-25% | **53%** | OOB, ladder flattened |
| `hardcore_07` (timer) | 30-50% | **52%** | marginal +2pp |

## Root cause — CONFIRMED by git-bisect (281 commits)

| Commit | hc06 WR (N=100) | |
|---|---|---|
| `7f39b3bd` (#2717, parent) | **17%** | in-band ✓ |
| **`f5387e66` (#2719)** `fix(combat): channel routing round path` | **51%** | **OOB ✗** |

Before #2719, `/round/execute` dropped `action.channel` → every round attack was physical. The hc06 policy (`CHANNEL_EXPLOIT_MAP`) attacks the armored boss/elites with `psionico`; the bug silently downgraded it. #2719 correctly routes the channel → exploit lands → 17%→51%. **#2719 is a correct fix — the band was ratified *under the bug*.** (#2725 ER1 = refuted, A/B byte-identical.)

## Fix — hc06 re-tuned (evidence, not blind)

`boss_hp_multiplier 0.65 → 1.04` in `damage_curves.yaml`, calibrated post-#2719:

| boss_hp_mult | WR N=40 | WR N=100 | |
|---|---|---|---|
| 0.65 (old) | — | 53% | OOB |
| **1.04 (new)** | **20%** | **22%** | **in-band** (def 78%, timeout 0% — all 3 class bands) |
| 1.05 | 12.5% | — | OOB-low |

Steep lever → value picked at N≥40, ratified N=100 (L-073, never N≤20). `canonical-suite.yaml` updated.

## Systemic guardrail (the real ask — so it can't recur with SPEC A..Q churn)

Root gap: SoT §5 declared a merge gate but it was **never wired per-PR** → #2719 slipped.

- **`.github/workflows/combat-balance-gate.yml`** — per-PR canonical-oracle gate, path-filtered to combat code/data, N=40 seed 424242 **shards 4 = ratification config = deterministic**. **Phase 1 = warn-only** (hc07 still marginally OOB); flip to blocking once hc07 is in-band.
- **`CANONICAL-AI-PLAYTEST.md` §9** — band-invalidation protocol: a correct fix that shifts a band ⇒ block + human re-ratify, **never** auto-update the band (Stockfish-fishtest discipline).
- **Follow-up (documented)**: gate a `random`-policy band too (mechanic-robust) — hc06's fragility came from the greedy policy hardcoding the channel exploit.

## hc07

`fisico`-only policy → **#2719-independent**. 52% (CI straddles the 50% ceiling), drifted from ~40% for an un-bisected reason. Marginal → separate low-priority follow-up; gate stays warn-only until resolved.

## ⚠️ Notes for merge

- **Forbidden path**: touches `.github/workflows/` → not auto-mergeable, surfaced for explicit review.
- **Balance ratification** (`damage_curves.yaml`) = master-dd merge gate.
- AI regression **510/510 green**. Report: `docs/playtest/2026-06-14-canonical-forensic-n100.md`.