### PR TITLE
feat(spec-j): lethal consent state machine + coop transport (PR2)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -509,6 +509,62 @@ function createCoopRouter({
     }
   });
 
+  // SPEC-J sez.5 -- host opens a lethal-consent round. The host (TV), having a
+  // lethal-flagged mission, supplies the at-risk player ids (those whose creature
+  // participates, SPEC-K 6.4). The server opens the round on the orchestrator +
+  // broadcasts the anonymous waiting snapshot (`lethal_consent_open`, F5: counts
+  // only). Players then confirm via the `lethal_consent_confirm` WS intent. The
+  // round resolves to `granted` only when EVERY at-risk player confirms; anti-
+  // deadlock (timeout / delivery-fail) resolves to soft (NON parte lethal).
+  router.post('/coop/lethal/open', (req, res) => {
+    const {
+      code,
+      host_token: hostToken,
+      at_risk_player_ids: atRisk,
+      timeout_ms: timeoutMs,
+    } = req.body || {};
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    // Codex/coop-validator: empty (or all-non-string) at-risk would trivially
+    // grant -> lethal would proceed with NOBODY having confirmed. A lethal
+    // mission MUST name its at-risk players; reject otherwise (mirror route/open).
+    const ids = Array.isArray(atRisk) ? atRisk.filter((x) => typeof x === 'string' && x) : [];
+    if (ids.length === 0) {
+      return res
+        .status(400)
+        .json({ error: 'at_risk_player_ids richiesto (array di id non vuoto)' });
+    }
+    try {
+      const snap = orch.openLethalConsent(ids, { timeoutMs });
+      room.broadcast({ type: 'lethal_consent_open', payload: snap });
+      return res.json({ ok: true, consent: snap });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'lethal_open_failed' });
+    }
+  });
+
+  // SPEC-J sez.5 -- host aborts a stuck lethal-consent round (deterministic
+  // anti-deadlock escape: the always-on TV arbiter can always resolve a round
+  // where a player never responds). Resolves the pending round to soft (NON
+  // parte lethal) + broadcasts the resolution. The AUTOMATIC timeout timer
+  // (sez.5 trigger a) is a follow-up; this guarantees "mai loop bloccato" now.
+  router.post('/coop/lethal/cancel', (req, res) => {
+    const { code, host_token: hostToken } = req.body || {};
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    const snap = orch.evalLethalConsentTimeout({ deliveryFailed: true });
+    if (!snap) return res.status(409).json({ error: 'no_consent_round_open' });
+    room.broadcast({
+      type: 'lethal_consent_resolved',
+      payload: { outcome: orch.lethalConsentOutcome(), consent: snap },
+    });
+    return res.json({ ok: true, outcome: orch.lethalConsentOutcome(), consent: snap });
+  });
+
   return router;
 }
 

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -12,6 +12,7 @@ const { checkNidoUnlock } = require('../../routes/sessionHelpers');
 const { emergeBrancoTraitFromPulses } = require('../identity/brancoTraitEmergence');
 const { emergeIdentity, emitCreatureNamed } = require('../identity/identityService');
 const { aggregateFormPulses } = require('../formPulseVc');
+const consentSM = require('./lethalConsent');
 
 // CAMP-1/CAMP-2 - run.id is the SistemaState persistence key (server writes
 // SistemaState under run.id; Godot client keys CampaignState.campaign_id on
