### PR TITLE
fix(ci): unbreak evo-rollout-status + daily-tracker-refresh scheduled crons

### DIFF
--- a/.github/workflows/daily-tracker-refresh.yml
+++ b/.github/workflows/daily-tracker-refresh.yml
@@ -14,6 +14,9 @@ env:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,9 +30,28 @@ jobs:
         run: python -m pip install --upgrade pip && pip install PyYAML
       - name: Aggiorna tracker e README
         run: python scripts/daily_tracker_refresh.py --export-json reports/daily_tracker_summary.json
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: 'chore: refresh tracker index'
-          commit_author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
-          branch: main
+      - name: Open tracker-refresh PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          # main e' protetto: il bot github-actions non puo' pushare diretto
+          # (403 -> git-auto-commit-action exit 128). Consegna via PR branch +
+          # auto-PR, idioma riusato da ai-sim-nightly (B3) e skiv-monitor.
+          if git diff --quiet -- docs/00-INDEX.md; then
+            echo "Tracker index invariato -- nessun PR necessario"
+            exit 0
+          fi
+          BRANCH="automation/daily-tracker-refresh"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add docs/00-INDEX.md
+          git commit -m "chore: refresh tracker index"
+          git push origin "$BRANCH" --force
+          gh pr create \
+            --title "chore: daily tracker index refresh" \
+            --body "Auto-refresh indice tracker (docs/00-INDEX.md) generato da scripts/daily_tracker_refresh.py. main e' protetto: consegna via PR (mai auto-commit diretto su main). Rollback: git revert <sha> oppure chiudi il PR." \
+            --label "automation" \
+            --base main --head "$BRANCH" \
+            --repo "${{ github.repository }}" || echo "PR gia' esistente per $BRANCH (aggiornato via force-push)"

--- a/tools/roadmap/update_status.py
+++ b/tools/roadmap/update_status.py
@@ -410,6 +410,7 @@ def write_status_markdown(
             species_samples=format_samples(species_metrics.samples_species),
         )
     )
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
     return content
 


### PR DESCRIPTION
## Summary

Two **scheduled (cron)** workflows on `main` have failed every run for 8+ days. They are not PR-triggered (so PR CI was unaffected) but kept `main` red. Both root causes confirmed via **run-logs** (ground truth), not status markers.

| Job | Workflow | Failing run | Root cause | Fix |
| --- | --- | --- | --- | --- |
| 1 | `evo-rollout-status.yml` | [27544524508](https://github.com/MasterDD-L34D/Game/actions/runs/27544524508) | `FileNotFoundError` writing `docs/roadmap/evo-rollout-status.md` (dir absent) | `parent.mkdir` in script |
| 2 | `daily-tracker-refresh.yml` | [27563475667](https://github.com/MasterDD-L34D/Game/actions/runs/27563475667) | bot `403` pushing protected `main` -> `exit 128` | commit via PR, not direct push |

## JOB 1 -- evo rollout status sync

**Root cause** (exact traceback from run 27544524508):
```
File ".../tools/roadmap/update_status.py", line 631, in main
File ".../tools/roadmap/update_status.py", line 413, in write_status_markdown
FileNotFoundError: [Errno 2] No such file or directory: '.../docs/roadmap/evo-rollout-status.md'
```
`write_status_markdown` did `path.write_text()` **without** creating the parent dir, while its sibling writers already do (`write_weekly_template` -> `ensure_weekly_dir`, `write_kanban_export` -> `path.parent.mkdir(parents=True, exist_ok=True)`). `docs/roadmap/` does not exist on `main`, and `write_status_markdown` is the first writer in `main()`, so it blew up before the weekly-template writer could create the tree.

**Fix:** add `path.parent.mkdir(parents=True, exist_ok=True)` before the write -- one line, mirrors the existing sibling pattern, also fixes local runs (the script's docstring states it is meant to run locally + in CI). Smaller + more correct than a workflow `mkdir -p` step (which would not fix local runs and would add forbidden-path churn). Feature is **not** dead -- all 4 input reports + `tasks.yml` exist on `main` and the script otherwise runs end-to-end.

**Verification (local, python 3.11.15 = CI parity):**
- Pre-fix: reproduced the exact `FileNotFoundError`, exit 1.
- Post-fix: exit 0; `docs/roadmap/evo-rollout-status.md` + `docs/roadmap/status/evo-weekly-*.md` + `reports/evo/rollout/status_export.json` generated, `tasks.yml` updated. (Generated artifacts discarded; only the 1-line source fix is committed.)
- This workflow has no commit/push step (only generate + upload-artifact), so the mkdir makes it fully green.

## JOB 2 -- daily tracker refresh

**Root cause** (exact, run 27563475667 -- the python step `Aggiorna tracker e README` succeeded; only the commit step failed):
```
remote: Permission to MasterDD-L34D/Game.git denied to github-actions[bot].
fatal: ... error: 403
Error: Invalid status code: 128
```
`stefanzweifel/git-auto-commit-action@v5` was configured with `branch: main` -> direct push to a protected branch -> `github-actions[bot]` `403` -> `exit 128`.

**Fix:** deliver the tracker-index update via a **PR** instead of a direct push, reusing the repo's existing idiom (`ai-sim-nightly.yml` B3 "commit via PR, NOT auto-commit to main" + `skiv-monitor.yml` / `qa-export.yml`). No new dependency (drops the `git-auto-commit-action`, uses `gh pr create`). Details:
- job-scoped `permissions: { contents: write, pull-requests: write }`;
- diff-gated on `docs/00-INDEX.md` (the real artifact -- README markers were removed in the 2026-04-14 restructuring, so `update_readme` is already a silent no-op; the export JSON is timestamp churn and is no longer committed);
- **rolling branch** `automation/daily-tracker-refresh` + `--force` -> one continuously-updated PR (not 365 PRs/yr); `gh pr create ... || echo` is a no-op when the PR already exists;
- label `automation` (verified present in repo).

**Verification:** workflow YAML parses; the changed step is a direct adaptation of currently-green workflows; the python step is already proven green by the run-log. Final confirmation: master-dd can run `workflow_dispatch` after merge.

## Rollback (03A)

`git revert <merge_sha>` restores both files. JOB 2 alone: re-add the `git-auto-commit-action` step (reverts to the failing direct-push behaviour). No data/schema/migration impact; no runtime code touched.

## Notes

- Touches `.github/workflows/` (forbidden path) -> **master-dd merge required**, not auto-merge L3.
- Commit carries ADR-0011 trailers (`Coding-Agent` + `Trace-Id`); no `Co-Authored-By`.
- Scope is exactly 2 files (+29 / -6). No new npm/pip deps.