### PR TITLE
test(spec-p): anti-brick automatic test + #5/#2 reconciliation

### DIFF
--- a/docs/design/evo-tactics-failure-as-lore.md
+++ b/docs/design/evo-tactics-failure-as-lore.md
@@ -160,6 +160,17 @@ degrado.
 
 - Oggi il wire `stresswave -> pressure/spawn` e' DEAD (`biomeModifiers.js:188`): da attivare
   (combat PR + band-verify) prima dell'uso runtime.
+- **Riconciliazione 2026-06-17 (verificato, ground-truth):** la riga sopra precede ER6. Il wire
+  StressWave combat-side E' STATO attivato da SPEC-I ER6
+  (`apps/backend/services/combat/stressWave.js`, ratificato 2026-06-10 opz. C, flag
+  `STRESSWAVE_EVENTS_ENABLED` default ON, gate N=40 PASSED) come EVENT-TRIGGER bounded
+  (rescue/overrun one-shot), NON come feed continuo `stresswave -> sistema_pressure`: l'ASSENZA di
+  quel feed e' INTENZIONALE (doctrine sez.3; `docs/hubs/combat.md:65` "NESSUN feed di
+  sistema_pressure"). Il `biomeModifiers.js:188` citato sopra e' il reader read-only diagnostico
+  (`getBiomeStressProfile`), non il wire runtime -- che vive in `stressWave.js` e consuma quel
+  reader. Telegraph diegetico LIVE: raw event `stresswave_event` + `stresswave_event_latest`
+  (public tier) + 4o slot biomeChip. Quindi acceptance #5, lato "wire StressWave attivato lato
+  combat", e' SODDISFATTA per-design via ER6 (NON un gap da costruire); il flip resta a master-dd.
 - Telegraph diegetico (mirror SPEC-I biomeChip): il bioma ferito si legge come descrittore
   ("bioma in cicatrice / instabile"), mai come numero. Granularita' direzionale eventuale =
   coerente con ER3.
@@ -287,6 +298,11 @@ SPEC-P e' implementabile/chiudibile quando:
 1. i 4 trigger run-fail (sez. 3) emettono `run_failed` tier-tagged dall'event-log;
 2. l'epilogo run-end (sez. 4) ha trigger + payload + tier definiti, con l'ownership decisa
    in PA1, e consuma l'output J5 (QA2);
+   - _[Verificato 2026-06-17: BACKEND MET -- `apps/backend/services/narrative/failureEpilogue.js`
+     (`buildEpilogue` payload tier-`public` + consuma J5 `fallen` + `emitFailureEpilogue` ->
+     chronicle `run_epilogue` + `codex_update`), WIRED a `routes/session.js:3704-3731`, 16 test
+     `tests/services/failureEpilogue.test.js`. La resa diegetica (voce Skiv/Custode) = surface PA1
+     Godot (item-3, cross-repo) by design -- backend assembla i DATA.]_
 3. l'aggancio Codex (sez. 5) emette eventi che il consumer SPEC-H raccoglie (no Codex
    costruito qui);
 4. il degrado meta-network (sez. 6, A13 write-side) -- NATURA PA4 (entrambi); mechanism LIVE
@@ -294,9 +310,18 @@ SPEC-P e' implementabile/chiudibile quando:
    meta-network + trigger + magnitudine N=40;
 5. il telegraph (sez. 7) e il recovery-telegraph (PA3) sono diegetici (nessun float, nessuna
    sigla; visibile PRE-run; il wire StressWave va attivato lato combat);
+   - _[Riconciliazione 2026-06-17: "wire StressWave attivato lato combat" = SODDISFATTO per-design
+     via ER6 (`stressWave.js`, default ON, event-trigger; NESSUN feed pressure by design) -- vedi
+     sez.7. Il telegraph IN-run e' gia' LIVE (biomeChip + `stresswave_event`). Il "visibile PRE-run"
+     (PA3, schermata selezione missione) resta surface Godot cross-repo (item-3, residuo noto sez.6),
+     NON un gap backend.]_
 6. l'invariante anti-brick (sez. 8) e' verificabile con un test AUTOMATICO esplicito (es.
    N>=5 run fallite consecutive sullo stesso bioma -> `metaNetworkCompletability` conferma la
    campagna ancora completabile + recovery path raggiungibile), non solo design-rationale;