@@ -163,6 +164,10 @@ class CoopOrchestrator {
     // PR-1 §22 coop-WS surface — combat session id (POST /api/session/start)
     // linked back via coopStore.linkSession so phase_change can surface it.
     this.sessionId = null;
+    // SPEC-J sez.5 -- per-player lethal-consent round (pure state in lethalConsent.js).
+    // null = no round open. Set by openLethalConsent; the anonymous snapshot is
+    // what the coop transport broadcasts (F5: no per-player roster).
+    this.lethalConsent = null;
   }
 
   _getWorldEnricher() {
@@ -280,6 +285,7 @@ class CoopOrchestrator {
     this.creatureIdentities.clear();
     this.onboardingChoice = null;
     this.onboardingChoices.clear();
+    this.lethalConsent = null; // SPEC-J: never carry a consent round across runs
     this._setPhase('character_creation');
     this._emit('run_started', { run_id: this.run.id });
     return this.run;
@@ -323,6 +329,7 @@ class CoopOrchestrator {
     this.creatureIdentities.clear();
     this.onboardingChoice = null;
     this.onboardingChoices.clear();
+    this.lethalConsent = null; // SPEC-J: never carry a consent round across runs
     this._setPhase('onboarding');
     this._emit('run_started', { run_id: this.run.id, with_onboarding: true });
     return this.run;
@@ -957,6 +964,70 @@ class CoopOrchestrator {
       tally.all_connected_voted = connected.length > 0 && connectedVoted === connected.length;
     }
     return tally;
+  }
+
+  // === SPEC-J sez.5 -- lethal consent (per-player device confirm, NOT quorum) ===
+
+  /**
+   * Open a lethal-consent round for the at-risk players (those whose creature
+   * participates in the lethal mission, SPEC-K 6.4). Host-initiated (the route
+   * layer authorizes). Emits `lethal_consent_open` with the anonymous snapshot.
+   * @returns the anonymous snapshot (F5: counts only).
+   */
+  openLethalConsent(atRiskPlayerIds = [], { timeoutMs } = {}) {
+    this.lethalConsent = consentSM.open(atRiskPlayerIds, { now: this.now(), timeoutMs });
+    const snap = consentSM.snapshot(this.lethalConsent);
+    this._emit('lethal_consent_open', snap);
+    return snap;
+  }
+
+  /**
+   * An at-risk player confirms (WS intent, socket-bound identity). Emits
+   * `lethal_consent_confirmed`; when the round resolves to `granted` it also
+   * emits `lethal_consent_resolved`. Throws when no round is open.
+   * @returns the anonymous snapshot.
+   */
+  confirmLethalConsent(playerId) {
+    if (!this.lethalConsent) throw new Error('lethal_consent_not_open');
+    const before = this.lethalConsent.status;
+    this.lethalConsent = consentSM.confirm(this.lethalConsent, playerId, { now: this.now() });
+    const snap = consentSM.snapshot(this.lethalConsent);
+    this._emit('lethal_consent_confirmed', snap);
+    if (before === 'pending' && this.lethalConsent.status === 'granted') {
+      this._emit('lethal_consent_resolved', { outcome: 'granted', snapshot: snap });
+    }
+    return snap;
+  }
+
+  /**
+   * Anti-deadlock sweep (sez.5): resolve a still-pending round to soft when the
+   * timeout has elapsed (post delivery-receipt) or delivery failed. Emits
+   * `lethal_consent_resolved` on a soft resolution. Safe to call repeatedly.
+   * @returns the anonymous snapshot.
+   */
+  evalLethalConsentTimeout({ deliveryFailed = false } = {}) {
+    if (!this.lethalConsent) return null;
+    const before = this.lethalConsent.status;
+    if (deliveryFailed) this.lethalConsent = consentSM.markDeliveryFailed(this.lethalConsent);
+    this.lethalConsent = consentSM.evalTimeout(this.lethalConsent, { now: this.now() });
+    const snap = consentSM.snapshot(this.lethalConsent);
+    if (before === 'pending' && this.lethalConsent.status !== 'pending') {
+      this._emit('lethal_consent_resolved', {
+        outcome: consentSM.outcome(this.lethalConsent),
+        snapshot: snap,
+      });
+    }
+    return snap;
+  }
+
+  /** Anonymous snapshot (F5) of the current round, or null when none is open. */
+  lethalConsentSnapshot() {
+    return this.lethalConsent ? consentSM.snapshot(this.lethalConsent) : null;
+  }
+
+  /** 'granted' only when every at-risk player confirmed; else 'soft'. */
+  lethalConsentOutcome() {
+    return consentSM.outcome(this.lethalConsent);
   }
 
   /**

--- a/apps/backend/services/coop/lethalConsent.js
+++ b/apps/backend/services/coop/lethalConsent.js
@@ -1,0 +1,139 @@
+// =============================================================================
+// SPEC-J sez.5 -- lethal consent state machine.
+//
+// Spec: docs/design/evo-tactics-lethal-wounds-rituals.md (sez.5 + sez.8;
+// reconstruction point-9). A lethal mission needs the device confirm of EVERY
+// player whose creature participates ("a rischio") -- per-player, NOT a quorum
+// (SPEC-K 6.4).
+//
+// Anti-deadlock (sez.5, two distinct fallback triggers):
+//   (a) device online but no response -> timeout after delivery-receipt -> soft;
+//   (b) delivery FAILED (offline / retries exhausted) -> IMMEDIATE soft fallback.
+// Fallback default = NON parte lethal (soft-death). Mai loop bloccato.
+//
+// Visibility (SPEC-B 3.10 / F5): the `snapshot` is anonymous/aggregated -- counts
+// only, never the roster of who confirmed / who is pending.
+//
+// Pure: no transport, no time source of its own (caller injects `now`). The
+// timeout VALUE is a tuning design-call (master-dd); here it is a parameter with
+// a PROPOSED default -- the state-machine logic is value-neutral.
+// =============================================================================
+
+'use strict';
+
+// PROPOSED default (master-dd to ratify). 120s: long enough for a player to read
+// the non-silenceable prompt + confirm on their device, short enough to not
+// stall the table. Tuning value, not a balance lever.
+const DEFAULT_TIMEOUT_MS = 120000;
+
+const SOFT_STATUSES = new Set(['pending', 'timeout_soft', 'fallback_soft']);
+
+/**
+ * Open a consent round for the at-risk players (deduped, non-empty strings).
+ * No at-risk players -> trivially `granted` (nobody to consent).
+ */
+function open(atRiskPlayerIds, { now = 0, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const at_risk = [
+    ...new Set(
+      (Array.isArray(atRiskPlayerIds) ? atRiskPlayerIds : []).filter(
+        (x) => typeof x === 'string' && x,
+      ),
+    ),
+  ];
+  return {
+    at_risk,
+    confirmed: {},
+    opened_at: Number(now) || 0,
+    timeout_ms: Number.isFinite(Number(timeoutMs)) ? Number(timeoutMs) : DEFAULT_TIMEOUT_MS,
+    delivery_failed: false,
+    status: at_risk.length === 0 ? 'granted' : 'pending',
+    resolved_at: at_risk.length === 0 ? Number(now) || 0 : null,
+  };
+}
+
+function _allConfirmed(state) {
+  return state.at_risk.length > 0 && state.at_risk.every((id) => state.confirmed[id]);
+}
+
+/**
+ * An at-risk player confirms. Non-at-risk ids are ignored (a player cannot
+ * consent on another's behalf). Idempotent: a re-confirm keeps the first ts and
+ * does not re-resolve. Resolving to `granted` only happens from `pending`.
+ */
+function confirm(state, playerId, { now = 0 } = {}) {
+  if (!state || state.status !== 'pending') return state;
+  if (!state.at_risk.includes(playerId)) return state;
+  const next = { ...state, confirmed: { ...state.confirmed } };
+  if (next.confirmed[playerId] === undefined) next.confirmed[playerId] = Number(now) || 0;
+  if (_allConfirmed(next)) {
+    next.status = 'granted';
+    next.resolved_at = Number(now) || 0;
+  }
+  return next;
+}
+
+/** Anti-deadlock trigger (b): mark delivery as failed (offline / retries out). */
+function markDeliveryFailed(state) {
+  if (!state || state.status !== 'pending') return state;
+  return { ...state, delivery_failed: true };
+}
+
+/**
+ * Anti-deadlock evaluation. Only acts on a still-`pending` round:
+ *   - delivery failed -> immediate `fallback_soft`;
+ *   - else now-opened_at >= timeout_ms -> `timeout_soft`.
+ * A resolved (`granted`/soft) round is never downgraded.
+ */
+function evalTimeout(state, { now = 0 } = {}) {
+  if (!state || state.status !== 'pending') return state;
+  if (state.delivery_failed) {
+    return { ...state, status: 'fallback_soft', resolved_at: Number(now) || 0 };
+  }
+  if ((Number(now) || 0) - state.opened_at >= state.timeout_ms) {
+    return { ...state, status: 'timeout_soft', resolved_at: Number(now) || 0 };
+  }
+  return state;
+}
+
+/** Anonymous aggregate (F5): counts only, never the per-player roster. */
+function snapshot(state) {
+  if (!state)
+    return {
+      total: 0,
+      confirmed_count: 0,
+      pending_count: 0,
+      all_confirmed: false,
+      status: 'pending',
+    };
+  const total = state.at_risk.length;
+  const confirmed_count = state.at_risk.filter((id) => state.confirmed[id]).length;
+  return {
+    total,
+    confirmed_count,
+    pending_count: Math.max(0, total - confirmed_count),
+    all_confirmed: total > 0 && confirmed_count === total,
+    status: state.status,
+  };
+}
+
+/** 'granted' only when every at-risk player confirmed; every soft state -> 'soft'. */
+function outcome(state) {
+  if (!state) return 'soft';
+  return state.status === 'granted' ? 'granted' : 'soft';
+}
+
+function isGranted(state) {
+  return outcome(state) === 'granted';
+}
+
+module.exports = {
+  DEFAULT_TIMEOUT_MS,
+  SOFT_STATUSES,
+  open,
+  confirm,
+  markDeliveryFailed,
+  evalTimeout,
+  snapshot,
+  outcome,
+  isGranted,
+};

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1784,6 +1784,48 @@ function createWsServer({
             }
             return;
           }
+          // SPEC-J sez.5 — drain lethal_consent_confirm intents (per-player
+          // device confirm, socket-bound identity; NOT quorum). Phone sends
+          // { action: 'lethal_consent_confirm' } after the host opened the round
+          // (POST /coop/lethal/open). Broadcasts the anonymous waiting snapshot
+          // (lethal_consent_waiting, F5) + acks. A non-at-risk confirm is a no-op
+          // (the orchestrator ignores it). No open round -> lethal_consent_not_open.
+          if (action === 'lethal_consent_confirm' && coopStore) {
+            try {
+              const orch = coopStore.get(room.code);
+              if (!orch) {
+                socket.send(
+                  JSON.stringify({ type: 'error', payload: { code: 'run_not_started' } }),
+                );
+                return;
+              }
+              const snap = orch.confirmLethalConsent(playerId);
+              room.broadcast({ type: 'lethal_consent_waiting', payload: snap });
+              // When the last at-risk player confirms, surface the resolution
+              // explicitly so clients dismiss the waiting UI (don't make them
+              // parse `status` out of the waiting snapshot).
+              if (snap.status === 'granted') {
+                room.broadcast({
+                  type: 'lethal_consent_resolved',
+                  payload: { outcome: 'granted', consent: snap },
+                });
+              }
+              socket.send(
+                JSON.stringify({
+                  type: 'lethal_consent_confirm_accepted',
+                  payload: { consent: snap },
+                }),
+              );
+            } catch (err) {
+              socket.send(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { code: err.message || 'lethal_consent_confirm_failed' },
+                }),
+              );
+            }
+            return;
+          }
           // 2026-05-06 phone smoke W6 fix — drain lineage_choice (debrief
           // phase) server-side via coopOrchestrator.submitDebriefChoice.
           // Pre-fix the intent was relayed to host Godot → silent drop,

--- a/tests/api/coopLethalConsentOpen.test.js
+++ b/tests/api/coopLethalConsentOpen.test.js
@@ -1,0 +1,141 @@
+// SPEC-J sez.5 -- POST /api/coop/lethal/open: the host opens a per-player
+// lethal-consent round and the server broadcasts the anonymous waiting snapshot
+// (lethal_consent_open, F5: counts only). Players then confirm via the
+// lethal_consent_confirm WS intent (orchestrator-tested separately). Mirrors
+// coopRouteChoiceBroadcast.test.js (host posts -> broadcast to phones).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const broadcasts = [];
+  const origGetRoom = lobby.getRoom.bind(lobby);
+  lobby.getRoom = function (code) {
+    const room = origGetRoom(code);
+    if (room && !room.__broadcastWrapped) {
+      const origBroadcast = room.broadcast.bind(room);
+      room.broadcast = function (msg) {
+        broadcasts.push({ code, msg });
+        return origBroadcast(msg);
+      };
+      room.__broadcastWrapped = true;
+    }
+    return room;
+  };
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app, lobby, coopStore, broadcasts };
+}
+
+async function setupRun(app) {
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'TV', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  await request(app).post('/api/lobby/join').send({ code, player_name: 'P1' });
+  await request(app)
+    .post('/api/coop/run/start')
+    .send({ code, host_token: hostToken, scenario_stack: ['enc_demo_01'] });
+  return { code, hostToken };
+}
+
+test('POST /coop/lethal/open: broadcasts anonymous lethal_consent_open snapshot', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupRun(app);
+  broadcasts.length = 0;
+  const res = await request(app)
+    .post('/api/coop/lethal/open')
+    .send({ code, host_token: hostToken, at_risk_player_ids: ['p1', 'p2'], timeout_ms: 5000 });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.ok, true);
+  assert.equal(res.body.consent.total, 2);
+  assert.equal(res.body.consent.confirmed_count, 0);
+  const ev = broadcasts.find((b) => b.msg.type === 'lethal_consent_open');
+  assert.ok(ev, 'lethal_consent_open must be broadcast');
+  assert.equal(ev.msg.payload.total, 2);
+  assert.equal(ev.msg.payload.status, 'pending');
+  // F5: the broadcast must NOT leak the per-player roster.
+  assert.equal(ev.msg.payload.at_risk, undefined);
+});
+
+test('POST /coop/lethal/open: empty at-risk -> 400 (must NOT trivially grant lethal)', async () => {
+  const { app } = buildApp();
+  const { code, hostToken } = await setupRun(app);
+  const res = await request(app)
+    .post('/api/coop/lethal/open')
+    .send({ code, host_token: hostToken, at_risk_player_ids: [] });
+  assert.equal(res.status, 400);
+});
+
+test('POST /coop/lethal/open: all-non-string at-risk -> 400 (no empty-grant via type hole)', async () => {
+  const { app } = buildApp();
+  const { code, hostToken } = await setupRun(app);
+  const res = await request(app)
+    .post('/api/coop/lethal/open')
+    .send({ code, host_token: hostToken, at_risk_player_ids: [1, 2, null] });
+  assert.equal(res.status, 400);
+});
+
+test('POST /coop/lethal/open: missing at_risk_player_ids -> 400', async () => {
+  const { app } = buildApp();
+  const { code, hostToken } = await setupRun(app);
+  const res = await request(app)
+    .post('/api/coop/lethal/open')
+    .send({ code, host_token: hostToken });
+  assert.equal(res.status, 400);
+});
+
+test('POST /coop/lethal/cancel: host aborts a stuck round -> soft + broadcast (no hang)', async () => {
+  const { app, broadcasts } = buildApp();
+  const { code, hostToken } = await setupRun(app);
+  await request(app)
+    .post('/api/coop/lethal/open')
+    .send({ code, host_token: hostToken, at_risk_player_ids: ['p1', 'p2'] });
+  broadcasts.length = 0;
+  const res = await request(app)
+    .post('/api/coop/lethal/cancel')
+    .send({ code, host_token: hostToken });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.outcome, 'soft', 'abort resolves to soft (NON parte lethal)');
+  const ev = broadcasts.find((b) => b.msg.type === 'lethal_consent_resolved');
+  assert.ok(ev, 'lethal_consent_resolved broadcast');
+  assert.equal(ev.msg.payload.outcome, 'soft');
+});
+
+test('POST /coop/lethal/cancel: missing host_token -> 403', async () => {
+  const { app } = buildApp();
+  const { code } = await setupRun(app);
+  const res = await request(app).post('/api/coop/lethal/cancel').send({ code });
+  assert.equal(res.status, 403);
+});
+
+test('POST /coop/lethal/open: missing host_token -> 403', async () => {
+  const { app } = buildApp();
+  const { code } = await setupRun(app);
+  const res = await request(app)
+    .post('/api/coop/lethal/open')
+    .send({ code, at_risk_player_ids: ['p1'] });
+  assert.equal(res.status, 403);
+});
+
+test('POST /coop/lethal/open: run not started -> 409', async () => {
+  const { app } = buildApp();
+  let r = await request(app).post('/api/lobby/create').send({ host_name: 'TV', max_players: 4 });
+  const code = r.body.code;
+  const hostToken = r.body.host_token;
+  const res = await request(app)
+    .post('/api/coop/lethal/open')
+    .send({ code, host_token: hostToken, at_risk_player_ids: ['p1'] });
+  assert.equal(res.status, 409);
+});

