### PR TITLE
feat(spec-f): crossbreed/confirm commit route (slice 3)

### DIFF
--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -13,9 +13,10 @@
 // from this DI-clean router (NOT routes/skiv.js, the fs-json monitor):
 //   GET  /api/skiv/share/:lineage_id?format=json       — share-safe export card
 //   GET  /api/skiv/crossbreed/history/:lineage_id       — crossbreed log read
-//   POST /api/skiv/crossbreed                           — offspring proposal
-// Slice 3 (POST /crossbreed/confirm + cooldown/rate-limit) is gated on
-// unanswered design-calls — NOT built here.
+//   POST /api/skiv/crossbreed                           — offspring proposal (+ crossbreed_seed)
+//   POST /api/skiv/crossbreed/confirm                   — commit (persist + cooldown + rate-limit)
+// Slice 3 policies are ADR-2026-04-27 ratified (cooldown 1/campaign, rate-limit
+// 10/h IP, history FIFO cap 10) -- impl of ratified defaults, no open design-call.
 //
 // Auth: stateless (read-only data lookup, no mutation). Future hardening
 // can add JWT token check via shared AUTH_SECRET if exposed publicly.
@@ -23,9 +24,34 @@
 'use strict';
 
 const express = require('express');
+const crypto = require('crypto');
 const companionPickerDefault = require('../services/companion/companionPicker');
 const { sanitizeWhitelist, signatureFor } = require('../services/skiv/companionStateStore');
 const { rollMatingOffspring: rollMatingOffspringDefault } = require('../services/metaProgression');
