### PR TITLE
feat(SPEC-F): Custode portable /share + /crossbreed-propose HTTP routes (slices 0-2)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -41,6 +41,8 @@ const { createSkivRouter } = require('./routes/skiv');
 // Sprint 3 §II (2026-04-27) — AncientBeast wiki cross-link slug bridge.
 const { createSpeciesWikiRouter } = require('./routes/speciesWiki');
 const { createCoopStore } = require('./services/coop/coopStore');
+// SPEC-F -- Custode portable companion store singleton (share/crossbreed routes).
+const { createCompanionStateStore } = require('./services/skiv/companionStateStore');
 // S22-B Task 8 -- metaStore factory for server-side offspring roll on mating quorum.
 const { createMetaStore } = require('./services/metaProgression');
 const { LobbyService } = require('./services/network/wsSession');
@@ -840,7 +842,12 @@ function createApp(options = {}) {
   );
   // 2026-05-20 — Combat readonly diagnostic (status-penalties + biome-modifiers).
   app.use('/api/combat', createCombatRouter());
-  app.use('/api', createCompanionRouter());
+  // SPEC-F -- companion store singleton threaded into the companion router so
+  // the Custode /skiv/share + /skiv/crossbreed routes can read/propose. Prisma
+  // write-through when the delegate is present; in-memory fallback otherwise
+  // (mirrors coopStore at :799). rollMatingOffspring defaults inside the router.
+  const companionStore = createCompanionStateStore({ prisma: repo.prisma });
+  app.use('/api', createCompanionRouter({ store: companionStore }));
 
   // Skiv ticket #7 — unit diary persistence MVP (backend-only, JSONL append).
   app.use('/api', createDiaryRouter(options.diary || {}));

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -8,6 +8,15 @@
 //   POST /api/companion/pick    — runtime pick from skiv_archetype_pool.yaml
 //   GET  /api/companion/pool    — debug: enumerate full pool for biome
 //
+// SPEC-F (Custode Portable Framework) store-backed surface — slices 0-2
+// (read + propose, NO persisted mutation). Route PATHS per spec :51-52, served
+// from this DI-clean router (NOT routes/skiv.js, the fs-json monitor):
+//   GET  /api/skiv/share/:lineage_id?format=json       — share-safe export card
+//   GET  /api/skiv/crossbreed/history/:lineage_id       — crossbreed log read
+//   POST /api/skiv/crossbreed                           — offspring proposal
+// Slice 3 (POST /crossbreed/confirm + cooldown/rate-limit) is gated on
+// unanswered design-calls — NOT built here.
+//
 // Auth: stateless (read-only data lookup, no mutation). Future hardening
 // can add JWT token check via shared AUTH_SECRET if exposed publicly.
 
@@ -15,8 +24,14 @@
 
 const express = require('express');
 const companionPickerDefault = require('../services/companion/companionPicker');
+const { sanitizeWhitelist, signatureFor } = require('../services/skiv/companionStateStore');
+const { rollMatingOffspring: rollMatingOffspringDefault } = require('../services/metaProgression');
 
