### PR TITLE
feat(od-059): campaign-scoped read-only biome-memory carry-over (#1673)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3728,6 +3728,54 @@ function createSessionRouter(options = {}) {
       } catch {
         /* best-effort -- never blocks session end */
       }
+      // OD-059 (#1673) -- accumulate campaign-scoped READ-ONLY NARRATIVE
+      // biome-familiarity for each surviving player unit. Carry-over: persists
+      // ACROSS the encounters/sessions of one run (the inert session-scoped
+      // `unit.cumulative_biome_turns` never did). Band-safe: writes ONLY
+      // `campaign.biomeMemory`; reads NO combat state; touches NO mechanical
+      // primitive. Best-effort -- never blocks session end.
+      //
+      // turn-delta = `session.turn` (the encounter's total round count at /end),
+      // applied per SURVIVING player unit. DESIGN-KNOB (REVERSIBLE, flagged for
+      // master-dd): the exact delta semantics -- always vs victory-only vs
+      // rounds-alive vs a flat +1 -- is a narrative-tuning call, not a mechanical
+      // one (no band impact either way). Simplest defensible default chosen here.
+      try {
+        const campaignId = session.campaign_id;
+        const biomeId = session.biome_id;
+        if (campaignId && biomeId) {
+          const { recordBiomeTurns } = require('../services/campaign/campaignStore');
+          const turnDelta = Number.isFinite(session.turn) ? session.turn : 0;
+          const survivors = (session.units || []).filter(
+            // B5: minions are expendable, not campaign creatures -- exclude.
+            (u) => u && u.controlled_by === 'player' && !u.is_minion && (u.hp ?? 0) > 0,
+          );
+          for (const u of survivors) {
+            recordBiomeTurns(campaignId, u.id, biomeId, turnDelta);
+          }
+        }
+      } catch {
+        /* best-effort -- biome-memory carry-over never blocks session end */
+      }
+      // OD-059 read-only surface: structured biome-familiarity for the player
+      // unit(s) of THIS encounter, for the debrief/end payload. STRUCTURED DATA
+      // only `{ [unitId]: { [biomeId]: turns } }` -- no prose copy; narrative
+      // rendering + thresholds = master-dd / Godot design-call. Pure read; never
+      // mutates combat state. {} when no campaign / no familiarity yet.
+      let biomeFamiliarity = {};
+      try {
+        if (session.campaign_id) {
+          const { getBiomeMemory } = require('../services/campaign/campaignStore');
+          for (const u of session.units || []) {
+            if (u && u.controlled_by === 'player' && !u.is_minion) {
+              const mem = getBiomeMemory(session.campaign_id, u.id);
+              if (mem && Object.keys(mem).length) biomeFamiliarity[u.id] = mem;
+            }
+          }
+        }
+      } catch {
+        biomeFamiliarity = {};
+      }
       // SPEC-P sez.4/5 -- assemble the failure epilogue + codex hook on run-fail.
       // Reads the UPDATED woundedBiomes (after the A13 block above). No-op on
       // victory / no campaign_id. Best-effort -- never blocks session end.
