### PR TITLE
fix(coop): G2 campaign_id + G3 nido broadcast + G5 tally host (#2746)

### DIFF
--- a/apps/backend/services/coop/coopStore.js
+++ b/apps/backend/services/coop/coopStore.js
@@ -52,9 +52,15 @@ function createCoopStore({ lobby } = {}) {
       if (orch?.run?.id === campaignId) {
         orch.setSessionId(sessionId);
         // Mirror onto the lobby room so the VERSIONED publishPhaseChange
-        // (the channel the phone composer consumes) carries session_id.
+        // (the channel the phone composer consumes) carries session_id +
+        // campaign_id. G2 #2746 — room.campaignId was never set, so every
+        // versioned phase_change shipped campaign_id: null and the Godot
+        // phone lost the CampaignState link (run.id == campaign_id).
         const room = lobby?.getRoom?.(orch.roomCode);
-        if (room) room.sessionId = sessionId;
+        if (room) {
+          room.sessionId = sessionId;
+          room.campaignId = campaignId;
+        }
         return true;
       }
     }

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1610,7 +1610,12 @@ function createWsServer({
                 );
                 return;
               }
-              const allPids = Array.from(room.players.values()).map((p) => p.id);
+              // G5 #2746 — role-aware quorum so the TV-mirror host is not
+              // counted in worldTally.total (the phone saw "2 waiting / 3
+              // total" with 2 players). Mirrors lifecycleQuorumPids used by
+              // character_create / lineage_choice (#2707/#2708): host counts
+              // only when it actually plays (submitter or owns a character).
+              const allPids = lifecycleQuorumPids(room, orch, playerId);
               // B-NEW-1 fix 2026-05-08 — connected-only quorum so phone
               // smoke does not stall when 2nd player WS dropped mid-vote.
               const connectedPids = Array.from(room.players.values())
@@ -1949,6 +1954,12 @@ function createWsServer({
                 room.publishPhaseChange('world_setup');
               } else if (result.phase === 'ended') {
                 room.publishPhaseChange('ended');
+              } else if (result.phase === 'nido') {
+                // G3 #2746 — Nido-hub gate: next_macro routes to 'nido' when
+                // unlocked. Pre-fix no phase_change was published for nido, so
+                // phones could not enter MODE_NIDO (host had to send `phase nido`
+                // manually). 'nido' is whitelisted in KNOWN_PHASES.
+                room.publishPhaseChange('nido');
               }
               socket.send(
                 JSON.stringify({

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1610,12 +1610,27 @@ function createWsServer({
                 );
                 return;
               }
-              // G5 #2746 — role-aware quorum so the TV-mirror host is not
-              // counted in worldTally.total (the phone saw "2 waiting / 3
-              // total" with 2 players). Mirrors lifecycleQuorumPids used by
-              // character_create / lineage_choice (#2707/#2708): host counts
-              // only when it actually plays (submitter or owns a character).
-              const allPids = lifecycleQuorumPids(room, orch, playerId);
+              // G5 #2746 — eligible voters = device players; the TV-mirror
+              // host counts only when it actually plays (owns a character).
+              // Computed independently of the submitter (NOT lifecycleQuorumPids,
+              // whose submitter self-include would let a non-playing host vote
+              // into the set) so the tally denominator stays stable across
+              // votes. The membership gate then rejects a non-playing host vote
+              // BEFORE voteWorld persists it -- otherwise the stored host vote
+              // would be counted by worldTally while a later submitter recomputes
+              // allPids without the host, yielding accept > total / false quorum
+              // (Codex P2 #2756).
+              const allPids = Array.from(room.players.values())
+                .filter(
+                  (p) =>
+                    (p.id !== room.hostId && p.role !== 'host') ||
+                    Boolean(orch.characters?.has?.(p.id)),
+                )
+                .map((p) => p.id);
+              if (!allPids.includes(playerId)) {
+                socket.send(JSON.stringify({ type: 'error', payload: { code: 'not_a_player' } }));
+                return;
+              }
               // B-NEW-1 fix 2026-05-08 — connected-only quorum so phone
               // smoke does not stall when 2nd player WS dropped mid-vote.
               const connectedPids = Array.from(room.players.values())

--- a/tests/api/coopWorldVoteHostFilter.test.js
+++ b/tests/api/coopWorldVoteHostFilter.test.js
@@ -132,3 +132,74 @@ test('G5 #2746: world_vote tally total excludes the TV-mirror host', async () =>
     await wsHandle.close();
   }
 });
+
+test('G5 #2746 (Codex P2): non-playing host world_vote rejected, tally stays consistent', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Cat' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    orch._setPhase('world_setup');
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    const p2Ws = openWs(port, { code: room.code, player_id: p2.player_id, token: p2.player_token });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws), waitOpen(p2Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+      waitForMessage(p2Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // The TV-mirror host (no character) sends a world_vote: must be rejected,
+    // NOT persisted (else it pollutes the tally numerator while the denominator
+    // recomputes without the host -> accept > total).
+    hostWs.send(
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'world_vote', scenario_id: 'enc_tutorial_01', choice: 'accept' },
+      }),
+    );
+    const hostErr = await waitForMessage(hostWs, (m) => m.type === 'error', 2000);
+    assert.equal(hostErr.payload.code, 'not_a_player', 'non-playing host vote rejected');
+
+    // Now a real player votes; the tally must reflect only the 2 players.
+    p1Ws.send(
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'world_vote', scenario_id: 'enc_tutorial_01', choice: 'accept' },
+      }),
+    );
+    const tallyMsg = await waitForMessage(
+      p2Ws,
+      (m) => m.type === 'world_tally' && m.payload?.accept >= 1,
+      2000,
+    );
+    const tally = tallyMsg.payload;
+    assert.equal(tally.total, 2, `total must be 2 players (got ${tally.total})`);
+    assert.equal(tally.accept, 1, `only p1 counted, host vote not persisted (got ${tally.accept})`);
+    assert.ok(tally.accept <= tally.total, 'accept must never exceed total');
+    assert.equal(tally.pending, 1, `p2 still pending (got ${tally.pending})`);
+
+    hostWs.close();
+    p1Ws.close();
+    p2Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});

