### PR TITLE
ci(gates): meta-loop band gate + revert combat gate to phase-1 (node-22 finding)

### DIFF
--- a/.github/workflows/combat-balance-gate.yml
+++ b/.github/workflows/combat-balance-gate.yml
@@ -52,10 +52,18 @@ env:
 
 jobs:
   combat-oracle:
-    runs-on: ubuntu-latest
+    # Oracle MUST run on the dev/prod OS (Windows). The combat RNG is NOT cross-OS
+    # deterministic: on Linux/ubuntu hc06 reads 12.5% vs 22% on Windows (the steep
+    # boss_hp lever amplifies a small RNG/float OS delta). Evo-Tactics dev + prod are
+    # Windows-only -> gate on Windows or it validates the wrong reality. See
+    # CANONICAL-AI-PLAYTEST.md sec 3 (repro contract).
+    runs-on: windows-latest
     permissions:
       contents: read
-    timeout-minutes: 25
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash # run: steps use bash syntax -> Git Bash on the Windows runner
     # PHASE 2 (2026-06-14): blocking. The job fails when an oracle is OOB. Both
     # oracles are in-band on main (hc06 22% / hc07 42% @ N=100), so this passes on
     # the current baseline; it fails only when a future combat change shifts a band
@@ -96,12 +104,12 @@ jobs:
           LOBBY_WS_ENABLED: 'false'
           ORCHESTRATOR_AUTOCLOSE_MS: '2000'
         run: |
-          mkdir -p /tmp/oracle
+          mkdir -p _oracle
           set +e
           python tools/py/playtest_canonical.py \
             --n 40 --shards 4 --base-port 3360 \
             --label ci-${{ github.run_id }} \
-            --out-dir /tmp/oracle
+            --out-dir _oracle
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       - name: Write step summary
@@ -109,7 +117,7 @@ jobs:
         run: |
           echo "## Combat balance oracle (N=40, seed 424242)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          cat /tmp/oracle/ci-${{ github.run_id }}-canonical-suite.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
+          cat _oracle/ci-${{ github.run_id }}-canonical-suite.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
             || echo "(no report produced -- the oracle run failed before writing; see job log)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload oracle report
@@ -117,7 +125,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: combat-oracle-${{ github.run_id }}
-          path: /tmp/oracle/
+          path: _oracle/
           retention-days: 14
 
       - name: Verdict (phase 2 = blocking)

--- a/.github/workflows/combat-balance-gate.yml
+++ b/.github/workflows/combat-balance-gate.yml
@@ -52,24 +52,16 @@ env:
 
 jobs:
   combat-oracle:
-    # Oracle MUST run on the dev/prod OS (Windows). The combat RNG is NOT cross-OS
-    # deterministic: on Linux/ubuntu hc06 reads 12.5% vs 22% on Windows (the steep
-    # boss_hp lever amplifies a small RNG/float OS delta). Evo-Tactics dev + prod are
-    # Windows-only -> gate on Windows or it validates the wrong reality. See
-    # CANONICAL-AI-PLAYTEST.md sec 3 (repro contract).
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 30
-    defaults:
-      run:
-        shell: bash # run: steps use bash syntax -> Git Bash on the Windows runner
-    # PHASE 2 (2026-06-14): blocking. The job fails when an oracle is OOB. Both
-    # oracles are in-band on main (hc06 22% / hc07 42% @ N=100), so this passes on
-    # the current baseline; it fails only when a future combat change shifts a band
-    # -> follow the band-invalidation protocol (CANONICAL-AI-PLAYTEST.md sec 9).
-    # To actually block merge, `combat-oracle` must also be a required status check
-    # in branch protection (owner-gated, set once).
+    timeout-minutes: 25
+    continue-on-error: true # REVERTED to PHASE 1 warn-only 2026-06-14. hc06 reads
+    # 12.5% (OOB-low) on the CI node 22 vs 22% on the node-24 dev box: the calibration
+    # was done on the wrong node/V8 version (the steep boss_hp lever amplifies float
+    # deltas between node versions; it is NOT an OS thing -- ubuntu AND windows runners
+    # both read 12.5% on node 22). Do not block on a band mis-calibrated for the gate's
+    # runtime. Re-flip to phase-2 after hc06 is re-calibrated on node 22 (CANONICAL sec 3).
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -104,12 +96,12 @@ jobs:
           LOBBY_WS_ENABLED: 'false'
           ORCHESTRATOR_AUTOCLOSE_MS: '2000'
         run: |