@@ -3873,6 +3921,10 @@ function createSessionRouter(options = {}) {
         // (N=40 F2: the axis was dead without unitStatsById).
         debrief_payload: vcSnapshotToDebriefPayload(vcSnapshot, unitStatsById(session)),
         debrief,
+        // OD-059 (#1673) -- READ-ONLY NARRATIVE biome-familiarity carry-over.
+        // Structured data only `{ [unitId]: { [biomeId]: turns } }`; {} when no
+        // campaign. Narrative rendering + thresholds = master-dd / Godot.
+        biome_familiarity: biomeFamiliarity,
       });
     } catch (err) {
       next(err);

--- a/apps/backend/services/campaign/biomeMemory.js
+++ b/apps/backend/services/campaign/biomeMemory.js
@@ -1,0 +1,56 @@
+// =============================================================================
+// biomeMemory -- OD-059 (#1673): campaign-scoped READ-ONLY NARRATIVE
+// biome-familiarity carry-over.
+//
+// WHY (issue #1673 / OD-059): the only "biome turns" primitive in the build is
+// the per-UNIT, MECHANICAL `unit.cumulative_biome_turns` -- which is session-
+// scoped and inert (no cross-encounter carry-over, no consumer). #1673 asked for
+// a campaign-scoped familiarity that PERSISTS across encounters of the same run.
+// Master-dd verdict (OD-059) = option A: reuse the pure-fn PATTERN (mirror of
+// `services/worldgen/biomeWound.js`) and build a SEPARATE carry-over layer.
+//
+// HARD CONSTRAINT (SoT 19.3 narrative freeze) -- band-safe BY CONSTRUCTION:
+//   * This layer is READ-ONLY NARRATIVE. It writes ONLY to `campaign.biomeMemory`
+//     and surfaces STRUCTURED DATA. It must NEVER write `unit.cumulative_biome_turns`,
+//     touch a combat resolver / mutationTriggerEvaluator / reinforcementSpawner /
+//     biomePopulation / pressure. The AI combat sim reads NONE of these fields =>
+//     no N=40 needed.
+//   * `biomeMemory` (campaign, narrative) and `cumulative_biome_turns` (unit,
+//     mechanical, inert) are SEPARATE namespaces -- intentionally NOT coupled.
+//   * Structured data only: `{ [unitId]: { [biomeId]: turns } }`. Narrative
+//     rendering + thresholds = master-dd / Godot design-call, flagged downstream.
+// =============================================================================
+
+'use strict';
+
+/**
+ * Accumulate per-unit per-biome familiarity turns. Pure: returns a NEW nested
+ * object, never mutates the input. Tolerant of garbage input (treated as empty /
+ * no-op). Mirror of `biomeWound.woundBiome` immutable shape.
+ *
+ * @param {object} memory prior state `{ [unitId]: { [biomeId]: int } }` (or garbage)
+ * @param {string} unitId player unit id
+ * @param {string} biomeId biome id
+ * @param {number} delta turns to add for this encounter (coerced to non-neg int)
+ * @returns {object} a new `{ [unitId]: { [biomeId]: int } }`
+ */
+function accumulate(memory, unitId, biomeId, delta) {
+  // Tolerant clone: any non-object (null/undefined/string/number) -> empty base.
+  const base = memory && typeof memory === 'object' ? memory : {};
+  const next = {};
+  for (const uid of Object.keys(base)) {
+    const inner = base[uid];
+    next[uid] = inner && typeof inner === 'object' ? { ...inner } : {};
+  }
+  // No-op (return the clone) when the keys are missing -- never write garbage keys.
+  if (!unitId || !biomeId) return next;
+  // Coerce delta: non-finite -> no-op add (0); floor floats; clamp negatives to 0.
+  const d = Number(delta);
+  const add = Number.isFinite(d) ? Math.max(0, Math.floor(d)) : 0;
+  if (!next[unitId]) next[unitId] = {};
+  const cur = Number(next[unitId][biomeId]) || 0;
+  next[unitId][biomeId] = cur + add;
+  return next;
+}
+
+module.exports = { accumulate };

--- a/apps/backend/services/campaign/biomeMemory.js
+++ b/apps/backend/services/campaign/biomeMemory.js
@@ -23,6 +23,14 @@
 
 'use strict';
 
+// Anti prototype-pollution (Codex P1): unit/biome ids are user-controlled (the
+// session-start path preserves body-provided unit ids). A reserved key like
+// `__proto__` would index Object.prototype instead of an own bucket, letting one
+// `/end` request poison every object in the process. Reject reserved keys + use
+// own-property checks so user ids never resolve onto the prototype chain.
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
 /**
  * Accumulate per-unit per-biome familiarity turns. Pure: returns a NEW nested
  * object, never mutates the input. Tolerant of garbage input (treated as empty /
@@ -39,17 +47,21 @@ function accumulate(memory, unitId, biomeId, delta) {
   const base = memory && typeof memory === 'object' ? memory : {};
   const next = {};
   for (const uid of Object.keys(base)) {
+    if (FORBIDDEN_KEYS.has(uid)) continue; // defensive: never carry a poisoned key forward
     const inner = base[uid];
     next[uid] = inner && typeof inner === 'object' ? { ...inner } : {};
   }
   // No-op (return the clone) when the keys are missing -- never write garbage keys.
   if (!unitId || !biomeId) return next;
+  // Reject reserved keys before indexing user-controlled ids (prototype pollution).
+  if (FORBIDDEN_KEYS.has(String(unitId)) || FORBIDDEN_KEYS.has(String(biomeId))) return next;
   // Coerce delta: non-finite -> no-op add (0); floor floats; clamp negatives to 0.
   const d = Number(delta);
   const add = Number.isFinite(d) ? Math.max(0, Math.floor(d)) : 0;
-  if (!next[unitId]) next[unitId] = {};
-  const cur = Number(next[unitId][biomeId]) || 0;
-  next[unitId][biomeId] = cur + add;
+  if (!hasOwn(next, unitId)) next[unitId] = {};
+  const inner = next[unitId];
+  const cur = Number(hasOwn(inner, biomeId) ? inner[biomeId] : 0) || 0;
+  inner[biomeId] = cur + add;
   return next;
 }
 

--- a/apps/backend/services/campaign/campaignStore.js
+++ b/apps/backend/services/campaign/campaignStore.js
@@ -77,6 +77,16 @@ function createCampaign(playerId, campaignDefId = 'default_campaign_mvp', opts =
     emergentBrancoTrait: opts.emergentBrancoTrait || null,
     // SPEC-P A13 -- biomi feriti cross-run (degrade bounded, cap 2). Persistito qui.
     woundedBiomes: Array.isArray(opts.woundedBiomes) ? [...opts.woundedBiomes] : [],
+    // OD-059 (#1673) -- campaign-scoped READ-ONLY NARRATIVE biome-familiarity
+    // carry-over `{ [unitId]: { [biomeId]: turns } }`. Accumulates ACROSS the
+    // encounters/sessions of one run (the carry-over `unit.cumulative_biome_turns`
+    // -- session-scoped, mechanical, inert -- never gave). SEPARATE namespace from
+    // that primitive; never coupled. Narrative-only: read by the debrief surface,
+    // read by NO combat resolver / mutation / reinforcement / pressure (band-safe).
+    biomeMemory:
+      opts.biomeMemory && typeof opts.biomeMemory === 'object'
+        ? structuredClone(opts.biomeMemory)
+        : {},
     // SPEC-I ER7 -- popolazione discreta per ruolo trofico, cross-run. Avanza a
     // season-tick (campaign.js advance-season). { [biomeId]: { apex|prey|... :
     // { state:'abundant'|'stable'|'depleted', seasons:int } } }. Vuoto = nessun
@@ -192,6 +202,46 @@ function getPermanentFlag(id, key) {
   return list.find((f) => f.key === key) || null;
 }
 
+/**
+ * OD-059 (#1673) -- accumulate per-unit per-biome familiarity turns onto the
+ * campaign (READ-ONLY NARRATIVE carry-over). Additive via the pure
+ * `biomeMemory.accumulate` (immutable) + `updateCampaign`. Calling this across the
+ * separate sessions of the SAME campaign run accumulates (the OD-059 fix).
+ *
+ * Band-safe by construction: writes ONLY `campaign.biomeMemory`. Never touches
+ * `unit.cumulative_biome_turns` (the mechanical/inert primitive) or any combat
+ * state. Returns the updated campaign, or null when the campaign is not found.
+ *
+ * @param {string} id campaign id
+ * @param {string} unitId player unit id
+ * @param {string} biomeId biome id
+ * @param {number} delta turns to add for this encounter
+ * @returns {object|null}
+ */
+function recordBiomeTurns(id, unitId, biomeId, delta) {
+  const cur = _campaigns.get(id);
+  if (!cur) return null;
+  const { accumulate } = require('./biomeMemory');
+  const next = accumulate(cur.biomeMemory || {}, unitId, biomeId, delta);
+  return updateCampaign(id, { biomeMemory: next });
+}
+
+/**
+ * OD-059 -- read accessor for one unit's biome-familiarity map. Pure read, never
+ * mutates. Returns a clone `{ [biomeId]: turns }`, or `{}` when the campaign /
+ * unit is unknown.
+ *
+ * @param {string} id campaign id
+ * @param {string} unitId player unit id
+ * @returns {object} `{ [biomeId]: int }`
+ */
+function getBiomeMemory(id, unitId) {
+  const cur = _campaigns.get(id);
+  if (!cur || !unitId) return {};
+  const inner = (cur.biomeMemory || {})[unitId];
+  return inner && typeof inner === 'object' ? { ...inner } : {};
+}
+
 function deleteCampaign(id) {
   const cur = _campaigns.get(id);
   if (!cur) return false;
@@ -215,6 +265,8 @@ module.exports = {
   recordChapter,
   recordPermanentFlag,
   getPermanentFlag,
+  recordBiomeTurns,
+  getBiomeMemory,
   deleteCampaign,
   _resetStore,
 };

--- a/tests/api/biomeMemoryWire.test.js
+++ b/tests/api/biomeMemoryWire.test.js
@@ -1,0 +1,109 @@
+// biomeMemory wiring integration -- OD-059 (#1673). Two /start->/end cycles under
+// the SAME campaign_id + biome_id accumulate the campaign-scoped familiarity
+// (cross-encounter carry-over). READ-ONLY NARRATIVE: surfaced as STRUCTURED DATA
+// in the /end debrief payload, never written into combat state. Mirror of
+// a13BiomeWoundWire.test.js harness.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+const {
+  getCampaign,
+  getBiomeMemory,
+} = require('../../apps/backend/services/campaign/campaignStore');
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'bmem-wire-'));
+}
+
+// Both factions alive at /end -> board 'abandon' (no wipe wound noise); the
+// player unit p1 survives so it earns familiarity.
+const ALIVE = [
+  { id: 'p1', controlled_by: 'player', hp: 10, max_hp: 10, position: { x: 0, y: 0 } },
+  { id: 's1', controlled_by: 'sistema', hp: 5, max_hp: 5, position: { x: 5, y: 5 } },
+];
+
+async function runEnd(app, campaignId, units, biomeId) {
+  const ss = await request(app)
+    .post('/api/session/start')
+    .send({ units, campaign_id: campaignId, biome_id: biomeId });
+  const end = await request(app).post('/api/session/end').send({ session_id: ss.body.session_id });
+  return end;
+}
+
+test('OD-059 wire: two /start->/end cycles, same campaign + biome -> familiarity accumulates', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'bmem_pl1' });
+  const cid = start.body.campaign.id;
+
+  await runEnd(app, cid, ALIVE, 'savana'); // encounter #1
+  const after1 = getBiomeMemory(cid, 'p1').savana;
+  assert.ok(after1 >= 0, 'familiarity recorded after first encounter');
+
+  await runEnd(app, cid, ALIVE, 'savana'); // encounter #2 (separate session, same biome)
+  const after2 = getBiomeMemory(cid, 'p1').savana;
+  assert.equal(after2, after1 * 2, 'cross-encounter carry-over accumulates');
+});
+
+test('OD-059 wire: /end debrief payload exposes structured biome_familiarity (no prose)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'bmem_pl2' });
+  const cid = start.body.campaign.id;
+  const end = await runEnd(app, cid, ALIVE, 'caverna');
+
+  const fam = end.body.biome_familiarity;
+  assert.ok(fam && typeof fam === 'object', 'biome_familiarity present in /end payload');
+  // Structured data only: { [unitId]: { [biomeId]: turns } }. No prose strings.
+  assert.ok('p1' in fam, 'surviving player unit keyed');
+  assert.equal(typeof fam.p1.caverna, 'number', 'familiarity is a structured turn count');
+});
+
+test('OD-059 wire: no campaign_id -> no familiarity write, no payload (backward compat)', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const ss = await request(app)
+    .post('/api/session/start')
+    .send({ units: ALIVE, biome_id: 'savana' }); // no campaign_id
+  const end = await request(app).post('/api/session/end').send({ session_id: ss.body.session_id });
+  assert.equal(end.body.finalized, true);
+  // No campaign -> the surface is an empty object, never throws.
+  assert.deepEqual(end.body.biome_familiarity, {});
+});
+
+// GUARDRAIL (band-safety): the wire must NOT write the mechanical/inert unit
+// primitive `cumulative_biome_turns`, and the read accessor must not mutate it.
+test('GUARDRAIL: the wire never sets unit.cumulative_biome_turns on the campaign', async (t) => {
+  const baseDir = tmp();
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const start = await request(app).post('/api/campaign/start').send({ player_id: 'bmem_guard' });
+  const cid = start.body.campaign.id;
+  await runEnd(app, cid, ALIVE, 'savana');
+  const camp = getCampaign(cid);
+  // Campaign carries familiarity ONLY under biomeMemory; never a cumulative_biome_turns field.
+  assert.equal('cumulative_biome_turns' in camp, false);
+  assert.ok(camp.biomeMemory && typeof camp.biomeMemory === 'object');
+  assert.equal(typeof getBiomeMemory(cid, 'p1').savana, 'number');
+});

