### PR TITLE
feat(combat): A2 -- pressure_tier_floor backend Sistema mirror, flag-gated (#2744)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2092,6 +2092,11 @@ function createSessionRouter(options = {}) {
         // ADR-2026-04-19 + 04-20: encounter payload per reinforcementSpawner + objectiveEvaluator.
         // 2026-04-26: anche YAML-loaded via encounter_id (PCG G1 wire).
         encounter: encounterPayload,
+        // A2 (TKT-PRESSURE-TIER-ENCOUNTER): passthrough del floor per-encounter
+        // verso il Sistema (computeSistemaTier / aiProgressMeter / declareSistemaIntents
+        // / reinforcementSpawner via effectivePressure). Flag-gated OFF di default
+        // -> il valore e' inerte finche' PRESSURE_TIER_FLOOR_ENABLED!=='true'.
+        pressure_tier_floor: encounterPayload?.pressure_tier_floor ?? null,
         // M11 pilot (ADR-2026-04-21c): biome_id + log trait env deltas applicati.
         biome_id: biomeIdRaw,
         biome_costs_log: biomeCostsLog,

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -424,12 +424,17 @@ function publicSessionView(session) {
       pp_tier: (u.pp || 0) >= 10 ? 3 : (u.pp || 0) >= 6 ? 2 : (u.pp || 0) >= 3 ? 1 : 0,
     };
   });
-  const pressure = Number.isFinite(Number(session.sistema_pressure))
+  const rawPressure = Number.isFinite(Number(session.sistema_pressure))
     ? Number(session.sistema_pressure)
     : 0;