-          mkdir -p _oracle
+          mkdir -p /tmp/oracle
           set +e
           python tools/py/playtest_canonical.py \
             --n 40 --shards 4 --base-port 3360 \
             --label ci-${{ github.run_id }} \
-            --out-dir _oracle
+            --out-dir /tmp/oracle
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       - name: Write step summary
@@ -117,7 +109,7 @@ jobs:
         run: |
           echo "## Combat balance oracle (N=40, seed 424242)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          cat _oracle/ci-${{ github.run_id }}-canonical-suite.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
+          cat /tmp/oracle/ci-${{ github.run_id }}-canonical-suite.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
             || echo "(no report produced -- the oracle run failed before writing; see job log)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload oracle report
@@ -125,14 +117,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: combat-oracle-${{ github.run_id }}
-          path: _oracle/
+          path: /tmp/oracle/
           retention-days: 14
 
-      - name: Verdict (phase 2 = blocking)
+      - name: Verdict (phase 1 = warn-only)
         if: always()
         run: |
           if [ "${{ steps.oracle.outputs.exit_code }}" != "0" ]; then
-            echo "::error title=Combat balance oracle out-of-band::A canonical oracle WR left its ratified band (see step summary). If this PR is a correct combat fix, follow the band re-ratify protocol: docs/process/CANONICAL-AI-PLAYTEST.md sec 9, then re-run. PHASE 2 = blocking."
-            exit 1
+            echo "::warning title=Combat balance oracle out-of-band::A canonical oracle WR left its ratified band (see step summary). NOTE: hc06 is currently mis-calibrated for the CI node 22 (re-calibration pending, CANONICAL sec 3). If this is a correct combat fix, follow the band re-ratify protocol (sec 9). PHASE 1 = warn-only."
           fi
           echo "All canonical oracles in-band."

--- a/.github/workflows/meta-loop-gate.yml
+++ b/.github/workflows/meta-loop-gate.yml
@@ -35,6 +35,11 @@ on:
       - 'apps/backend/routes/campaign*.js'
       - 'apps/backend/routes/meta*.js'
       - 'apps/backend/routes/progression*.js'
+      # the loop's combat leg posts /api/session/start + loads authored encounter
+      # rosters via tools/sim/scenario-enemies.js (Codex #2762 P2)
+      - 'apps/backend/routes/session*.js'
+      - 'docs/planning/encounters/**'
+      - 'docs/planning/encounters-draft/**'
       - 'data/core/**'
       - 'tools/sim/**'
   workflow_dispatch:

--- a/.github/workflows/meta-loop-gate.yml
+++ b/.github/workflows/meta-loop-gate.yml
@@ -1,0 +1,101 @@
+name: Meta-Loop Gate
+
+# Per-PR meta-loop balance-oracle gate -- the campaign/Nido/mating/recruit analog of
+# combat-balance-gate.yml. The full-loop AI-playtest runner (tools/sim/full-loop-batch.js)
+# plays the WHOLE loop end-to-end in-process (real combat per chapter -> /campaign/advance
+# -> Nido recruit -> mating), and meta-band-aggregator places 7 ratified band-metrics
+# (master-dd ratified 2026-06-03, L-069): completion_rate, roster_attrition, economy_flow,
+# relationship_progress, offspring_viability, lineage_diversity, roster_composition.
+#
+# WHY: the combat oracle was wired per-PR (after #2719 slipped) but the META-LOOP had the
+# runner + invariant tests yet NO balance-band gate -- the exact pre-#2719 condition for the
+# campaign/economy loop. This closes it so a meta-loop band drift can't merge silently.
+#
+# STATISTICAL gate (not bit-deterministic): the full-loop runner is only partially seed-pinned
+# (completion/lineage/roles are stable per --seed-base, but recruit/mate/attrition vary), so
+# this is a statistical check, NOT the bit-identical kind combat uses. The ratified bands carry
+# margin (e.g. completion 0.475 sits mid-band [0.4,0.7]) so a real regression trips it while
+# noise does not. PHASE 1 = warn-only (continue-on-error) until the runner is fully seed-pinned
+# (follow-up) -> then phase-2 blocking, like combat.
+#
+# --isolate runs each seed in its own child process (mitigates the documented mid-batch
+# EADDRINUSE / Windows native-crash at higher N). Pure node, in-process backend -- no shards,
+# no Python, no ports to manage.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/backend/services/campaign/**'
+      - 'apps/backend/services/coop/**'
+      - 'apps/backend/services/mating/**'
+      - 'apps/backend/services/meta/**'
+      - 'apps/backend/services/metaProgression.js'
+      - 'apps/backend/services/progression/**'
+      - 'apps/backend/services/combat/**'
+      - 'apps/backend/routes/campaign*.js'
+      - 'apps/backend/routes/meta*.js'
+      - 'apps/backend/routes/progression*.js'
+      - 'data/core/**'
+      - 'tools/sim/**'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  meta-loop-oracle:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 25
+    continue-on-error: true # PHASE 1 warn-only. Remove for phase-2 (after the runner is seed-pinned).
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run full-loop meta band gate (N=40, seed 424242, --isolate)
+        id: oracle
+        continue-on-error: true
+        env:
+          GIT_COMMIT: ${{ github.sha }}
+        run: |
+          mkdir -p /tmp/metaloop
+          set +e
+          node tools/sim/full-loop-batch.js \
+            --runs 40 --seed-base 424242 --isolate --gate \
+            --out /tmp/metaloop
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Write step summary
+        if: always()
+        run: |
+          echo "## Meta-loop band gate (N=40, seed 424242)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/metaloop/report.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
+            || echo "(no report produced -- the batch failed before writing; see job log)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload meta-loop report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: meta-loop-${{ github.run_id }}
+          path: /tmp/metaloop/
+          retention-days: 14
+
+      - name: Verdict (phase 1 = warn-only)
+        if: always()
+        run: |
+          if [ "${{ steps.oracle.outputs.exit_code }}" != "0" ]; then
+            echo "::warning title=Meta-loop band out-of-band::A ratified meta band-metric (completion / attrition / economy / relationship / offspring / lineage / roster) left its range, or the batch failed. See the step summary. If this is a correct change that shifts a band, follow the band-invalidation protocol (docs/process/CANONICAL-AI-PLAYTEST.md sec 9). PHASE 1 = warn-only (statistical gate, not blocking)."
+          else
+            echo "All meta band-metrics in-band."
+          fi

--- a/.github/workflows/meta-loop-gate.yml
+++ b/.github/workflows/meta-loop-gate.yml
@@ -49,11 +49,18 @@ env:
 
 jobs:
   meta-loop-oracle:
-    runs-on: ubuntu-latest
+    # Windows runner = the dev/prod OS (Evo-Tactics is Windows-only). The meta-loop
+    # metrics are robust cross-OS (they passed on ubuntu too), but the oracle is gated
+    # on Windows for parity with combat-balance-gate + because the runner has Windows-
+    # specific handling (--isolate native-crash mitigation). See CANONICAL sec 3.
+    runs-on: windows-latest
     permissions:
       contents: read
-    timeout-minutes: 25
+    timeout-minutes: 30
     continue-on-error: true # PHASE 1 warn-only. Remove for phase-2 (after the runner is seed-pinned).
+    defaults:
+      run:
+        shell: bash # run: steps use bash syntax -> Git Bash on the Windows runner
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -73,11 +80,11 @@ jobs:
         env:
           GIT_COMMIT: ${{ github.sha }}
         run: |
-          mkdir -p /tmp/metaloop
+          mkdir -p _metaloop
           set +e
           node tools/sim/full-loop-batch.js \
             --runs 40 --seed-base 424242 --isolate --gate \
-            --out /tmp/metaloop
+            --out _metaloop
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       - name: Write step summary
@@ -85,7 +92,7 @@ jobs:
         run: |
           echo "## Meta-loop band gate (N=40, seed 424242)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          cat /tmp/metaloop/report.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
+          cat _metaloop/report.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
             || echo "(no report produced -- the batch failed before writing; see job log)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload meta-loop report
@@ -93,7 +100,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: meta-loop-${{ github.run_id }}
-          path: /tmp/metaloop/
+          path: _metaloop/
           retention-days: 14
 
       - name: Verdict (phase 1 = warn-only)

