### PR TITLE
chore(balance): widen hc06 win-rate band 0.15-0.25 -> 0.15-0.30 (master-dd decision A)

### DIFF
--- a/data/core/balance/damage_curves.yaml
+++ b/data/core/balance/damage_curves.yaml
@@ -72,8 +72,16 @@ encounter_classes:
     # low enemy_damage) -- fragile (iter7 hit 67% uncontrolled) and re-opens the
     # stalemate M7 closed. enemy_damage_multiplier_override knob now wired for
     # hc06 (OD-032 C) if that path is pursued.
+    # 2026-06-17 (master-dd decision A, decision backlog): WR upper bound widened
+    # 0.25 -> 0.30 (ASYMMETRIC: lower 0.15 unchanged). hc06's boss_hp lever is
+    # razor-steep + node/V8-sensitive at the cliff (see #2764 node-22 re-cal),
+    # so the upper tail varies more than a flat knob would; the wider ceiling
+    # absorbs that variance without touching the calibrated knob. WR stays
+    # ~22-23% @ N=100 (boss_hp 1.02, ratified #2764) = in-band by construction;
+    # no re-calibration, tolerance increase only. (B2 gate-policy-random = the
+    # other half of decision A; its dossier is uncommitted -> NOT implemented.)
     target_bands:
-      win_rate: [0.15, 0.25]
+      win_rate: [0.15, 0.30]
       defeat_rate: [0.75, 0.85]
       timeout_rate: [0.00, 0.05]
     # M7-#2 Phase E iter7 (post iter6 RED wr 63.3%): 1.4 → 1.8 (+0.4).

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -31,7 +31,7 @@ composite_metric: '0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio'
 scenarios:
   - id: enc_tutorial_06_hardcore
     role: balance_oracle
-    target_band: [0.15, 0.25]
+    target_band: [0.15, 0.30] # WR upper widened 0.25->0.30 2026-06-17 (master-dd decision A, asymmetric; absorbs steep boss_hp-lever upper variance, knob unchanged ~22-23%)
     ratified_knob: { boss_hp_multiplier: 1.02 }
     last_wr_n40: '0.23 (N=100 2026-06-14 on node 22, seed 424242; also 0.23 on node 24 = cross-runtime-robust)'
     status: ratified

--- a/tests/ai/damageCurves.test.js
+++ b/tests/ai/damageCurves.test.js
@@ -106,7 +106,7 @@ test('getTargetBands: returns 3 rate ranges for class', () => {
   loadDamageCurves();
   const bands = getTargetBands('hardcore');
   assert.ok(bands);
-  assert.deepEqual(bands.win_rate, [0.15, 0.25]);
+  assert.deepEqual(bands.win_rate, [0.15, 0.3]);
   assert.deepEqual(bands.defeat_rate, [0.75, 0.85]);
   assert.deepEqual(bands.timeout_rate, [0.0, 0.05]);
 });