--- a/tests/services/biomeMemory.test.js
+++ b/tests/services/biomeMemory.test.js
@@ -67,3 +67,17 @@ test('accumulate: missing unitId or biomeId -> no-op returning a clone (no garba
   assert.deepEqual(accumulate({ p1: { savana: 3 } }, 'p1', null, 5), { p1: { savana: 3 } });
   assert.deepEqual(accumulate({ p1: { savana: 3 } }, '', '', 5), { p1: { savana: 3 } });
 });
+
+test('accumulate: GUARDRAIL rejects prototype-pollution keys (Codex P1) -- no global poison', () => {
+  // unitId = __proto__ would otherwise index Object.prototype and poison every object.
+  for (const evil of ['__proto__', 'constructor', 'prototype']) {
+    const r1 = accumulate({ p1: { savana: 3 } }, evil, 'savana', 9);
+    assert.deepEqual(r1, { p1: { savana: 3 } }, `reserved unitId ${evil} -> no-op clone`);
+    const r2 = accumulate({ p1: { savana: 3 } }, 'p1', evil, 9);
+    assert.deepEqual(r2, { p1: { savana: 3 } }, `reserved biomeId ${evil} -> no-op clone`);
+  }
+  // No prototype anywhere was polluted by any of the above writes.
+  assert.equal({}.savana, undefined, 'Object.prototype not polluted');
+  assert.equal({}.polluted, undefined, 'no stray polluted key');
+  assert.equal(Object.prototype.savana, undefined, 'Object.prototype clean');
+});