-  // A2: apply the per-encounter pressure_tier_floor BEFORE deriving the tier.
-  // Flag OFF (default) -> effectivePressure returns `pressure` unchanged.
-  const tier = computeSistemaTier(effectivePressure(pressure, session.pressure_tier_floor));
+  // A2: apply the per-encounter pressure_tier_floor BEFORE deriving the tier AND
+  // expose the *effective* pressure (not raw) so the client meter -- which
+  // recomputes label/bar/cap client-side from sistema_pressure -- stays consistent
+  // with sistema_tier when the flag is ON (Codex P2 #2773). Flag OFF (default):
+  // sistema_pressure is already clamped 0..100 (applyPressureDelta) so
+  // effectivePressure == raw -> byte-identical.
+  const pressure = effectivePressure(rawPressure, session.pressure_tier_floor);
+  const tier = computeSistemaTier(pressure);
   // Atlas live in-match telemetry (pressure player-side, momentum, warnings)
   const atlas = buildAtlasLive(session);
   return {

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -427,7 +427,9 @@ function publicSessionView(session) {
   const pressure = Number.isFinite(Number(session.sistema_pressure))
     ? Number(session.sistema_pressure)
     : 0;
-  const tier = computeSistemaTier(pressure);
+  // A2: apply the per-encounter pressure_tier_floor BEFORE deriving the tier.
+  // Flag OFF (default) -> effectivePressure returns `pressure` unchanged.
+  const tier = computeSistemaTier(effectivePressure(pressure, session.pressure_tier_floor));
   // Atlas live in-match telemetry (pressure player-side, momentum, warnings)
   const atlas = buildAtlasLive(session);
   return {
@@ -765,6 +767,37 @@ function computeSistemaTier(pressure) {
   return tier;
 }
 
+// A2 (TKT-PRESSURE-TIER-ENCOUNTER, mirror Godot-v2 PR #221).
+// encounter.pressure_tier_floor (int 1-5) raises the *effective* Sistema
+// pressure for a single encounter (early easier / late harder) without a
+// global pressure buff that would break first-encounter fairness (P6).
+//
+// FLOOR_MIN maps a floor level to the minimum effective pressure it enforces.
+// Mirrors the canonical tier thresholds (0/25/50/75/95 = Calm/Alert/Escalated/
+// Critical/Apex). Floor 0 / unset / out-of-range = no floor.
+const FLOOR_MIN = Object.freeze({ 1: 0, 2: 25, 3: 50, 4: 75, 5: 95 });
+
+// Feature flag (default OFF). When OFF, effectivePressure returns the input
+// pressure clamped exactly like computeSistemaTier already does -> back-compat
+// byte-identical. Flip-ON only after N=40 band-verify + master-dd ratify.
+function isPressureTierFloorEnabled() {
+  return process.env.PRESSURE_TIER_FLOOR_ENABLED === 'true';
+}
+
+// Pure helper: effective pressure after applying the per-encounter tier floor.
+// - flag OFF -> input pressure clamped 0..100 (identical to pre-A2).
+// - flag ON + floor integer in [1,5] -> max(clamped pressure, FLOOR_MIN[floor]).
+// - floor 0 / unset / out-of-range -> no floor (clamped pressure only).
+// Single source of truth reused by every tier-derivation call-site so a
+// partial floor does not re-break cross-stack parity (Codex P2 #2771).
+function effectivePressure(pressure, floor) {
+  const p = Number.isFinite(Number(pressure)) ? Math.max(0, Math.min(100, Number(pressure))) : 0;
+  if (!isPressureTierFloorEnabled()) return p;
+  const f = Number(floor);
+  if (!Number.isInteger(f) || f < 1 || f > 5) return p;
+  return Math.max(p, FLOOR_MIN[f]);
+}
+
 function applyPressureDelta(current, delta) {
   const base = Number.isFinite(Number(current)) ? Number(current) : 0;
   const d = Number.isFinite(Number(delta)) ? Number(delta) : 0;
@@ -845,6 +878,9 @@ module.exports = {
   facingFromMove,
   predictCombat,
   computeSistemaTier,
+  effectivePressure,
+  isPressureTierFloorEnabled,
+  FLOOR_MIN,
   applyPressureDelta,
   SISTEMA_PRESSURE_TIERS,
   PRESSURE_DELTAS,

--- a/apps/backend/services/ai/aiProgressMeter.js
+++ b/apps/backend/services/ai/aiProgressMeter.js
@@ -17,6 +17,12 @@
 
 'use strict';
 
+// A2 (TKT-PRESSURE-TIER-ENCOUNTER): per-encounter pressure_tier_floor mirror.
+// sessionHelpers owns the single effectivePressure SoT (flag-gated, default OFF).
+// reinforcementSpawner already requires sessionHelpers top-level; sessionHelpers
+// only lazy-requires this module inside publicSessionView, so no circular hazard.
+const { effectivePressure } = require('../../routes/sessionHelpers');
+
 // Mirror sistema_pressure tier definitions da declareSistemaIntents.js.
 // Centralizza qui per single source-of-truth + evitare circular dep.
 const PRESSURE_TIERS = [
@@ -67,7 +73,12 @@ function getProgressMeterState(session) {
     };
   }
 
-  const pressure = Number(session.sistema_pressure || 0);
+  // A2: apply the per-encounter pressure_tier_floor before deriving the meter
+  // tier/next (flag OFF -> effectivePressure returns the value unchanged). The
+  // surfaced `pressure` reflects the effective value so the HUD mirrors the
+  // floored tier (parity with Godot-v2 PR #221).
+  const rawPressure = Number(session.sistema_pressure || 0);
+  const pressure = effectivePressure(rawPressure, session.pressure_tier_floor);
   const tier = tierForPressure(pressure);
   const next = nextTier(pressure);
   const distance = next ? Math.max(0, next.threshold - pressure) : null;

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -39,6 +39,10 @@
 const { selectAiPolicy, stepAway, DEFAULT_ATTACK_RANGE, loadAiConfig } = require('./policy');
 const { selectAiPolicyUtility } = require('./utilityBrain');
 const { ARCHETYPE_VULN_CHANNEL } = require('../../routes/sessionConstants');
+// A2 (TKT-PRESSURE-TIER-ENCOUNTER): per-encounter pressure_tier_floor mirror.
+// sessionHelpers owns the single effectivePressure SoT (flag-gated, default OFF).
+// No circular hazard: sessionHelpers requires ./policy, not this module.
+const { effectivePressure } = require('../../routes/sessionHelpers');
 
 // K4 Approach B — commit-window anti-flip guard helpers.
 // Detect direction reversal (oscillation) between consecutive utility-brain
@@ -107,8 +111,10 @@ const PRESSURE_TIER_INTENT_CAP = [
   { threshold: 95, intents_per_round: 4 }, // Apex (tutorial_05 BOSS baseline)
 ];
 
-function intentsCapForPressure(pressure) {
-  const p = Number.isFinite(Number(pressure)) ? Math.max(0, Math.min(100, Number(pressure))) : 0;
+// A2: optional `floor` (encounter.pressure_tier_floor) raises the effective
+// pressure before the cap lookup. flag OFF / floor unset -> identical to pre-A2.
+function intentsCapForPressure(pressure, floor) {
+  const p = effectivePressure(pressure, floor);
   let cap = PRESSURE_TIER_INTENT_CAP[0].intents_per_round;
   for (const t of PRESSURE_TIER_INTENT_CAP) {
     if (p >= t.threshold) cap = t.intents_per_round;
@@ -202,7 +208,8 @@ function createDeclareSistemaIntents(deps) {
     // AI War pattern: pressure-driven intent cap.
     // Tier piu' alto (player vincente) → SIS dichiara piu' intents.
     // Calm: 1 intent/round, Critical/Apex: 3.
-    const intentsCap = intentsCapForPressure(session.sistema_pressure);
+    // A2: per-encounter pressure_tier_floor (flag OFF -> no-op = back-compat).
+    const intentsCap = intentsCapForPressure(session.sistema_pressure, session.pressure_tier_floor);
 
     const intents = [];
     const decisions = [];
@@ -515,4 +522,8 @@ function createDeclareSistemaIntents(deps) {
   };
 }
 
-module.exports = { createDeclareSistemaIntents, computePersistentHighThreat };
+module.exports = {
+  createDeclareSistemaIntents,
+  computePersistentHighThreat,
+  intentsCapForPressure,
+};

--- a/apps/backend/services/combat/reinforcementSpawner.js
+++ b/apps/backend/services/combat/reinforcementSpawner.js
@@ -26,7 +26,7 @@
 
 'use strict';
 
-const { computeSistemaTier } = require('../../routes/sessionHelpers');
+const { computeSistemaTier, effectivePressure } = require('../../routes/sessionHelpers');
 const { defaultRng } = require('./pseudoRng');
 // TKT-WORLDGEN-GAPA (2026-05-29): foodweb whitelist filter for the spawn pool.
 const { filterReinforcementPool, applyPopulationToPool } = require('../worldgen/foodwebFilter');
@@ -238,7 +238,11 @@ function tick(session, encounter, opts = {}) {
     return { spawned: [], budget_used: 0, skipped: true, reason: 'no_entry_tiles' };
   }
 
-  const tier = computeSistemaTier(session.pressure ?? 0);
+  // A2: floor the budget-driving pressure with the per-encounter tier floor
+  // (flag OFF -> effectivePressure returns the input unchanged = back-compat).
+  const tier = computeSistemaTier(
+    effectivePressure(session.pressure ?? 0, session.pressure_tier_floor),
+  );
   const minTier = policy.min_tier || 'Alert';
   if (!tierMeetsMin(tier.label, minTier)) {
     return {

--- a/docs/hubs/combat.md
+++ b/docs/hubs/combat.md
@@ -79,6 +79,7 @@ Per una panoramica e mappa completa dei doc del workstream vedi [docs/combat/REA
 - `packs/evo_tactics_pack/data/balance/movement_profiles.yaml` — profili movimento (heavy/medium/light) con terrain cost multiplier. Pattern W6.
 - `packs/evo_tactics_pack/data/balance/species_resistances.yaml` — matrice resistenze per 5 archetipi specie (corazzato/bioelettrico/psionico/termico/adattivo). Pattern W2.
 - `packs/evo_tactics_pack/data/balance/sistema_pressure.yaml` — AI War "AI Progress" meter: 5 tier da Calm (0) a Apex (95) con intents_per_round + reinforcement_budget + unlocked_intent_types. Gate capabilities SIS via `computeSistemaTier()` in `sessionHelpers.js`.
+- **A2 pressure_tier_floor** (TKT-PRESSURE-TIER-ENCOUNTER, mirror Godot-v2 PR #221): helper `effectivePressure(p, floor)` in `sessionHelpers.js` alza la pressure _effettiva_ per-encounter (`encounter.pressure_tier_floor` 1-5, FLOOR_MIN 0/25/50/75/95) PRIMA di OGNI derivazione tier -- publicSessionView `sistema_tier`, `reinforcementSpawner` budget (`:241`), `aiProgressMeter`, `declareSistemaIntents` `intentsCapForPressure`. Flag `PRESSURE_TIER_FLOOR_ENABLED` **default OFF** (back-compat byte-identical: con flag OFF `effectivePressure` = clamp identico al pre-A2). Flip-ON gated da N=40 band-verify + ratifica master-dd dei valori floor (NON calibrati). Spec: `docs/design/2026-06-16-pressure-tier-floor-backend-mirror.md`.
 - `packs/evo_tactics_pack/pack_manifest.yaml` — manifest esplicito di tutti i file dati del pack. Pattern O2.
 
 ## Invarianti di design combat

--- a/tests/ai/pressureTierFloor.test.js
+++ b/tests/ai/pressureTierFloor.test.js
@@ -149,8 +149,10 @@ test('publicSessionView: flag ON + floor 4 -> sistema_tier Critical', () => {
   withFlag('true', () => {
     const view = publicSessionView(mockSessionForView({ pressure_tier_floor: 4 }));
     assert.equal(view.sistema_tier.label, 'Critical');
-    // sistema_pressure surface stays the RAW value (floor only shapes the tier).
-    assert.equal(view.sistema_pressure, 0);
+    // Codex P2 #2773: sistema_pressure surface = EFFECTIVE (floored) so the client
+    // meter (recomputed client-side from sistema_pressure) stays consistent with
+    // sistema_tier when the flag is ON. floor 4 -> FLOOR_MIN 75 (Critical).
+    assert.equal(view.sistema_pressure, 75);
   });
 });
 
@@ -158,6 +160,8 @@ test('publicSessionView: flag OFF + floor 4 -> sistema_tier Calm (back-compat)',
   withFlag('false', () => {
     const view = publicSessionView(mockSessionForView({ pressure_tier_floor: 4 }));
     assert.equal(view.sistema_tier.label, 'Calm');
+    // back-compat: flag OFF -> sistema_pressure stays the raw (clamped) value.
+    assert.equal(view.sistema_pressure, 0);
   });
 });
 

--- a/tests/ai/pressureTierFloor.test.js
+++ b/tests/ai/pressureTierFloor.test.js
@@ -1,0 +1,287 @@
+// tests/ai/pressureTierFloor.test.js -- A2 (TKT-PRESSURE-TIER-ENCOUNTER).
+//
+// Mirror Godot-v2 PR #221: encounter.pressure_tier_floor raises the effective
+// Sistema pressure per-encounter. Flag-gated (PRESSURE_TIER_FLOOR_ENABLED,
+// default OFF) -> back-compat byte-identical when OFF / unset / out-of-range.
+//
+// IMPORTANT: every test sets/restores process.env.PRESSURE_TIER_FLOOR_ENABLED
+// in a finally block. effectivePressure reads the flag at call-time (not module
+// load) so toggling per-test is safe without re-require.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  effectivePressure,
+  isPressureTierFloorEnabled,
+  computeSistemaTier,
+  publicSessionView,
+  FLOOR_MIN,
+} = require('../../apps/backend/routes/sessionHelpers');
+const { tick } = require('../../apps/backend/services/combat/reinforcementSpawner');
+const { getProgressMeterState } = require('../../apps/backend/services/ai/aiProgressMeter');
+const { intentsCapForPressure } = require('../../apps/backend/services/ai/declareSistemaIntents');
+
+const FLAG = 'PRESSURE_TIER_FLOOR_ENABLED';
+
+function withFlag(value, fn) {
+  const prev = process.env[FLAG];
+  if (value === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  }
+}
+
+// -- flag helper --
+
+test('isPressureTierFloorEnabled: true only when env === "true"', () => {
+  withFlag('true', () => assert.equal(isPressureTierFloorEnabled(), true));
+  withFlag('false', () => assert.equal(isPressureTierFloorEnabled(), false));
+  withFlag('1', () => assert.equal(isPressureTierFloorEnabled(), false));
+  withFlag(undefined, () => assert.equal(isPressureTierFloorEnabled(), false));
+});
+
+// -- effectivePressure: flag OFF (back-compat) --
+
+test('effectivePressure: flag OFF -> input clamped, floor ignored', () => {
+  withFlag('false', () => {
+    assert.equal(effectivePressure(0, 5), 0);
+    assert.equal(effectivePressure(30, 4), 30);
+    assert.equal(effectivePressure(150, 5), 100, 'clamps high like computeSistemaTier');
+    assert.equal(effectivePressure(-5, 3), 0, 'clamps low');
+    assert.equal(effectivePressure(NaN, 5), 0, 'NaN -> 0');
+    assert.equal(effectivePressure(undefined, 5), 0);
+    assert.equal(effectivePressure(null, 5), 0);
+  });
+});
+
+test('effectivePressure: flag UNSET behaves like OFF', () => {
+  withFlag(undefined, () => {
+    assert.equal(effectivePressure(10, 5), 10);
+  });
+});
+
+// -- effectivePressure: flag ON --
+
+test('effectivePressure: flag ON, floor raises pressure to FLOOR_MIN', () => {
+  withFlag('true', () => {
+    assert.equal(effectivePressure(0, 2), 25, 'floor 2 -> min 25');
+    assert.equal(effectivePressure(0, 3), 50, 'floor 3 -> min 50');
+    assert.equal(effectivePressure(0, 4), 75, 'floor 4 -> min 75');
+    assert.equal(effectivePressure(0, 5), 95, 'floor 5 -> min 95');
+  });
+});
+
+test('effectivePressure: flag ON, pressure above floor wins (max)', () => {
+  withFlag('true', () => {
+    assert.equal(effectivePressure(80, 3), 80, 'p 80 > floor-min 50 -> 80');
+    assert.equal(effectivePressure(40, 3), 50, 'p 40 < floor-min 50 -> 50');
+  });
+});
+
+test('effectivePressure: flag ON, floor 0 / 1 -> no raise', () => {
+  withFlag('true', () => {
+    assert.equal(effectivePressure(10, 0), 10, 'floor 0 -> no floor');
+    assert.equal(effectivePressure(10, 1), 10, 'floor 1 -> min 0 -> no raise');
+    assert.equal(effectivePressure(0, 1), 0);
+  });
+});
+
+test('effectivePressure: flag ON, out-of-range / non-int floor -> no floor', () => {
+  withFlag('true', () => {
+    assert.equal(effectivePressure(10, 6), 10, 'floor 6 out of range');
+    assert.equal(effectivePressure(10, -1), 10);
+    assert.equal(effectivePressure(10, 2.5), 10, 'non-integer floor ignored');
+    assert.equal(effectivePressure(10, null), 10, 'null floor');
+    assert.equal(effectivePressure(10, undefined), 10, 'unset floor');
+    assert.equal(effectivePressure(10, 'x'), 10, 'NaN floor');
+  });
+});
+
+test('FLOOR_MIN: canonical mapping mirrors tier thresholds', () => {
+  assert.deepEqual({ ...FLOOR_MIN }, { 1: 0, 2: 25, 3: 50, 4: 75, 5: 95 });
+});
+
+// -- computeSistemaTier(effectivePressure(...)) gate canonico --
+
+test('computeSistemaTier floored: flag ON, low pressure + floor 4 -> Critical', () => {
+  withFlag('true', () => {
+    const tier = computeSistemaTier(effectivePressure(0, 4));
+    assert.equal(tier.label, 'Critical');
+    assert.equal(tier.intents_per_round, 3);
+    assert.equal(tier.reinforcement_budget, 3);
+  });
+});
+
+test('computeSistemaTier floored: flag OFF, same input -> Calm (back-compat)', () => {
+  withFlag('false', () => {
+    const tier = computeSistemaTier(effectivePressure(0, 4));
+    assert.equal(tier.label, 'Calm');
+    assert.equal(tier.reinforcement_budget, 0);
+  });
+});
+
+// -- publicSessionView.sistema_tier floored --
+
+function mockSessionForView(overrides = {}) {
+  return {
+    session_id: 's-floor',
+    turn: 1,
+    active_unit: null,
+    turn_order: [],
+    turn_index: 0,
+    units: [],
+    grid: { width: 6, height: 6 },
+    events: [],
+    sistema_pressure: 0,
+    sistema_counter: 0,
+    ...overrides,
+  };
+}
+
+test('publicSessionView: flag ON + floor 4 -> sistema_tier Critical', () => {
+  withFlag('true', () => {
+    const view = publicSessionView(mockSessionForView({ pressure_tier_floor: 4 }));
+    assert.equal(view.sistema_tier.label, 'Critical');
+    // sistema_pressure surface stays the RAW value (floor only shapes the tier).
+    assert.equal(view.sistema_pressure, 0);
+  });
+});
+
+test('publicSessionView: flag OFF + floor 4 -> sistema_tier Calm (back-compat)', () => {
+  withFlag('false', () => {
+    const view = publicSessionView(mockSessionForView({ pressure_tier_floor: 4 }));
+    assert.equal(view.sistema_tier.label, 'Calm');
+  });
+});
+
+test('publicSessionView: flag ON, no floor -> sistema_tier from raw pressure', () => {
+  withFlag('true', () => {
+    const view = publicSessionView(mockSessionForView({ sistema_pressure: 30 }));
+    assert.equal(view.sistema_tier.label, 'Alert');
+  });
+});
+
+// -- aiProgressMeter floored --
+
+test('getProgressMeterState: flag ON + floor 5 -> Apex tier surfaced', () => {
+  withFlag('true', () => {
+    const state = getProgressMeterState({ sistema_pressure: 0, pressure_tier_floor: 5 });
+    assert.equal(state.tier.name, 'Apex');
+    assert.equal(state.pressure, 95, 'effective pressure reflected in meter');
+    assert.equal(state.next_tier, null, 'Apex has no next tier');
+  });
+});
+
+test('getProgressMeterState: flag OFF + floor 5 -> Calm (back-compat)', () => {
+  withFlag('false', () => {
+    const state = getProgressMeterState({ sistema_pressure: 0, pressure_tier_floor: 5 });
+    assert.equal(state.tier.name, 'Calm');
+    assert.equal(state.pressure, 0);
+  });
+});
+
+// -- intentsCapForPressure floored --
+
+test('intentsCapForPressure: flag ON + floor 5 -> cap 4 (Apex)', () => {
+  withFlag('true', () => {
+    assert.equal(intentsCapForPressure(0, 5), 4);
+    assert.equal(intentsCapForPressure(0, 3), 3, 'floor 3 -> Escalated cap');
+  });
+});
+
+test('intentsCapForPressure: flag OFF + floor 5 -> cap 1 (back-compat Calm)', () => {
+  withFlag('false', () => {
+    assert.equal(intentsCapForPressure(0, 5), 1);
+  });
+});
+
+test('intentsCapForPressure: no floor arg unchanged vs single-arg legacy', () => {
+  withFlag('true', () => {
+    assert.equal(intentsCapForPressure(30), 2, 'Alert cap, no floor');
+    assert.equal(intentsCapForPressure(95), 4, 'Apex cap, no floor');
+  });
+});
+
+// -- reinforcement budget floored --
+
+function mockReinforceSession(overrides = {}) {
+  return {
+    pressure: 10, // Calm -> below min_tier Alert (no spawn baseline)
+    round: 3,
+    turn: 3,
+    grid: { width: 10, height: 10 },
+    units: [
+      { id: 'p1', controlled_by: 'player', position: [0, 0], hp: 10 },
+      { id: 'p2', controlled_by: 'player', position: [1, 0], hp: 10 },
+    ],
+    ...overrides,
+  };
+}
+
+function mockReinforceEncounter(overrides = {}) {
+  return {
+    reinforcement_pool: [{ unit_id: 'minion_01', weight: 1.0, max_spawns: 5, hp: 6, mod: 2 }],
+    reinforcement_entry_tiles: [
+      [9, 9],
+      [8, 9],
+      [9, 8],
+      [7, 9],
+    ],
+    reinforcement_policy: {
+      enabled: true,
+      min_tier: 'Alert',
+      cooldown_rounds: 0,
+      max_total_spawns: 10,
+    },
+    ...overrides,
+  };
+}
+
+test('reinforcement budget: flag ON + floor 4 lifts Calm -> Critical (budget 3)', () => {
+  withFlag('true', () => {
+    const session = mockReinforceSession({ pressure: 10, pressure_tier_floor: 4 });
+    const enc = mockReinforceEncounter();
+    const res = tick(session, enc, { rng: () => 0.5 });
+    assert.notEqual(res.skipped, true, 'no skip -- tier now meets min');
+    assert.equal(res.budget_used, 3, 'Critical reinforcement_budget = 3');
+    assert.equal(res.spawned.length, 3);
+    assert.equal(res.spawned[0].tier_at_spawn, 'Critical');
+  });
+});
+
+test('reinforcement budget: flag OFF + floor 4 -> Calm skip (back-compat)', () => {
+  withFlag('false', () => {
+    const session = mockReinforceSession({ pressure: 10, pressure_tier_floor: 4 });
+    const enc = mockReinforceEncounter();
+    const res = tick(session, enc, { rng: () => 0.5 });
+    assert.equal(res.skipped, true, 'Calm < min_tier Alert -> skip');
+    assert.match(res.reason, /tier_below_min/);
+    assert.equal(res.spawned.length, 0);
+  });
+});
+
+// -- regression: floor unset == pre-A2 identical (flag ON too) --
+
+test('regression: flag ON but floor unset -> reinforcement identical to baseline', () => {
+  withFlag('true', () => {
+    const session = mockReinforceSession({ pressure: 30 }); // Alert, no floor
+    const enc = mockReinforceEncounter();
+    const res = tick(session, enc, { rng: () => 0.5 });
+    assert.equal(res.budget_used, 1, 'Alert budget unchanged when floor unset');
+    assert.equal(res.spawned.length, 1);
+  });
+});
+
+test('regression: flag ON but floor unset -> publicSessionView tier from raw pressure', () => {
+  withFlag('true', () => {
+    const view = publicSessionView(mockSessionForView({ sistema_pressure: 75 }));
+    assert.equal(view.sistema_tier.label, 'Critical', 'raw pressure 75 -> Critical, no floor');
+  });
+});


### PR DESCRIPTION
## Sommario (#2744 A2 -- BUILD)

Implementa la spec A2 (PR #2771): mirror Game/-side della feature Godot **TKT-PRESSURE-TIER-ENCOUNTER** (PR #221). Il Sistema backend ora rispetta `encounter.pressure_tier_floor`, **flag-gated OFF di default** (zero impatto balance finche' non ratificato).

## Cosa fa

- **Helper unico** `effectivePressure(p, floor)` in `sessionHelpers.js` (esportato, SoT): flag ON + floor 1-5 -> `max(p, FLOOR_MIN[floor])` (FLOOR_MIN 0/25/50/75/95); flag OFF / floor unset / out-of-range -> `p` clampato (identico a pre-A2).
- Applicato **PRIMA di OGNI derivazione tier** (completeness, Codex P2 #2771): `publicSessionView` sistema_tier · `reinforcementSpawner` budget (`:241`) · `aiProgressMeter` getProgressMeterState · `declareSistemaIntents` intentsCapForPressure.
- **Plumbing**: `encounter.pressure_tier_floor -> session.pressure_tier_floor` (`session.js`, accanto a `encounter`/`encounter_class`).

## Back-compat (sicurezza)

Flag `PRESSURE_TIER_FLOOR_ENABLED` **default OFF** -> `effectivePressure` ritorna la pressione clampata identica a quanto `computeSistemaTier` gia' fa -> **byte-identical**. Le pressure-value writes (`applyPressureDelta`) restano non-floored (il floor e' view/derive-time, non muta lo stato).

## Test

- Nuovo `tests/ai/pressureTierFloor.test.js` (22 test: flag ON/OFF, floor 0/1/5/out-of-range/null, computeSistemaTier/reinforcement/sistema_tier floored, regression flag-OFF identico).
- **AI suite 532/0** (510 baseline invariati + 22) · combat/sistema-touched **132/0**.
- `combat.md` aggiornato (DoD `services/combat`).

## Gate flip-ON (owner-gated, NON in questa PR)

I valori floor (1-4 su 10 encounter da #2769) sono NON calibrati. Flip `PRESSURE_TIER_FLOOR_ENABLED=true` solo dopo **N=40 band-verify** per encounter_class + **ratifica master-dd** dei valori. Questa PR ship il meccanismo "dark".

## Rollback (03A)

`git revert <sha>`: rimuove helper + threading + plumbing + test. Zero impatto runtime (flag OFF = no-op).

## Note

Combat-sensitive ma flag-OFF byte-identical (provato dai 510 baseline test invariati). Tutto dentro `apps/backend`; no forbidden-path; no nuove dipendenze. Trailer ADR-0011.