--- a/tests/scripts/test_calibrate_target_bands.py
+++ b/tests/scripts/test_calibrate_target_bands.py
@@ -42,9 +42,11 @@ def test_load_missing_class_returns_none():
 def test_hardcore_bands_match_adr():
     """OD-032 (2026-05-21) band revised to engine reality: hardcore win 15-25%,
     defeat 75-85%, timeout 0-5%. turn_limit_defeat=25 converts unresolved games
-    to defeat at turn 25 (M7 anti-stalemate timer) → timeout ~0 structurally."""
+    to defeat at turn 25 (M7 anti-stalemate timer) -> timeout ~0 structurally.
+    2026-06-17 (master-dd decision A): WR upper widened 25->30% (asymmetric;
+    absorbs hc06 steep boss_hp-lever upper variance, knob unchanged ~22-23%)."""
     b = load_target_bands("hardcore")
-    assert b["win_rate"] == [0.15, 0.25]
+    assert b["win_rate"] == [0.15, 0.30]
     assert b["defeat_rate"] == [0.75, 0.85]
     assert b["timeout_rate"] == [0.00, 0.05]
 
@@ -58,7 +60,7 @@ def test_boss_bands_match_adr():
 
 def test_verdict_green_when_in_band():
     b = load_target_bands("hardcore")
-    # win 0.20 in [0.15,0.25], defeat 0.80 in [0.75,0.85], timeout 0.02 in [0.00,0.05]
+    # win 0.20 in [0.15,0.30], defeat 0.80 in [0.75,0.85], timeout 0.02 in [0.00,0.05]
     v, _ = verdict_for(0.20, 0.80, 0.02, b)
     assert v == "GREEN"
 
@@ -66,8 +68,8 @@ def test_verdict_green_when_in_band():
 def test_verdict_amber_within_5pp():
     """±5pp tolerance da band edge."""
     b = load_target_bands("hardcore")
-    # win_rate 0.28 is 3pp sopra hi (0.25) → AMBER; defeat+timeout in-band
-    v, reasons = verdict_for(0.28, 0.80, 0.02, b)
+    # win_rate 0.33 is 3pp sopra hi (0.30) -> AMBER; defeat+timeout in-band
+    v, reasons = verdict_for(0.33, 0.80, 0.02, b)
     assert v == "AMBER"
     assert any("win_rate" in r for r in reasons)
 

--- a/tools/py/calibrate_drift_verify.py
+++ b/tools/py/calibrate_drift_verify.py
@@ -44,7 +44,7 @@ TOOLS_PY = REPO_ROOT / "tools" / "py"
 SCENARIO_MAP = {
     "hardcore_06": {
         "script": "batch_calibrate_hardcore06.py",
-        "target_band": (0.15, 0.25),
+        "target_band": (0.15, 0.30),
         "scenario_id": "enc_tutorial_06_hardcore",
         "args_extra": ["--encounter-class", "hardcore"],
     },

--- a/tools/py/calibrate_optuna.py
+++ b/tools/py/calibrate_optuna.py
@@ -70,7 +70,7 @@ BACKEND_INDEX = REPO_ROOT / "apps" / "backend" / "index.js"
 SCENARIO_CFG = {
     "hardcore_06": {
         "scenario_id": "enc_tutorial_06_hardcore",
-        "target_band": (0.15, 0.25),
+        "target_band": (0.15, 0.30),
         "target_center": 0.20,
         "batch_script": "batch_calibrate_hardcore06.py",
         # OD-032 A+C: boss_hp = difficulty/WR lever; enemy_damage = lethality lever
@@ -89,10 +89,11 @@ SCENARIO_CFG = {
         "fixed_overrides": {"turn_limit_defeat_override": 41},
         "extra_batch_args": ["--encounter-class", "hardcore"],
         # Multi-band objective = CANONICAL hardcore target_bands (damage_curves.yaml
-        # hardcore: win 15-25%, defeat 75-85%, timeout 0-5%, revised OD-032
-        # 2026-05-21). WR primary-weighted (hard constraint). See parse_objective_multiband.
+        # hardcore: win 15-30%, defeat 75-85%, timeout 0-5%, revised OD-032
+        # 2026-05-21; WR upper widened 25->30% 2026-06-17 master-dd decision A).
+        # WR primary-weighted (hard constraint). See parse_objective_multiband.
         "secondary_bands": {
-            "win_rate": (0.15, 0.25),
+            "win_rate": (0.15, 0.30),
             "defeat_rate": (0.75, 0.85),
             "timeout_rate": (0.00, 0.05),
         },

--- a/tools/py/calibrate_parallel.py
+++ b/tools/py/calibrate_parallel.py
@@ -47,7 +47,7 @@ BACKEND_INDEX = REPO_ROOT / "apps" / "backend" / "index.js"
 SCENARIO_MAP = {
     "hardcore_06": {
         "script": "batch_calibrate_hardcore06.py",
-        "target_band": (0.15, 0.25),
+        "target_band": (0.15, 0.30),
         "scenario_id": "enc_tutorial_06_hardcore",
         "encounter_class": "hardcore",
         "extra_args": ["--encounter-class", "hardcore"],

--- a/tools/py/calibrate_sprt.py
+++ b/tools/py/calibrate_sprt.py
@@ -51,7 +51,7 @@ TOOLS_PY = REPO_ROOT / "tools" / "py"
 SCENARIO_MAP = {
     "hardcore_06": {
         "script": "batch_calibrate_hardcore06.py",
-        "target_band": (0.15, 0.25),
+        "target_band": (0.15, 0.30),
         "scenario_id": "enc_tutorial_06_hardcore",
         "extra_args": ["--encounter-class", "hardcore"],
     },


### PR DESCRIPTION
## What

Widen the **hardcore_06 (hc06)** win-rate target band from `(0.15, 0.25)` to `(0.15, 0.30)` -- **asymmetric**: lower bound `0.15` unchanged, upper bound `0.25 -> 0.30`.

This is a **DECIDED design-call value** (master-dd decision A, decision backlog 2026-06-17: "banda 15-30% asimm"). Not re-decided here -- implemented.

## Why (decided-value rationale)

- **master-dd decision A**: the asymmetric widen absorbs hc06's steep `boss_hp`-lever upper variance.
- hc06's `boss_hp` knob is razor-steep + node/V8-sensitive at the cliff (see #2764 node-22 re-cal). The upper tail varies more than a flat knob would; the wider ceiling tolerates that without touching the calibrated value.
- **Knob unchanged**: `boss_hp_multiplier: 1.02` (ratified #2764). Calibrated WR stays ~22-23% @ N=100, already in-band at the tighter `(0.15, 0.25)`.
- **In-band by construction**: widening the ceiling keeps hc06 in-band -- no re-calibration, tolerance increase only. The risk in this change is multi-file **sync correctness**, not WR.

## Files changed (8) -- full hc06 band sync list

Each ref was verified to be hardcore_06 before editing (anti-pattern #19):

| # | File | Change | hc06-ownership verified |
|---|------|--------|-------------------------|
| 1 | `data/core/balance/damage_curves.yaml` | `hardcore:` block `win_rate [0.15,0.25] -> [0.15,0.30]` + **additive** dated note (OD-032 history preserved) | `hardcore:` class block, line 76 |
| 2 | `tools/py/calibrate_parallel.py` | `SCENARIO_MAP["hardcore_06"].target_band (0.15,0.25)->(0.15,0.30)` | key `"hardcore_06"` |
| 3 | `tools/py/calibrate_drift_verify.py` | `SCENARIO_MAP["hardcore_06"].target_band` | key `"hardcore_06"` |
| 4 | `tools/py/calibrate_optuna.py` | `SCENARIO_CFG["hardcore_06"].target_band` **+** `secondary_bands.win_rate` (line ~95) **+** stale `win 15-25%` comment refreshed | both refs inside the `hardcore_06` block (multi-band objective) |
| 5 | `tools/py/calibrate_sprt.py` | `SCENARIO_MAP["hardcore_06"].target_band` | key `"hardcore_06"` |
| 6 | `tests/scripts/test_calibrate_target_bands.py` | `test_hardcore_bands_match_adr` assert `[0.15,0.25]->[0.15,0.30]`; **AMBER fixture re-centered** `0.28 -> 0.33` (was "3pp above hi 0.25"; with new hi 0.30, 0.28 is now in-band so it would falsely read GREEN -- 0.33 keeps the AMBER path exercised) | `load_target_bands("hardcore")` |
| 7 | `tests/ai/damageCurves.test.js` | `getTargetBands('hardcore').win_rate [0.15,0.25]->[0.15,0.3]` | `getTargetBands('hardcore')` |
| 8 | `docs/playtest/canonical-suite.yaml` | `enc_tutorial_06_hardcore` `target_band [0.15,0.25]->[0.15,0.30]` | scenario `enc_tutorial_06_hardcore` |

### Note on the manifest (file 8, NOT in the original 7-file ask)
The CI **Combat Balance Gate** runs `playtest_canonical.py`, which reads the enforced band from the **manifest** `canonical-suite.yaml` (`band = sc["target_band"]`), **not** from `calibrate_parallel.SCENARIO_MAP` (that is imported only for the id->key map). So the manifest is the load-bearing band source for the gate and had to be synced too. Verified via dry-run below.

## NOT included

- **B2 gate-policy-random** (the other half of decision A) is **NOT implemented** -- its design lives in an uncommitted dossier (`docs/reports/2026-06-17` dossier is not in the repo). **Blocked-on-missing-dossier**, flagged here, not fabricated.
- No `boss_hp` knob / calibrated-value change. Band only.
- No touch to `.github/workflows/`, `migrations/`, `packages/contracts/`, `services/generation/`.

## Verify evidence

- `node --test tests/ai/damageCurves.test.js` -> **21 pass / 0 fail**
- `pytest tests/scripts/test_calibrate_target_bands.py tests/test_playtest_canonical.py` -> **28 passed** (incl. the generic `test_in_band` fixture, still `[0.15,0.25]`, **unchanged + green**)
- `game_cli.py validate-datasets` -> **exit 0**, "Tutti i dataset YAML sono validi"
- 4 calibrator config imports print `(0.15, 0.3)` for hc06 (incl. optuna secondary `win_rate`)
- `playtest_canonical.py --dry-run` -> `enc_tutorial_06_hardcore ... band=[15%, 30%]` (hc07 unchanged `[30%, 50%]`)
- `npm run format:check` -> exit 0 (5 pre-existing warnings, all in untouched files)

N=10 is a band-read smoke, **not** a ratification -- the CI gate runs the real **N=100**.

## Rollback (03A)

`git revert <merge-sha>`. One value per file, no cross-file coupling beyond the band literal; reverting restores `(0.15, 0.25)` across all 8 sources atomically. No data migration, no knob touched.

## Review gate

master-dd decision A is the documented authorization for the value. Do **not** merge -- gated on master-dd review per CONTRIBUTING.

---
Coding-Agent: claude-opus-4-8 | Trace-Id: 019ed319-d8df-7632-b366-c14cf0ccd95f