### PR TITLE
fix(encounters): enc_caverna_02 loss_conditions.time_limit=14 (A2 follow-up)

### DIFF
--- a/docs/planning/encounters/enc_caverna_02.yaml
+++ b/docs/planning/encounters/enc_caverna_02.yaml
@@ -19,6 +19,13 @@ objective:
   type: capture_point
   target_zone: [4, 4, 5, 5]
   hold_turns: 3
+  # A2 follow-up (#2774): capture_point senza loss timer -> attrition runaway
+  # con pressure_tier_floor ON (artefatto -0.25 standard nell'evidenza N=40).
+  # time_limit generoso (estimated_turns 12 + buffer) cap l'attrition senza
+  # indurire l'encounter (10 sarebbe piu' stretto dell'estimate -> rischio
+  # timeout-artefatto opposto).
+  loss_conditions:
+    time_limit: 14
 
 player_spawn:
   - [0, 4]


### PR DESCRIPTION
## Sommario

Follow-up dell'evidenza A2 N=40 (PR #2774): `enc_caverna_02` (capture_point **senza loss timer**) flippa 100%->0% nella classe `standard` in config strong con `pressure_tier_floor` ON = **attrition runaway** (artefatto authoring, NON valore floor). Era l'unico Delta standard nell'evidenza.

## Fix

Aggiunge `objective.loss_conditions.time_limit: 14` -- generoso (`estimated_turns: 12` + buffer): cap l'attrition senza indurire l'encounter. **10 sarebbe piu' stretto dell'estimate** (rischio timeout-artefatto opposto), quindi 14 (la decisione iniziale era 10, corretta su ground-truth `estimated_turns=12`).

## Effetto

Toglie l'artefatto -0.25 standard -> il flip-ON A2 diventa pulito su tutte le classi. Schema-valid (`encounter.schema.json`), prettier-clean. Encounter-data only.

## Rollback (03A)

`git revert <sha>`. Zero impatto runtime finche' A2 e' flag-OFF.