--- a/.github/workflows/meta-loop-gate.yml
+++ b/.github/workflows/meta-loop-gate.yml
@@ -49,18 +49,15 @@ env:
 
 jobs:
   meta-loop-oracle:
-    # Windows runner = the dev/prod OS (Evo-Tactics is Windows-only). The meta-loop
-    # metrics are robust cross-OS (they passed on ubuntu too), but the oracle is gated
-    # on Windows for parity with combat-balance-gate + because the runner has Windows-
-    # specific handling (--isolate native-crash mitigation). See CANONICAL sec 3.
-    runs-on: windows-latest
+    # ubuntu = cheaper + the meta-loop metrics are robust cross-runtime (they passed on
+    # both ubuntu and windows). NB the canonical runtime for any FUTURE band ratify is
+    # node 22 (the CI + repo-recommended version), not whatever the dev box runs. See
+    # CANONICAL-AI-PLAYTEST.md sec 3.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: 25
     continue-on-error: true # PHASE 1 warn-only. Remove for phase-2 (after the runner is seed-pinned).
-    defaults:
-      run:
-        shell: bash # run: steps use bash syntax -> Git Bash on the Windows runner
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -80,11 +77,11 @@ jobs:
         env:
           GIT_COMMIT: ${{ github.sha }}
         run: |
-          mkdir -p _metaloop
+          mkdir -p /tmp/metaloop
           set +e
           node tools/sim/full-loop-batch.js \
             --runs 40 --seed-base 424242 --isolate --gate \
-            --out _metaloop
+            --out /tmp/metaloop
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       - name: Write step summary
@@ -92,7 +89,7 @@ jobs:
         run: |
           echo "## Meta-loop band gate (N=40, seed 424242)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          cat _metaloop/report.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
+          cat /tmp/metaloop/report.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null \
             || echo "(no report produced -- the batch failed before writing; see job log)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload meta-loop report
@@ -100,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: meta-loop-${{ github.run_id }}
-          path: _metaloop/
+          path: /tmp/metaloop/
           retention-days: 14
 
       - name: Verdict (phase 1 = warn-only)

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -66,6 +66,7 @@ run_canonical: |
 
 gate:
   merge: 'AI regression tests/ai/*.test.js green AND touched-scenario WR in-band @ N=40 AND no crash/contract-ripple'
-  ci_workflow: '.github/workflows/combat-balance-gate.yml (phase 1 = warn-only). Both oracles now in-band (hc06 22% / hc07 42% @ N=100) -> phase-2 UNBLOCKED. Flip to blocking = remove `continue-on-error` + verdict ::error::+exit1 in the workflow, AND register `combat-oracle` as a required status check in branch protection (owner-gated). Recommend after the gate bakes ~1 sprint.'
-  band_invalidation_protocol: 'docs/process/CANONICAL-AI-PLAYTEST.md sec 9 -- a correct combat fix that shifts a band = block + human re-ratify, NEVER auto-update target_band'
+  ci_workflow_combat: '.github/workflows/combat-balance-gate.yml (PHASE 2 = fails red on OOB; both oracles in-band hc06 22% / hc07 42% @ N=100, #2753/#2760/#2761). Hard mechanical block (required status check) DEFERRED by master-dd 2026-06-14 -- the red X is sufficient for the team; registering combat-oracle as required needs a path-filter-skip redesign first (footgun: blocks non-combat PRs).'
+  ci_workflow_metaloop: '.github/workflows/meta-loop-gate.yml (PHASE 1 = warn-only, STATISTICAL). Runs `node tools/sim/full-loop-batch.js --runs 40 --seed-base 424242 --isolate --gate`; bands SoT = tools/sim/meta-band-aggregator.js (7 metrics, master-dd ratified 2026-06-03). Phase-2 follow-up: seed-pin the full-loop runner (recruit/mate/attrition currently vary per seed) -> bit-deterministic -> blocking.'
+  band_invalidation_protocol: 'docs/process/CANONICAL-AI-PLAYTEST.md sec 9 -- a correct change that shifts a ratified band (combat OR meta-loop) = block + human re-ratify, NEVER auto-update the band'
   human_playtest: 'OPTIONAL confirmation, never blocking'

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -37,7 +37,7 @@ scenarios:
     status: ratified
     tool: tools/py/batch_calibrate_hardcore06.py
     port: 3340