--- a/tests/services/coop/coopOrchestratorLethalConsent.test.js
+++ b/tests/services/coop/coopOrchestratorLethalConsent.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+// SPEC-J sez.5 -- CoopOrchestrator lethal-consent integration. Wraps the pure
+// lethalConsent state machine with the orchestrator's event stream (_emit) so
+// the coop transport (REST open + WS confirm intent) can drive it and broadcast
+// the anonymous waiting snapshot.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
+
+// The orchestrator exposes a listener set via _listeners (most coop tests use
+// orch.subscribe). Provide a resilient hookup that works with either.
+function listen(orch) {
+  const events = [];
+  if (typeof orch.subscribe === 'function') orch.subscribe((e) => events.push(e));
+  else orch._listeners.add((e) => events.push(e));
+  return events;
+}
+
+test('openLethalConsent: opens a pending round + emits lethal_consent_open', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1', now: () => 100 });
+  const events = listen(orch);
+  const snap = orch.openLethalConsent(['p1', 'p2'], { timeoutMs: 5000 });
+  assert.equal(snap.total, 2);
+  assert.equal(snap.confirmed_count, 0);
+  assert.equal(snap.status, 'pending');
+  assert.ok(events.some((e) => e.kind === 'lethal_consent_open'));
+});
+
+test('confirmLethalConsent: all at-risk confirm -> granted + resolved event', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1', now: () => 1 });
+  const events = listen(orch);
+  orch.openLethalConsent(['p1', 'p2'], { timeoutMs: 5000 });
+  orch.confirmLethalConsent('p1');
+  assert.equal(orch.lethalConsentOutcome(), 'soft'); // not all yet
+  const snap = orch.confirmLethalConsent('p2');
+  assert.equal(snap.all_confirmed, true);
+  assert.equal(orch.lethalConsentOutcome(), 'granted');
+  assert.ok(events.some((e) => e.kind === 'lethal_consent_confirmed'));
+  assert.ok(events.some((e) => e.kind === 'lethal_consent_resolved'));
+});
+
+test('confirmLethalConsent: throws when no round is open', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  assert.throws(() => orch.confirmLethalConsent('p1'), /lethal_consent_not_open/);
+});
+
+test('evalLethalConsentTimeout: timeout -> soft + resolved event', () => {
+  const clock = { t: 0 };
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1', now: () => clock.t });
+  const events = listen(orch);
+  orch.openLethalConsent(['p1'], { timeoutMs: 1000 });
+  clock.t = 1000;
+  const snap = orch.evalLethalConsentTimeout();
+  assert.equal(snap.status, 'timeout_soft');
+  assert.equal(orch.lethalConsentOutcome(), 'soft');
+  assert.ok(events.some((e) => e.kind === 'lethal_consent_resolved'));
+});
+
+test('evalLethalConsentTimeout: delivery failed -> immediate soft fallback', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1', now: () => 0 });
+  orch.openLethalConsent(['p1'], { timeoutMs: 999999 });
+  const snap = orch.evalLethalConsentTimeout({ deliveryFailed: true });
+  assert.equal(snap.status, 'fallback_soft');
+  assert.equal(orch.lethalConsentOutcome(), 'soft');
+});
+
+test('lethalConsentSnapshot: null-safe before any round', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  assert.equal(orch.lethalConsentSnapshot(), null);
+  assert.equal(orch.lethalConsentOutcome(), 'soft');
+});
+
+test('startRun clears a stale consent round (no carry-over across runs)', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1', now: () => 0 });
+  orch.openLethalConsent(['p1'], { timeoutMs: 5000 });
+  assert.ok(orch.lethalConsentSnapshot());
+  orch.startRun({ scenarioStack: ['e1'] });
+  assert.equal(orch.lethalConsentSnapshot(), null, 'pending round must not survive a new run');
+});
+
+test('evalLethalConsentTimeout (deliveryFailed) resolves a pending round to soft (host-cancel path)', () => {
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1', now: () => 0 });
+  const events = listen(orch);
+  orch.openLethalConsent(['p1', 'p2'], { timeoutMs: 999999 });
+  const snap = orch.evalLethalConsentTimeout({ deliveryFailed: true });
+  assert.equal(snap.status, 'fallback_soft');
+  assert.equal(orch.lethalConsentOutcome(), 'soft');
+  assert.ok(events.some((e) => e.kind === 'lethal_consent_resolved'));
+});