--- a/tests/api/coopWorldVoteHostFilter.test.js
+++ b/tests/api/coopWorldVoteHostFilter.test.js
@@ -1,0 +1,134 @@
+// G5 #2746 — world_vote drain must not count the TV-mirror host in the tally.
+//
+// The WS world_vote handler passed UNFILTERED room player ids (host included)
+// as allPlayerIds to orch.voteWorld -> worldTally.total counted the host TV,
+// so 2 players showed "2 waiting / 3 total". The connected_* path already
+// filtered the host (all_connected_accepted was correct), so this was a
+// display-only inflation. Fix mirrors the role-aware lifecycle quorum
+// (lifecycleQuorumPids, #2707/#2708) used by character_create / lineage_choice.
+//
+// Ref: MasterDD-L34D/Game#2746 voce G5.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const { LobbyService, createWsServer } = require('../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+async function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+test('G5 #2746: world_vote tally total excludes the TV-mirror host', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Cat' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    orch._setPhase('world_setup');
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    const p2Ws = openWs(port, { code: room.code, player_id: p2.player_id, token: p2.player_token });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws), waitOpen(p2Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+      waitForMessage(p2Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // One player votes; the broadcast tally must count only the 2 players.
+    p1Ws.send(
+      JSON.stringify({
+        type: 'intent',
+        payload: { action: 'world_vote', scenario_id: 'enc_tutorial_01', choice: 'accept' },
+      }),
+    );
+
+    // Skip the connect-snapshot world_tally (accept 0); assert on the tally
+    // produced by p1's vote.
+    const tallyMsg = await waitForMessage(
+      p2Ws,
+      (m) => m.type === 'world_tally' && m.payload?.accept >= 1,
+      2000,
+    );
+    const tally = tallyMsg.payload;
+    assert.equal(tally.total, 2, `total must exclude the host TV (got ${tally.total})`);
+    assert.equal(tally.accept, 1);
+    assert.equal(
+      tally.pending,
+      1,
+      `pending = players not yet voted, host excluded (got ${tally.pending})`,
+    );
+
+    hostWs.close();
+    p1Ws.close();
+    p2Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});