--- a/tests/services/biomeMemory.test.js
+++ b/tests/services/biomeMemory.test.js
@@ -1,0 +1,69 @@
+// biomeMemory -- OD-059 (#1673) campaign-scoped READ-ONLY NARRATIVE biome-familiarity
+// carry-over. Pure accumulate fn: { [unitId]: { [biomeId]: turns } }. Tolerant of
+// garbage input, never mutates. Mirror of services/worldgen/biomeWound.js pure-fn shape.
+//
+// HARD CONSTRAINT (SoT 19.3 freeze): this is a NARRATIVE layer. It is band-safe by
+// construction -- it shares NO namespace with the mechanical/inert unit primitive
+// `unit.cumulative_biome_turns`. The combat sim reads none of it.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { accumulate } = require('../../apps/backend/services/campaign/biomeMemory');
+
+test('accumulate: seeds a new {unitId:{biomeId:turns}} entry from empty', () => {
+  const r = accumulate({}, 'p1', 'savana', 3);
+  assert.deepEqual(r, { p1: { savana: 3 } });
+});
+
+test('accumulate: adds to an existing biome under the same unit (carry-over core)', () => {
+  const r = accumulate({ p1: { savana: 3 } }, 'p1', 'savana', 4);
+  assert.deepEqual(r, { p1: { savana: 7 } });
+});
+
+test('accumulate: keeps biomes in separate buckets under the same unit', () => {
+  const r = accumulate({ p1: { savana: 3 } }, 'p1', 'caverna', 2);
+  assert.deepEqual(r, { p1: { savana: 3, caverna: 2 } });
+});
+
+test('accumulate: keeps units in separate buckets', () => {
+  const r = accumulate({ p1: { savana: 3 } }, 'p2', 'savana', 5);
+  assert.deepEqual(r, { p1: { savana: 3 }, p2: { savana: 5 } });
+});
+
+test('accumulate: does not mutate the input object (immutable, returns new)', () => {
+  const input = { p1: { savana: 3 } };
+  const r = accumulate(input, 'p1', 'savana', 4);
+  assert.deepEqual(input, { p1: { savana: 3 } }, 'input untouched');
+  assert.notEqual(r, input, 'new top-level object');
+  assert.notEqual(r.p1, input.p1, 'new nested object (no shared ref)');
+});
+
+test('accumulate: coerces delta to a non-negative integer (floors floats, drops negatives)', () => {
+  assert.deepEqual(accumulate({}, 'p1', 'savana', 2.9), { p1: { savana: 2 } });
+  assert.deepEqual(accumulate({}, 'p1', 'savana', -5), { p1: { savana: 0 } });
+  assert.deepEqual(accumulate({}, 'p1', 'savana', 0), { p1: { savana: 0 } });
+});
+
+test('accumulate: tolerant of garbage memory input -> treated as empty', () => {
+  assert.deepEqual(accumulate(null, 'p1', 'savana', 1), { p1: { savana: 1 } });
+  assert.deepEqual(accumulate(undefined, 'p1', 'savana', 1), { p1: { savana: 1 } });
+  assert.deepEqual(accumulate('garbage', 'p1', 'savana', 1), { p1: { savana: 1 } });
+  assert.deepEqual(accumulate(42, 'p1', 'savana', 1), { p1: { savana: 1 } });
+});
+
+test('accumulate: tolerant of garbage delta -> no-op returning a clone', () => {
+  assert.deepEqual(accumulate({ p1: { savana: 3 } }, 'p1', 'savana', NaN), { p1: { savana: 3 } });
+  assert.deepEqual(accumulate({ p1: { savana: 3 } }, 'p1', 'savana', 'x'), { p1: { savana: 3 } });
+  assert.deepEqual(accumulate({ p1: { savana: 3 } }, 'p1', 'savana', undefined), {
+    p1: { savana: 3 },
+  });
+});
+
+test('accumulate: missing unitId or biomeId -> no-op returning a clone (no garbage keys)', () => {
+  assert.deepEqual(accumulate({ p1: { savana: 3 } }, null, 'savana', 5), { p1: { savana: 3 } });
+  assert.deepEqual(accumulate({ p1: { savana: 3 } }, 'p1', null, 5), { p1: { savana: 3 } });
+  assert.deepEqual(accumulate({ p1: { savana: 3 } }, '', '', 5), { p1: { savana: 3 } });
+});