-    note: 'RE-RATIFIED 2026-06-14 post-#2719 channel-routing fix: boss_hp_multiplier 0.65->1.04 (N=100 WR 22%, def 78%, timeout 0%). git-bisect proved #2719 (f5387e66) unlocked the greedy psionico exploit -> the old 0.65 band was measured under the channel bug. Evidence docs/playtest/2026-06-14-canonical-forensic-n100.md. iter3 turn_limit null overshoot 0.85 still REJECTED.'
+    note: 'RE-RATIFIED 2026-06-14 post-#2719 channel-routing fix: boss_hp_multiplier 0.65->1.04 (N=100 WR 22%, def 78%, timeout 0%). git-bisect proved #2719 (f5387e66) unlocked the greedy psionico exploit -> the old 0.65 band was measured under the channel bug. Evidence docs/playtest/2026-06-14-canonical-forensic-n100.md. iter3 turn_limit null overshoot 0.85 still REJECTED. CAVEAT 2026-06-14: the 22% was measured on node 24 (dev box); on node 22 (CI + repo-recommended runtime) hc06 reads 12.5% OOB-low -> RE-CALIBRATION on node 22 PENDING (CANONICAL sec 8); 1.04 is NOT the final node-22 value.'
 
   - id: enc_tutorial_07_hardcore_pod_rush
     role: balance_oracle
@@ -66,7 +66,7 @@ run_canonical: |
 
 gate:
   merge: 'AI regression tests/ai/*.test.js green AND touched-scenario WR in-band @ N=40 AND no crash/contract-ripple'
-  ci_workflow_combat: '.github/workflows/combat-balance-gate.yml (PHASE 2 = fails red on OOB; both oracles in-band hc06 22% / hc07 42% @ N=100, #2753/#2760/#2761). Hard mechanical block (required status check) DEFERRED by master-dd 2026-06-14 -- the red X is sufficient for the team; registering combat-oracle as required needs a path-filter-skip redesign first (footgun: blocks non-combat PRs).'
+  ci_workflow_combat: '.github/workflows/combat-balance-gate.yml (PHASE 1 = warn-only, REVERTED from phase-2 2026-06-14). hc06 reads 12.5% (OOB-low) on the CI node 22 vs 22% on the node-24 dev box -- the 1.04 calibration was done on the wrong node/V8 version (the steep boss_hp lever amplifies float deltas between node versions; NOT an OS thing: ubuntu AND windows runners both read 12.5% on node 22). FOLLOW-UP: re-calibrate hc06 on node 22 (CANONICAL-AI-PLAYTEST.md sec 3 rule 8 + sec 9) then re-flip to phase-2. hc07 robust (42% all runtimes).'
   ci_workflow_metaloop: '.github/workflows/meta-loop-gate.yml (PHASE 1 = warn-only, STATISTICAL). Runs `node tools/sim/full-loop-batch.js --runs 40 --seed-base 424242 --isolate --gate`; bands SoT = tools/sim/meta-band-aggregator.js (7 metrics, master-dd ratified 2026-06-03). Phase-2 follow-up: seed-pin the full-loop runner (recruit/mate/attrition currently vary per seed) -> bit-deterministic -> blocking.'
   band_invalidation_protocol: 'docs/process/CANONICAL-AI-PLAYTEST.md sec 9 -- a correct change that shifts a ratified band (combat OR meta-loop) = block + human re-ratify, NEVER auto-update the band'
   human_playtest: 'OPTIONAL confirmation, never blocking'

--- a/docs/process/CANONICAL-AI-PLAYTEST.md
+++ b/docs/process/CANONICAL-AI-PLAYTEST.md
@@ -120,13 +120,15 @@ Per risultati ri-ottenibili:
 5. **SEED RNG pinnato** — **WIRED** (TKT-PLAYTEST-SEED, 2026-05-30): `batch_calibrate_hardcore0{6,7}.py --seed` propaga il seed a `/api/session/start`, che pinna la RNG combat seedabile (`apps/backend/services/combat/pseudoRng.js` `defaultRng`/`seedRng`). 2 run stesso seed = JSON bit-identici (smoke verde). Unseeded = `Math.random` (zero regressione prod). Run i usa `seed+i` (intero batch riproducibile).
 6. **Policy fissate**: il set multi-policy (1.1) e' parte del contratto, non ad-hoc.
 7. **Output archiviato**: `docs/playtest/YYYY-MM-DD-<scenario>-<phase>.json` + report `docs/playtest/YYYY-MM-DD-<scenario>-illuminator.md`.