--- a/tests/services/coop/coopStoreLinkCampaignId.test.js
+++ b/tests/services/coop/coopStoreLinkCampaignId.test.js
@@ -1,0 +1,59 @@
+// G2 #2746 — coopStore.linkSession must mirror campaignId onto the lobby room.
+//
+// Room.publishPhaseChange sends `campaign_id: this.campaignId ?? null`, but the
+// coop flow never set room.campaignId: linkSession mirrored only sessionId. So
+// every versioned phase_change carried campaign_id: null, and the Godot phone
+// (which keys CampaignState on campaign_id) lost the link. Fix mirrors
+// room.campaignId = campaignId in linkSession (run.id == campaign_id).
+//
+// Ref: MasterDD-L34D/Game#2746 voce G2.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { LobbyService } = require('../../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+
+test('G2: linkSession mirrors campaignId onto the lobby room', () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const room = lobby.createRoom({ hostName: 'TV' });
+
+  const orch = coopStore.getOrCreate(room.code);
+  orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  const campaignId = orch.run.id;
+
+  // createRoom returns a client descriptor; the live Room (with sessionId/
+  // campaignId/broadcast) is fetched via getRoom — same object linkSession mirrors onto.
+  const liveRoom = lobby.getRoom(room.code);
+  // Pre-condition: room has no campaignId yet.
+  assert.ok(!liveRoom.campaignId, 'room.campaignId should be unset before linkSession');
+
+  const linked = coopStore.linkSession(campaignId, 'sess_g2');
+  assert.equal(linked, true, 'linkSession found the matching orch');
+  assert.equal(liveRoom.sessionId, 'sess_g2', 'sessionId still mirrored (no regression)');
+  assert.equal(liveRoom.campaignId, campaignId, 'campaignId mirrored onto the room');
+});
+
+test('G2: versioned phase_change carries the campaign_id after linkSession', () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const room = lobby.createRoom({ hostName: 'TV' });
+
+  const orch = coopStore.getOrCreate(room.code);
+  orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  const campaignId = orch.run.id;
+  coopStore.linkSession(campaignId, 'sess_g2b');
+
+  // Capture the broadcast emitted by the versioned publisher on the live Room.
+  const liveRoom = lobby.getRoom(room.code);
+  const sent = [];
+  liveRoom.broadcast = (msg) => sent.push(msg);
+  liveRoom.publishPhaseChange('world_setup');
+
+  const pc = sent.find((m) => m.type === 'phase_change');
+  assert.ok(pc, 'phase_change broadcast emitted');
+  assert.equal(pc.payload.campaign_id, campaignId, 'phase_change carries the campaign_id');
+});

--- a/tests/services/network/wsSession-nido.test.js
+++ b/tests/services/network/wsSession-nido.test.js
@@ -131,6 +131,68 @@ test('N1: nido_start_mission intent -> startMissionFromNido -> phase_change worl
   }
 });
 