--- a/tests/services/campaignBiomeMemory.test.js
+++ b/tests/services/campaignBiomeMemory.test.js
@@ -1,0 +1,102 @@
+// campaignStore biomeMemory helpers -- OD-059 (#1673) campaign-scoped READ-ONLY
+// NARRATIVE biome-familiarity carry-over. Mirror of campaignPermanentFlags.test.js.
+//
+// Core OD-059 fix asserted here: two recordBiomeTurns calls under the SAME campaign
+// id but DIFFERENT sessions ACCUMULATE (cross-encounter carry-over -- the thing
+// `unit.cumulative_biome_turns` (session-scoped, mechanical, inert) never did).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createCampaign,
+  getCampaign,
+  recordBiomeTurns,
+  getBiomeMemory,
+  _resetStore,
+} = require('../../apps/backend/services/campaign/campaignStore');
+
+test('createCampaign initializes empty biomeMemory object', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  assert.deepEqual(c.biomeMemory, {});
+});
+
+test('createCampaign accepts biomeMemory in opts (clone, not shared ref)', () => {
+  _resetStore();
+  const seed = { u1: { savana: 4 } };
+  const c = createCampaign('p1', 'default', { biomeMemory: seed });
+  assert.deepEqual(c.biomeMemory, { u1: { savana: 4 } });
+  assert.notEqual(c.biomeMemory, seed, 'cloned, not the same ref');
+});
+
+test('recordBiomeTurns seeds a new familiarity entry', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  const updated = recordBiomeTurns(c.id, 'u1', 'savana', 3);
+  assert.deepEqual(updated.biomeMemory, { u1: { savana: 3 } });
+});
+
+test('OD-059 CORE: two calls, SAME campaign + DIFFERENT sessions -> ACCUMULATE', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  // encounter #1 (one session)
+  recordBiomeTurns(c.id, 'u1', 'savana', 3);
+  // encounter #2 (a SEPARATE session of the SAME campaign run) -> carry-over
+  recordBiomeTurns(c.id, 'u1', 'savana', 4);
+  const mem = getBiomeMemory(c.id, 'u1');
+  assert.deepEqual(mem, { savana: 7 }, 'cross-encounter familiarity accumulates');
+});
+
+test('recordBiomeTurns keeps biomes + units in separate buckets', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  recordBiomeTurns(c.id, 'u1', 'savana', 3);
+  recordBiomeTurns(c.id, 'u1', 'caverna', 2);
+  recordBiomeTurns(c.id, 'u2', 'savana', 5);
+  const fresh = getCampaign(c.id);
+  assert.deepEqual(fresh.biomeMemory, {
+    u1: { savana: 3, caverna: 2 },
+    u2: { savana: 5 },
+  });
+});
+
+test('getBiomeMemory returns the per-unit familiarity map', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  recordBiomeTurns(c.id, 'u1', 'savana', 6);
+  assert.deepEqual(getBiomeMemory(c.id, 'u1'), { savana: 6 });
+});
+
+test('getBiomeMemory returns {} for an unknown unit / campaign (no throw)', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  assert.deepEqual(getBiomeMemory(c.id, 'never_played'), {});
+  assert.deepEqual(getBiomeMemory('bad_campaign_id', 'u1'), {});
+});
+
+test('recordBiomeTurns ignores invalid input (no throw, no garbage keys)', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  assert.equal(recordBiomeTurns('nonexistent_id', 'u1', 'savana', 1), null);
+  // missing unit/biome -> clone with no garbage keys
+  recordBiomeTurns(c.id, null, 'savana', 1);
+  recordBiomeTurns(c.id, 'u1', null, 1);
+  assert.deepEqual(getCampaign(c.id).biomeMemory, {});
+});
+
+// GUARDRAIL (band-safety): the campaign-scoped narrative layer must NEVER write the
+// mechanical/inert unit primitive `cumulative_biome_turns`. Separate namespaces.
+test('GUARDRAIL: recordBiomeTurns never sets unit.cumulative_biome_turns', () => {
+  _resetStore();
+  const c = createCampaign('p1');
+  recordBiomeTurns(c.id, 'u1', 'savana', 9);
+  const fresh = getCampaign(c.id);
+  // The store has no `units` array; the layer touches only `biomeMemory`.
+  assert.equal('cumulative_biome_turns' in fresh, false);
+  assert.equal('units' in fresh, false);
+  // And the familiarity value is namespaced under biomeMemory, not a unit field.
+  assert.deepEqual(fresh.biomeMemory, { u1: { savana: 9 } });
+});


