### PR TITLE
feat(encounters): backport pressure_tier_floor in schema + 10 YAML (#2744 A1)

### DIFF
--- a/docs/planning/encounters/enc_capture_01.yaml
+++ b/docs/planning/encounters/enc_capture_01.yaml
@@ -12,6 +12,7 @@ name: 'Presidio della Forgia'
 biome_id: rovine_planari
 grid_size: [10, 10]
 difficulty_rating: 3
+pressure_tier_floor: 2
 estimated_turns: 10
 # M7-#2 Phase C (ADR-2026-04-20): standard class (multiplier 1.0x, no enrage)
 encounter_class: standard

--- a/docs/planning/encounters/enc_caverna_02.yaml
+++ b/docs/planning/encounters/enc_caverna_02.yaml
@@ -10,6 +10,7 @@ name: 'Eco nella Caverna'
 biome_id: caverna
 grid_size: [10, 10]
 difficulty_rating: 3
+pressure_tier_floor: 2
 estimated_turns: 12
 # M7-#2 Phase C (ADR-2026-04-20): standard class (multiplier 1.0x, no enrage)
 encounter_class: standard

--- a/docs/planning/encounters/enc_escort_01.yaml
+++ b/docs/planning/encounters/enc_escort_01.yaml
@@ -13,6 +13,7 @@ name: 'Il Messaggero delle Spine'
 biome_id: savana
 grid_size: [12, 8]
 difficulty_rating: 3
+pressure_tier_floor: 2
 estimated_turns: 12
 # M7-#2 Phase C (ADR-2026-04-20): standard class (multiplier 1.0x, no enrage)
 encounter_class: standard

--- a/docs/planning/encounters/enc_frattura_03.yaml
+++ b/docs/planning/encounters/enc_frattura_03.yaml
@@ -14,6 +14,7 @@ name: 'Il Canto dello Strappo'
 biome_id: frattura_abissale_sinaptica
 grid_size: [12, 12]
 difficulty_rating: 5
+pressure_tier_floor: 4
 estimated_turns: 16
 # M7-#2 Phase C (ADR-2026-04-20): hardcore class (multiplier 1.4x + enrage 40% HP)
 # Multi-wave survival, no singolo boss — damage scaling enemy-wide.

--- a/docs/planning/encounters/enc_hardcore_reinf_01.yaml
+++ b/docs/planning/encounters/enc_hardcore_reinf_01.yaml
@@ -13,6 +13,7 @@ name: "Marea dell'Apex"
 biome_id: rovine_planari
 grid_size: [10, 10]
 difficulty_rating: 5
+pressure_tier_floor: 4
 estimated_turns: 15
 # M7-#2 Phase C (ADR-2026-04-20): hardcore class (multiplier 1.4x + enrage 40% HP)
 # Reinforcement waves continue → damage scaling pressure-amplificato.

--- a/docs/planning/encounters/enc_savana_01.yaml
+++ b/docs/planning/encounters/enc_savana_01.yaml
@@ -10,6 +10,7 @@ name: 'Pattuglia della Savana'
 biome_id: savana
 grid_size: [10, 10]
 difficulty_rating: 2
+pressure_tier_floor: 2
 estimated_turns: 10
 # M7-#2 Phase C (ADR-2026-04-20): standard class (multiplier 1.0x, no enrage)
 # Prima missione non-tutorial. No boss, gating baseline Pilastro 1.

--- a/docs/planning/encounters/enc_savana_skiv_solo_vs_pack.yaml
+++ b/docs/planning/encounters/enc_savana_skiv_solo_vs_pack.yaml
@@ -29,6 +29,7 @@ name: 'Solo Contro il Branco'
 biome_id: savana
 grid_size: [8, 8]
 difficulty_rating: 4
+pressure_tier_floor: 3
 estimated_turns: 7
 encounter_class: hardcore
 

--- a/docs/planning/encounters/enc_survival_01.yaml
+++ b/docs/planning/encounters/enc_survival_01.yaml
@@ -12,6 +12,7 @@ name: 'Ultimo Fiato'
 biome_id: caverna
 grid_size: [8, 8]
 difficulty_rating: 4
+pressure_tier_floor: 3
 estimated_turns: 10
 # M7-#2 Phase C (ADR-2026-04-20): hardcore class (multiplier 1.4x + enrage 40% HP)
 encounter_class: hardcore

--- a/docs/planning/encounters/enc_tutorial_01.yaml
+++ b/docs/planning/encounters/enc_tutorial_01.yaml
@@ -10,6 +10,7 @@ name: 'Primi Passi nella Savana'
 biome_id: savana
 grid_size: [8, 8]
 difficulty_rating: 1
+pressure_tier_floor: 1
 estimated_turns: 6
 # M7-#2 Phase C (ADR-2026-04-20): tutorial class (multiplier 1.0x, no enrage)
 encounter_class: tutorial

--- a/docs/planning/encounters/enc_tutorial_02.yaml
+++ b/docs/planning/encounters/enc_tutorial_02.yaml
@@ -10,6 +10,7 @@ name: 'Difesa della Duna'
 biome_id: savana
 grid_size: [8, 8]
 difficulty_rating: 1
+pressure_tier_floor: 1
 estimated_turns: 8
 # M7-#2 Phase C (ADR-2026-04-20): tutorial class (multiplier 1.0x, no enrage)
 encounter_class: tutorial

--- a/schemas/evo/encounter.schema.json
+++ b/schemas/evo/encounter.schema.json
@@ -188,6 +188,12 @@
       "maximum": 5,
       "description": "1-5 star difficulty"
     },