--- a/tests/services/coop/lethalConsent.test.js
+++ b/tests/services/coop/lethalConsent.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+// SPEC-J sez.5 -- lethal consent state machine (per-player device confirm, NOT
+// quorum; SPEC-K 6.4). Pure: no transport. Anti-deadlock (sez.5): two distinct
+// fallback triggers -- (a) timeout post delivery-receipt, (b) delivery failed
+// -> immediate fallback. Fallback default = NON parte lethal (soft). The
+// snapshot is anonymous/aggregated (F5: no names, just counts).
+//
+// The timeout VALUE is a tuning design-call (master-dd); here it is a parameter
+// with a PROPOSED default -- the state machine logic is value-neutral.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const lc = require('../../../apps/backend/services/coop/lethalConsent');
+
+// --- open ----------------------------------------------------------------
+
+test('open: pending with the dedup-ed at-risk roster', () => {
+  const s = lc.open(['p1', 'p2', 'p2', '', null], { now: 1000, timeoutMs: 5000 });
+  assert.deepEqual(s.at_risk, ['p1', 'p2']);
+  assert.equal(s.status, 'pending');
+  assert.equal(s.opened_at, 1000);
+  assert.equal(s.timeout_ms, 5000);
+});
+
+test('open: no at-risk players -> trivially granted (nobody to consent)', () => {
+  const s = lc.open([], { now: 0 });
+  assert.equal(s.status, 'granted');
+  assert.equal(lc.outcome(s), 'granted');
+});
+
+test('open: default timeout is a finite proposed value (design-call param)', () => {
+  const s = lc.open(['p1']);
+  assert.ok(Number.isFinite(s.timeout_ms) && s.timeout_ms > 0);
+});
+
+// --- confirm -------------------------------------------------------------
+
+test('confirm: an at-risk player confirms; all confirmed -> granted', () => {
+  let s = lc.open(['p1', 'p2'], { now: 0, timeoutMs: 5000 });
+  s = lc.confirm(s, 'p1', { now: 10 });
+  assert.equal(s.status, 'pending');
+  assert.equal(lc.outcome(s), 'soft'); // not all yet -> still soft
+  s = lc.confirm(s, 'p2', { now: 20 });
+  assert.equal(s.status, 'granted');
+  assert.equal(s.resolved_at, 20);
+  assert.equal(lc.outcome(s), 'granted');
+});
+
+test('confirm: a non-at-risk player is ignored (cannot grant for others)', () => {
+  let s = lc.open(['p1'], { now: 0 });
+  s = lc.confirm(s, 'intruder', { now: 5 });
+  assert.equal(s.status, 'pending');
+  assert.equal(Object.keys(s.confirmed).length, 0);
+});
+
+test('confirm: idempotent re-confirm does not double-resolve / change ts', () => {
+  let s = lc.open(['p1'], { now: 0 });
+  s = lc.confirm(s, 'p1', { now: 5 });
+  const firstResolved = s.resolved_at;
+  s = lc.confirm(s, 'p1', { now: 99 });
+  assert.equal(s.status, 'granted');
+  assert.equal(s.resolved_at, firstResolved); // unchanged
+});
+
+// --- anti-deadlock (sez.5) -----------------------------------------------
+
+test('evalTimeout: timeout post-receipt -> soft fallback (status timeout_soft)', () => {
+  let s = lc.open(['p1'], { now: 0, timeoutMs: 1000 });
+  s = lc.evalTimeout(s, { now: 999 });
+  assert.equal(s.status, 'pending'); // not yet
+  s = lc.evalTimeout(s, { now: 1000 });
+  assert.equal(s.status, 'timeout_soft');
+  assert.equal(lc.outcome(s), 'soft');
+});
+
+test('markDeliveryFailed + evalTimeout: delivery fail -> immediate soft fallback', () => {
+  let s = lc.open(['p1'], { now: 0, timeoutMs: 999999 });
+  s = lc.markDeliveryFailed(s);
+  s = lc.evalTimeout(s, { now: 1 }); // well before timeout
+  assert.equal(s.status, 'fallback_soft');
+  assert.equal(lc.outcome(s), 'soft');
+});
+
+test('evalTimeout: already granted is not downgraded by a late timeout check', () => {
+  let s = lc.open(['p1'], { now: 0, timeoutMs: 100 });
+  s = lc.confirm(s, 'p1', { now: 10 });
+  s = lc.evalTimeout(s, { now: 99999 });
+  assert.equal(s.status, 'granted');
+  assert.equal(lc.outcome(s), 'granted');
+});
+
+// --- snapshot (F5 anonymous aggregate) -----------------------------------
+
+test('snapshot: anonymous counts only, no player ids/names leaked', () => {
+  let s = lc.open(['p1', 'p2', 'p3'], { now: 0 });
+  s = lc.confirm(s, 'p1', { now: 1 });
+  const snap = lc.snapshot(s);
+  assert.equal(snap.total, 3);
+  assert.equal(snap.confirmed_count, 1);
+  assert.equal(snap.pending_count, 2);
+  assert.equal(snap.all_confirmed, false);
+  assert.equal(snap.status, 'pending');
+  // F5: no roster of who confirmed / who is pending.
+  assert.equal(snap.at_risk, undefined);
+  assert.equal(snap.confirmed, undefined);
+});
+
+// --- outcome / isGranted -------------------------------------------------
+
+test('isGranted: true only on granted, false on every soft state', () => {
+  assert.equal(lc.isGranted(lc.open([], { now: 0 })), true); // trivial
+  assert.equal(lc.isGranted(lc.open(['p1'], { now: 0 })), false); // pending
+});