+
+// SPEC-F slice 3 -- crossbreed offspring is rolled by the engine, but with a
+// SEEDED rng so the proposal preview (slice 2) and the committed confirm
+// (slice 3) produce the SAME offspring (genre signal: fusion preview-integrity).
+// mulberry32: a tiny self-contained deterministic stream from a 32-bit seed
+// (the combat pseudoRng is a process-global cursor, wrong shape for a per-request
+// seed). The proposal returns its seed; confirm reuses it.
+function makeSeededRng(seed) {
+  let a = Number(seed) >>> 0 || 1;
+  return function seededRng() {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomCrossbreedSeed() {
+  return crypto.randomBytes(4).readUInt32BE(0);
+}
+
+// ADR-2026-04-27 ratified defaults: crossbreed rate-limit 10/h per IP.
+const CROSSBREED_RATE_LIMIT = 10;
+const CROSSBREED_RATE_WINDOW_MS = 60 * 60 * 1000;
 
 function createCompanionRouter({
   companionPicker = companionPickerDefault,
@@ -33,6 +59,33 @@ function createCompanionRouter({
   rollMatingOffspring = rollMatingOffspringDefault,
 } = {}) {
   const router = express.Router();
+
+  // Per-router in-memory crossbreed/confirm rate-limit (10/h per IP, ADR-04-27).
+  // Per-instance so each test app + each backend process tracks independently.
+  const _crossbreedHits = new Map(); // ip -> number[] (ms timestamps within the window)
+  function crossbreedRateLimited(ip) {
+    const now = Date.now();
+    const key = ip || 'unknown';
+    const recent = (_crossbreedHits.get(key) || []).filter(
+      (t) => now - t < CROSSBREED_RATE_WINDOW_MS,
+    );
+    if (recent.length >= CROSSBREED_RATE_LIMIT) {
+      _crossbreedHits.set(key, recent);
+      return true;
+    }
+    recent.push(now);
+    _crossbreedHits.set(key, recent);
+    return false;
+  }
+
+  // Cooldown 1 crossbreed per campaign per lineage (ADR-04-27). Tracked IN-MEMORY
+  // (per-router), NOT on the crossbreed_history item: the ratified
+  // skiv_companion schema (packages/contracts, additionalProperties:false) does
+  // not model a campaign_id on the event, and that schema is a forbidden-path
+  // change. In-memory matches the rate-limit's durability (per-process / per-run);
+  // a durable cross-restart cooldown needs a contracts schema field = master-dd.
+  const _crossbreedCampaigns = new Set(); // `${campaignId}::${lineageId}`
+  const cooldownKey = (campaignId, lineageId) => `${campaignId}::${lineageId}`;
 
   /**
    * POST /api/companion/pick
@@ -215,6 +268,12 @@ function createCompanionRouter({
       return res.status(422).json({ error: 'crossbreed_requires_biological' });
     }
     // Step 4: roll offspring (engine-owned genetics, gene-encoder lineage chain).
+    // Seeded rng so the client can replay the EXACT same offspring at /confirm
+    // (preview-integrity): the seed is generated here and echoed back; /confirm
+    // accepts it. A client may also pass its own crossbreed_seed to re-preview.
+    const seed = Number.isFinite(Number(body.crossbreed_seed))
+      ? Number(body.crossbreed_seed)
+      : randomCrossbreedSeed();
     const biomeId = body.biome_id || local.biome_id || partner.biome_id || null;
     let result;
     try {
@@ -222,7 +281,7 @@ function createCompanionRouter({
         parentA: local,
         parentB: partner,
         biomeId,
-        context: { useGeneEncoder: true },
+        context: { useGeneEncoder: true, rng: makeSeededRng(seed) },
       });
     } catch (err) {
       return res
@@ -235,11 +294,128 @@ function createCompanionRouter({
         reason: (result && result.reason) || 'unknown',
       });
     }
-    // Step 5: propose only -- NO store write (slice 3 confirm is gated).
+    // Step 5: propose only -- NO store write (commit is /crossbreed/confirm).
     return res.json({
       proposal: result.offspring,
       tier: result.tier,
       visual_hints: result.visual_hints,
+      crossbreed_seed: seed,
+    });
+  });
+
+  /**
+   * POST /api/skiv/crossbreed/confirm
+   * Body: { lineage_id, partner_card_json, campaign_id, biome_id?, crossbreed_seed? }
+   *
+   * Crossbreed COMMIT (slice 3 -- persists). Re-runs the slice-2 validation
+   * gates (local exists, partner signature, both biological), then enforces the
+   * ADR-2026-04-27 ratified policies:
+   *   - rate-limit 10/h per IP (429 rate_limited);
+   *   - cooldown 1 per campaign (409 crossbreed_cooldown_active) -- tracked by
+   *     campaign_id on the persisted history entry;
+   * rolls the offspring with the (optionally client-supplied) crossbreed_seed so
+   * the committed creature matches the slice-2 preview, then appends a
+   * crossbreed event to crossbreed_history via store.addCrossbreedEvent (FIFO 10,
+   * = the Nido lineage record). A NEW playable lineage/ambassador from the
+   * offspring is SPEC-E follow-up; this records the event + returns the card.
+   */
+  router.post('/skiv/crossbreed/confirm', (req, res) => {
+    if (!requireStore(res)) return;
+    const body = req.body || {};
+    const lineageId = String(body.lineage_id || '');
+    const partner = body.partner_card_json;
+    const campaignId = body.campaign_id ? String(body.campaign_id) : '';
+    if (!partner || typeof partner !== 'object') {
+      return res.status(400).json({ error: 'partner_card_required' });
+    }
+    if (!campaignId) {
+      return res.status(400).json({ error: 'campaign_id_required' });
+    }
+    // Rate-limit BEFORE any store work (cheap abuse guard, ADR-04-27).
+    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    if (crossbreedRateLimited(ip)) {
+      return res.status(429).json({ error: 'rate_limited' });
+    }
+    let local;
+    try {
+      local = store.getCompanionState(lineageId);
+    } catch (err) {
+      return res
+        .status(500)
+        .json({ error: 'companion_crossbreed_failed', message: String(err.message || err) });
+    }
+    if (!local) {
+      return res.status(404).json({ error: 'lineage_not_found' });
+    }
+    let expectedSig;
+    try {
+      expectedSig = signatureFor(partner);
+    } catch (err) {
+      return res
+        .status(400)
+        .json({ error: 'partner_card_invalid', message: String(err.message || err) });
+    }
+    if (partner.companion_card_signature !== expectedSig) {
+      return res.status(400).json({ error: 'signature_mismatch' });
+    }
+    if (!local.species_id || !partner.species_id) {
+      return res.status(422).json({ error: 'crossbreed_requires_biological' });
+    }
+    // Cooldown 1/campaign (ADR-04-27): this campaign already crossbred this lineage.
+    if (_crossbreedCampaigns.has(cooldownKey(campaignId, lineageId))) {
+      return res.status(409).json({ error: 'crossbreed_cooldown_active' });
+    }
+    // Roll with the preview seed (or a fresh one) so confirm == the previewed offspring.
+    const seed = Number.isFinite(Number(body.crossbreed_seed))
+      ? Number(body.crossbreed_seed)
+      : randomCrossbreedSeed();
+    const biomeId = body.biome_id || local.biome_id || partner.biome_id || null;
+    let result;
+    try {
+      result = rollMatingOffspring({
+        parentA: local,
+        parentB: partner,
+        biomeId,
+        context: { useGeneEncoder: true, rng: makeSeededRng(seed) },
+      });
+    } catch (err) {
+      return res
+        .status(500)
+        .json({ error: 'companion_crossbreed_failed', message: String(err.message || err) });
+    }
+    if (!result || result.success === false) {
+      return res.status(422).json({
+        error: 'crossbreed_rejected',
+        reason: (result && result.reason) || 'unknown',
+      });
+    }
+    // Persist the crossbreed event into the lineage Nido record (FIFO 10).
+    // Schema-compliant fields ONLY (skiv_companion crossbreed_history item is
+    // additionalProperties:false): role / with_lineage_id / offspring_lineage_id /
+    // tier / biome_at_crossbreed. campaign_id + seed are NOT persisted here (not
+    // schema fields) -- the cooldown is tracked in-memory above.
+    try {
+      store.addCrossbreedEvent(lineageId, {
+        role: 'parent_a',
+        with_lineage_id: partner.lineage_id || null,
+        offspring_lineage_id: (result.offspring && result.offspring.lineage_id) || null,
+        tier: result.tier,
+        biome_at_crossbreed: biomeId,
+      });
+    } catch (err) {
+      return res
+        .status(500)
+        .json({ error: 'companion_crossbreed_failed', message: String(err.message || err) });
+    }
+    // Mark this campaign+lineage as having crossbred (cooldown 1/campaign).
+    _crossbreedCampaigns.add(cooldownKey(campaignId, lineageId));
+    return res.json({
+      confirmed: true,
+      offspring: result.offspring,
+      tier: result.tier,
+      visual_hints: result.visual_hints,
+      crossbreed_seed: seed,
+      history_count: (store.getCrossbreedHistory(lineageId) || []).length,
     });
   });
 

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -64,6 +64,16 @@ function makeStoreStub(seed = {}) {
       const s = states.get(lineageId);
       return s && Array.isArray(s.crossbreed_history) ? [...s.crossbreed_history] : [];
     },
+    // Slice 3 write path: append a crossbreed event to the lineage history
+    // (mirror of the real store.addCrossbreedEvent, FIFO cap 10).
+    addCrossbreedEvent(lineageId, event) {
+      const s = states.get(lineageId);
+      if (!s) throw new Error(`addCrossbreedEvent: no state for ${lineageId}`);
+      const ts = event.ts || '2026-06-17T00:00:00Z';
+      s.crossbreed_history = [...(s.crossbreed_history || []), { ...event, ts }].slice(-10);
+      states.set(lineageId, s);
+      return s;
+    },
     signatureFor,
     _states: states,
   };
@@ -334,4 +344,165 @@ test('POST /skiv/crossbreed missing partner_card_json → 400', async () => {
   const r = await postJson(app, '/api/skiv/crossbreed', { lineage_id: lineageId });
   assert.equal(r.status, 400);
   assert.equal(r.body.error, 'partner_card_required');
+});
+
+// ─── Slice 3: POST /api/skiv/crossbreed/confirm (persist + cooldown + rate-limit) ───
+
+const LINEAGE = 'skiv-savana-2026-0427-test';
+
+function rollStubOk() {
+  return (input) => ({
+    success: true,
+    offspring: { lineage_id: 'offspring-confirmed', gene_slots: {} },
+    tier: 'gold',
+    visual_hints: { glow: true },
+    _rng_is_fn: typeof input.context?.rng === 'function',
+  });
+}
+
+test('POST /skiv/crossbreed/confirm valid → 200 confirmed + PERSISTS to history', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  let captured = null;
+  const app = buildApp({
+    store,
+    rollMatingOffspring: (input) => {
+      captured = input;
+      return rollStubOk()(input);
+    },
+  });
+  const r = await postJson(app, '/api/skiv/crossbreed/confirm', {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+    biome_id: 'caverna',
+    campaign_id: 'camp-A',
+  });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.confirmed, true);
+  assert.equal(r.body.offspring.lineage_id, 'offspring-confirmed');
+  assert.equal(r.body.tier, 'gold'); // schema-valid engine tier (no-glow/gold/rainbow)
+  // engine got a seeded rng (preview-integrity) + a numeric crossbreed_seed echoed.
+  assert.equal(typeof captured.context.rng, 'function');
+  assert.equal(typeof r.body.crossbreed_seed, 'number');
+  // PERSISTED: schema-compliant event (skiv_companion item is
+  // additionalProperties:false -> with_lineage_id, NOT campaign_id/partner_lineage_id).
+  // Cooldown campaign_id is tracked in-memory, never on the history item.
+  const hist = store.getCrossbreedHistory(LINEAGE);
+  assert.equal(hist.length, 1);
+  assert.equal(hist[0].with_lineage_id, 'partner-lineage-9999');
+  assert.equal(hist[0].offspring_lineage_id, 'offspring-confirmed');
+  assert.equal(hist[0].campaign_id, undefined); // NOT persisted (schema-forbidden)
+});
+
+test('POST /skiv/crossbreed/confirm seed echo: a passed crossbreed_seed is reused (preview-match)', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const app = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  const r = await postJson(app, '/api/skiv/crossbreed/confirm', {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+    campaign_id: 'camp-seed',
+    crossbreed_seed: 123456,
+  });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.crossbreed_seed, 123456);
+});
+
+test('POST /skiv/crossbreed/confirm cooldown: 2nd confirm same campaign → 409', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const app = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  const body = {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+    campaign_id: 'camp-dup',
+  };
+  const r1 = await postJson(app, '/api/skiv/crossbreed/confirm', body);
+  assert.equal(r1.status, 200);
+  const r2 = await postJson(app, '/api/skiv/crossbreed/confirm', body);
+  assert.equal(r2.status, 409);
+  assert.equal(r2.body.error, 'crossbreed_cooldown_active');
+});
+
+test('POST /skiv/crossbreed/confirm different campaigns are allowed (cooldown is per-campaign)', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const app = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  const mk = (cid) => ({
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+    campaign_id: cid,
+  });
+  assert.equal((await postJson(app, '/api/skiv/crossbreed/confirm', mk('c1'))).status, 200);
+  assert.equal((await postJson(app, '/api/skiv/crossbreed/confirm', mk('c2'))).status, 200);
+});
+
+test('POST /skiv/crossbreed/confirm missing campaign_id → 400', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const app = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  const r = await postJson(app, '/api/skiv/crossbreed/confirm', {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+  });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'campaign_id_required');
+});
+
+test('POST /skiv/crossbreed/confirm rate-limit: 11th request in-window → 429', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const app = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  let last;
+  for (let i = 0; i < 11; i += 1) {
+    last = await postJson(app, '/api/skiv/crossbreed/confirm', {
+      lineage_id: LINEAGE,
+      partner_card_json: makePartnerCard(),
+      campaign_id: `camp-rl-${i}`, // distinct campaigns -> cooldown never trips
+    });
+  }
+  assert.equal(last.status, 429);
+  assert.equal(last.body.error, 'rate_limited');
+});
+
+test('POST /skiv/crossbreed/confirm re-uses the validation gates (404 / 400 / 422)', async () => {
+  // 404 unknown local
+  let app = buildApp({ store: makeStoreStub(), rollMatingOffspring: rollStubOk() });
+  let r = await postJson(app, '/api/skiv/crossbreed/confirm', {
+    lineage_id: 'nope',
+    partner_card_json: makePartnerCard(),
+    campaign_id: 'c',
+  });
+  assert.equal(r.status, 404);
+  // 400 signature mismatch
+  app = buildApp({
+    store: makeStoreStub({ [LINEAGE]: makeShareState() }),
+    rollMatingOffspring: rollStubOk(),
+  });
+  const bad = makePartnerCard();
+  bad.companion_card_signature = 'deadbeef'.repeat(8);
+  r = await postJson(app, '/api/skiv/crossbreed/confirm', {
+    lineage_id: LINEAGE,
+    partner_card_json: bad,
+    campaign_id: 'c',
+  });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'signature_mismatch');
+  // 422 narrative partner (no species_id)
+  app = buildApp({
+    store: makeStoreStub({ [LINEAGE]: makeShareState() }),
+    rollMatingOffspring: rollStubOk(),
+  });
+  r = await postJson(app, '/api/skiv/crossbreed/confirm', {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard({ species_id: undefined }),
+    campaign_id: 'c',
+  });
+  assert.equal(r.status, 422);
+  assert.equal(r.body.error, 'crossbreed_requires_biological');
+});
+
+test('POST /skiv/crossbreed (proposal, slice 2) now returns a crossbreed_seed for preview-match', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const app = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  const r = await postJson(app, '/api/skiv/crossbreed', {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+  });
+  assert.equal(r.status, 200);
+  assert.equal(typeof r.body.crossbreed_seed, 'number');
 });