### PR DESCRIPTION
## Summary (OD-059 / #1673)

Builds the **BiomeMemory** carry-over layer: a campaign-scoped, **READ-ONLY NARRATIVE** biome-familiarity counter that persists ACROSS the encounters of one run. Master-dd verdict = **option A** (reuse the pure-fn PATTERN of `services/worldgen/biomeWound.js`, build a SEPARATE carry-over layer).

The pre-existing `unit.cumulative_biome_turns` primitive is per-unit, **mechanical, session-scoped, and inert** (no cross-encounter carry-over, no consumer). #1673 asked for a campaign-scoped familiarity that survives encounter boundaries. This adds it as a distinct namespace.

### Files changed
- `apps/backend/services/campaign/biomeMemory.js` (new) -- pure `accumulate(memory, unitId, biomeId, delta)` -> new `{ [unitId]: { [biomeId]: turns } }`, immutable, tolerant of garbage input.
- `apps/backend/services/campaign/campaignStore.js` -- init `biomeMemory: {}` + `recordBiomeTurns(id, unitId, biomeId, delta)` (additive) + `getBiomeMemory(id, unitId)` (pure read).
- `apps/backend/routes/session.js` -- `/end` write block (per surviving player unit) adjacent to the A13 wound block; `biome_familiarity` structured-data surface in the `/end` response.
- Tests: `tests/services/biomeMemory.test.js`, `tests/services/campaignBiomeMemory.test.js`, `tests/api/biomeMemoryWire.test.js`.

