### PR TITLE
SPEC-G (Tri-Sorgente): reward power_level metadata + offer-layer anti-agency test

### DIFF
--- a/apps/backend/services/rewards/rewardOffer.js
+++ b/apps/backend/services/rewards/rewardOffer.js
@@ -16,6 +16,8 @@
 
 'use strict';
 
+const { resolvePowerLevel } = require('./rewardPowerLevel');
+
 const DEFAULT_TEMPERATURE = 0.7;
 const DEFAULT_OFFER_SIZE = 3;
 
@@ -210,8 +212,13 @@ function buildOffer(pool, context = {}) {
   const sampledIdx = softmaxSample(scores, offerSize, rng, temperature);
   const offers = sampledIdx.map((i) => {
     const c = pool[i];
+    // SPEC-G sez. 4: every offered card carries a resolved power_level (fail-closed
+    // to `suggerimento` if YAML omits/garbles it). Inert metadata — never touches
+    // scoring/selection above; only normalizes the surfaced card object.
+    const card =
+      c.power_level === resolvePowerLevel(c) ? c : { ...c, power_level: resolvePowerLevel(c) };
     return {
-      card: c,
+      card,
       score: scores[i],
       components: {
         base: BASE_BY_RARITY[c.rarity || 'common'] || 1.0,

--- a/apps/backend/services/rewards/rewardPowerLevel.js
+++ b/apps/backend/services/rewards/rewardPowerLevel.js
@@ -1,0 +1,39 @@
+// V2 Tri-Sorgente — reward card power-level resolver (SPEC-G sez. 4).
+//
+// Master-DD ratified 2026-06-17. Inert declarative metadata: this field has
+// ZERO behavioral consumer (no scoring/selection/application reads it) — it is a
+// UX-safety declaration ("niente furto di agency opaco"). The actual control path
+// (controllo_reale + consent on private device) is SPEC-K, not built here.
+//
+// Power levels (data/core/rewards/*.yaml `power_level:` field):
+//   suggerimento   — soft bias (FairMath/weight) on future scoring/options.
+//   vista          — reveals information (telegraph, lore, intel).
+//   controllo_reale— grants tangible control over ANOTHER actor; requires explicit
+//                    consent on a private device (SPEC-K). ZERO such cards today.
+//
+// Fail-closed default: a card missing/invalid power_level is treated as the safest
+// level (`suggerimento`).
+
+'use strict';
+
+const POWER_LEVELS = Object.freeze(['suggerimento', 'vista', 'controllo_reale']);
+const DEFAULT_POWER_LEVEL = 'suggerimento';
+
+/**
+ * Resolve a card's power_level fail-closed.
+ *
+ * @param {object} card — reward card definition
+ * @returns {string} the card's power_level if a valid enum member, else
+ *   `suggerimento` (the safest, lowest-authority level).
+ */
+function resolvePowerLevel(card) {
+  const declared = card && card.power_level;
+  if (POWER_LEVELS.includes(declared)) return declared;
+  return DEFAULT_POWER_LEVEL;
+}
+
+module.exports = {
+  resolvePowerLevel,
+  POWER_LEVELS,
+  DEFAULT_POWER_LEVEL,
+};

--- a/data/core/rewards/reward_pool_mvp.yaml
+++ b/data/core/rewards/reward_pool_mvp.yaml
@@ -1,7 +1,7 @@
 # V2 Tri-Sorgente — reward card pool seed (MVP).
 #
-# Pool piccolo (15 carte) per tutorial + Act 1. Espandibile.
-# Carta shape: { id, label, rarity, roll_bucket?, synergy_tags[],
+# Pool piccolo (17 carte) per tutorial + Act 1. Espandibile.
+# Carta shape: { id, label, rarity, power_level, roll_bucket?, synergy_tags[],
 #   personality_weights[], action_affinities[], exclusion_tags?,
 #   max_copies?, effect: {type, params} }
 #
@@ -10,6 +10,17 @@
 # Personality weights: { mbti?: "INTJ", ennea?: "5", weight: 0..2 }
 # Action affinities: { action: "attack_executed", weight: 0..1 }
 # Effect types: trait_grant | stat_bonus | ability_unlock | pe_bonus
+#
+# power_level (SPEC-G sez. 4, master-dd ratified 2026-06-17) — modello di potere
+# della carta, sicurezza di agency ("niente furto di agency opaco"):
+#   suggerimento    — bias morbido (FairMath/weight) su scoring/opzioni future.
+#   vista           — rivela informazione (telegraph, lore, intel).
+#   controllo_reale — concede controllo tangibile su un ALTRO actor; richiede
+#                     consenso esplicito su device privato (SPEC-K, non costruito).
+# Default fail-closed: carta senza power_level valido -> trattata come suggerimento.
+# Metadata inerte (zero consumer comportamentale: scoring/selection/apply non lo
+# leggono). Tutte le carte MVP = suggerimento, ECCETTO rwd_apex_scent = vista.
+# ZERO carte controllo_reale (nessuna agisce su un altro actor oggi).
 
 schema_version: '1.0'
 pool_id: reward_pool_mvp
@@ -18,6 +29,7 @@ cards:
   - id: rwd_claws_sharp
     label: 'Artigli affilati'
     rarity: common
+    power_level: suggerimento
     roll_bucket: 5
     synergy_tags: [offense, melee]
     personality_weights:
@@ -32,6 +44,7 @@ cards:
   - id: rwd_elastic_skin
     label: 'Pelle elastica'
     rarity: common
+    power_level: suggerimento
     roll_bucket: 3
     synergy_tags: [defense, tank]
     personality_weights:
@@ -46,6 +59,7 @@ cards:
   - id: rwd_spring_legs
     label: 'Zampe a molla'
     rarity: common
+    power_level: suggerimento
     roll_bucket: 7
     synergy_tags: [mobility, skirmisher]
     personality_weights:
@@ -60,6 +74,7 @@ cards:
   - id: rwd_whip_tail
     label: 'Coda frusta cinetica'
     rarity: uncommon
+    power_level: suggerimento
     roll_bucket: 9
     synergy_tags: [offense, ranged]
     personality_weights:
@@ -73,6 +88,7 @@ cards:
   - id: rwd_serrated_teeth
     label: 'Denti seghettati'
     rarity: uncommon
+    power_level: suggerimento
     roll_bucket: 12
     synergy_tags: [offense, bleeding]
     personality_weights:
@@ -87,6 +103,7 @@ cards:
   - id: rwd_hydro_regul
     label: 'Scheletro idro-regolante'
     rarity: rare
+    power_level: suggerimento
     roll_bucket: 14
     synergy_tags: [defense, utility]
     personality_weights:
@@ -100,6 +117,7 @@ cards:
   - id: rwd_pe_boost_5
     label: 'Rivelazione tattica (+5 PE)'
     rarity: common
+    power_level: suggerimento
     roll_bucket: 2
     synergy_tags: [progression]
     personality_weights: []
@@ -112,6 +130,7 @@ cards:
   - id: rwd_pe_boost_10
     label: 'Epifania (+10 PE)'
     rarity: uncommon
+    power_level: suggerimento
     roll_bucket: 11
     synergy_tags: [progression]
     personality_weights: []
@@ -124,6 +143,7 @@ cards:
   - id: rwd_stat_hp_plus
     label: 'Resistenza incrementata'
     rarity: common
+    power_level: suggerimento
     roll_bucket: 6
     synergy_tags: [defense, tank]
     personality_weights:
@@ -139,6 +159,7 @@ cards:
   - id: rwd_stat_atk_plus
     label: 'Aggressività crescente'
     rarity: common
+    power_level: suggerimento
     roll_bucket: 8
     synergy_tags: [offense, melee]
     personality_weights:
@@ -154,6 +175,7 @@ cards:
   - id: rwd_stat_def_plus
     label: 'Postura difensiva'
     rarity: common
+    power_level: suggerimento
     roll_bucket: 4
     synergy_tags: [defense]
     personality_weights:
@@ -169,6 +191,7 @@ cards:
   - id: rwd_surge_burst
     label: 'Burst Surge'
     rarity: rare
+    power_level: suggerimento
     roll_bucket: 16
     synergy_tags: [offense, burst]
     personality_weights:
@@ -183,6 +206,7 @@ cards:
   - id: rwd_focus_stance
     label: 'Focus mentale'
     rarity: uncommon
+    power_level: suggerimento
     roll_bucket: 10
     synergy_tags: [utility, buff]
     personality_weights:
@@ -197,6 +221,7 @@ cards:
   - id: rwd_support_heal
     label: 'Cura empatica'
     rarity: uncommon
+    power_level: suggerimento
     roll_bucket: 13
     synergy_tags: [support, heal]
     personality_weights:
@@ -211,6 +236,8 @@ cards:
   - id: rwd_apex_scent
     label: "Traccia dell'Apex"
     rarity: epic
+    # vista: rivela informazione (telegraph/intel narrativo), nessun controllo su altri.
+    power_level: vista
     roll_bucket: 18
     synergy_tags: [utility, narrative]
     personality_weights:
@@ -230,6 +257,7 @@ cards:
   - id: rwd_anomaly_resilienza_temporale
     label: "Anomalia: Resilienza Temporale"
     rarity: legendary
+    power_level: suggerimento
     roll_bucket: 20
     synergy_tags: [anomaly, transformative, defense, time]
     personality_weights:
@@ -244,6 +272,7 @@ cards:
   - id: rwd_anomaly_simbiosi_apex
     label: "Anomalia: Simbiosi Apex"
     rarity: legendary
+    power_level: suggerimento
     roll_bucket: 20
     synergy_tags: [anomaly, transformative, mating, evolve]
     personality_weights:

--- a/tests/api/rewardOffer.test.js
+++ b/tests/api/rewardOffer.test.js
@@ -24,6 +24,12 @@ const {
   addFragments,
   getFragments,
 } = require('../../apps/backend/services/rewards/skipFragmentStore');
+const {
+  resolvePowerLevel,
+  POWER_LEVELS,
+  DEFAULT_POWER_LEVEL,
+} = require('../../apps/backend/services/rewards/rewardPowerLevel');
+const { loadPool } = require('../../apps/backend/services/rewards/rewardPoolLoader');
 const { createApp } = require('../../apps/backend/app');
 
 // ─── Pure function tests ──────────────────────────────────────────────
@@ -82,6 +88,41 @@ test('scoreCard: composite score respects weights', () => {
   const score = scoreCard(card, ctx);
   // base 1.0 + roll 1.0 + synergy 0.5 = 2.5
   assert.ok(score > 2.0, `expected >2.0, got ${score}`);
+});
+
+// ─── SPEC-G power_level resolver (anti-agency) ─────────────────────────
+
+test('resolvePowerLevel: valid enum member passes through', () => {
+  assert.equal(resolvePowerLevel({ power_level: 'suggerimento' }), 'suggerimento');
+  assert.equal(resolvePowerLevel({ power_level: 'vista' }), 'vista');
+  assert.equal(resolvePowerLevel({ power_level: 'controllo_reale' }), 'controllo_reale');
+});
+
+test('resolvePowerLevel: missing / garbage fails closed to suggerimento', () => {
+  assert.equal(DEFAULT_POWER_LEVEL, 'suggerimento');
+  assert.equal(resolvePowerLevel({}), 'suggerimento');
+  assert.equal(resolvePowerLevel({ power_level: undefined }), 'suggerimento');
+  assert.equal(resolvePowerLevel({ power_level: null }), 'suggerimento');
+  assert.equal(resolvePowerLevel({ power_level: 'CONTROLLO_REALE' }), 'suggerimento');
+  assert.equal(resolvePowerLevel({ power_level: 'controllo reale' }), 'suggerimento');
+  assert.equal(resolvePowerLevel({ power_level: 42 }), 'suggerimento');
+  assert.equal(resolvePowerLevel(null), 'suggerimento');
+  assert.equal(resolvePowerLevel(undefined), 'suggerimento');
+});
+
+test('buildOffer: every offered card carries a valid power_level (fail-closed)', () => {
+  const pool = Array.from({ length: 6 }, (_, i) => ({
+    id: `c${i}`,
+    rarity: 'common',
+    roll_bucket: i + 1,
+    // intentionally NO power_level → must fail-closed to suggerimento
+  }));
+  const result = buildOffer(pool, { seed: 7, rollBucket: 3, offerSize: 4 });
+  assert.ok(result.offers.length > 0);
+  for (const o of result.offers) {
+    assert.ok(POWER_LEVELS.includes(o.card.power_level), `unexpected: ${o.card.power_level}`);
+    assert.equal(o.card.power_level, 'suggerimento');
+  }
 });
 
 test('softmaxSample: respects n without replacement', () => {
@@ -155,6 +196,75 @@ test('POST /api/rewards/offer: returns 3 offers from MVP pool', async (t) => {
   assert.equal(res.body.pool_id, 'reward_pool_mvp');
   assert.equal(res.body.offers.length, 3);
   assert.equal(res.body.skip_available, true);
+});
+
+// ─── SPEC-G anti-agency (offer layer) ──────────────────────────────────
+
+test('MVP pool: every card declares a valid power_level + ZERO controllo_reale', () => {
+  const poolDoc = loadPool('reward_pool_mvp');
+  assert.ok(poolDoc && Array.isArray(poolDoc.cards), 'MVP pool loads');
+  assert.ok(poolDoc.cards.length > 0, 'MVP pool non-empty');
+  for (const card of poolDoc.cards) {
+    const lvl = resolvePowerLevel(card);
+    assert.ok(POWER_LEVELS.includes(lvl), `${card.id}: ${lvl}`);
+    assert.notEqual(
+      lvl,
+      'controllo_reale',
+      `${card.id} is controllo_reale — needs SPEC-K consent path, not in MVP pool`,
+    );
+  }
+  // Ratified 2026-06-17: rwd_apex_scent = vista; all others = suggerimento.
+  const apex = poolDoc.cards.find((c) => c.id === 'rwd_apex_scent');
+  assert.ok(apex, 'rwd_apex_scent present');
+  assert.equal(resolvePowerLevel(apex), 'vista');
+});
+
+test('POST /api/rewards/offer: offered cards carry power_level, none controllo_reale', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app)
+    .post('/api/rewards/offer')
+    .send({ campaign_id: 'c_pl', actor_id: 'u_pl', roll_bucket: 10, seed: 42 });
+  assert.equal(res.status, 200);
+  assert.ok(res.body.offers.length > 0);
+  for (const o of res.body.offers) {
+    assert.ok(POWER_LEVELS.includes(o.card.power_level), `unexpected: ${o.card.power_level}`);
+    assert.notEqual(o.card.power_level, 'controllo_reale');
+  }
+});
+
+test('POST /api/rewards/offer: payload carries only offering actor cards (no other-player private content)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app)
+    .post('/api/rewards/offer')
+    .send({ campaign_id: 'c_agency', actor_id: 'owner_actor', roll_bucket: 10, seed: 42 });
+  assert.equal(res.status, 200);
+  // Offer is scoped to the single requesting actor: actor_id echoes the requester
+  // and there is no per-other-player card content in the payload (no controllo_reale
+  // card targeting another actor can leak here — SPEC-K territory, not built).
+  assert.equal(res.body.actor_id, 'owner_actor');
+  const topLevelKeys = Object.keys(res.body).sort();
+  assert.deepEqual(topLevelKeys, [
+    'actor_id',
+    'campaign_id',
+    'offer_size',
+    'offers',
+    'pool_id',
+    'skip_available',
+    'skip_fragment_delta',
+  ]);
+  // Each offer entry exposes only the standard card/score/components shape — no
+  // foreign-actor identity or private state riding along.
+  for (const o of res.body.offers) {
+    assert.deepEqual(Object.keys(o).sort(), ['card', 'components', 'score']);
+    assert.ok(!('target_actor_id' in o.card), 'no foreign-actor target on card');
+    assert.ok(!('owner_id' in o.card), 'no foreign owner_id on card');
+  }
 });
 
 test('POST /api/rewards/skip: increments fragments', async (t) => {


### PR DESCRIPTION
## Summary

SPEC-G (Tri-Sorgente, sez. 4 "Modello di potere delle carte: suggerimento / vista / controllo reale") -- adds the `power_level` reward-card metadata field plus an offer-layer anti-agency test. **UNFLAGGED**: the field is inert declarative metadata with zero behavioral consumer, so there is nothing to gate.

Implements `docs/design/evo-tactics-tri-sorgente-extended-doctrine.md` sez. 4 + acceptance items 2 and 7.

## Master-DD ratified values (2026-06-17) -- implemented as-is

- `power_level` enum (snake_case): `suggerimento` | `vista` | `controllo_reale`.
- Every card in `data/core/rewards/reward_pool_mvp.yaml` = `suggerimento` **except** `rwd_apex_scent` = `vista`. **ZERO** `controllo_reale` cards (none targets another actor today; controllo_reale needs the SPEC-K consent path, not built).
- Default fail-closed: a card missing/invalid `power_level` is treated as `suggerimento`.

## Changes (4 files, zero forbidden paths)

- `data/core/rewards/reward_pool_mvp.yaml` -- `power_level` on all **17** cards (16 `suggerimento` + 1 `vista`, 0 `controllo_reale`); header doc comment documents the field, enum, fail-closed default, and ratify date.
- `apps/backend/services/rewards/rewardPowerLevel.js` (new) -- pure `resolvePowerLevel(card)` (valid enum member passes through, else fail-closed `suggerimento`) + exported `POWER_LEVELS` / `DEFAULT_POWER_LEVEL`.
- `apps/backend/services/rewards/rewardOffer.js` -- `buildOffer` normalizes the surfaced card's `power_level` (fail-closed) so every offered card carries a resolved value even if YAML omits it. **Never touches scoring/selection** (scores are computed on the original cards before this point; the `components` block still reads the original card).
- `tests/api/rewardOffer.test.js` -- pure-fn tests for `resolvePowerLevel` (valid pass-through; missing/garbage -> `suggerimento`) + offer-layer anti-agency: every offered card has a valid-enum `power_level`, ZERO `controllo_reale` in the MVP pool / offer, and the `/rewards/offer` payload carries only the offering actor's cards (no foreign-actor/private content).

## Band-neutral / inert-metadata argument

`power_level` had **0 hits anywhere in code** before this PR (grep). No scoring, selection, or application path reads it. The reward engine's `buildOffer` returns the full card object (`card: c`), so the new YAML field auto-surfaces as `offers[].card.power_level` with zero consumer change. The only code addition copies/validates the metadata field on the surfaced card -- it does not alter rarity base, roll/personality/action/synergy components, softmax sampling, or selection. AI suite unchanged (543/543), so no N=40 needed.

## Test evidence

- `node --test tests/api/rewardOffer.test.js` -> **23/23 pass** (6 new SPEC-G tests green).
- `node --test tests/ai/*.test.js` -> **543/543 pass** (baseline >= 382, band-neutral).
- `python3 tools/py/game_cli.py validate-datasets` -> green ("Tutti i dataset YAML sono validi", 2 pre-existing pack warnings unrelated to rewards; reward pool parses to 17 cards via the loader in the green tests).
- `npm run format:check` -> touched files prettier-clean (the other 5 warnings are pre-existing, untouched files).

## Rollback

Revert this single squash commit. The field is inert metadata with no consumer, so reverting removes the YAML field, the helper module, and the tests with zero behavioral impact on offer/skip/fragments.

## Flagged residue (out of scope, future slices)

- **`controllo_reale` apply/consent path = SPEC-K** -- no card-apply route exists in the reward engine (`/offer`, `/skip`, `/fragments` only). A `controllo_reale` card acting on another actor requires the explicit-consent-on-private-device path (SPEC-K 6.4), not built. Hence ZERO `controllo_reale` cards in the MVP pool today.
- **Narrative / doctrinal sources (sez. 3)** -- only the reward source is wired; narrativa/dottrinale sorgenti are a later slice.
- The contracts `tri-sorgente.schema.json` is a registered orphan (not validated against the live `/rewards/offer` route); left untouched (forbidden path, and adding the YAML field requires no schema change).

Do NOT merge -- gated for master-dd review.