+test('G3 #2746: next_macro -> nido phase broadcasts phase_change(nido) to phones', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01', 'enc_tutorial_02'] });
+    // Post-combat debrief + Nido unlocked: next_macro must route to the nido
+    // hub. Pre-fix the drain only published world_setup/ended -> phones never
+    // saw phase_change(nido) and could not enter MODE_NIDO (gap G3).
+    orch.phase = 'debrief';
+    orch._nidoUnlocked = true;
+
+    const hostWs = openWs(port, {
+      code: room.code,
+      player_id: room.host_id,
+      token: room.host_token,
+    });
+    const p1Ws = openWs(port, {
+      code: room.code,
+      player_id: p1.player_id,
+      token: p1.player_token,
+    });
+    await Promise.all([waitOpen(hostWs), waitOpen(p1Ws)]);
+    await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'hello'),
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+    ]);
+
+    hostWs.send(
+      JSON.stringify({ type: 'intent', payload: { action: 'next_macro', choice: 'advance' } }),
+    );
+
+    // Host ack confirms the orch advanced into the nido phase.
+    const ack = await waitForMessage(hostWs, (m) => m.type === 'next_macro_accepted', 2000);
+    assert.equal(ack.payload.phase, 'nido');
+
+    // Both phones must receive a versioned phase_change(nido).
+    const [hostPc, p1Pc] = await Promise.all([
+      waitForMessage(hostWs, (m) => m.type === 'phase_change' && m.payload?.phase === 'nido', 2000),
+      waitForMessage(p1Ws, (m) => m.type === 'phase_change' && m.payload?.phase === 'nido', 2000),
+    ]);
+    assert.equal(hostPc.payload.phase, 'nido');
+    assert.equal(p1Pc.payload.phase, 'nido');
+    assert.equal(typeof hostPc.version, 'number');
+
+    hostWs.close();
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
 test('N1: nido_start_mission by non-host returns error not_host', async () => {
   const lobby = new LobbyService();
   const coopStore = createCoopStore({ lobby });


### PR DESCRIPTION
## Riferimento

Issue #2746 — chiude i **3 gap backend-side restanti** (G2, G3, G5) dal playtest AI GGv2 item-5/6. G1 (#2751) e G4 (#2748) già mergiati → con questa PR l'issue è risolta lato Game (resta solo il re-check QA phone GGv2).

## G2 [P2] — `campaign_id` mai propagato sul canale versionato

`Room.publishPhaseChange` manda `campaign_id: this.campaignId ?? null`, ma nel flusso coop `room.campaignId` non veniva mai settato: `coopStore.linkSession` mirrorava solo `sessionId`. Risultato: ogni `phase_change` versionato shippava `campaign_id: null` e il phone Godot (che keya `CampaignState` su `campaign_id`) perdeva il link.

**Fix** (`coopStore.js` `linkSession`): mirror anche `room.campaignId = campaignId` (`run.id == campaign_id` nel flusso coop), accanto a `room.sessionId`.

## G3 [P2] — phase `nido` mai broadcastata

Il drain WS `next_macro` pubblicava `phase_change` solo per `world_setup`/`ended`. Con Nido sbloccato `submitNextMacro` ritorna `phase: 'nido'` (`advance.action = 'nido'`), ma **nessun** `phase_change` partiva → i phone non potevano entrare in `MODE_NIDO` (workaround playtest: host mandava `phase nido` a mano).

**Fix** (`wsSession.js` drain `next_macro`): ramo `else if (result.phase === 'nido') room.publishPhaseChange('nido')`. `nido` è già whitelisted in `KNOWN_PHASES`.

## G5 [P3] — `world_tally` conta l'host TV

Il drain `world_vote` passava gli id **non filtrati** (host incluso) come `allPlayerIds` a `orch.voteWorld` → `worldTally.total` contava l'host TV: 2 player vedevano "2 in attesa / 3 totali". Il path `connected_*` filtrava già l'host (`all_connected_accepted` corretto) → era inflazione display-only.

**Fix** (`wsSession.js` drain `world_vote`): `allPids = lifecycleQuorumPids(room, orch, playerId)` — stesso quorum role-aware self-selecting di `character_create`/`lineage_choice` (#2707/#2708): l'host conta solo se gioca davvero (submitter o possiede un PG).

## Test (TDD — rosso verificato prima del fix)

- **Nuovo** `tests/services/coop/coopStoreLinkCampaignId.test.js` (G2, +2): `linkSession` mirrora `campaignId` sulla Room viva; `publishPhaseChange` porta il `campaign_id`.
- **Nuovo** `tests/api/coopWorldVoteHostFilter.test.js` (G5, +1): `world_tally` da drain WS → `total: 2` (host escluso), `pending: 1`.
- `tests/services/network/wsSession-nido.test.js` (G3, +1): `next_macro` → `phase: nido` → phone ricevono `phase_change(nido)` versionato.
- RED pre-fix: 4 test rossi (campaign_id null / total 3 / nido timeout).

```
G2/G3/G5 mirati                              7/7   pass
coop + WS + coop services cluster          378/378 pass
tests/ai/*.test.js (DoD baseline)          510/510 pass
prettier --check (file toccati)             clean
```

## Changelog

- fix(coop): `campaign_id` propagato sul canale versionato (G2) + phase `nido` broadcastata dal drain next_macro (G3) + `world_tally.total` esclude l'host TV (G5) — #2746.

## Rollback plan (03A)

Revert del singolo commit (`git revert 0d914eb6`): nessuna migration, nessun cambio schema/contracts. Superficie = 2 file backend (`coopStore.js` + `wsSession.js`), 3 hunk indipendenti.

## Note governance

- `wsSession.js`/`coopStore.js` non in forbidden-path; canale coop-WS sensibile → girata la suite coop+WS completa (378 verde).
- Merge = Eduardo only. Dopo merge: spunto G2/G3/G5 su #2746 → issue chiusa backend-side. Resta il re-check QA phone GGv2 (lane Lenovo, separato).
