### PR TITLE
feat(spec-j): lethal-death model + mission-flag + failure-as-lore (PR1)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1104,6 +1104,19 @@ function createSessionRouter(options = {}) {
         /* wound system best-effort; never block the hit */
       }
 
+      // SPEC-J slice 1: lethal-death resolution (sez. 3/5/7, forks J1/J4/J5).
+      // Default soft-death: a KO is NOT permadeath. A real death (creature
+      // leaves the roster + creature_death chronicle beat / succession trigger)
+      // only fires when LETHAL_MISSIONS_ENABLED==='true' AND the mission is
+      // flagged lethal AND per-player device consent is granted (PR2). With the
+      // kill switch unset + no consent producer this is inert (band-neutral).
+      // Best-effort, never blocks the hit.
+      try {
+        require('../services/combat/lethalDeath').applyLethalKoIfDead(target, session);
+      } catch {
+        /* lethal-death best-effort; never block the hit */
+      }
+
       // Combat parity GAP-1 (2026-06-07): on_hit_status producer hook. Ports
       // STEP 3 of the removed Python resolver — for each ATTACKER trait that
       // carries an `on_hit_status` block in trait_mechanics.yaml, the target
@@ -2124,6 +2137,11 @@ function createSessionRouter(options = {}) {
         // / reinforcementSpawner via effectivePressure). Flag-gated OFF di default
         // -> il valore e' inerte finche' PRESSURE_TIER_FLOOR_ENABLED!=='true'.
         pressure_tier_floor: encounterPayload?.pressure_tier_floor ?? null,
+        // SPEC-J: per-mission lethal flag (default-off, point-9). Source =
+        // encounter payload `lethal:true` or req.body.lethal. Strict boolean.
+        // Inert unless LETHAL_MISSIONS_ENABLED && per-player consent (PR2);
+        // markCreatureFallen never fires otherwise (band-neutral).
+        lethal: encounterPayload?.lethal === true || req.body?.lethal === true,
         // M11 pilot (ADR-2026-04-21c): biome_id + log trait env deltas applicati.
         biome_id: biomeIdRaw,
         biome_costs_log: biomeCostsLog,

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -532,6 +532,11 @@ function publicSessionView(session) {
     // false->true transition to fire the one-shot diegetic hint ("il Sistema
     // reagisce al tuo tempo rubato") -- public tier, no raw numbers (ER3).
     overcharge_used_this_run: !!session.overcharge_used,
+    // SPEC-J sez.8 -- existence of a lethal-gated mission is `public` (everyone
+    // knows the run is at risk). The per-player consent + anonymous "waiting"
+    // state are NOT here (private / aggregated, produced by the PR2 consent
+    // state-machine). Default false -> non-lethal soft-death run.
+    lethal: !!session.lethal,
     // M1 ADR-2026-05-18 -- campaign scope + Sistema learning state (read-only surface).
     campaign_id: session.campaign_id || null,
     sistema_state: session.sistema_state || { units_observed: {} },

--- a/apps/backend/services/chronicle/chronicleEmitters.js
+++ b/apps/backend/services/chronicle/chronicleEmitters.js
@@ -146,10 +146,52 @@ function emitHeirloom(ctx, opts = {}) {
   );
 }
 
+/**
+ * Append a `creature_death` chronicle event when a creature dies in a lethal
+ * mission (SPEC-J failure-as-lore J5 + SPEC-D death beat). Reuses the existing
+ * `creature_death` chronicle type -- a soft-death KO is NOT a death (the creature
+ * falls and recovers), so only the lethal path emits this. The fall is `public`
+ * (the branco always remembers its dead -- J5 opzione A: lineage automatica),
+ * and by default opens the succession of a new MVP (SPEC-E E2 / J4 -- carried as
+ * `succession_trigger` so SPEC-E can consume it without re-deriving the trigger).
+ * Best-effort: no campaign_id / no creature -> no-op. Never throws (combat must
+ * not break on a chronicle slip).
+ *
+ * @param ctx  { campaign_id, creature_id, creature_name?, species_id?, biome_id?,
+ *               lineage_id?, encounter_id?, turn?, succession_trigger? }
+ * @param opts { baseDir? }
+ */
+function emitCreatureFell(ctx, opts = {}) {
+  if (!ctx || typeof ctx !== 'object') return { ok: false, error: 'no_ctx' };
+  const runId = ctx.campaign_id;
+  if (!runId) return { ok: false, error: 'no_campaign_id' };
+  if (!ctx.creature_id) return { ok: false, error: 'no_creature' };
+  return appendEvent(
+    runId,
+    {
+      type: 'creature_death',
+      actor_id: ctx.creature_id,
+      tier: 'public',
+      payload: {
+        creature_id: ctx.creature_id,
+        creature_name: ctx.creature_name || null,
+        species_id: ctx.species_id || null,
+        biome_id: ctx.biome_id || null,
+        lineage_id: ctx.lineage_id || null,
+        encounter_id: ctx.encounter_id || null,
+        turn: Number.isFinite(Number(ctx.turn)) ? Number(ctx.turn) : null,
+        succession_trigger: ctx.succession_trigger !== false,
+      },
+    },
+    { baseDir: opts.baseDir },
+  );
+}
+
 module.exports = {
   emitRunFailed,
   emitMutationLineage,
   emitHeirloom,
+  emitCreatureFell,
   deriveHeirloomName,
   DEFEAT_OUTCOMES,
 };

--- a/apps/backend/services/combat/lethalDeath.js
+++ b/apps/backend/services/combat/lethalDeath.js
@@ -1,0 +1,166 @@
+// =============================================================================
+// SPEC-J slice 1 -- lethal consent + death model.
+//
+// Spec: docs/design/evo-tactics-lethal-wounds-rituals.md (sez. 3, 5, 7; forks
+// J1/J4/J5 ratified 2026-06-08, all opzione A; J2 closed by canon point-9).
+//
+// Default = SOFT-DEATH: a KO is NOT permadeath. The creature falls and recovers
+// (the wound-roll on KO -> `grave` scar is already LIVE in woundSystem; SPEC-J
+// does not touch it). A real death only happens when ALL of these hold:
+//   1. LETHAL_MISSIONS_ENABLED === 'true'  (master kill switch, default OFF);
+//   2. the mission is flagged lethal        (per-mission gate, default off, point-9);
+//   3. per-player device consent is granted (SPEC-K 6.4 -- produced by the PR2
+//      consent state-machine; ABSENT today -> falsy -> anti-deadlock soft fallback);
+//   4. it is a KO of a real player creature  (minions are expendable, B5).
+//
+// This module is PURE of I/O: it decides the outcome and mutates the fallen
+// unit's state. The chronicle `creature_fell` emission (failure-as-lore J5 +
+// SPEC-D death beat) happens at the wire site so this stays unit-testable.
+//
+// Band impact: with the kill switch unset, resolveKoOutcome ALWAYS returns
+// `soft` -> zero behavior change vs today (verify-first band-neutral by
+// construction, no new sim path reached).
+// =============================================================================
+
+'use strict';
+
+/**
+ * Master kill switch. Opt-in (default OFF) -- opposite polarity to woundSystem's
+ * opt-out, because lethal death is new + irreversible-in-fiction (a dead creature
+ * leaves the roster). Flip = master-dd, only after the PR2 consent state-machine
+ * is live and a lethal-mission N=40 / playtest sign-off.
+ */
+function isLethalEnabled() {
+  return process.env.LETHAL_MISSIONS_ENABLED === 'true';
+}
+
+/**
+ * Per-mission lethal gate (point-9: lethal is a property of the mission/node).
+ * Strict boolean -- no string coercion, so a stray `lethal: 'false'` can never
+ * arm a lethal mission by accident.
+ */
+function isMissionLethal(session) {
+  return !!(session && session.lethal === true);
+}
+
+/**
+ * Pure decision: does this KO produce a real death or the default soft-death?
+ * Order of guards is the spec's fail-closed chain (any unmet condition -> soft).
+ *
+ * @param unit  the KO'd unit
+ * @param ctx   { missionLethal:boolean, consentGranted:boolean, isKo:boolean }
+ * @returns {{ outcome: 'soft'|'death', reason: string }}
+ */
+function resolveKoOutcome(unit, ctx = {}) {
+  const { missionLethal = false, consentGranted = false, isKo = false } = ctx;
+  if (!unit || typeof unit !== 'object') return { outcome: 'soft', reason: 'no_unit' };
+  if (!isKo) return { outcome: 'soft', reason: 'not_ko' };
+  if (unit.controlled_by !== 'player' || unit.is_minion) {
+    return { outcome: 'soft', reason: 'not_player' };
+  }
+  if (!isLethalEnabled()) return { outcome: 'soft', reason: 'lethal_disabled' };
+  if (!missionLethal) return { outcome: 'soft', reason: 'mission_not_lethal' };
+  if (!consentGranted) return { outcome: 'soft', reason: 'no_consent' };
+  return { outcome: 'death', reason: 'lethal_consented' };
+}
+
+/**
+ * State change for a real death: the creature leaves the active roster. Mutates
+ * the unit (fallen flag + hp 0 + alive false) and returns a public descriptor
+ * for the failure-as-lore chronicle event (J5) / succession trigger (SPEC-E E2).
+ * Idempotent + never throws (combat must not break on a death-bookkeeping slip).
+ *
+ * @param unit  the unit that fell
+ * @param opts  { encounter_id?, turn? } -- context for the descriptor
+ * @returns {{ fallen:boolean, already_fallen?:boolean, creature_id?, creature_name?,
+ *             species_id?, biome_id?, lineage_id?, encounter_id?, turn? }}
+ */
+function markCreatureFallen(unit, opts = {}) {
+  if (!unit || typeof unit !== 'object' || !unit.id) return { fallen: false };
+  const alreadyFallen = !!(unit.status && unit.status.fallen);
+  if (!unit.status || typeof unit.status !== 'object') unit.status = {};
+  unit.status.fallen = true;
+  unit.alive = false;
+  unit.hp = 0;
+  const desc = {
+    fallen: true,
+    creature_id: unit.id,
+    creature_name: unit.name || null,
+    species_id: unit.species_id || null,
+    biome_id: unit.biome_id || null,
+    lineage_id: unit.lineage_id || null,
+    encounter_id: opts.encounter_id || null,
+    turn: Number.isFinite(Number(opts.turn)) ? Number(opts.turn) : null,
+  };
+  if (alreadyFallen) desc.already_fallen = true;
+  return desc;
+}
+
+/**
+ * Per-player device consent (SPEC-K 6.4). Shape produced by the PR2 consent
+ * state-machine: `session.lethalConsent = { granted: boolean, ... }`. ABSENT
+ * today -> falsy -> anti-deadlock soft fallback (sez. 5: fallback default = NON
+ * parte lethal). Strict `=== true` so a half-built consent object never arms.
+ */
+function isConsentGranted(session) {
+  return !!(session && session.lethalConsent && session.lethalConsent.granted === true);
+}
+
+/**
+ * Thin wire orchestrator, called from the combat KO path (routes/session.js,
+ * right after maybeApplyCombatWound). Decides soft-death vs real death for a unit
+ * that just dropped to <=0 HP and, on death, mutates the unit (fallen) + emits
+ * the `creature_death` chronicle event (failure-as-lore J5 / succession trigger).
+ *
+ * Default-OFF + no consent producer today -> always returns `soft` -> the death
+ * branch is never reached in current play (band-neutral by construction).
+ *
+ * The chronicle emit is best-effort (its own try/catch): a chronicle slip never
+ * un-does the death nor breaks combat. The emitter is injectable for tests.
+ *
+ * @param target  the unit that took the hit
+ * @param session combat session ({ lethal, lethalConsent, campaign_id, ... })
+ * @param deps    { emitCreatureFell? } -- test injection
+ * @returns {{ outcome:'soft'|'death', reason:string, fallen?:boolean }}
+ */
+function applyLethalKoIfDead(target, session, deps = {}) {
+  if (!target || typeof target !== 'object' || Number(target.hp || 0) > 0) {
+    return { outcome: 'soft', reason: 'not_ko' };
+  }
+  const outcome = resolveKoOutcome(target, {
+    missionLethal: isMissionLethal(session),
+    consentGranted: isConsentGranted(session),
+    isKo: true,
+  });
+  if (outcome.outcome !== 'death') return outcome;
+  const desc = markCreatureFallen(target, {
+    encounter_id: session && session.encounter_id,
+    turn: session && session.turn,
+  });
+  try {
+    const emit =
+      deps.emitCreatureFell || require('../chronicle/chronicleEmitters').emitCreatureFell;
+    emit({
+      campaign_id: session && session.campaign_id,
+      creature_id: desc.creature_id,
+      creature_name: desc.creature_name,
+      species_id: desc.species_id,
+      biome_id: desc.biome_id || (session && session.biome_id) || null,
+      lineage_id: desc.lineage_id,
+      encounter_id: desc.encounter_id,
+      turn: desc.turn,
+    });
+  } catch {
+    /* chronicle best-effort -- a slip never un-does the death */
+  }
+  return { outcome: 'death', reason: outcome.reason, fallen: true };
+}
+
+module.exports = {
+  isLethalEnabled,
+  isMissionLethal,
+  isConsentGranted,
+  resolveKoOutcome,
+  markCreatureFallen,
+  applyLethalKoIfDead,
+};

--- a/apps/backend/services/combat/lethalDeath.js
+++ b/apps/backend/services/combat/lethalDeath.js
@@ -77,9 +77,14 @@ function resolveKoOutcome(unit, ctx = {}) {
  */
 function markCreatureFallen(unit, opts = {}) {
   if (!unit || typeof unit !== 'object' || !unit.id) return { fallen: false };
-  const alreadyFallen = !!(unit.status && unit.status.fallen);
-  if (!unit.status || typeof unit.status !== 'object') unit.status = {};
-  unit.status.fallen = true;
+  const alreadyFallen = !!unit.fallen;
+  // Codex #2789 P2: the canonical marker is TOP-LEVEL (`unit.fallen`), NOT under
+  // `unit.status`. syncStatusesFromRoundState (sessionRoundBridge) rebuilds
+  // `unit.status` from the orchestrator status list and only whitelists
+  // wounds/wounded_perma, so a `status.fallen` would be wiped after the next
+  // round sync. Top-level unit fields are never rebuilt and publicSessionView
+  // spreads `...u`, so clients + later consumers see `fallen`.
+  unit.fallen = true;
   unit.alive = false;
   unit.hp = 0;
   const desc = {
@@ -104,6 +109,20 @@ function markCreatureFallen(unit, opts = {}) {
  */
 function isConsentGranted(session) {
   return !!(session && session.lethalConsent && session.lethalConsent.granted === true);
+}
+
+/**
+ * Resolve the encounter id for death provenance. Codex #2789 P2: /api/session/start
+ * loads the YAML payload into `session.encounter` but never assigns
+ * `session.encounter_id`, so reading that field alone yields null for YAML
+ * encounters. Fall back to the stored payload's `encounter_id` / `id`.
+ */
+function resolveEncounterId(session) {
+  if (!session || typeof session !== 'object') return null;
+  if (session.encounter_id) return session.encounter_id;
+  const enc = session.encounter;
+  if (enc && typeof enc === 'object') return enc.encounter_id || enc.id || null;
+  return null;
 }
 
 /**
@@ -134,7 +153,7 @@ function applyLethalKoIfDead(target, session, deps = {}) {
   });
   if (outcome.outcome !== 'death') return outcome;
   const desc = markCreatureFallen(target, {
-    encounter_id: session && session.encounter_id,
+    encounter_id: resolveEncounterId(session),
     turn: session && session.turn,
   });
   try {

--- a/tests/api/lethalMissionFlag.test.js
+++ b/tests/api/lethalMissionFlag.test.js
@@ -1,0 +1,55 @@
+// tests/api/lethalMissionFlag.test.js -- SPEC-J slice 1 integration.
+//
+// Proves the lethal mission-flag passthrough chain end-to-end:
+//   req.body.lethal -> session.lethal -> publicSessionView.lethal (sez.8 public).
+// And the band-neutral default: a session started without the flag is non-lethal.
+// The death path itself stays inert (LETHAL_MISSIONS_ENABLED unset + no consent
+// producer in PR1) -- exercised at unit level in tests/services/combat/lethalDeath.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+async function startScenario(app, extra = {}) {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units: scenario.body.units, ...extra });
+  return res;
+}
+
+test('start with lethal:true -> public state exposes lethal:true', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await startScenario(app, { lethal: true });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.lethal, true, 'lethal flag surfaced public (SPEC-J sez.8)');
+});
+
+test('default start -> non-lethal (lethal:false), band-neutral soft-death run', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await startScenario(app);
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.lethal, false, 'no flag -> non-lethal default');
+});
+
+test('lethal flag does NOT coerce from a truthy string in the body', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await startScenario(app, { lethal: 'true' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.lethal, false, 'string "true" must not arm a lethal mission');
+});

--- a/tests/services/chronicleEmitters.test.js
+++ b/tests/services/chronicleEmitters.test.js
@@ -12,6 +12,7 @@ const {
   emitRunFailed,
   emitMutationLineage,
   emitHeirloom,
+  emitCreatureFell,
 } = require('../../apps/backend/services/chronicle/chronicleEmitters');
 const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
 
@@ -209,4 +210,63 @@ test('emitHeirloom: filters non-string mutations', () => {
     { baseDir },
   );
   assert.deepEqual(getChronicle('c', { baseDir })[0].payload.mutations, ['ok', 'ok2']);
+});
+
+// SPEC-J -- creature_death emitter (failure-as-lore J5 + SPEC-D death beat).
+test('emitCreatureFell: a lethal death appends a public creature_death event', () => {
+  const baseDir = tmp();
+  const out = emitCreatureFell(
+    {
+      campaign_id: 'c1',
+      creature_id: 'u_apex',
+      creature_name: 'Vorshak',
+      species_id: 'dune_stalker',
+      biome_id: 'savana',
+      lineage_id: 'lin_3',
+      encounter_id: 'enc_lethal_01',
+      turn: 9,
+    },
+    { baseDir },
+  );
+  assert.equal(out.ok, true);
+  const chron = getChronicle('c1', { baseDir });
+  assert.equal(chron.length, 1);
+  assert.equal(chron[0].type, 'creature_death');
+  assert.equal(chron[0].tier, 'public');
+  assert.equal(chron[0].actor_id, 'u_apex');
+  assert.equal(chron[0].payload.creature_name, 'Vorshak');
+  assert.equal(chron[0].payload.species_id, 'dune_stalker');
+  assert.equal(chron[0].payload.biome_id, 'savana');
+  assert.equal(chron[0].payload.lineage_id, 'lin_3');
+  assert.equal(chron[0].payload.encounter_id, 'enc_lethal_01');
+  assert.equal(chron[0].payload.turn, 9);
+  // Succession trigger (SPEC-E E2 / J4): default true (a fall opens succession).
+  assert.equal(chron[0].payload.succession_trigger, true);
+});
+
+test('emitCreatureFell: succession_trigger can be opted out (e.g. non-MVP creature)', () => {
+  const baseDir = tmp();
+  emitCreatureFell({ campaign_id: 'c', creature_id: 'u2', succession_trigger: false }, { baseDir });
+  assert.equal(getChronicle('c', { baseDir })[0].payload.succession_trigger, false);
+});
+
+test('emitCreatureFell: no creature_id -> no_creature no-op (a fall commemorates a creature)', () => {
+  const baseDir = tmp();
+  const out = emitCreatureFell({ campaign_id: 'c' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'no_creature');
+  assert.equal(getChronicle('c', { baseDir }).length, 0);
+});
+
+test('emitCreatureFell: no campaign_id -> no_campaign_id (no event)', () => {
+  const baseDir = tmp();
+  const out = emitCreatureFell({ creature_id: 'u1' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'no_campaign_id');
+  assert.equal(fs.readdirSync(baseDir).length, 0);
+});
+
+test('emitCreatureFell: null/invalid ctx -> no_ctx (never throws)', () => {
+  assert.equal(emitCreatureFell(null).error, 'no_ctx');
+  assert.equal(emitCreatureFell('x').error, 'no_ctx');
 });

--- a/tests/services/combat/lethalDeath.test.js
+++ b/tests/services/combat/lethalDeath.test.js
@@ -140,10 +140,14 @@ test('resolveKoOutcome: bad unit -> soft, never throws', () => {
 
 // --- markCreatureFallen (state mutation, pure of I/O) --------------------
 
-test('markCreatureFallen: sets fallen state, hp=0, returns descriptor', () => {
+test('markCreatureFallen: sets the fallen marker TOP-LEVEL (survives round-sync), hp=0', () => {
   const u = playerUnit({ hp: 5, species_id: 'dune_stalker', name: 'Skiv' });
   const desc = lethalDeath.markCreatureFallen(u, { encounter_id: 'enc_x', turn: 4 });
-  assert.equal(u.status.fallen, true);
+  // Codex #2789 P2: status.* is rebuilt by syncStatusesFromRoundState (only
+  // wounds/wounded_perma whitelisted) -> the canonical marker MUST be top-level
+  // (publicSessionView spreads ...u, so clients see it; round-sync never touches
+  // top-level unit fields).
+  assert.equal(u.fallen, true);
   assert.equal(u.alive, false);
   assert.equal(u.hp, 0);
   assert.equal(desc.fallen, true);
@@ -155,9 +159,9 @@ test('markCreatureFallen: sets fallen state, hp=0, returns descriptor', () => {
 });
 
 test('markCreatureFallen: idempotent (already fallen -> no error, stays fallen)', () => {
-  const u = playerUnit({ status: { fallen: true } });
+  const u = playerUnit({ fallen: true });
   const desc = lethalDeath.markCreatureFallen(u, {});
-  assert.equal(u.status.fallen, true);
+  assert.equal(u.fallen, true);
   assert.equal(desc.fallen, true);
   assert.equal(desc.already_fallen, true);
 });
@@ -208,7 +212,7 @@ test('applyLethalKoIfDead: target not KO (hp>0) -> soft, no emit, not fallen', (
     const r = lethalDeath.applyLethalKoIfDead(u, lethalSession(), { emitCreatureFell: emit });
     assert.equal(r.outcome, 'soft');
     assert.equal(emit.calls.length, 0);
-    assert.notEqual(u.status.fallen, true);
+    assert.notEqual(u.fallen, true);
   });
 });
 
@@ -220,7 +224,7 @@ test('applyLethalKoIfDead: kill switch OFF (default) -> soft, not fallen, no emi
     assert.equal(r.outcome, 'soft');
     assert.equal(r.reason, 'lethal_disabled');
     assert.equal(emit.calls.length, 0);
-    assert.notEqual(u.status.fallen, true);
+    assert.notEqual(u.fallen, true);
   });
 });
 
@@ -231,7 +235,7 @@ test('applyLethalKoIfDead: enabled + lethal + consent + player KO -> death, fall
     const r = lethalDeath.applyLethalKoIfDead(u, lethalSession(), { emitCreatureFell: emit });
     assert.equal(r.outcome, 'death');
     assert.equal(r.fallen, true);
-    assert.equal(u.status.fallen, true);
+    assert.equal(u.fallen, true);
     assert.equal(emit.calls.length, 1);
     assert.equal(emit.calls[0].campaign_id, 'camp_1');
     assert.equal(emit.calls[0].creature_id, 'p1');
@@ -240,6 +244,19 @@ test('applyLethalKoIfDead: enabled + lethal + consent + player KO -> death, fall
     assert.equal(emit.calls[0].turn, 6);
     // biome falls back to the session biome when the unit carries none.
     assert.equal(emit.calls[0].biome_id, 'badlands');
+  });
+});
+
+test('applyLethalKoIfDead: encounter_id falls back to the stored YAML payload', () => {
+  // Codex #2789 P2: /api/session/start loads the YAML into session.encounter but
+  // never assigns session.encounter_id -> provenance would be null. Resolve it
+  // from session.encounter.{encounter_id,id}.
+  withLethalEnv('true', () => {
+    const u = playerUnit({ hp: 0 });
+    const emit = fakeEmitter();
+    const sess = lethalSession({ encounter_id: undefined, encounter: { id: 'enc_yaml_07' } });
+    lethalDeath.applyLethalKoIfDead(u, sess, { emitCreatureFell: emit });
+    assert.equal(emit.calls[0].encounter_id, 'enc_yaml_07');
   });
 });
 
@@ -257,7 +274,7 @@ test('applyLethalKoIfDead: lethal mission WITHOUT consent -> soft, not fallen, n
     assert.equal(r.outcome, 'soft');
     assert.equal(r.reason, 'no_consent');
     assert.equal(emit.calls.length, 0);
-    assert.notEqual(u.status.fallen, true);
+    assert.notEqual(u.fallen, true);
   });
 });
 
@@ -270,6 +287,6 @@ test('applyLethalKoIfDead: a throwing emitter still records the death (chronicle
     const r = lethalDeath.applyLethalKoIfDead(u, lethalSession(), { emitCreatureFell: boom });
     assert.equal(r.outcome, 'death');
     assert.equal(r.fallen, true);
-    assert.equal(u.status.fallen, true);
+    assert.equal(u.fallen, true);
   });
 });

--- a/tests/services/combat/lethalDeath.test.js
+++ b/tests/services/combat/lethalDeath.test.js
@@ -1,0 +1,275 @@
+'use strict';
+
+// SPEC-J slice 1 -- lethal death model (soft-death default, lethal opt-in
+// mission-flag + per-player consent, fallen-state mutation). Pure module: no
+// chronicle I/O here (the wire site emits creature_fell). Default-OFF: with the
+// kill switch unset every KO resolves to `soft` -> byte-identical to today.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const lethalDeath = require('../../../apps/backend/services/combat/lethalDeath');
+
+function playerUnit(over = {}) {
+  return { id: 'p1', controlled_by: 'player', is_minion: false, hp: 0, status: {}, ...over };
+}
+
+// --- env kill switch -----------------------------------------------------
+
+function withLethalEnv(value, fn) {
+  const prev = process.env.LETHAL_MISSIONS_ENABLED;
+  if (value === undefined) delete process.env.LETHAL_MISSIONS_ENABLED;
+  else process.env.LETHAL_MISSIONS_ENABLED = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.LETHAL_MISSIONS_ENABLED;
+    else process.env.LETHAL_MISSIONS_ENABLED = prev;
+  }
+}
+
+test('isLethalEnabled: default OFF (unset / anything but "true")', () => {
+  withLethalEnv(undefined, () => assert.equal(lethalDeath.isLethalEnabled(), false));
+  withLethalEnv('false', () => assert.equal(lethalDeath.isLethalEnabled(), false));
+  withLethalEnv('1', () => assert.equal(lethalDeath.isLethalEnabled(), false));
+  withLethalEnv('true', () => assert.equal(lethalDeath.isLethalEnabled(), true));
+});
+
+test('isMissionLethal: only when session.lethal === true (strict)', () => {
+  assert.equal(lethalDeath.isMissionLethal({ lethal: true }), true);
+  assert.equal(lethalDeath.isMissionLethal({ lethal: false }), false);
+  assert.equal(lethalDeath.isMissionLethal({ lethal: 'true' }), false); // no string coercion
+  assert.equal(lethalDeath.isMissionLethal({}), false);
+  assert.equal(lethalDeath.isMissionLethal(null), false);
+});
+
+// --- resolveKoOutcome (pure decision) ------------------------------------
+
+test('resolveKoOutcome: not a KO -> soft', () => {
+  withLethalEnv('true', () => {
+    const out = lethalDeath.resolveKoOutcome(playerUnit(), {
+      missionLethal: true,
+      consentGranted: true,
+      isKo: false,
+    });
+    assert.equal(out.outcome, 'soft');
+    assert.equal(out.reason, 'not_ko');
+  });
+});
+
+test('resolveKoOutcome: minion is never killed (B5 expendable) -> soft', () => {
+  withLethalEnv('true', () => {
+    const out = lethalDeath.resolveKoOutcome(playerUnit({ is_minion: true }), {
+      missionLethal: true,
+      consentGranted: true,
+      isKo: true,
+    });
+    assert.equal(out.outcome, 'soft');
+    assert.equal(out.reason, 'not_player');
+  });
+});
+
+test('resolveKoOutcome: non-player (sistema/enemy) -> soft', () => {
+  withLethalEnv('true', () => {
+    const out = lethalDeath.resolveKoOutcome(playerUnit({ controlled_by: 'sistema' }), {
+      missionLethal: true,
+      consentGranted: true,
+      isKo: true,
+    });
+    assert.equal(out.outcome, 'soft');
+    assert.equal(out.reason, 'not_player');
+  });
+});
+
+test('resolveKoOutcome: kill switch OFF -> soft even with mission lethal + consent', () => {
+  withLethalEnv('false', () => {
+    const out = lethalDeath.resolveKoOutcome(playerUnit(), {
+      missionLethal: true,
+      consentGranted: true,
+      isKo: true,
+    });
+    assert.equal(out.outcome, 'soft');
+    assert.equal(out.reason, 'lethal_disabled');
+  });
+});
+
+test('resolveKoOutcome: mission not lethal -> soft (default soft-death)', () => {
+  withLethalEnv('true', () => {
+    const out = lethalDeath.resolveKoOutcome(playerUnit(), {
+      missionLethal: false,
+      consentGranted: true,
+      isKo: true,
+    });
+    assert.equal(out.outcome, 'soft');
+    assert.equal(out.reason, 'mission_not_lethal');
+  });
+});
+
+test('resolveKoOutcome: lethal mission WITHOUT consent -> soft (anti-deadlock fallback)', () => {
+  withLethalEnv('true', () => {
+    const out = lethalDeath.resolveKoOutcome(playerUnit(), {
+      missionLethal: true,
+      consentGranted: false,
+      isKo: true,
+    });
+    assert.equal(out.outcome, 'soft');
+    assert.equal(out.reason, 'no_consent');
+  });
+});
+
+test('resolveKoOutcome: enabled + lethal + consent + KO of a player -> death', () => {
+  withLethalEnv('true', () => {
+    const out = lethalDeath.resolveKoOutcome(playerUnit(), {
+      missionLethal: true,
+      consentGranted: true,
+      isKo: true,
+    });
+    assert.equal(out.outcome, 'death');
+    assert.equal(out.reason, 'lethal_consented');
+  });
+});
+
+test('resolveKoOutcome: bad unit -> soft, never throws', () => {
+  withLethalEnv('true', () => {
+    assert.equal(
+      lethalDeath.resolveKoOutcome(null, { missionLethal: true, consentGranted: true, isKo: true })
+        .outcome,
+      'soft',
+    );
+  });
+});
+
+// --- markCreatureFallen (state mutation, pure of I/O) --------------------
+
+test('markCreatureFallen: sets fallen state, hp=0, returns descriptor', () => {
+  const u = playerUnit({ hp: 5, species_id: 'dune_stalker', name: 'Skiv' });
+  const desc = lethalDeath.markCreatureFallen(u, { encounter_id: 'enc_x', turn: 4 });
+  assert.equal(u.status.fallen, true);
+  assert.equal(u.alive, false);
+  assert.equal(u.hp, 0);
+  assert.equal(desc.fallen, true);
+  assert.equal(desc.creature_id, 'p1');
+  assert.equal(desc.creature_name, 'Skiv');
+  assert.equal(desc.species_id, 'dune_stalker');
+  assert.equal(desc.encounter_id, 'enc_x');
+  assert.equal(desc.turn, 4);
+});
+
+test('markCreatureFallen: idempotent (already fallen -> no error, stays fallen)', () => {
+  const u = playerUnit({ status: { fallen: true } });
+  const desc = lethalDeath.markCreatureFallen(u, {});
+  assert.equal(u.status.fallen, true);
+  assert.equal(desc.fallen, true);
+  assert.equal(desc.already_fallen, true);
+});
+
+test('markCreatureFallen: bad input -> { fallen:false }, never throws', () => {
+  assert.equal(lethalDeath.markCreatureFallen(null, {}).fallen, false);
+  assert.equal(lethalDeath.markCreatureFallen({}, {}).fallen, false); // no id
+});
+
+// --- isConsentGranted -----------------------------------------------------
+
+test('isConsentGranted: only when session.lethalConsent.granted === true', () => {
+  assert.equal(lethalDeath.isConsentGranted({ lethalConsent: { granted: true } }), true);
+  assert.equal(lethalDeath.isConsentGranted({ lethalConsent: { granted: false } }), false);
+  assert.equal(lethalDeath.isConsentGranted({ lethalConsent: {} }), false);
+  assert.equal(lethalDeath.isConsentGranted({}), false); // absent today (PR2 produces it)
+  assert.equal(lethalDeath.isConsentGranted(null), false);
+});
+
+// --- applyLethalKoIfDead (thin wire orchestrator, injectable emitter) ------
+
+function fakeEmitter() {
+  const calls = [];
+  const fn = (ctx) => {
+    calls.push(ctx);
+    return { ok: true };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function lethalSession(over = {}) {
+  return {
+    lethal: true,
+    campaign_id: 'camp_1',
+    encounter_id: 'enc_lethal_01',
+    turn: 6,
+    biome_id: 'badlands',
+    lethalConsent: { granted: true },
+    ...over,
+  };
+}
+
+test('applyLethalKoIfDead: target not KO (hp>0) -> soft, no emit, not fallen', () => {
+  withLethalEnv('true', () => {
+    const u = playerUnit({ hp: 3 });
+    const emit = fakeEmitter();
+    const r = lethalDeath.applyLethalKoIfDead(u, lethalSession(), { emitCreatureFell: emit });
+    assert.equal(r.outcome, 'soft');
+    assert.equal(emit.calls.length, 0);
+    assert.notEqual(u.status.fallen, true);
+  });
+});
+
+test('applyLethalKoIfDead: kill switch OFF (default) -> soft, not fallen, no emit (band-neutral)', () => {
+  withLethalEnv(undefined, () => {
+    const u = playerUnit({ hp: 0 });
+    const emit = fakeEmitter();
+    const r = lethalDeath.applyLethalKoIfDead(u, lethalSession(), { emitCreatureFell: emit });
+    assert.equal(r.outcome, 'soft');
+    assert.equal(r.reason, 'lethal_disabled');
+    assert.equal(emit.calls.length, 0);
+    assert.notEqual(u.status.fallen, true);
+  });
+});
+
+test('applyLethalKoIfDead: enabled + lethal + consent + player KO -> death, fallen, emits creature ctx', () => {
+  withLethalEnv('true', () => {
+    const u = playerUnit({ hp: 0, name: 'Skiv', species_id: 'dune_stalker' });
+    const emit = fakeEmitter();
+    const r = lethalDeath.applyLethalKoIfDead(u, lethalSession(), { emitCreatureFell: emit });
+    assert.equal(r.outcome, 'death');
+    assert.equal(r.fallen, true);
+    assert.equal(u.status.fallen, true);
+    assert.equal(emit.calls.length, 1);
+    assert.equal(emit.calls[0].campaign_id, 'camp_1');
+    assert.equal(emit.calls[0].creature_id, 'p1');
+    assert.equal(emit.calls[0].creature_name, 'Skiv');
+    assert.equal(emit.calls[0].encounter_id, 'enc_lethal_01');
+    assert.equal(emit.calls[0].turn, 6);
+    // biome falls back to the session biome when the unit carries none.
+    assert.equal(emit.calls[0].biome_id, 'badlands');
+  });
+});
+
+test('applyLethalKoIfDead: lethal mission WITHOUT consent -> soft, not fallen, no emit', () => {
+  withLethalEnv('true', () => {
+    const u = playerUnit({ hp: 0 });
+    const emit = fakeEmitter();
+    const r = lethalDeath.applyLethalKoIfDead(
+      u,
+      lethalSession({ lethalConsent: { granted: false } }),
+      {
+        emitCreatureFell: emit,
+      },
+    );
+    assert.equal(r.outcome, 'soft');
+    assert.equal(r.reason, 'no_consent');
+    assert.equal(emit.calls.length, 0);
+    assert.notEqual(u.status.fallen, true);
+  });
+});
+
+test('applyLethalKoIfDead: a throwing emitter still records the death (chronicle best-effort)', () => {
+  withLethalEnv('true', () => {
+    const u = playerUnit({ hp: 0 });
+    const boom = () => {
+      throw new Error('chronicle down');
+    };
+    const r = lethalDeath.applyLethalKoIfDead(u, lethalSession(), { emitCreatureFell: boom });
+    assert.equal(r.outcome, 'death');
+    assert.equal(r.fallen, true);
+    assert.equal(u.status.fallen, true);
+  });
+});


### PR DESCRIPTION
## SPEC-J slice 1 (backend) -- lethal mission-flag + soft-death model + failure-as-lore

Builds the lethal layer on top of the LIVE `woundSystem` (J1 KO->grave wound
already shipped #2535/#2714 -- this PR does NOT touch combat math). Design is
fully ratified (J1-J5 all opzione A, 2026-06-08; J2 closed by canon point-9),
so this is implementation only -- no open design-call.

Spec: `docs/design/evo-tactics-lethal-wounds-rituals.md` (sez. 3/5/7/8).

### What

- **`services/combat/lethalDeath.js`** (new, pure):
  - `isLethalEnabled()` -- env kill switch `LETHAL_MISSIONS_ENABLED`, **default OFF** (opt-in).
  - `isMissionLethal(session)` -- strict per-mission flag (point-9, no string coercion).
  - `resolveKoOutcome(unit, ctx)` -- fail-closed chain: `soft` unless `enabled && lethal && consent && player-KO` -> `death` (minions exempt, B5).
  - `markCreatureFallen(unit, opts)` -- roster state change + public descriptor (idempotent, never throws).
  - `applyLethalKoIfDead(target, session)` -- thin wire orchestrator (injectable emitter).
- **`chronicle/chronicleEmitters.js`** -- `emitCreatureFell` reuses the existing `creature_death` chronicle type (a soft KO is NOT a death). `public` tier (J5 lineage-auto + SPEC-D death beat); carries `succession_trigger` for SPEC-E E2 (J4).
- **`routes/session.js`** -- `lethal` flag passthrough at `/session/start` (A2 pattern) + `applyLethalKoIfDead` wired into the `performAttack` KO path (best-effort, never blocks the hit).
- **`routes/sessionHelpers.js`** -- `publicSessionView.lethal` (SPEC-J sez.8: existence of a lethal mission is `public`).

### Band impact: NEUTRAL (by construction)

Kill switch unset + no consent producer (PR2) + no encounter sets `lethal:true`
-> `resolveKoOutcome` always returns `soft` -> every KO is byte-identical to
today. The death branch is never reached in current play. Verified by unit +
integration tests and a live composition smoke probe.

### Out of scope (next slices, gated)

- **PR2**: consent state-machine (per-player device confirm, SPEC-B 3.10/F5 visibility, anti-deadlock timeout/fallback, SPEC-K 6.4) -> produces `session.lethalConsent.granted`.
- **PR3**: Nido ritual heal/transform (J3), device-owned, costs resources (SPEC-E E6).
- Godot device UI for consent/ritual = item-3 cross-repo.
- SPEC-J doc flip `review_needed -> active` = master-dd, gated on full closure.
- **Flip `LETHAL_MISSIONS_ENABLED=true`** = master-dd, only after PR2 consent is live + a lethal-mission N=40 / playtest sign-off (wound magnitudes are already RATIFIED-PROVISIONAL; lethal activation is the new gate).

### Tests

- `lethalDeath` 19/19, `chronicleEmitters` +6 (38/38), `lethalMissionFlag` integration 3/3.
- Regression: AI suite **543/543**, combat/session/chronicle suites green, `format:check` clean (my files).

### Rollback (03A)

Pure-additive, default-OFF. Revert this squash commit -> zero residue (no
migration, no schema, no data, no flag flipped). Even un-reverted the feature
is inert until `LETHAL_MISSIONS_ENABLED=true` + a consent producer exist.

### Guardrails

Zero forbidden-path files (only `apps/backend/*` + `tests/*`). No new deps. No
contracts/migrations/workflows/generation touched. <50 new lines outside test files.