+    "pressure_tier_floor": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5,
+      "description": "Godot-v2 pressure tier floor (TKT-PRESSURE-TIER-ENCOUNTER, ADR vault 2026-05-10): scala pressure Sistema per encounter (early easier / late harder), risolve conflitto pilastri P5<->P6. 0 = no floor (default/unset). Valori set 1-5. Consumato dal frontend Godot; no-op runtime backend."
+    },
     "estimated_turns": {
       "type": "integer",
       "minimum": 1,


### PR DESCRIPTION
## Sommario (#2744 -- A1)

Il dataset encounter consumato dal frontend Godot (`Game-Godot-v2/.../encounters.json`) porta `pressure_tier_floor` (hand-authored, feature **TKT-PRESSURE-TIER-ENCOUNTER** lato Godot-v2, ADR vault 2026-05-10 -- risolve conflitto pilastri P5<->P6) **assente dagli YAML sorgente** di questo repo.

**Ground truth** (diff campo-per-campo vs `Game-Godot-v2/data/encounters/encounters.json`, 21 encounter): il drift e' **un solo campo** `pressure_tier_floor`, su **14 encounter**. Nessun altro drift (terrain/lethal citati nell'issue non driftano oggi). 0 orfani.

## Cosa fa questa PR (A1)

- Definisce `pressure_tier_floor` in `schemas/evo/encounter.schema.json` (integer 0-5, **optional**, 0 = no floor / default; no-op runtime backend, consumato dal frontend Godot).
- Backporta il campo sui **10 encounter new-schema** in `docs/planning/encounters/` coi valori presi dal json Godot (range 1-4).

| Encounter | valore |
| --- | --- |
| enc_capture_01 | 2 |
| enc_caverna_02 | 2 |
| enc_escort_01 | 2 |
| enc_frattura_03 | 4 |
| enc_hardcore_reinf_01 | 4 |
| enc_savana_01 | 2 |
| enc_savana_skiv_solo_vs_pack | 3 |
| enc_survival_01 | 3 |
| enc_tutorial_01 | 1 |
| enc_tutorial_02 | 1 |

## Validazione

- `schema:lint` (tools/automation/evo_schema_lint.py) -> verde.
- `jsonschema` Draft202012: **19/19** YAML new-schema validano vs schema aggiornato, 0 fail.
- Coperto da `tests/scripts/encounterSchema.test.js` (valida `docs/planning/encounters/enc_*.yaml` vs schema in CI).

## Fuori scope (4 encounter legacy)

`elite_01`, `standard_01`, `tutorial_01`, `enc_savana_pack_clash` vivono in `data/encounters/` in **formato legacy diverso** (`id`/`difficulty`/`groups`/`grid`, non lo schema encounter). `pressure_tier_floor` non vi mappa: la loro sorgente per il json Godot e' da chiarire (Godot-authored o pipeline legacy). Lasciati intatti; flag in #2744 per follow-up.

## A2 (separato, owner-gated)

Wire di `pressure_tier_floor` come **gameplay** nel backend (consumer combat/Sistema) + N=40. Spec da redigere; non in questa PR (qui il campo e' pass-through/display, allinea YAML come SoT).

## Rollback (03A)

`git revert <sha>`: rimuove campo schema + 10 backport. Nessun effetto runtime (campo optional, zero consumer backend), nessuna migrazione.

## Note

- Tocca `schemas/evo/` (ripple validatori, non forbidden-path) + `docs/planning/encounters/`. 16 righe, sotto soglia 50. Nessuna nuova dipendenza.
- Trailer ADR-0011 (Coding-Agent + Trace-Id), no Co-Authored-By.