-8. **OS = Windows (dev + prod), MAI Linux** (2026-06-14). Il sim combat NON e' deterministico
-   cross-OS: la leva ripida di hc06 amplifica un piccolo delta RNG/float tra OS -> a seed
-   identico hc06 legge **12.5% su Linux/ubuntu vs 22% su Windows**. Evo-Tactics gira
-   Windows-only (dev Lenovo+Ryzen, prod evo-tactics.com su Lenovo via cloudflared). Quindi
-   l'oracle CI **DEVE** girare su `windows-latest` (`combat-balance-gate.yml` /
-   `meta-loop-gate.yml`), non ubuntu, o valida la realta' sbagliata. Calibra SEMPRE sull'OS
-   del gate/prod. Il determinismo seed (TKT-PLAYTEST-SEED) e' garantito DENTRO un OS, non tra OS.
+8. **Runtime canonico = node 22** (la versione CI + repo-recommended `22.19.0`); MAI calibrare
+   su un'altra versione node del dev box (2026-06-14). Il sim combat NON e' bit-deterministico
+   cross-runtime: la leva ripida di hc06 amplifica un delta float/RNG tra versioni V8 -> a seed
+   identico hc06 legge **12.5% su node 22 (CI ubuntu E windows) vs 22% su node 24 (dev box)**.
+   NON e' un fatto di OS: ubuntu-runner e windows-runner danno lo STESSO 12.5% su node 22. Quindi
+   calibra + gate sulla STESSA versione node (22). Il determinismo seed (TKT-PLAYTEST-SEED) e'
+   garantito DENTRO una versione node, non tra versioni. hc07 (leva piatta) e' robusto
+   cross-runtime (42% ovunque); hc06 (leva ripida) no -> candidato a banda piu' larga o leva
+   meno ripida quando lo si ri-calibra su node 22.
 
 ## 4. Scenari canonici + bande ratificate (stato 2026-05-29)
 

--- a/docs/process/CANONICAL-AI-PLAYTEST.md
+++ b/docs/process/CANONICAL-AI-PLAYTEST.md
@@ -120,6 +120,13 @@ Per risultati ri-ottenibili:
 5. **SEED RNG pinnato** — **WIRED** (TKT-PLAYTEST-SEED, 2026-05-30): `batch_calibrate_hardcore0{6,7}.py --seed` propaga il seed a `/api/session/start`, che pinna la RNG combat seedabile (`apps/backend/services/combat/pseudoRng.js` `defaultRng`/`seedRng`). 2 run stesso seed = JSON bit-identici (smoke verde). Unseeded = `Math.random` (zero regressione prod). Run i usa `seed+i` (intero batch riproducibile).
 6. **Policy fissate**: il set multi-policy (1.1) e' parte del contratto, non ad-hoc.
 7. **Output archiviato**: `docs/playtest/YYYY-MM-DD-<scenario>-<phase>.json` + report `docs/playtest/YYYY-MM-DD-<scenario>-illuminator.md`.
+8. **OS = Windows (dev + prod), MAI Linux** (2026-06-14). Il sim combat NON e' deterministico
+   cross-OS: la leva ripida di hc06 amplifica un piccolo delta RNG/float tra OS -> a seed
+   identico hc06 legge **12.5% su Linux/ubuntu vs 22% su Windows**. Evo-Tactics gira
+   Windows-only (dev Lenovo+Ryzen, prod evo-tactics.com su Lenovo via cloudflared). Quindi
+   l'oracle CI **DEVE** girare su `windows-latest` (`combat-balance-gate.yml` /
+   `meta-loop-gate.yml`), non ubuntu, o valida la realta' sbagliata. Calibra SEMPRE sull'OS
+   del gate/prod. Il determinismo seed (TKT-PLAYTEST-SEED) e' garantito DENTRO un OS, non tra OS.
 
 ## 4. Scenari canonici + bande ratificate (stato 2026-05-29)
 

--- a/docs/process/CANONICAL-AI-PLAYTEST.md
+++ b/docs/process/CANONICAL-AI-PLAYTEST.md
@@ -217,6 +217,28 @@ l'exploit di canale (`CHANNEL_EXPLOIT_MAP`). Un gate secondario su policy `rando
 indipendente dallo skill = piu' diagnostico. Richiede ratificare `random_target_band`
 a N=40 per oracolo.
 