-function createCompanionRouter({ companionPicker = companionPickerDefault } = {}) {
+function createCompanionRouter({
+  companionPicker = companionPickerDefault,
+  store = null,
+  rollMatingOffspring = rollMatingOffspringDefault,
+} = {}) {
   const router = express.Router();
 
   /**
@@ -68,6 +83,164 @@ function createCompanionRouter({ companionPicker = companionPickerDefault } = {}
         .status(500)
         .json({ error: 'companion_pool_failed', message: String(err.message || err) });
     }
+  });
+
+  // ─── SPEC-F slices 0-2: Custode portable store-backed routes ──────────
+  //
+  // Guard: these routes need the companion store singleton injected. When the
+  // store is absent (e.g. a minimal test mounting only the picker) they return
+  // 503 instead of throwing, so the picker routes above stay independent.
+  function requireStore(res) {
+    if (!store) {
+      res.status(503).json({ error: 'companion_store_unavailable' });
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * GET /api/skiv/share/:lineage_id?format=json[&include_diary=true]
+   *
+   * Share-safe export card (SPEC-F export contract, spec :97-116). Returns the
+   * sanitized whitelist subset only -- raw/ephemeral PII (session_id, hp_current,
+   * _notes, ...) is dropped by sanitizeWhitelist. voice_diary_portable is
+   * stripped to [] unless BOTH ?include_diary=true AND a stored consent boolean
+   * are truthy (default opt-out, spec :135-138). Signature is recomputed
+   * server-side via signatureFor (transport integrity, spec :111-114).
+   *
+   * format=json is the only supported format in v1 (qr/card = follow-up).
+   */
+  router.get('/skiv/share/:lineage_id', (req, res) => {
+    if (!requireStore(res)) return;
+    const lineageId = String(req.params.lineage_id || '');
+    const format = req.query.format ? String(req.query.format) : 'json';
+    if (format !== 'json') {
+      return res.status(400).json({ error: 'unsupported_format', format });
+    }
+    let state;
+    try {
+      state = store.getCompanionState(lineageId);
+    } catch (err) {
+      return res
+        .status(500)
+        .json({ error: 'companion_share_failed', message: String(err.message || err) });
+    }
+    if (!state) {
+      return res.status(404).json({ error: 'lineage_not_found' });
+    }
+    // Whitelist-only export (defense-in-depth; drops any PII present on state).
+    const card = sanitizeWhitelist(state);
+    // Diary opt-out enforcement: include only with consent AND explicit request.
+    const includeDiary = String(req.query.include_diary || '') === 'true';
+    const hasConsent = Boolean(state.voice_diary_consent);
+    if (!includeDiary || !hasConsent) {
+      card.voice_diary_portable = [];
+    }
+    card.generated_at = new Date().toISOString();
+    // Recompute signature server-side over the final whitelist payload.
+    card.companion_card_signature = signatureFor(card);
+    return res.json(card);
+  });
+
+  /**
+   * GET /api/skiv/crossbreed/history/:lineage_id
+   *
+   * Read-only crossbreed log. Returns [] (count 0) when the lineage is absent
+   * (graceful, not an error -- mirrors store.getCrossbreedHistory).
+   */
+  router.get('/skiv/crossbreed/history/:lineage_id', (req, res) => {
+    if (!requireStore(res)) return;
+    const lineageId = String(req.params.lineage_id || '');
+    let history;
+    try {
+      history = store.getCrossbreedHistory(lineageId) || [];
+    } catch (err) {
+      return res
+        .status(500)
+        .json({ error: 'companion_history_failed', message: String(err.message || err) });
+    }
+    return res.json({ lineage_id: lineageId, count: history.length, history });
+  });
+
+  /**
+   * POST /api/skiv/crossbreed
+   * Body: { lineage_id, partner_card_json, biome_id? }
+   *
+   * Crossbreed PROPOSAL (slice 2 -- NO store write). Steps:
+   *   1. getCompanionState(lineage_id) -> 404 if missing.
+   *   2. Verify partner card integrity: signatureFor(partner) must equal
+   *      partner.companion_card_signature else 400 signature_mismatch.
+   *   3. Biological gate: BOTH parents need species_id else 422
+   *      crossbreed_requires_biological (narrative Custodi cannot breed,
+   *      spec sez. 4 + reconstruction pt5).
+   *   4. rollMatingOffspring({parentA: local, parentB: partner, biomeId,
+   *      context:{useGeneEncoder:true}}) -- engine owns the genetics.
+   *   5. Return {proposal, tier, visual_hints}. No persistence.
+   *
+   * partner_card_url fetch is deferred (SSRF -- v1 is JSON-only).
+   */
+  router.post('/skiv/crossbreed', (req, res) => {
+    if (!requireStore(res)) return;
+    const body = req.body || {};
+    const lineageId = String(body.lineage_id || '');
+    const partner = body.partner_card_json;
+    if (!partner || typeof partner !== 'object') {
+      return res.status(400).json({ error: 'partner_card_required' });
+    }
+    let local;
+    try {
+      local = store.getCompanionState(lineageId);
+    } catch (err) {
+      return res
+        .status(500)
+        .json({ error: 'companion_crossbreed_failed', message: String(err.message || err) });
+    }
+    if (!local) {
+      return res.status(404).json({ error: 'lineage_not_found' });
+    }
+    // Step 2: verify partner signature (transport integrity).
+    let expectedSig;
+    try {
+      expectedSig = signatureFor(partner);
+    } catch (err) {
+      return res
+        .status(400)
+        .json({ error: 'partner_card_invalid', message: String(err.message || err) });
+    }
+    if (partner.companion_card_signature !== expectedSig) {
+      return res.status(400).json({ error: 'signature_mismatch' });
+    }
+    // Step 3: biological gate -- both parents must have species_id.
+    if (!local.species_id || !partner.species_id) {
+      return res.status(422).json({ error: 'crossbreed_requires_biological' });
+    }
+    // Step 4: roll offspring (engine-owned genetics, gene-encoder lineage chain).
+    const biomeId = body.biome_id || local.biome_id || partner.biome_id || null;
+    let result;
+    try {
+      result = rollMatingOffspring({
+        parentA: local,
+        parentB: partner,
+        biomeId,
+        context: { useGeneEncoder: true },
+      });
+    } catch (err) {
+      return res
+        .status(500)
+        .json({ error: 'companion_crossbreed_failed', message: String(err.message || err) });
+    }
+    if (!result || result.success === false) {
+      return res.status(422).json({
+        error: 'crossbreed_rejected',
+        reason: (result && result.reason) || 'unknown',
+      });
+    }
+    // Step 5: propose only -- NO store write (slice 3 confirm is gated).
+    return res.json({
+      proposal: result.offspring,
+      tier: result.tier,
+      visual_hints: result.visual_hints,
+    });
   });
 
   return router;

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -1,0 +1,337 @@
+// SPEC-F (Custode Portable Framework) — /api/skiv/* store-backed HTTP routes.
+//
+// Slices 0-2 (read + propose, NO persisted mutation):
+//   GET  /api/skiv/share/:lineage_id?format=json
+//   GET  /api/skiv/crossbreed/history/:lineage_id
+//   POST /api/skiv/crossbreed  (propose offspring, no store write)
+//
+// Routes are served from the DI companion router (createCompanionRouter),
+// NOT routes/skiv.js (the decoupled fs-json monitor). Both `store` and
+// `rollMatingOffspring` are injected so tests stub them deterministically
+// (band-neutral, no combat sim -> no N=40 needed).
+//
+// Mirror: tests/routes/companion.test.js (express app.listen(0) + fetch, DI stubs).
+// Reference: docs/design/evo-tactics-custode-portable-framework.md (route names :51-52,
+// export contract :97-116, voice_diary opt-out :135-138).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const { createCompanionRouter } = require('../../apps/backend/routes/companion');
+const { signatureFor } = require('../../apps/backend/services/skiv/companionStateStore');
+
+// A whitelist-shaped Custode state mirroring makeValidState from
+// tests/services/skivCompanionState.test.js, plus non-whitelist PII so we can
+// assert /share strips it.
+function makeShareState(overrides = {}) {
+  const base = {
+    schema_version: '0.2.0',
+    unit_id: 'skiv',
+    species_id: 'dune_stalker',
+    biome_id: 'savana',
+    lineage_id: 'skiv-savana-2026-0427-test',
+    companion_card_signature: null,
+    mbti_axes: {
+      E_I: { value: 0.68, coverage: 'full' },
+      T_F: { value: 0.72, coverage: 'full' },
+    },
+    progression: { level: 4, job: 'stalker' },
+    cabinet: ['ambush'],
+    mutations: [],
+    aspect: { label: 'dune', lifecycle: 'adult' },
+    crossbreed_history: [],
+    voice_diary_portable: [{ ts: '2026-06-08T00:00:00Z', line: 'sabbia segue' }],
+    share_url: null,
+    // --- non-whitelist PII / ephemeral (must never leave via /share) ---
+    session_id: 'sess-secret-123',
+    hp_current: 7,
+    _notes: 'private',
+    ...overrides,
+  };
+  return base;
+}
+
+// Build a deterministic in-memory store stub exposing only the methods the
+// routes call: getCompanionState, getCrossbreedHistory.
+function makeStoreStub(seed = {}) {
+  const states = new Map(Object.entries(seed));
+  return {
+    getCompanionState(lineageId) {
+      return states.get(lineageId) || null;
+    },
+    getCrossbreedHistory(lineageId) {
+      const s = states.get(lineageId);
+      return s && Array.isArray(s.crossbreed_history) ? [...s.crossbreed_history] : [];
+    },
+    signatureFor,
+    _states: states,
+  };
+}
+
+function buildApp({ store, rollMatingOffspring } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createCompanionRouter({ store, rollMatingOffspring }));
+  return app;
+}
+
+async function getJson(app, path) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, async () => {
+      const port = server.address().port;
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}${path}`);
+        const data = await res.json();
+        server.close();
+        resolve({ status: res.status, body: data });
+      } catch (err) {
+        server.close();
+        reject(err);
+      }
+    });
+  });
+}
+
+async function postJson(app, path, body) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, async () => {
+      const port = server.address().port;
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const data = await res.json();
+        server.close();
+        resolve({ status: res.status, body: data });
+      } catch (err) {
+        server.close();
+        reject(err);
+      }
+    });
+  });
+}
+
+// ─── Slice 1: GET /api/skiv/share/:lineage_id ───────────────────────────
+
+test('GET /skiv/share unknown lineage → 404 lineage_not_found', async () => {
+  const app = buildApp({ store: makeStoreStub() });
+  const r = await getJson(app, '/api/skiv/share/nope');
+  assert.equal(r.status, 404);
+  assert.equal(r.body.error, 'lineage_not_found');
+});
+
+test('GET /skiv/share returns ONLY whitelist fields (PII stripped)', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({ [lineageId]: makeShareState() }),
+  });
+  const r = await getJson(app, `/api/skiv/share/${lineageId}`);
+  assert.equal(r.status, 200);
+  // PII / ephemeral must be absent.
+  assert.equal('session_id' in r.body, false);
+  assert.equal('hp_current' in r.body, false);
+  assert.equal('_notes' in r.body, false);
+  // Whitelist fields present.
+  assert.equal(r.body.lineage_id, lineageId);
+  assert.equal(r.body.species_id, 'dune_stalker');
+});
+
+test('GET /skiv/share strips voice_diary_portable to [] without consent', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({ [lineageId]: makeShareState() }),
+  });
+  // include_diary requested but no stored consent → still stripped.
+  const r = await getJson(app, `/api/skiv/share/${lineageId}?include_diary=true`);
+  assert.equal(r.status, 200);
+  assert.deepEqual(r.body.voice_diary_portable, []);
+});
+
+test('GET /skiv/share includes diary only with consent AND include_diary=true', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({
+      [lineageId]: makeShareState({ voice_diary_consent: true }),
+    }),
+  });
+  // consent present but include_diary not requested → still stripped.
+  const stripped = await getJson(app, `/api/skiv/share/${lineageId}`);
+  assert.deepEqual(stripped.body.voice_diary_portable, []);
+  // consent + include_diary=true → included.
+  const included = await getJson(app, `/api/skiv/share/${lineageId}?include_diary=true`);
+  assert.equal(included.body.voice_diary_portable.length, 1);
+});
+
+test('GET /skiv/share sets generated_at + recomputed companion_card_signature', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({ [lineageId]: makeShareState() }),
+  });
+  const r = await getJson(app, `/api/skiv/share/${lineageId}`);
+  assert.equal(r.status, 200);
+  assert.match(r.body.companion_card_signature, /^[a-f0-9]{64}$/);
+  assert.equal(typeof r.body.generated_at, 'string');
+});
+
+// ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────
+
+test('GET /skiv/crossbreed/history unknown lineage → [] count 0', async () => {
+  const app = buildApp({ store: makeStoreStub() });
+  const r = await getJson(app, '/api/skiv/crossbreed/history/nope');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.lineage_id, 'nope');
+  assert.equal(r.body.count, 0);
+  assert.deepEqual(r.body.history, []);
+});
+
+test('GET /skiv/crossbreed/history populated returns seeded entries', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const seeded = makeShareState({
+    crossbreed_history: [{ ts: '2026-06-08T00:00:00Z', partner_lineage_id: 'partner-x' }],
+  });
+  const app = buildApp({ store: makeStoreStub({ [lineageId]: seeded }) });
+  const r = await getJson(app, `/api/skiv/crossbreed/history/${lineageId}`);
+  assert.equal(r.status, 200);
+  assert.equal(r.body.count, 1);
+  assert.equal(r.body.history[0].partner_lineage_id, 'partner-x');
+});
+
+// ─── Slice 2: POST /api/skiv/crossbreed (propose, NO persist) ───────────
+
+function makePartnerCard(overrides = {}) {
+  const partner = {
+    schema_version: '0.2.0',
+    unit_id: 'partner',
+    species_id: 'reef_drifter',
+    biome_id: 'oceano',
+    lineage_id: 'partner-lineage-9999',
+    mbti_axes: { E_I: { value: 0.3, coverage: 'full' } },
+    progression: { level: 2 },
+    cabinet: [],
+    mutations: [],
+    aspect: {},
+    crossbreed_history: [],
+    voice_diary_portable: [],
+    share_url: null,
+    ...overrides,
+  };
+  partner.companion_card_signature = signatureFor(partner);
+  return partner;
+}
+
+test('POST /skiv/crossbreed missing local lineage → 404', async () => {
+  const app = buildApp({ store: makeStoreStub() });
+  const r = await postJson(app, '/api/skiv/crossbreed', {
+    lineage_id: 'nope',
+    partner_card_json: makePartnerCard(),
+  });
+  assert.equal(r.status, 404);
+  assert.equal(r.body.error, 'lineage_not_found');
+});
+
+test('POST /skiv/crossbreed partner signature mismatch → 400', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({ [lineageId]: makeShareState() }),
+  });
+  const partner = makePartnerCard();
+  partner.companion_card_signature = 'deadbeef'.repeat(8); // 64 hex but wrong
+  const r = await postJson(app, '/api/skiv/crossbreed', {
+    lineage_id: lineageId,
+    partner_card_json: partner,
+  });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'signature_mismatch');
+});
+
+test('POST /skiv/crossbreed narrative partner (no species_id) → 422', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({ [lineageId]: makeShareState() }),
+  });
+  const partner = makePartnerCard({ species_id: undefined });
+  const r = await postJson(app, '/api/skiv/crossbreed', {
+    lineage_id: lineageId,
+    partner_card_json: partner,
+  });
+  assert.equal(r.status, 422);
+  assert.equal(r.body.error, 'crossbreed_requires_biological');
+});
+
+test('POST /skiv/crossbreed narrative LOCAL (no species_id) → 422', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({
+      [lineageId]: makeShareState({ species_id: undefined }),
+    }),
+  });
+  const r = await postJson(app, '/api/skiv/crossbreed', {
+    lineage_id: lineageId,
+    partner_card_json: makePartnerCard(),
+  });
+  assert.equal(r.status, 422);
+  assert.equal(r.body.error, 'crossbreed_requires_biological');
+});
+
+test('POST /skiv/crossbreed valid → 200 {proposal,tier,visual_hints}, no persist', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const store = makeStoreStub({ [lineageId]: makeShareState() });
+  let captured = null;
+  const rollStub = (input) => {
+    captured = input;
+    return {
+      success: true,
+      offspring: { lineage_id: 'offspring-xyz', gene_slots: {} },
+      tier: 'rare',
+      visual_hints: { glow: true },
+    };
+  };
+  const app = buildApp({ store, rollMatingOffspring: rollStub });
+  const r = await postJson(app, '/api/skiv/crossbreed', {
+    lineage_id: lineageId,
+    partner_card_json: makePartnerCard(),
+    biome_id: 'caverna',
+  });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.proposal.lineage_id, 'offspring-xyz');
+  assert.equal(r.body.tier, 'rare');
+  assert.deepEqual(r.body.visual_hints, { glow: true });
+  // engine called with biological parents + gene-encoder + chosen biome.
+  assert.equal(captured.parentA.species_id, 'dune_stalker');
+  assert.equal(captured.parentB.species_id, 'reef_drifter');
+  assert.equal(captured.biomeId, 'caverna');
+  assert.equal(captured.context.useGeneEncoder, true);
+  // NO store write: crossbreed_history still empty.
+  assert.deepEqual(store.getCrossbreedHistory(lineageId), []);
+});
+
+test('POST /skiv/crossbreed defaults biome to local biome_id when omitted', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const store = makeStoreStub({ [lineageId]: makeShareState() });
+  let captured = null;
+  const app = buildApp({
+    store,
+    rollMatingOffspring: (input) => {
+      captured = input;
+      return { success: true, offspring: {}, tier: 'common', visual_hints: {} };
+    },
+  });
+  await postJson(app, '/api/skiv/crossbreed', {
+    lineage_id: lineageId,
+    partner_card_json: makePartnerCard(),
+  });
+  assert.equal(captured.biomeId, 'savana');
+});
+
+test('POST /skiv/crossbreed missing partner_card_json → 400', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({ [lineageId]: makeShareState() }),
+  });
+  const r = await postJson(app, '/api/skiv/crossbreed', { lineage_id: lineageId });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'partner_card_required');
+});


### PR DESCRIPTION
## Summary

Builds the missing SPEC-F (Custode Portable Framework) HTTP routes, **slices 0-2 only** (read + propose, **NO persisted mutation**). The LIVE `companionStateStore` and `rollMatingOffspring` engine are reused as-is; nothing in genetics/store is reimplemented.

Route PATHS follow the spec (`docs/design/evo-tactics-custode-portable-framework.md` :51-52) but are served from the **DI-clean companion router** (`routes/companion.js`), not `routes/skiv.js` (the decoupled fs-json monitor, left untouched).

### Slices
- **Slice 0 (wiring):** `companionStateStore` singleton instantiated in `app.js` (prisma write-through, in-memory fallback -- mirrors `coopStore`), threaded into `createCompanionRouter({ store })`.
- **Slice 1 (reads):**
  - `GET /api/skiv/share/:lineage_id?format=json` -> 404 `lineage_not_found` if unknown; else `sanitizeWhitelist(state)` (PII stripped), `voice_diary_portable` -> `[]` unless `?include_diary=true` **AND** a stored consent boolean is truthy (default opt-out, spec :135-138), `generated_at` set, signature recomputed via `signatureFor`. `format=json` only.
  - `GET /api/skiv/crossbreed/history/:lineage_id` -> `{lineage_id, count, history}` (`[]` if absent).
- **Slice 2 (propose, no persist):** `POST /api/skiv/crossbreed` `{lineage_id, partner_card_json, biome_id?}` -> 404 missing local / 400 `signature_mismatch` / 422 `crossbreed_requires_biological` (either parent lacks `species_id`) / 200 `{proposal, tier, visual_hints}` via `rollMatingOffspring({..., context:{useGeneEncoder:true}})`. **No store write.**

**Slice 3** (`POST /crossbreed/confirm` + cooldown/rate-limit) is **not built** -- gated on open design-calls.

### Design defaults applied (reversible)
- Path prefix `/api/skiv/*` per spec, served from companion router.
- Partner card JSON-only (`partner_card_json`); no server-side `partner_card_url` fetch (SSRF deferred).
- Diary: strip unless `?include_diary=true` + stored `voice_diary_consent` truthy.

## Test evidence
TDD-first (failing specs written before impl). 14 new tests in `tests/routes/skivCustode.test.js` (express `listen(0)` + fetch, both `store` and `rollMatingOffspring` DI-stubbed -- band-neutral, no combat sim).

- `node --test tests/routes/skivCustode.test.js tests/routes/companion.test.js tests/services/skivCompanionState.test.js tests/api/skivRoute.test.js` -> **55/55 pass** (14 new + 8 companion + 21 store + 12 monitor regression).
- `node --test tests/ai/*.test.js` -> **543/543 pass** (baseline preserved, >=382).
- `npx prettier --check` on touched files -> clean.
- Boot smoke `createApp()` -> OK (`type: object`).

## Files changed
- `apps/backend/app.js` (slice 0 wiring)
- `apps/backend/routes/companion.js` (3 routes + DI)
- `tests/routes/skivCustode.test.js` (new)

Zero files in forbidden paths (`.github/workflows/`, `migrations/`, `packages/contracts/`, `services/generation/`). No new deps.

## Rollback (03A)
Pure-additive. Revert this single squash commit -> the 3 new routes disappear, `companion.js`/`app.js` return to picker-only behavior. The injected store is unused by any other surface; `routes/skiv.js` monitor untouched. No schema/migration/contract change -> no data or downstream impact.

## Open design-calls (slice 3 gate)
1. **Path prefix** -- using `/api/skiv/*` per spec (decided).
2. **partner_card_url fetch** -- deferred (SSRF); JSON-only for v1.
3. **Cooldown / rate-limit** (1/campaign crossbreed, 10/h IP import) -- **open** (slice 3).
4. **+Nido materialization** (offspring append to `crossbreed_history` + Nido on confirm) -- **open** (slice 3, requires store write + persistence semantics).
5. **Diary consent source** -- interim impl reads `state.voice_diary_consent`; canonical consent storage location (extraction snapshot vs Nido settings, spec :135-138) -- **open** (where the boolean is persisted, since `saveCompanionState` strips non-whitelist fields).

Coding-Agent: claude-opus-4-8