### PR DESCRIPTION
## SPEC-F slice 3 -- POST /api/skiv/crossbreed/confirm

Commits a crossbreed (slices 0-2 propose/share/history shipped in #2783). Picked because the genre research (fusion mechanics: Cassette Beasts, Voidling) ranked crossbreed a high-value player-facing surface.

### What

- **Re-runs the slice-2 gates** (local 404 / partner signature 400 / both-biological 422), then enforces the **ADR-2026-04-27 ratified** policies: **rate-limit 10/h per IP** (429) + **cooldown 1 per campaign per lineage** (409).
- **Fusion preview-integrity**: offspring is rolled with a SEEDED rng (mulberry32) so `confirm` == the slice-2 preview. The proposal now returns `crossbreed_seed`; confirm reuses it. Persists via `store.addCrossbreedEvent` (Nido record, FIFO 10).

### Verify-first findings (anti-pattern #19)

- The handoff flagged '3 open design-calls' for slice 3 -- they are **RATIFIED defaults** (ADR-04-27: cooldown 1/campaign, rate-limit 10/h, history cap 10, diary opt-in), not open value-calls. Slice 3 = implementation, no master-dd value-call.
- `skiv_companion` `crossbreed_history` item is **`additionalProperties: false`** (allowed: role / with_lineage_id / offspring_lineage_id / tier [enum no-glow/gold/rainbow] / biome_at_crossbreed). Persisted events use ONLY schema fields -- verified by an AJV check + a real store+engine smoke (engine tier = `gold`, schema-valid).
- **`campaign_id` is NOT a schema field** -> the cooldown is tracked **in-memory** (per-router, like the rate-limit), holding within a process/run. A durable cross-restart cooldown needs a `packages/contracts` schema field = **forbidden-path = master-dd**.
- A new playable lineage/ambassador from the offspring = **SPEC-E follow-up**; this records the event + returns the offspring card.

### Band impact: NEUTRAL

No combat sim path (DI-stubbed engine + store in tests). `packages/contracts` NOT modified (forbidden-path respected).

### Tests

skivCustode 22/22 (+8 slice-3: persist, seed-echo, cooldown, per-campaign, missing-campaign 400, rate-limit 429, gate-reuse 404/400/422, proposal-seed), skiv/companion regression 63/63, AI 543/543.

### Residuals (gated)
Durable cooldown (contracts schema field = master-dd); offspring -> new playable lineage (SPEC-E); QR/card export format (v1 = JSON only).

### Rollback
Pure-additive (1 new route + proposal gains a field + 2 helpers). Revert the squash commit -> zero residue.