### PR TITLE
feat(spec-j): Nido wound rituals heal/transform (PR3)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3358,6 +3358,71 @@ function createSessionRouter(options = {}) {
     }
   });
 
+  // POST /api/session/:id/nido/ritual — SPEC-J sez.6 Nido wound ritual (J3).
+  // Heal or transform a creature's `grave` scar. The ritual ACTION is `private`
+  // (device-owned, SPEC-K 7.6); its esito is `public` (chronicle scar_healed /
+  // scar_transformed). Operates on the live scar (status.wounds + the persisted
+  // cross-encounter map session.lastMissionWounds). Resource cost (SPEC-E E6) is
+  // NOT enforced here — the campaign resource pool is Godot/client-owned
+  // (godotV2State); the caller is trusted to have paid. 409 when no scar.
+  //   body: { unit_id, location, kind: 'heal'|'transform' }
+  router.post('/:id/nido/ritual', (req, res, next) => {
+    try {
+      const { error, session } = resolveSession(req.params.id);
+      if (error) return res.status(error.status).json(error.body);
+      const body = req.body || {};
+      const unitId = String(body.unit_id || '').trim();
+      const location = String(body.location || '').trim();
+      const kind = body.kind;
+      if (!unitId || !location) {
+        return res.status(400).json({ error: 'unit_id + location richiesti' });
+      }
+      if (kind !== 'heal' && kind !== 'transform') {
+        return res.status(400).json({ error: "kind deve essere 'heal' o 'transform'" });
+      }
+      const unit = (session.units || []).find((u) => u && String(u.id) === unitId);
+      if (!unit) return res.status(404).json({ error: `unit ${unitId} non in sessione` });
+      const nidoRitual = require('../services/combat/nidoRitual');
+      const sessionMap = session.lastMissionWounds || null;
+      const result =
+        kind === 'heal'
+          ? nidoRitual.healScar(unit, location, { sessionMap })
+          : nidoRitual.transformScar(unit, location, { sessionMap });
+      const okFlag = kind === 'heal' ? result.healed : result.transformed;
+      if (!okFlag) {
+        return res.status(409).json({ error: 'ritual_unavailable', reason: result.reason, kind });
+      }
+      // esito public -> chronicle (best-effort, never blocks the ritual).
+      try {
+        require('../services/chronicle/chronicleEmitters').emitScarRitual({
+          campaign_id: session.campaign_id,
+          creature_id: unit.id,
+          creature_name: unit.name || null,
+          species_id: unit.species_id || null,
+          kind,
+          location,
+          mark: result.mark || null,
+          turn: session.turn,
+        });
+      } catch {
+        /* chronicle best-effort */
+      }
+      return res.json({
+        session_id: session.session_id,
+        ritual: {
+          kind,
+          unit_id: unit.id,
+          location,
+          scar: result.scar || null,
+          mark: result.mark || null,
+        },
+        state: publicSessionView(session),
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   // TKT-M15 — Promotion engine endpoints.
   //
   // GET /api/session/:id/promotion-eligibility — return all units' promotion

--- a/apps/backend/services/chronicle/chronicleEmitters.js
+++ b/apps/backend/services/chronicle/chronicleEmitters.js
@@ -187,11 +187,52 @@ function emitCreatureFell(ctx, opts = {}) {
   );
 }
 
+/**
+ * Append a scar-ritual outcome event (SPEC-J sez.6 / J3). The Nido ritual ACTION
+ * is `private` (device-owned), but its ESITO is `public` -- the branco sees the
+ * creature healed or transformed. `kind:'heal'` -> `scar_healed`;
+ * `kind:'transform'` -> `scar_transformed` (carries the failure-as-lore `mark`).
+ * Best-effort: no campaign_id / no creature / bad kind -> no-op. Never throws.
+ *
+ * @param ctx  { campaign_id, creature_id, kind:'heal'|'transform', location?,
+ *               mark?, species_id?, creature_name?, turn?, actor_id? }
+ * @param opts { baseDir? }
+ */
+function emitScarRitual(ctx, opts = {}) {
+  if (!ctx || typeof ctx !== 'object') return { ok: false, error: 'no_ctx' };
+  const runId = ctx.campaign_id;
+  if (!runId) return { ok: false, error: 'no_campaign_id' };
+  if (!ctx.creature_id) return { ok: false, error: 'no_creature' };
+  if (ctx.kind !== 'heal' && ctx.kind !== 'transform') {
+    return { ok: false, error: 'invalid_kind' };
+  }
+  const type = ctx.kind === 'transform' ? 'scar_transformed' : 'scar_healed';
+  return appendEvent(
+    runId,
+    {
+      type,
+      actor_id: ctx.actor_id || ctx.creature_id,
+      tier: 'public',
+      payload: {
+        creature_id: ctx.creature_id,
+        creature_name: ctx.creature_name || null,
+        species_id: ctx.species_id || null,
+        kind: ctx.kind,
+        location: ctx.location || null,
+        mark: ctx.kind === 'transform' ? ctx.mark || null : null,
+        turn: Number.isFinite(Number(ctx.turn)) ? Number(ctx.turn) : null,
+      },
+    },
+    { baseDir: opts.baseDir },
+  );
+}
+
 module.exports = {
   emitRunFailed,
   emitMutationLineage,
   emitHeirloom,
   emitCreatureFell,
+  emitScarRitual,
   deriveHeirloomName,
   DEFEAT_OUTCOMES,
 };

--- a/apps/backend/services/chronicle/chronicleStore.js
+++ b/apps/backend/services/chronicle/chronicleStore.js
@@ -38,6 +38,8 @@ const ALLOWED_EVENT_TYPES = new Set([
   'creature_death',
   'mutation_acquired',
   'scar_earned', // SPEC-J wound -> narrative layer
+  'scar_healed', // SPEC-J sez.6 Nido ritual outcome (clean recovery)
+  'scar_transformed', // SPEC-J sez.6 Nido ritual outcome (failure-as-lore mark)
   'legacy_formed', // M-2 legacy figure
   'run_failed', // A3 failure-as-lore (SPEC-P)
   'biome_wound', // A13 biome-wound cross-run (SPEC-P)

--- a/apps/backend/services/combat/nidoRitual.js
+++ b/apps/backend/services/combat/nidoRitual.js
@@ -1,0 +1,119 @@
+// =============================================================================
+// SPEC-J sez.6 / fork J3 -- Nido wound rituals (heal / transform).
+//
+// Spec: docs/design/evo-tactics-lethal-wounds-rituals.md (sez.6; J3 ratified
+// 2026-06-08 = opzione A: heal O transform, scelta del player).
+//
+// Operates on a creature's `grave` scars (woundSystem -- the cross-encounter
+// scar that carries a stat-malus). Two outcomes:
+//   - HEAL:      remove the scar (and its malus) -- a clean recovery at the Nido;
+//   - TRANSFORM: remove the scar but crystallize it into a permanent narrative
+//                mark (failure-as-lore: the wound becomes part of the creature's
+//                story). The mark is derived deterministically from the scar (no
+//                new content pool -> no content-ratify gate, deriveHeirloomName
+//                pattern). The MECHANICAL trait/mutation grant is deferred (which
+//                trait + effect = balance, SPEC-E follow-up); here transform is a
+//                narrative record.
+//
+// Pure of I/O: mutates the unit (+ an optional persisted scar map) and returns a
+// descriptor. The chronicle `scar_healed`/`scar_transformed` emission happens at
+// the wire site. Never throws.
+//
+// NOT here (forward-work): the resource cost (SPEC-E E6). The campaign resource
+// pool is Godot/client-owned (godotV2State), so cost-enforcement is not backend-
+// ownable today -- a ritual endpoint trusts the caller to have paid.
+// =============================================================================
+
+'use strict';
+
+const SEVERITY_GRAVE = 'grave';
+
+/** All `grave` wounds (= scars) the unit currently carries. */
+function graveWoundsOf(unit) {
+  return unit && unit.status && Array.isArray(unit.status.wounds)
+    ? unit.status.wounds.filter((w) => w && w.severity === SEVERITY_GRAVE)
+    : [];
+}
+
+/** The grave scar at a given location, or null. lieve/media are NOT scars. */
+function findScar(unit, location) {
+  if (!unit || typeof unit !== 'object' || !location) return null;
+  return graveWoundsOf(unit).find((w) => w.location === location) || null;
+}
+
+/**
+ * Remove the grave scar at `location` from the unit's live wounds AND from the
+ * persisted cross-encounter scar map (so it does not get restored at the next
+ * encounter start). Other wounds (lieve/media, other locations) are untouched.
+ */
+function _removeGraveAt(unit, location, sessionMap) {
+  if (unit.status && Array.isArray(unit.status.wounds)) {
+    unit.status.wounds = unit.status.wounds.filter(
+      (w) => !(w && w.severity === SEVERITY_GRAVE && w.location === location),
+    );
+  }
+  if (sessionMap && typeof sessionMap === 'object' && Array.isArray(sessionMap[unit.id])) {
+    sessionMap[unit.id] = sessionMap[unit.id].filter(
+      (w) => !(w && w.severity === SEVERITY_GRAVE && w.location === location),
+    );
+  }
+}
+
+/**
+ * Heal a scar: remove it (and its malus). Clean recovery.
+ *
+ * @param unit      the scarred creature
+ * @param location  scar location (testa|torso|arti_anteriori|arti_posteriori)
+ * @param opts      { sessionMap? } -- persisted cross-encounter scar map
+ * @returns {{ healed:boolean, scar?:object, unit_id?:string, reason?:string }}
+ */
+function healScar(unit, location, opts = {}) {
+  if (!unit || typeof unit !== 'object' || !unit.id) return { healed: false, reason: 'no_unit' };
+  const scar = findScar(unit, location);
+  if (!scar) return { healed: false, reason: 'no_scar' };
+  _removeGraveAt(unit, location, opts.sessionMap);
+  return { healed: true, scar: { ...scar }, unit_id: unit.id };
+}
+
+/**
+ * Deterministic narrative mark derived from a scar (no RNG, no content pool).
+ * The transform outcome that the chronicle / lineage can carry as failure-as-lore.
+ */
+function deriveScarMark(scar) {
+  return {
+    id: `scar_${scar.location}`,
+    origin_location: scar.location,
+    origin_stat: scar.stat || null,
+  };
+}
+
+/**
+ * Transform a scar into a permanent narrative mark (failure-as-lore). Removes the
+ * scar's malus like a heal, but crystallizes it into a `mark`. Mechanical
+ * trait/mutation grant = deferred (SPEC-E / balance).
+ *
+ * @param opts { sessionMap?, permanentMarks? } -- permanentMarks is an optional
+ *             campaign-level array the mark is appended to (narrative record).
+ * @returns {{ transformed:boolean, scar?:object, mark?:object, unit_id?:string, reason?:string }}
+ */
+function transformScar(unit, location, opts = {}) {
+  if (!unit || typeof unit !== 'object' || !unit.id) {
+    return { transformed: false, reason: 'no_unit' };
+  }
+  const scar = findScar(unit, location);
+  if (!scar) return { transformed: false, reason: 'no_scar' };
+  _removeGraveAt(unit, location, opts.sessionMap);
+  const mark = deriveScarMark(scar);
+  if (Array.isArray(opts.permanentMarks)) {
+    opts.permanentMarks.push({ creature_id: unit.id, ...mark });
+  }
+  return { transformed: true, scar: { ...scar }, mark, unit_id: unit.id };
+}
+
+module.exports = {
+  graveWoundsOf,
+  findScar,
+  healScar,
+  transformScar,
+  deriveScarMark,
+};

--- a/tests/api/nidoRitualWire.test.js
+++ b/tests/api/nidoRitualWire.test.js
@@ -1,0 +1,94 @@
+// tests/api/nidoRitualWire.test.js -- SPEC-J sez.6 Nido ritual endpoint (J3).
+//
+// POST /api/session/:id/nido/ritual { unit_id, location, kind } heals or
+// transforms a creature's grave scar. Resource cost (SPEC-E E6) is NOT enforced
+// (campaign resources are Godot-owned). The scar transformation logic itself is
+// unit-tested in tests/services/combat/nidoRitual; this proves the wire +
+// validation + the chronicle esito.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+// Start a session, seeding a grave scar onto the first player unit so the ritual
+// has something to act on (start preserves player-unit status; only sistema
+// units are cloned for the damage multiplier).
+async function startWithScar(app, location = 'torso') {
+  const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
+  const units = JSON.parse(JSON.stringify(scenario.body.units));
+  const pg = units.find((u) => u && u.controlled_by === 'player');
+  pg.status = pg.status || {};
+  pg.status.wounds = [{ location, severity: 'grave', stat: 'defense_mod', malus: -2 }];
+  const res = await request(app).post('/api/session/start').send({ units });
+  return { sid: res.body.session_id, pgId: pg.id };
+}
+
+test('nido/ritual heal: removes the grave scar, esito 200', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid, pgId } = await startWithScar(app);
+  const res = await request(app)
+    .post(`/api/session/${sid}/nido/ritual`)
+    .send({ unit_id: pgId, location: 'torso', kind: 'heal' });
+  assert.equal(res.status, 200, JSON.stringify(res.body).slice(0, 200));
+  assert.equal(res.body.ritual.kind, 'heal');
+  assert.equal(res.body.ritual.unit_id, pgId);
+  const pg = res.body.state.units.find((u) => u.id === pgId);
+  assert.equal(
+    (pg.status.wounds || []).some((w) => w.location === 'torso' && w.severity === 'grave'),
+    false,
+    'grave scar healed in the public state',
+  );
+});
+
+test('nido/ritual transform: removes scar + returns the narrative mark', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid, pgId } = await startWithScar(app, 'arti_anteriori');
+  const res = await request(app)
+    .post(`/api/session/${sid}/nido/ritual`)
+    .send({ unit_id: pgId, location: 'arti_anteriori', kind: 'transform' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.ritual.kind, 'transform');
+  assert.ok(res.body.ritual.mark && res.body.ritual.mark.id);
+  assert.equal(res.body.ritual.mark.origin_location, 'arti_anteriori');
+});
+
+test('nido/ritual: no scar at location -> 409 ritual_unavailable (no_scar)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid, pgId } = await startWithScar(app);
+  const res = await request(app)
+    .post(`/api/session/${sid}/nido/ritual`)
+    .send({ unit_id: pgId, location: 'arti_posteriori', kind: 'heal' });
+  assert.equal(res.status, 409);
+  assert.equal(res.body.reason, 'no_scar');
+});
+
+test('nido/ritual: invalid kind -> 400; unknown unit -> 404', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid, pgId } = await startWithScar(app);
+  const bad = await request(app)
+    .post(`/api/session/${sid}/nido/ritual`)
+    .send({ unit_id: pgId, location: 'torso', kind: 'banish' });
+  assert.equal(bad.status, 400);
+  const ghost = await request(app)
+    .post(`/api/session/${sid}/nido/ritual`)
+    .send({ unit_id: 'no_such_unit', location: 'torso', kind: 'heal' });
+  assert.equal(ghost.status, 404);
+});