### PR DESCRIPTION
## SPEC-J PR2 (backend) -- lethal consent state machine + coop transport

Implements SPEC-J sez.5/8 (consent flow + visibility). Per-player **device** confirm (SPEC-K 6.4) -- NOT a quorum: a lethal mission needs EVERY at-risk player to confirm. Continues #2789 (PR1) + #2790 (PR3).

### What

- **`services/coop/lethalConsent.js`** (new, pure state machine): `open` / `confirm` / `markDeliveryFailed` / `evalTimeout` / `snapshot` / `outcome` / `isGranted`.
  - Resolves to `granted` ONLY when every at-risk player confirms. A subset never grants; a non-at-risk confirm is a no-op.
  - **Anti-deadlock** (sez.5): timeout post-receipt OR delivery-fail -> `soft` (NON parte lethal). A `granted` round is never downgraded.
  - `snapshot` is **anonymous/aggregated** (F5): counts only -- never the roster of who confirmed / who is pending.
  - The timeout VALUE is a `timeoutMs` parameter (PROPOSED **120s** default) -- a tuning design-call, **master-dd to ratify**.
- **`coopOrchestrator.js`**: `openLethalConsent` / `confirmLethalConsent` / `evalLethalConsentTimeout` / `lethalConsentSnapshot` / `lethalConsentOutcome` (+ `_emit` events). Cleared on `startRun`/`startOnboarding`.
- **`routes/coop.js`**: `POST /coop/lethal/open` (host; rejects empty/non-string at-risk -> no empty-grant) + `POST /coop/lethal/cancel` (host deterministic anti-deadlock escape -> soft + broadcast).
- **`wsSession.js`**: `lethal_consent_confirm` WS intent (socket-bound player identity); broadcasts the anonymous `lethal_consent_waiting` + `lethal_consent_resolved` on grant.