+   - _[Costruito 2026-06-17: test automatico `tests/services/failureLoreAntiBrick.test.js` (7 test:
+     N>=5 fail consecutivi stesso bioma -> set bounded (idempotente+cap) + `checkCompletable` ok ogni
+     stagione + recovery node raggiungibile + heal-exit + worst-case cap-many distinti + control
+     oracle-teeth). MET.]_
 7. la visibilita' (sez. 9) e' coerente con SPEC-B (degrado grezzo `secret`, recap/telegraph
    `public`, dettaglio caduto `private`, identita' opt-in);
 8. QA1/QA2 restano ratificati e PA1-PA4 sono ratificati da Eduardo; il flip

--- a/tests/services/failureLoreAntiBrick.test.js
+++ b/tests/services/failureLoreAntiBrick.test.js
@@ -155,12 +155,43 @@ test('realistic interleave (fail, fail, recover, re-fail) stays bounded + comple
   assert.equal(checkCompletable(net, { seasons: ALL_SEASONS }).ok, true);
 });
 
-test('defensive: wounding a non-node biome never strands the graph (topology-invariant)', () => {
+test('non-node wound is bounded + RECOVERABLE (heal) -- recovery is mechanism-level, not routing-gated', () => {
+  // `caverna` is an encounter-only biome, NOT a meta-network node. A run can still wound it
+  // (woundBiome keys on session.biome_id), consuming a slot. The anti-brick guarantee for
+  // such a wound is NOT graph-routing (there is no node to route to) but the HEAL mechanism:
+  // a victory in that same encounter clears it (healBiome keys on biome_id, node or not), so
+  // the slot is never permanently stuck. Asserting only the wound-independent checkCompletable
+  // would prove nothing about this wound (Codex PR #2777 P2) -- prove the recovery instead.
   const net = realNetwork();
-  // `caverna` is an encounter biome, not a meta-network node -> wounding it cannot
-  // touch graph topology; the campaign stays completable.
+  const map = biomeToNode(net);
+  assert.ok(!map.has('caverna'), 'fixture is genuinely a non-node biome');
+
   let wounded = [];
   for (let i = 0; i < 5; i++) wounded = applyDefeat(wounded, 'caverna');
-  assert.deepEqual(wounded, ['caverna']);
+  assert.deepEqual(wounded, ['caverna']); // bounded (idempotent), one slot consumed
+  assert.ok(pressureDelta(wounded) <= ER2_PRESSURE_CAP); // never escalates past ER2
+
+  // recovery: a victory in caverna heals it -> the slot is freed, no permanent stuck state.
+  const healed = healBiome(wounded, 'caverna');
+  assert.equal(healed.healed, true);
+  assert.deepEqual(healed.wounded, []);
+  assert.equal(pressureDelta(healed.wounded), 0);
+});
+
+test('mixed wound at cap (1 node + 1 non-node) -> not bricked: completable + node recovery routable + non-node healable', () => {
+  // The exact Codex scenario: a non-node biome consumes one of the two slots. Prove it is
+  // NOT a brick on every axis: (a) campaign stays completable, (b) the node-biome wound has a
+  // routable recovery node, (c) the non-node wound is still healable (mechanism-level), and
+  // (d) pressure stays pinned at the ER2 cap, never above.
+  const net = realNetwork();
+  const map = biomeToNode(net);
+  let wounded = [];
+  wounded = applyDefeat(wounded, 'caverna'); // non-node slot
+  wounded = applyDefeat(wounded, 'savana'); // node slot (DESERTO_CALDO = start)
+  assert.equal(wounded.length, MAX_WOUNDED_BIOMES);
+
   assert.equal(checkCompletable(net, { seasons: ALL_SEASONS }).ok, true);
+  assert.ok(nodeReachableSomeSeason(net, map.get('savana')), 'node wound recovery routable');
+  assert.equal(healBiome(wounded, 'caverna').healed, true); // non-node wound recoverable
+  assert.equal(pressureDelta(wounded), ER2_PRESSURE_CAP); // never above ER2 even at cap
 });

--- a/tests/services/failureLoreAntiBrick.test.js
+++ b/tests/services/failureLoreAntiBrick.test.js
@@ -1,0 +1,166 @@
+'use strict';
+// =============================================================================
+// SPEC-P failure-as-lore -- acceptance gate #6: anti-brick invariant (sez.8).
+//
+// Acceptance #6 (verbatim): the anti-brick invariant must be verifiable with an
+// EXPLICIT AUTOMATIC test (e.g. N>=5 consecutive failed runs in the same biome ->
+// `metaNetworkCompletability` confirms the campaign is still completable + the
+// recovery path is reachable), NOT just design-rationale.
+//
+// Invariant P1 (sez.8): no state renders the campaign unplayable. It holds because:
+//   (a) wounds are BOUNDED -- woundBiome is idempotent + capped at MAX_WOUNDED_BIOMES,
+//       and pressureDelta never exceeds the ER2 cap (no unbounded difficulty climb);
+//   (b) wounds are a campaign-state TAG -- they never mutate the meta-network graph
+//       topology, so `checkCompletable` is preserved by construction; and
+//   (c) every woundable biome's node stays reachable from the start, so the recovery
+//       move (win there -> healBiome) is always physically routable; and
+//   (d) healBiome provides the recovery transition (wounded set shrinks back).
+//
+// This test encodes (a)-(d) against the REAL alpha network + a control graph that
+// PROVES the completability oracle has teeth (a stranded graph -> ok:false), so the
+// green here is signal, not a constant-true.
+// =============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  MAX_WOUNDED_BIOMES,
+  ER2_PRESSURE_CAP,
+  woundBiome,
+  healBiome,
+  pressureDelta,
+} = require('../../apps/backend/services/worldgen/biomeWound');
+const {
+  checkCompletable,
+  _reachable,
+} = require('../../apps/backend/services/worldgen/metaNetworkCompletability');
+const resolver = require('../../apps/backend/services/worldgen/metaNetworkResolver');
+
+const ALL_SEASONS = [null, 'spring', 'summer', 'autumn', 'winter'];
+
+function realNetwork() {
+  resolver._resetCache();
+  return resolver.getNetwork();
+}
+
+// biome_id -> node.id map (the wounded set keys on session.biome_id == node biome_id).
+function biomeToNode(net) {
+  const m = new Map();
+  for (const n of net.nodes) if (n.biome_id) m.set(n.biome_id, n.id);
+  return m;
+}
+
+// Mirror the session-end loop (routes/session.js): a defeat in `biomeId` applies
+// woundBiome; the persisted set only changes when `added` is true.
+function applyDefeat(wounded, biomeId) {
+  const r = woundBiome(wounded, biomeId);
+  return r.added ? r.wounded : wounded;
+}
+
+// A wounded biome's node is reachable (recovery routable) if it sits in the
+// reachable set under at least one season.
+function nodeReachableSomeSeason(net, nodeId) {
+  const key = String(nodeId).toLowerCase();
+  return ALL_SEASONS.some((s) => _reachable(net, net.start_node, s).has(key));
+}
+
+test('control: the completability oracle has teeth (a stranded graph -> ok:false)', () => {
+  // T is only reachable via a prior_node_cleared[Z] gate, and Z is never reachable.
+  const stranded = {
+    start_node: 'A',
+    nodes: [{ id: 'A' }, { id: 'T', terminal: true }],
+    edges: [{ from: 'A', to: 'T', type: 'corridor', conditions: { prior_node_cleared: ['Z'] } }],
+  };
+  assert.equal(checkCompletable(stranded, { seasons: [null] }).ok, false);
+});
+
+test('cap invariant: MAX_WOUNDED_BIOMES < graph node count (a recovery node always survives)', () => {
+  const net = realNetwork();
+  assert.ok(
+    MAX_WOUNDED_BIOMES < net.nodes.length,
+    `cap ${MAX_WOUNDED_BIOMES} must be < ${net.nodes.length} nodes so not every node can be wounded at once`,
+  );
+});
+
+test('N>=5 consecutive fails in the same biome -> set bounded + still completable + recovery reachable', () => {
+  const net = realNetwork();
+  const map = biomeToNode(net);
+  // FORESTA_TEMPERATA -> foresta_miceliale: a non-start node, reachable from start.
+  const biomeId = 'foresta_miceliale';
+  assert.ok(map.has(biomeId), 'fixture biome is a real graph node');
+
+  let wounded = [];
+  for (let i = 0; i < 6; i++) wounded = applyDefeat(wounded, biomeId);
+
+  // (a) bounded: idempotent -> repeated same-biome fails never grow the set past 1.
+  assert.deepEqual(wounded, [biomeId]);
+  // (a) bounded: pressure never escapes the ER2 cap (no unbounded climb).
+  assert.ok(pressureDelta(wounded) <= ER2_PRESSURE_CAP);
+  // (b) completable: the graph stays solvable in EVERY season despite the wounds.
+  const comp = checkCompletable(net, { seasons: ALL_SEASONS });
+  assert.equal(comp.ok, true, `campaign completable; stranded=${JSON.stringify(comp.stranded)}`);
+  // (c) recovery reachable: the wounded node is routable, so winning there is possible.
+  assert.ok(nodeReachableSomeSeason(net, map.get(biomeId)), 'recovery node reachable from start');
+});
+
+test('recovery win heals the biome (anti-brick exit): wounded set shrinks, degrade clears', () => {
+  let wounded = ['foresta_miceliale'];
+  const r = healBiome(wounded, 'foresta_miceliale');
+  assert.equal(r.healed, true);
+  assert.deepEqual(r.wounded, []);
+  assert.equal(pressureDelta(r.wounded), 0);
+});
+
+test('worst case: cap-many distinct biomes wounded -> completable + each recovery node reachable + bounded', () => {
+  const net = realNetwork();
+  const map = biomeToNode(net);
+  // savana (DESERTO_CALDO = start) + foresta_miceliale (FORESTA_TEMPERATA).
+  const biomes = ['savana', 'foresta_miceliale'];
+  assert.equal(biomes.length, MAX_WOUNDED_BIOMES);
+
+  let wounded = [];
+  for (const b of biomes) {
+    assert.ok(map.has(b), `${b} is a real graph node`);
+    wounded = applyDefeat(wounded, b);
+  }
+  assert.equal(wounded.length, MAX_WOUNDED_BIOMES);
+
+  // A further distinct fail past the cap is rejected -> set stays bounded.
+  const overflow = woundBiome(wounded, 'mezzanotte_orbitale');
+  assert.equal(overflow.capped, true);
+  assert.deepEqual(overflow.wounded, wounded);
+
+  // pressure pinned at the ER2 cap, never above it.
+  assert.equal(pressureDelta(wounded), ER2_PRESSURE_CAP);
+
+  // completable in every season + every wounded node still routable for recovery.
+  const comp = checkCompletable(net, { seasons: ALL_SEASONS });
+  assert.equal(comp.ok, true, `stranded=${JSON.stringify(comp.stranded)}`);
+  for (const b of wounded) {
+    assert.ok(nodeReachableSomeSeason(net, map.get(b)), `recovery node for ${b} reachable`);
+  }
+});
+
+test('realistic interleave (fail, fail, recover, re-fail) stays bounded + completable', () => {
+  const net = realNetwork();
+  let wounded = [];
+  wounded = applyDefeat(wounded, 'savana'); // run 1: lose in savana
+  wounded = applyDefeat(wounded, 'savana'); // run 2: lose again (idempotent)
+  wounded = healBiome(wounded, 'savana').wounded; // run 3: win in savana -> heal
+  assert.deepEqual(wounded, []);
+  wounded = applyDefeat(wounded, 'savana'); // run 4: lose in the healed biome
+  assert.deepEqual(wounded, ['savana']);
+  assert.ok(pressureDelta(wounded) <= ER2_PRESSURE_CAP);
+  assert.equal(checkCompletable(net, { seasons: ALL_SEASONS }).ok, true);
+});
+
+test('defensive: wounding a non-node biome never strands the graph (topology-invariant)', () => {
+  const net = realNetwork();
+  // `caverna` is an encounter biome, not a meta-network node -> wounding it cannot
+  // touch graph topology; the campaign stays completable.
+  let wounded = [];
+  for (let i = 0; i < 5; i++) wounded = applyDefeat(wounded, 'caverna');
+  assert.deepEqual(wounded, ['caverna']);
+  assert.equal(checkCompletable(net, { seasons: ALL_SEASONS }).ok, true);
+});


### PR DESCRIPTION
## Scopo

Verify-first di **SPEC-P failure-as-lore** (`docs/design/evo-tactics-failure-as-lore.md`, acceptance sez.12). Un workflow del 2026-06-17 aveva flaggato 3 gate UNMET (#6, #5, #2). Ground-truth (file:line/PR) di ciascuno -> costruito il gate **genuinamente** mancante; riconciliati i due falsi-positivi.

PR **gated**: NON mergia decisioni e **NON flippa** `doc_status` (`review_needed` resta; flip = master-dd, `source_of_truth:false`).

## Verdetto gate-by-gate (ground-truth)

| Gate | Stato reale | Evidenza |
| --- | --- | --- |
| **#6** anti-brick test automatico | era **MANCANTE** -> **COSTRUITO** | `tests/services/failureLoreAntiBrick.test.js` (7 test) |
| **#5** wire StressWave attivato combat | **MET per-design** (NON gap) | ER6 `apps/backend/services/combat/stressWave.js` (default ON, N=40 PASSED, opz. C 2026-06-10) |
| **#2** epilogo run-end surface | **gia' MET backend** | `apps/backend/services/narrative/failureEpilogue.js` wired `routes/session.js:3704-3731` + 16 test |

### #6 -- anti-brick (sez.8): genuinamente mancante, costruito
Le parti esistevano isolate (`woundBiome` cap+idempotente, `metaNetworkCompletability`, `healBiome`) ma **nessun test legava l'invariante** nello scenario letterale dell'acceptance. Nuovo test automatico:
- N>=5 fail consecutivi sullo **stesso** bioma -> wounded set **bounded** (idempotente, cap `MAX_WOUNDED_BIOMES=2`), `pressureDelta` <= cap ER2;
- `checkCompletable(rete alpha reale)` **ok in ogni stagione** (i wound sono tag di stato, non mutano la topologia del grafo);
- **recovery node raggiungibile** dal start (vincere li' -> `healBiome`);
- heal-exit (il set rientra), worst-case cap-many biomi distinti, e un **control** che prova che l'oracle ha denti (grafo stranded -> `ok:false`) = green non-vacuo.
- Collocato in `tests/services/` perche' **CI-guarded** (`tests/worldgen/` non e' nei glob di `scripts/run-test-api.cjs`).

### #5 -- StressWave: by-design, riconciliato (NON forzato build)
La riga sez.7 "`stresswave -> pressure/spawn` DEAD (`biomeModifiers.js:188`)" **precede ER6** (spec 2026-06-08, ER6 2026-06-10). Il wire combat **e' stato attivato** da SPEC-I ER6 (`stressWave.js`) come **event-trigger** (rescue/overrun); il feed continuo `stresswave -> sistema_pressure` e' **assente per-design** (`docs/hubs/combat.md:65` "NESSUN feed di sistema_pressure"). `biomeModifiers.js:188` = reader read-only diagnostico, **non** il wire runtime. -> nota di riconciliazione additiva in sez.7 + acceptance #5. (Il PA3 "visibile PRE-run" resta surface Godot cross-repo, item-3, residuo noto sez.6 -- non un gap backend.)

### #2 -- epilogo: gia' costruito (falso-positivo, anti-pattern #19)
`failureEpilogue.js`: `buildEpilogue` (payload tier-`public` + consuma J5 `fallen`) + `emitFailureEpilogue` -> chronicle `run_epilogue` + `codex_update`. **Wired** a `routes/session.js:3704-3731` (legge `woundedBiomes` aggiornati + deriva i caduti). 16 test. La resa diegetica (voce Skiv/Custode) = surface **PA1 Godot** (item-3, cross-repo) by design -- il backend assembla i DATA. -> annotato acceptance #2.

## Verifica
- `node --test tests/ai/*.test.js` -> **532/0** (DoD).
- Chain SPEC-P (`failureLoreAntiBrick` + `failureEpilogue` + `biomeWound` + `stressWave` + `metaNetworkCompletability` + api wires a13/stresswave/chronicle) -> **58/0**.
- `python tools/check_docs_governance.py --strict` -> **errors=0** (353 warning = stale legacy pre-esistenti).
- `prettier --check` touched files -> clean.
- Nessun codice runtime/balance toccato -> **no N=40** richiesto. Nessun forbidden-path. Nessuna nuova dipendenza.

## Merge / scope
- **NON auto-merge L3-eligible**: il test e' >50 righe **fuori** da `apps/backend/` (gate-6 L3) + edit a spec master-dd-owned -> **merge manuale master-dd**.
- Se master-dd concorda che #2/#5/#6 sono ora MET (#5 by-design), **tutti gli 8 acceptance sono soddisfatti** modulo i residui gia' tracciati (magnitudini N=40 PROPOSED su #4, surface Godot PA1/PA3 item-3): **raccomandato il flip `review_needed` -> `active`** di SPEC-P (step separato, owner-gated).

## Follow-up (non in questa PR)
- `tests/worldgen/*` (incl. `metaNetworkCompletability.test.js`) e' **CI-orphaned** (non nei glob di `run-test-api.cjs`). Wiring = cambio a `scripts/` separato.

Coding-Agent: claude-opus-4-8
Trace-Id: 019ed2a4-0017-7a84-8e42-a25021ba19ad