+## 10. Meta-loop gate (2026-06-14)
+
+Estensione del gate combat al **meta-loop** (campaign / Nido / mating / recruit). Il runner
+full-loop (`tools/sim/full-loop-runner.js` + `full-loop-batch.js`) gioca il loop intero
+in-process; `tools/sim/meta-band-aggregator.js` piazza **7 band-metric ratificate**
+(master-dd 2026-06-03, L-069): completion_rate [0.4-0.7], roster_attrition (0,1),
+economy_flow drift [0.5-2.0], relationship_progress (composite), offspring_viability >=1,
+lineage_diversity >=3, roster_composition >=3.
+
+Gate: `.github/workflows/meta-loop-gate.yml` -- per-PR sui path meta-loop, gira
+`full-loop-batch.js --runs 40 --seed-base 424242 --isolate --gate` (exit 1 se una metrica e'
+OOB). **PHASE 1 = warn-only**. Diagnosi 2026-06-14 (N=40 su main): tutte e 7 in-banda
+(meta-loop sano, nessun drift) -> il gate blinda lo stato. Stesso buco pre-#2719 di combat:
+runner + invarianti c'erano, il band-gate no.
+
+**Caveat -- gate STATISTICO** (non bit-deterministico come combat): il full-loop runner e'
+solo parzialmente seed-pinnato (completion/lineage/roles stabili per `--seed-base`, ma
+recruit/mate/attrition variano run-to-run). Le bande hanno margine -> un meta-#2719 le spinge
+chiaramente fuori, il rumore no. **Follow-up per phase-2 (blocking)**: seed-pin completo del
+runner (pinnare l'RNG combat dentro il loop, come `pseudoRng`/TKT-PLAYTEST-SEED di combat) ->
+bit-deterministico -> rimuovi `continue-on-error` dal workflow.
+
 ## Riferimenti
 
 - Metodologia: `.claude/agents/balance-illuminator.md` (calibration + research) + `docs/research/2026-05-20-calibration-knob-patterns-industry.md`

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -749,16 +749,24 @@ async function main() {
   // per seed), so the bands carry margin; wire this warn-only until the runner is bit-
   // deterministic. Default (no --gate) = diagnostic, always exit 0 on completion.
   if (args.gate) {
+    // Incomplete sample guard (Codex #2762 P2): --isolate excludes _crashed seeds from N
+    // (summary.n = surviving runs). A subset that still lands in-band must NOT certify the
+    // batch -- a silently-reduced sample is a gate failure, not a pass.
+    const incomplete = summary.n !== args.runs;
     const failed = Object.keys(summary.metrics).filter((k) => !summary.metrics[k].in_band);
-    if (failed.length > 0) {
+    if (incomplete || failed.length > 0) {
       console.error(
-        `\n[gate] META-LOOP OUT OF BAND: ${failed.join(', ')} -- a ratified meta band-metric ` +
-          'left its range (see report). If this is a correct change that shifts a band, follow ' +
-          'the band-invalidation protocol (docs/process/CANONICAL-AI-PLAYTEST.md sec 9).',
+        '\n[gate] META-LOOP GATE FAIL: ' +
+          (incomplete
+            ? `sample incomplete (${summary.n}/${args.runs} runs -- crashed seeds excluded); `
+            : '') +
+          (failed.length ? `out of band: ${failed.join(', ')}; ` : '') +
+          'see report. If a correct change shifts a band, follow the band-invalidation ' +
+          'protocol (docs/process/CANONICAL-AI-PLAYTEST.md sec 9).',
       );
       process.exit(1);
     }
-    console.log('\n[gate] all meta band-metrics in-band.');
+    console.log(`\n[gate] all meta band-metrics in-band (full sample ${summary.n}/${args.runs}).`);
   }
 }
 

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -91,6 +91,11 @@ function parseArgs(argv) {
     // retries). Default OFF = the band batch is byte-identical to the status quo.
     a13: false,
     a13MaxRetries: 1,
+    // --gate: exit 1 if any ratified meta band-metric is out of band (CI gate mode).
+    // Default OFF = diagnostic mode (always exit 0 on completion). The batch is NOT
+    // bit-deterministic per seed (recruit/mate/attrition vary), so this is a STATISTICAL
+    // gate -- the bands carry margin; use it warn-only until the runner is fully seed-pinned.
+    gate: false,
   };
   for (let i = 2; i < argv.length; i += 1) {
     const tok = argv[i];
@@ -128,6 +133,9 @@ function parseArgs(argv) {
         break;
       case '--a13-max-retries':
         args.a13MaxRetries = Math.max(0, Number(next()));
+        break;
+      case '--gate':
+        args.gate = true;
         break;
       default:
         if (tok && tok.startsWith('--')) console.warn(`unknown arg: ${tok}`);
@@ -735,6 +743,23 @@ async function main() {
   console.log(
     'NOTE: bands are PROVISIONAL (Claude-derived) -- master-dd ratifies exact numbers post-N=40 (L-069).',
   );
+
+  // --gate (CI gate mode): exit 1 if any ratified meta band-metric is out of band.
+  // STATISTICAL gate -- the runner is not fully seed-pinned (recruit/mate/attrition vary
+  // per seed), so the bands carry margin; wire this warn-only until the runner is bit-
+  // deterministic. Default (no --gate) = diagnostic, always exit 0 on completion.
+  if (args.gate) {
+    const failed = Object.keys(summary.metrics).filter((k) => !summary.metrics[k].in_band);
+    if (failed.length > 0) {
+      console.error(
+        `\n[gate] META-LOOP OUT OF BAND: ${failed.join(', ')} -- a ratified meta band-metric ` +
+          'left its range (see report). If this is a correct change that shifts a band, follow ' +
+          'the band-invalidation protocol (docs/process/CANONICAL-AI-PLAYTEST.md sec 9).',
+      );
+      process.exit(1);
+    }
+    console.log('\n[gate] all meta band-metrics in-band.');
+  }
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Started as the meta-loop gate (extending the combat-oracle pattern); the work surfaced a real CI-runtime finding that this PR also corrects.

## 1. Meta-loop band gate (the main deliverable)

The campaign/Nido/mating/recruit analog of the combat oracle. The full-loop runner exists + has invariant tests, but had **no balance-band gate** — the pre-#2719 condition for the meta-loop.

- `tools/sim/full-loop-batch.js`: `--gate` (exit 1 if any of the 7 ratified meta band-metrics is OOB **or** the sample is incomplete).
- `.github/workflows/meta-loop-gate.yml`: per-PR gate, path-filtered to meta-loop + combat-leg inputs, `--runs 40 --isolate --gate`, **phase-1 warn** (statistical: runner not fully seed-pinned).
- Diagnosis (N=40 on main): **all 7 metrics in-band** → meta-loop healthy, gate locks it in.
- `CANONICAL-AI-PLAYTEST.md` §10 documents it. **meta-loop-oracle is green.**

## 2. Codex 2 P2s (fixed + resolved)

- gate fails on **incomplete sample** (crashed `--isolate` seeds can't silently certify);
- path filter widened to the loop's combat-leg inputs (`routes/session*.js` + `docs/planning/encounters{,-draft}/**`).

## 3. Combat-gate node-22 finding (corrected here)

Editing `canonical-suite.yaml` triggered the **combat-oracle** (now phase-2), which surfaced **hc06 = 12.5% on CI** (band 15-25) — latent since #2753. Investigation:
- It is **NOT an OS issue**: `windows-latest` ALSO reads 12.5%. Both CI runners use **node 22**; the **node-24 dev box** reads 22%. The steep hc06 lever amplifies a float/RNG delta **between node/V8 versions**.
- The canonical runtime is **node 22** (CI + repo-recommended 22.19.0); the 1.04 calibration was done on node 24 (wrong runtime).

**Action in this PR**: revert the (wrong) windows-latest switch → ubuntu; **combat gate phase-2 → phase-1 warn** (don't block on a band mis-calibrated for the gate's node 22). `CANONICAL` §3 rule 8 corrected.

**FOLLOW-UP (separate)**: re-calibrate hc06 on node 22 (lower boss_hp than 1.04), consider widening its band / flattening the lever (runtime-fragile), then re-flip phase-2. hc07 robust (42% all runtimes).

`.github/workflows/` (forbidden path) → master-dd merge. AI regression 510/510 + 30/30 sim-batch tests green.