### Adversarial review

Reviewed by the `coop-phase-validator` agent -> **3 P1 fixed**, each with a regression test:
1. empty/non-string at-risk would trivially grant lethal without any confirm -> route rejects with 400.
2. `lethalConsent` not cleared on a new run -> stale pending round carried over -> now cleared in `startRun`/`startOnboarding`.
3. no anti-deadlock escape wired -> host-cancel (`/coop/lethal/cancel`) guarantees "mai loop bloccato".

### Out of scope (next)

- **AUTOMATIC timeout timer** (sez.5 trigger a): host-cancel is the deterministic escape meanwhile; the unattended timer driver is a follow-up.
- **consent -> death bridge**: set the linked combat session's `lethalConsent.granted` so PR1's death gate activates -- a cross-module connector (session <-> coop), next PR.
- Godot device UI (consent prompt) = item-3. Timeout value + `LETHAL_MISSIONS_ENABLED` flip = master-dd.

### Band impact: NEUTRAL

No automatic caller opens a consent round; lethal stays default-OFF (PR1). The coop transport endpoints are reached only by an explicit host action.

### Tests

lethalConsent 11/11, orchestrator 8/8, coop REST 8/8, coop regression **313/313**, AI **543/543**, format clean.

### Rollback (03A)
Pure-additive (new module + new methods + 2 REST endpoints + 1 WS intent). Revert the squash commit -> zero residue (no migration/schema/data/flag).