## Why this is READ-ONLY NARRATIVE + BAND-SAFE BY CONSTRUCTION

Per SoT 19.3 freeze, this layer is narrative only and **cannot affect combat balance**:
- It writes **ONLY** to the new `campaign.biomeMemory` field and surfaces structured data. It touches **no** combat resolver, `mutationTriggerEvaluator`, `reinforcementSpawner`, `biomePopulation`, or pressure.
- It **never** writes `unit.cumulative_biome_turns` (the mechanical/inert primitive). `biomeMemory` (campaign, narrative) and `cumulative_biome_turns` (unit, mechanical) are **separate namespaces, never coupled**.
- The AI combat sim reads **none** of these fields => **no N=40 needed**. A guardrail test in each layer asserts `cumulative_biome_turns` is never set.
- Exposes **structured data only** (`{ [unitId]: { [biomeId]: turns } }`) -- **no player-facing prose copy**.

## Test evidence (all run on node 22)

```
tests/services/biomeMemory.test.js  + campaignBiomeMemory.test.js  -> pass 18 / fail 0
tests/api/biomeMemoryWire.test.js (ORCHESTRATOR_AUTOCLOSE_MS=2000 STUB=1) -> pass 4 / fail 0
tests/ai/*.test.js (baseline preserved) -> pass 543 / fail 0   (>= ADR-L3 floor 382)
tests/api/a13BiomeWoundWire.test.js (adjacent handler regression) -> pass 11 / fail 0
prettier --check (touched files) -> All matched files use Prettier code style
```