--- a/tests/services/chronicleEmitters.test.js
+++ b/tests/services/chronicleEmitters.test.js
@@ -13,6 +13,7 @@ const {
   emitMutationLineage,
   emitHeirloom,
   emitCreatureFell,
+  emitScarRitual,
 } = require('../../apps/backend/services/chronicle/chronicleEmitters');
 const { getChronicle } = require('../../apps/backend/services/chronicle/chronicleStore');
 
@@ -269,4 +270,75 @@ test('emitCreatureFell: no campaign_id -> no_campaign_id (no event)', () => {
 test('emitCreatureFell: null/invalid ctx -> no_ctx (never throws)', () => {
   assert.equal(emitCreatureFell(null).error, 'no_ctx');
   assert.equal(emitCreatureFell('x').error, 'no_ctx');
+});
+
+// SPEC-J sez.6 -- scar ritual outcome (heal/transform), public esito.
+test('emitScarRitual: heal -> public scar_healed event', () => {
+  const baseDir = tmp();
+  const out = emitScarRitual(
+    {
+      campaign_id: 'c1',
+      creature_id: 'u1',
+      kind: 'heal',
+      location: 'torso',
+      species_id: 'dune_stalker',
+    },
+    { baseDir },
+  );
+  assert.equal(out.ok, true);
+  const ev = getChronicle('c1', { baseDir })[0];
+  assert.equal(ev.type, 'scar_healed');
+  assert.equal(ev.tier, 'public');
+  assert.equal(ev.actor_id, 'u1');
+  assert.equal(ev.payload.kind, 'heal');
+  assert.equal(ev.payload.location, 'torso');
+  assert.equal(ev.payload.species_id, 'dune_stalker');
+});
+
+test('emitScarRitual: transform -> scar_transformed with the narrative mark', () => {
+  const baseDir = tmp();
+  const out = emitScarRitual(
+    {
+      campaign_id: 'c2',
+      creature_id: 'u2',
+      kind: 'transform',
+      location: 'arti_anteriori',
+      mark: {
+        id: 'scar_arti_anteriori',
+        origin_location: 'arti_anteriori',
+        origin_stat: 'attack_mod',
+      },
+    },
+    { baseDir },
+  );
+  assert.equal(out.ok, true);
+  const ev = getChronicle('c2', { baseDir })[0];
+  assert.equal(ev.type, 'scar_transformed');
+  assert.equal(ev.payload.kind, 'transform');
+  assert.equal(ev.payload.mark.id, 'scar_arti_anteriori');
+});
+
+test('emitScarRitual: invalid kind -> invalid_kind no-op', () => {
+  const baseDir = tmp();
+  const out = emitScarRitual({ campaign_id: 'c', creature_id: 'u', kind: 'banish' }, { baseDir });
+  assert.equal(out.ok, false);
+  assert.equal(out.error, 'invalid_kind');
+  assert.equal(getChronicle('c', { baseDir }).length, 0);
+});
+
+test('emitScarRitual: no creature_id -> no_creature; no campaign_id -> no_campaign_id', () => {
+  const baseDir = tmp();
+  assert.equal(
+    emitScarRitual({ campaign_id: 'c', kind: 'heal' }, { baseDir }).error,
+    'no_creature',
+  );
+  assert.equal(
+    emitScarRitual({ creature_id: 'u', kind: 'heal' }, { baseDir }).error,
+    'no_campaign_id',
+  );
+});
+
+test('emitScarRitual: null/invalid ctx -> no_ctx (never throws)', () => {
+  assert.equal(emitScarRitual(null).error, 'no_ctx');
+  assert.equal(emitScarRitual('x').error, 'no_ctx');
 });

--- a/tests/services/combat/nidoRitual.test.js
+++ b/tests/services/combat/nidoRitual.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+// SPEC-J sez.6 / fork J3 -- Nido wound rituals (heal / transform). Pure service:
+// operates on a unit's `grave` scars (woundSystem) + an optional persisted scar
+// map; no chronicle I/O (the wire site emits). Resource cost (SPEC-E E6) is NOT
+// here -- the campaign resource pool is Godot/client-owned (godotV2State), so
+// cost-enforcement is forward-work, not part of this slice.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const nidoRitual = require('../../../apps/backend/services/combat/nidoRitual');
+
+function unitWithScar(over = {}) {
+  return {
+    id: 'u1',
+    name: 'Skiv',
+    species_id: 'dune_stalker',
+    status: {
+      wounds: [
+        { location: 'torso', severity: 'grave', stat: 'defense_mod', malus: -2 },
+        { location: 'testa', severity: 'lieve', stat: 'accuracy', malus: -1 },
+      ],
+    },
+    ...over,
+  };
+}
+
+// --- findScar ------------------------------------------------------------
+
+test('findScar: returns the grave wound at a location', () => {
+  const u = unitWithScar();
+  const scar = nidoRitual.findScar(u, 'torso');
+  assert.equal(scar.location, 'torso');
+  assert.equal(scar.severity, 'grave');
+});
+
+test('findScar: a lieve/media wound is NOT a scar (only grave)', () => {
+  const u = unitWithScar();
+  assert.equal(nidoRitual.findScar(u, 'testa'), null); // testa is lieve, not a scar
+});
+
+test('findScar: no scar / bad input -> null', () => {
+  assert.equal(nidoRitual.findScar(unitWithScar(), 'arti_anteriori'), null);
+  assert.equal(nidoRitual.findScar(null, 'torso'), null);
+  assert.equal(nidoRitual.findScar({ id: 'x' }, 'torso'), null);
+});
+
+// --- healScar ------------------------------------------------------------
+
+test('healScar: removes the grave scar from status.wounds, keeps other wounds', () => {
+  const u = unitWithScar();
+  const out = nidoRitual.healScar(u, 'torso');
+  assert.equal(out.healed, true);
+  assert.equal(out.scar.location, 'torso');
+  assert.equal(out.unit_id, 'u1');
+  // grave removed, the lieve testa wound preserved.
+  assert.equal(
+    u.status.wounds.some((w) => w.location === 'torso' && w.severity === 'grave'),
+    false,
+  );
+  assert.equal(
+    u.status.wounds.some((w) => w.location === 'testa'),
+    true,
+  );
+});
+
+test('healScar: also clears the scar from the persisted cross-encounter map', () => {
+  const u = unitWithScar();
+  const sessionMap = {
+    u1: [{ location: 'torso', severity: 'grave', stat: 'defense_mod', malus: -2 }],
+  };
+  nidoRitual.healScar(u, 'torso', { sessionMap });
+  assert.equal(
+    (sessionMap.u1 || []).some((w) => w.location === 'torso'),
+    false,
+  );
+});
+
+test('healScar: no scar at location -> { healed:false, reason }', () => {
+  const u = unitWithScar();
+  const out = nidoRitual.healScar(u, 'arti_posteriori');
+  assert.equal(out.healed, false);
+  assert.equal(out.reason, 'no_scar');
+});
+
+test('healScar: bad unit -> { healed:false }, never throws', () => {
+  assert.equal(nidoRitual.healScar(null, 'torso').healed, false);
+  assert.equal(nidoRitual.healScar({}, 'torso').healed, false);
+});
+
+// --- transformScar -------------------------------------------------------
+
+test('transformScar: removes the scar + returns a deterministic narrative mark', () => {
+  const u = unitWithScar();
+  const out = nidoRitual.transformScar(u, 'torso');
+  assert.equal(out.transformed, true);
+  assert.equal(out.scar.location, 'torso');
+  assert.ok(out.mark && typeof out.mark.id === 'string');
+  assert.equal(out.mark.origin_location, 'torso');
+  assert.equal(
+    u.status.wounds.some((w) => w.location === 'torso' && w.severity === 'grave'),
+    false,
+  );
+});
+
+test('transformScar: mark is deterministic for the same scar (no RNG / no content pool)', () => {
+  const a = nidoRitual.transformScar(unitWithScar(), 'torso');
+  const b = nidoRitual.transformScar(unitWithScar(), 'torso');
+  assert.deepEqual(a.mark, b.mark);
+});
+
+test('transformScar: records the mark into permanentMarks when provided (campaign lore)', () => {
+  const u = unitWithScar();
+  const permanentMarks = [];
+  nidoRitual.transformScar(u, 'torso', { permanentMarks });
+  assert.equal(permanentMarks.length, 1);
+  assert.equal(permanentMarks[0].creature_id, 'u1');
+  assert.equal(permanentMarks[0].origin_location, 'torso');
+});
+
+test('transformScar: also clears the persisted scar map', () => {
+  const u = unitWithScar();
+  const sessionMap = {
+    u1: [{ location: 'torso', severity: 'grave', stat: 'defense_mod', malus: -2 }],
+  };
+  nidoRitual.transformScar(u, 'torso', { sessionMap });
+  assert.equal(
+    (sessionMap.u1 || []).some((w) => w.location === 'torso'),
+    false,
+  );
+});
+
+test('transformScar: no scar -> { transformed:false, reason }, never throws', () => {
+  assert.equal(nidoRitual.transformScar(unitWithScar(), 'arti_anteriori').transformed, false);
+  assert.equal(nidoRitual.transformScar(null, 'torso').transformed, false);
+});


### PR DESCRIPTION
## SPEC-J PR3 (backend) -- Nido wound rituals (heal / transform)

Implements SPEC-J sez.6 / fork **J3** (ratified 2026-06-08 = opzione A: heal O
transform, scelta del player). Builds the backend ritual that operates on a
creature's `grave` scar (the cross-encounter scar from `woundSystem`).

Continues #2789 (PR1 lethal-death model). Spec: `docs/design/evo-tactics-lethal-wounds-rituals.md` (sez.6).

### What

- **`services/combat/nidoRitual.js`** (new, pure):
  - `findScar(unit, location)` -- the `grave` scar at a location (lieve/media are not scars).
  - `healScar(unit, location, {sessionMap})` -- clean recovery: removes the scar + its malus from `status.wounds` AND the persisted cross-encounter map.
  - `transformScar(unit, location, {sessionMap, permanentMarks})` -- removes the scar but crystallizes it into a **deterministic narrative mark** (failure-as-lore; no new content pool). Mechanical trait/mutation grant is deferred (which trait + effect = balance, SPEC-E follow-up).
- **`chronicle/chronicleEmitters.js`** -- `emitScarRitual` -> `scar_healed` / `scar_transformed` (`public` esito; sez.6: action private, outcome public). +2 whitelist types.
- **`routes/session.js`** -- `POST /api/session/:id/nido/ritual { unit_id, location, kind }` -> heal|transform, `409` when no scar, esito chronicled. Gate-5 surface.

### Scope decision (master-dd verdict)

Verify-first finding surfaced + ratified: there is **no backend campaign resource pool** (the campaign object + `godotV2State` carry no PE/PI; resources are Godot/client-owned). So **resource cost (SPEC-E E6) is NOT backend-enforceable** today. Verdict = build the mechanism + chronicle, **defer cost-enforcement** to SPEC-E/Godot. No cost values fixed here (premature while the resource SoT is client-side).

### Out of scope (forward-work)

- Resource-cost enforcement (SPEC-E E6) -- gated on a resource SoT.
- The `transform` mechanical trait/mutation grant (currently a narrative mark) -- balance / SPEC-E.
- Device-ownership UI (SPEC-K 7.6) -- item-3 Godot.

### Band impact: NEUTRAL

The endpoint is a player-action surface; no automatic combat/meta sim path calls it. combat-oracle + meta-loop-oracle unaffected (a scar only exists after a `grave` KO; healing it is an explicit between-encounter action).

### Tests

- `nidoRitual` 12/12, `nidoRitualWire` 4/4, `chronicleEmitters` +6 (29/29).
- Regression: AI suite **543/543**, combat/session/chronicle green, `format:check` clean.

### Rollback (03A)

Pure-additive (new service + new endpoint + 2 chronicle types). Revert the squash commit -> zero residue (no migration, no schema, no data, no flag).
