### PR TITLE
ci(balance): flip combat-oracle gate to phase-2 (blocking on OOB)

### DIFF
--- a/.github/workflows/combat-balance-gate.yml
+++ b/.github/workflows/combat-balance-gate.yml
@@ -17,13 +17,14 @@ name: Combat Balance Gate
 # without re-ratifying the bands. host 127.0.0.1 + LOBBY_WS_ENABLED=false +
 # DAMAGE_CURVES_PATH are all handled inside playtest_canonical.py.
 #
-# PHASE 1 (current): warn-only. The job carries `continue-on-error: true` and
-# the verdict step emits a ::warning:: (never blocks merge). Reason: hc07 is
-# still marginally OOB (52% vs [30-50], #2719-independent, un-bisected) so a
-# blocking gate would freeze merges on a pre-existing issue.
-# PHASE 2 (flip once hc07 is in-band): remove `continue-on-error` and change the
-# verdict step's ::warning:: -> ::error:: + `exit 1`. Then register this as a
-# required status check in branch protection.
+# PHASE 2 (current, 2026-06-14): blocking. The verdict step emits ::error:: +
+# `exit 1` when an oracle is OOB, failing the job. Both oracles are in-band on
+# main (hc06 22% / hc07 42% @ N=100, PR #2753 + #2760) so it passes on baseline.
+# PHASE 1 was warn-only (`continue-on-error`) until hc07 was re-centered.
+# FINAL STEP to make it actually block merge: register `combat-oracle` as a
+# required status check in branch protection (owner-gated, set once). Until then
+# the gate shows a hard red X on OOB but does not technically block.
+# Rollback to warn-only: re-add `continue-on-error: true` on the job.
 #
 # Band-invalidation protocol (correct-fix shifts a band): see
 # docs/process/CANONICAL-AI-PLAYTEST.md sec 9 -- block + human re-ratify, never
@@ -55,7 +56,12 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 25
-    continue-on-error: true # PHASE 1 warn-only. Remove for phase-2 blocking.
+    # PHASE 2 (2026-06-14): blocking. The job fails when an oracle is OOB. Both
+    # oracles are in-band on main (hc06 22% / hc07 42% @ N=100), so this passes on
+    # the current baseline; it fails only when a future combat change shifts a band
+    # -> follow the band-invalidation protocol (CANONICAL-AI-PLAYTEST.md sec 9).
+    # To actually block merge, `combat-oracle` must also be a required status check
+    # in branch protection (owner-gated, set once).
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -114,11 +120,11 @@ jobs:
           path: /tmp/oracle/
           retention-days: 14
 
-      - name: Verdict (phase 1 = warn-only)
+      - name: Verdict (phase 2 = blocking)
         if: always()
         run: |
           if [ "${{ steps.oracle.outputs.exit_code }}" != "0" ]; then
-            echo "::warning title=Combat balance oracle out-of-band::A canonical oracle WR left its ratified band (see step summary). If this PR is a correct combat fix, follow the band re-ratify protocol: docs/process/CANONICAL-AI-PLAYTEST.md sec 9. PHASE 1 = warn-only, not blocking."
-          else
-            echo "All canonical oracles in-band."
+            echo "::error title=Combat balance oracle out-of-band::A canonical oracle WR left its ratified band (see step summary). If this PR is a correct combat fix, follow the band re-ratify protocol: docs/process/CANONICAL-AI-PLAYTEST.md sec 9, then re-run. PHASE 2 = blocking."
+            exit 1
           fi
+          echo "All canonical oracles in-band."


### PR DESCRIPTION
Follow-up to #2753 + #2760. Both canonical oracles are now in-band on main (**hc06 22% / hc07 42%** @ N=100), so the combat-balance gate no longer false-flags → flip it from **warn-only** to **blocking**.

## Change

`.github/workflows/combat-balance-gate.yml`:
- remove the job-level `continue-on-error` → the job now **fails** on OOB
- verdict step `::warning::` → `::error::` + `exit 1`
- oracle step keeps `continue-on-error` so the step summary + artifact upload still run after an OOB result

## Behaviour

- **Passes on the current baseline** (both oracles in-band at N=40: hc06 20%, hc07 42.5%).
- **Fails (red X)** only when a future combat change pushes an oracle out of band → author follows the band-invalidation protocol (`CANONICAL-AI-PLAYTEST.md` §9: re-ratify or fix, never auto-update the band).

## ⚠️ Final owner step (one-time)

A failing check shows a hard red X but does **not technically block merge** until `combat-oracle` is registered as a **required status check** in branch protection (repo setting → `Settings ▸ Branches ▸ main ▸ Require status checks`). That's owner-gated; say the word and I can set it via `gh api` instead.

Rollback: re-add `continue-on-error: true` on the job (back to warn-only).

`.github/workflows/` (forbidden path) → master-dd merge.