Band-safety guardrail tests PASS (`campaignBiomeMemory.test.js` "GUARDRAIL: recordBiomeTurns never sets unit.cumulative_biome_turns" + `biomeMemoryWire.test.js` "GUARDRAIL: the wire never sets unit.cumulative_biome_turns").

## Rollback (03A)

Fully additive + best-effort. To revert: `git revert <both SHAs>`. No migration, no schema, no data change. The write/read blocks are isolated try/catch (never block session end); removing them leaves combat + A13 untouched. `biomeMemory` is a new field with a `{}` default -- absent it, the rest of the campaign state is unaffected.

## Flagged design-calls (master-dd / Godot)

These are intentionally NOT decided here (reversible, narrative-tuning, no band impact):
1. **Narrative copy** -- the surface is structured data only; the player-facing prose ("this creature knows the savana") = Godot/master-dd.
2. **Thresholds** -- when familiarity becomes "narratively meaningful" (e.g. >= N turns => a chronicle beat) = master-dd.
3. **Turn-delta semantics** -- current default = `session.turn` (encounter round count) per SURVIVING player unit. Alternatives flagged in code: always vs victory-only vs rounds-alive vs flat +1. Reversible knob.
4. **Whether it should ever become mechanical** -- this PR keeps it strictly narrative (SoT 19.3). Any future mechanical consumer = separate design-call + N=40.

Refs: OD-059, #1673. Do NOT merge -- gated for master-dd review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)