### PR TITLE
feat(spec-j): automatic lethal-consent timeout timer (sez.5 trigger-a)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -537,7 +537,18 @@ function createCoopRouter({
         .json({ error: 'at_risk_player_ids richiesto (array di id non vuoto)' });
     }
     try {
-      const snap = orch.openLethalConsent(ids, { timeoutMs });
+      // SPEC-J sez.5 trigger-(a): arm the automatic timeout. If no at-risk
+      // player responds before timeout_ms the orchestrator resolves the round
+      // to soft on its own and invokes onTimeout, which broadcasts the
+      // resolution so devices dismiss the waiting UI -- no host action needed
+      // ("mai loop bloccato"). The manual confirm (WS) / cancel (REST) paths
+      // broadcast themselves, so onTimeout fires ONLY from the timer.
+      const snap = orch.openLethalConsent(ids, {
+        timeoutMs,
+        onTimeout: (consent, outcome) => {
+          room.broadcast({ type: 'lethal_consent_resolved', payload: { outcome, consent } });
+        },
+      });
       room.broadcast({ type: 'lethal_consent_open', payload: snap });
       return res.json({ ok: true, consent: snap });
     } catch (err) {
@@ -548,8 +559,10 @@ function createCoopRouter({
   // SPEC-J sez.5 -- host aborts a stuck lethal-consent round (deterministic
   // anti-deadlock escape: the always-on TV arbiter can always resolve a round
   // where a player never responds). Resolves the pending round to soft (NON
-  // parte lethal) + broadcasts the resolution. The AUTOMATIC timeout timer
-  // (sez.5 trigger a) is a follow-up; this guarantees "mai loop bloccato" now.
+  // parte lethal) + broadcasts the resolution. Complements the AUTOMATIC timeout
+  // timer (sez.5 trigger a, armed at /coop/lethal/open): this is the immediate
+  // host-initiated override; the timer is the unattended fallback. Either way,
+  // "mai loop bloccato".
   router.post('/coop/lethal/cancel', (req, res) => {
     const { code, host_token: hostToken } = req.body || {};
     const room = authHost(code, hostToken);

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -93,11 +93,18 @@ class CoopOrchestrator {
     nidoUnlocked = false,
     chronicleBaseDir = null,
     namePool = null,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
   } = {}) {
     if (!roomCode) throw new Error('room_code_required');
     this.roomCode = roomCode;
     this.hostId = hostId || null;
     this.now = now;
+    // SPEC-J sez.5 trigger-(a) -- wall-clock scheduler for the automatic
+    // lethal-consent timeout (DI seam, default globals; tests inject a fake).
+    // Pure helpers stay time-source-free; only the auto-timer needs real time.
+    this._setTimeoutFn = typeof setTimeoutFn === 'function' ? setTimeoutFn : setTimeout;
+    this._clearTimeoutFn = typeof clearTimeoutFn === 'function' ? clearTimeoutFn : clearTimeout;
     // N1 Nido-hub — pre-seeded unlock flag (DI seam for tests + server-side
     // room construction). When true, debrief advance routes to 'nido' instead
     // of directly to world_setup. env NIDO_UNLOCKED=true also activates the
@@ -168,6 +175,9 @@ class CoopOrchestrator {
     // null = no round open. Set by openLethalConsent; the anonymous snapshot is
     // what the coop transport broadcasts (F5: no per-player roster).
     this.lethalConsent = null;
+    // SPEC-J sez.5 trigger-(a) -- handle of the one-shot auto-timeout timer for
+    // the open round (null = none scheduled). Cleared on any resolution / reset.
+    this._lethalConsentTimer = null;
   }
 
   _getWorldEnricher() {
@@ -285,6 +295,7 @@ class CoopOrchestrator {
     this.creatureIdentities.clear();
     this.onboardingChoice = null;
     this.onboardingChoices.clear();
+    this._clearLethalConsentTimer(); // SPEC-J: drop any armed auto-timeout
     this.lethalConsent = null; // SPEC-J: never carry a consent round across runs
     this._setPhase('character_creation');
     this._emit('run_started', { run_id: this.run.id });
@@ -329,6 +340,7 @@ class CoopOrchestrator {
     this.creatureIdentities.clear();
     this.onboardingChoice = null;
     this.onboardingChoices.clear();
+    this._clearLethalConsentTimer(); // SPEC-J: drop any armed auto-timeout
     this.lethalConsent = null; // SPEC-J: never carry a consent round across runs
     this._setPhase('onboarding');
     this._emit('run_started', { run_id: this.run.id, with_onboarding: true });
@@ -968,16 +980,67 @@ class CoopOrchestrator {
 
   // === SPEC-J sez.5 -- lethal consent (per-player device confirm, NOT quorum) ===
 
+  /** SPEC-J sez.5 trigger-(a) -- cancel the pending auto-timeout timer, if any. */
+  _clearLethalConsentTimer() {
+    if (this._lethalConsentTimer) {
+      this._clearTimeoutFn(this._lethalConsentTimer);
+      this._lethalConsentTimer = null;
+    }
+  }
+
   /**
    * Open a lethal-consent round for the at-risk players (those whose creature
    * participates in the lethal mission, SPEC-K 6.4). Host-initiated (the route
    * layer authorizes). Emits `lethal_consent_open` with the anonymous snapshot.
+   *
+   * SPEC-J sez.5 trigger-(a): for a `pending` round (>=1 at-risk player) this
+   * also arms a one-shot wall-clock timer at the round's `timeout_ms`. When it
+   * fires it auto-resolves the round to `timeout_soft` (NON parte lethal) with no
+   * host action -- the spec's "device online ma nessuna risposta -> timeout". The
+   * optional `onTimeout(snapshot, outcome)` callback lets the transport broadcast
+   * the resolution; it fires ONLY from the timer path (manual confirm/cancel
+   * paths broadcast themselves, so no double-broadcast). The timeout VALUE is a
+   * master-dd design-call (lethalConsent.DEFAULT_TIMEOUT_MS, PROPOSED); this only
+   * wires the firing.
    * @returns the anonymous snapshot (F5: counts only).
    */
-  openLethalConsent(atRiskPlayerIds = [], { timeoutMs } = {}) {
+  openLethalConsent(atRiskPlayerIds = [], { timeoutMs, onTimeout } = {}) {
+    this._clearLethalConsentTimer();
     this.lethalConsent = consentSM.open(atRiskPlayerIds, { now: this.now(), timeoutMs });
     const snap = consentSM.snapshot(this.lethalConsent);
     this._emit('lethal_consent_open', snap);
+    if (this.lethalConsent.status === 'pending' && this.lethalConsent.timeout_ms > 0) {
+      // Exact deadline captured at schedule time -> passed to the sweep as `now`
+      // so a sub-ms-early libuv fire still satisfies the elapsed check (see
+      // evalLethalConsentTimeout). Independent of state at fire time (which may
+      // have been reset to null by a run advance/reset).
+      const deadline = this.lethalConsent.opened_at + this.lethalConsent.timeout_ms;
+      const handle = this._setTimeoutFn(() => {
+        this._lethalConsentTimer = null;
+        // Re-validate via the shared sweep: only acts on a still-`pending`
+        // round, so a granted/already-soft round (race) is a no-op.
+        const before = this.lethalConsent && this.lethalConsent.status;
+        const resolved = this.evalLethalConsentTimeout({ now: deadline });
+        if (
+          typeof onTimeout === 'function' &&
+          before === 'pending' &&
+          this.lethalConsent &&
+          this.lethalConsent.status !== 'pending'
+        ) {
+          // State is already resolved; a transport failure here must never
+          // crash the timer callback (unhandled throw in setTimeout = process
+          // crash). Swallow like _emit does.
+          try {
+            onTimeout(resolved, consentSM.outcome(this.lethalConsent));
+          } catch {
+            // swallow transport error
+          }
+        }
+      }, this.lethalConsent.timeout_ms);
+      // Never let the auto-timeout keep the process alive (tests, graceful exit).
+      if (handle && typeof handle.unref === 'function') handle.unref();
+      this._lethalConsentTimer = handle;
+    }
     return snap;
   }
 
@@ -994,6 +1057,7 @@ class CoopOrchestrator {
     const snap = consentSM.snapshot(this.lethalConsent);
     this._emit('lethal_consent_confirmed', snap);
     if (before === 'pending' && this.lethalConsent.status === 'granted') {
+      this._clearLethalConsentTimer(); // round resolved -> auto-timeout moot
       this._emit('lethal_consent_resolved', { outcome: 'granted', snapshot: snap });
     }
     return snap;
@@ -1003,15 +1067,25 @@ class CoopOrchestrator {
    * Anti-deadlock sweep (sez.5): resolve a still-pending round to soft when the
    * timeout has elapsed (post delivery-receipt) or delivery failed. Emits
    * `lethal_consent_resolved` on a soft resolution. Safe to call repeatedly.
+   *
+   * `now` override: the auto-timer (sez.5 trigger-a) passes the exact round
+   * deadline (opened_at + timeout_ms). The firing is decided by libuv's
+   * monotonic clock while elapsed is measured against Date.now() -- the two can
+   * disagree by ~1ms, so a plain this.now() re-check could read elapsed as
+   * `timeout_ms - 1` and leave the round stuck pending forever (the "unattended
+   * fallback" silently fails). Pinning `now` to the deadline makes the timer's
+   * resolution deterministic. Defaults to this.now() for the manual paths.
    * @returns the anonymous snapshot.
    */
-  evalLethalConsentTimeout({ deliveryFailed = false } = {}) {
+  evalLethalConsentTimeout({ deliveryFailed = false, now } = {}) {
     if (!this.lethalConsent) return null;
     const before = this.lethalConsent.status;
     if (deliveryFailed) this.lethalConsent = consentSM.markDeliveryFailed(this.lethalConsent);
-    this.lethalConsent = consentSM.evalTimeout(this.lethalConsent, { now: this.now() });
+    const evalNow = now === undefined ? this.now() : now;
+    this.lethalConsent = consentSM.evalTimeout(this.lethalConsent, { now: evalNow });
     const snap = consentSM.snapshot(this.lethalConsent);
     if (before === 'pending' && this.lethalConsent.status !== 'pending') {
+      this._clearLethalConsentTimer(); // round resolved -> auto-timeout moot
       this._emit('lethal_consent_resolved', {
         outcome: consentSM.outcome(this.lethalConsent),
         snapshot: snap,
@@ -1272,6 +1346,10 @@ class CoopOrchestrator {
    */
   advanceScenarioOrEnd() {
     if (!this.run) throw new Error('no_run');
+    // SPEC-J: drop any armed auto-timeout before leaving the scenario (covers
+    // both the `ended` and `next_scenario` branches below; consent is per-
+    // scenario, the timer must never outlive its round).
+    this._clearLethalConsentTimer();
     this.run.currentIndex += 1;
     // M-2 -- run progression is the PROPOSED lifecycle proxy: emergence fires
     // here (scenario cleared / run complete), before phase transition, so the

--- a/apps/backend/services/coop/coopStore.js
+++ b/apps/backend/services/coop/coopStore.js
@@ -5,7 +5,7 @@
 
 const { CoopOrchestrator } = require('./coopOrchestrator');
 
-function createCoopStore({ lobby } = {}) {
+function createCoopStore({ lobby, orchestratorOptions = {} } = {}) {
   const orchestrators = new Map();
 
   function getOrCreate(roomCode) {
@@ -15,7 +15,10 @@ function createCoopStore({ lobby } = {}) {
       const room = lobby?.getRoom?.(code);
       orchestrators.set(
         code,
+        // orchestratorOptions = DI seam (e.g. setTimeoutFn for the SPEC-J
+        // auto-timeout in tests); roomCode/hostId always win.
         new CoopOrchestrator({
+          ...orchestratorOptions,
           roomCode: code,
           hostId: room?.hostId || null,
         }),
@@ -31,7 +34,15 @@ function createCoopStore({ lobby } = {}) {
 
   function remove(roomCode) {
     if (!roomCode) return false;
-    return orchestrators.delete(String(roomCode).toUpperCase());
+    const code = String(roomCode).toUpperCase();
+    // SPEC-J: drain any armed lethal-consent auto-timeout before evicting the
+    // orchestrator, else the timer closure pins the (now orphaned) orchestrator
+    // + room for up to timeout_ms and fires a broadcast into a dead room.
+    const orch = orchestrators.get(code);
+    if (orch && typeof orch._clearLethalConsentTimer === 'function') {
+      orch._clearLethalConsentTimer();
+    }
+    return orchestrators.delete(code);
   }
 
   function list() {

--- a/apps/backend/services/coop/lethalConsent.js
+++ b/apps/backend/services/coop/lethalConsent.js
@@ -44,7 +44,15 @@ function open(atRiskPlayerIds, { now = 0, timeoutMs = DEFAULT_TIMEOUT_MS } = {})
     at_risk,
     confirmed: {},
     opened_at: Number(now) || 0,
-    timeout_ms: Number.isFinite(Number(timeoutMs)) ? Number(timeoutMs) : DEFAULT_TIMEOUT_MS,
+    // Invariant: a consent round ALWAYS carries a positive timeout, so the
+    // auto-timeout (orchestrator sez.5 trigger-a) is always armable. A
+    // non-finite OR non-positive caller value (0 / negative) falls back to the
+    // PROPOSED default -- a "0 timeout" must never silently disable the
+    // unattended fallback and let a non-responsive device hang the round.
+    timeout_ms:
+      Number.isFinite(Number(timeoutMs)) && Number(timeoutMs) > 0
+        ? Number(timeoutMs)
+        : DEFAULT_TIMEOUT_MS,
     delivery_failed: false,
     status: at_risk.length === 0 ? 'granted' : 'pending',
     resolved_at: at_risk.length === 0 ? Number(now) || 0 : null,

--- a/tests/api/coopLethalConsentOpen.test.js
+++ b/tests/api/coopLethalConsentOpen.test.js
@@ -15,9 +15,9 @@ const { createCoopRouter } = require('../../apps/backend/routes/coop');
 const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
 const { LobbyService } = require('../../apps/backend/services/network/wsSession');
 
-function buildApp() {
+function buildApp({ orchestratorOptions } = {}) {
   const lobby = new LobbyService();
-  const coopStore = createCoopStore({ lobby });
+  const coopStore = createCoopStore({ lobby, orchestratorOptions });
   const broadcasts = [];
   const origGetRoom = lobby.getRoom.bind(lobby);
   lobby.getRoom = function (code) {
@@ -118,6 +118,42 @@ test('POST /coop/lethal/cancel: missing host_token -> 403', async () => {
   const { code } = await setupRun(app);
   const res = await request(app).post('/api/coop/lethal/cancel').send({ code });
   assert.equal(res.status, 403);
+});
+
+test('POST /coop/lethal/open: auto-timeout fires -> broadcasts soft resolution (sez.5 trigger-a, no host action)', async () => {
+  // Inject a fake scheduler into the orchestrator (via coopStore DI) so the
+  // auto-timeout is deterministic. fire() invokes the captured timer callback.
+  const timers = [];
+  const orchestratorOptions = {
+    now: () => 0,
+    setTimeoutFn(cb, delay) {
+      const h = { cb, delay, cleared: false, unref: () => h };
+      timers.push(h);
+      return h;
+    },
+    clearTimeoutFn(h) {
+      if (h) h.cleared = true;
+    },
+  };
+  const { app, broadcasts, coopStore } = buildApp({ orchestratorOptions });
+  const { code, hostToken } = await setupRun(app);
+  await request(app)
+    .post('/api/coop/lethal/open')
+    .send({ code, host_token: hostToken, at_risk_player_ids: ['p1', 'p2'], timeout_ms: 1000 });
+  broadcasts.length = 0;
+
+  // Player never responds; advance the orchestrator clock past the timeout and
+  // fire the armed timer (simulating wall-clock elapse).
+  coopStore.get(code).now = () => 1000;
+  assert.equal(timers.length, 1, 'auto-timeout timer armed at open');
+  timers[0].cb();
+
+  const ev = broadcasts.find((b) => b.msg.type === 'lethal_consent_resolved');
+  assert.ok(ev, 'auto-timeout broadcasts lethal_consent_resolved');
+  assert.equal(ev.msg.payload.outcome, 'soft', 'auto-timeout resolves to soft (NON parte lethal)');
+  assert.equal(ev.msg.payload.consent.status, 'timeout_soft');
+  // F5: the auto-resolution broadcast must NOT leak the per-player roster.
+  assert.equal(ev.msg.payload.consent.at_risk, undefined);
 });
 
 test('POST /coop/lethal/open: missing host_token -> 403', async () => {

--- a/tests/services/coop/coopOrchestratorLethalAutoTimer.test.js
+++ b/tests/services/coop/coopOrchestratorLethalAutoTimer.test.js
@@ -1,0 +1,283 @@
+'use strict';
+
+// SPEC-J sez.5 trigger-(a) -- automatic lethal-consent timeout timer.
+//
+// Until now the only way a still-`pending` consent round resolved was: every
+// at-risk player confirms (granted), the host aborts via POST /coop/lethal/cancel
+// (delivery-fail soft), or some caller manually pokes evalLethalConsentTimeout.
+// A device that is ONLINE but whose player simply never responds left the round
+// pending forever (the spec's trigger-(a): "device online ma nessuna risposta ->
+// timeout post delivery-receipt -> fallback"). This wires a one-shot wall-clock
+// timer at openLethalConsent that auto-resolves the round to `timeout_soft` after
+// the round's timeout_ms, with NO host intervention. "Mai loop bloccato."
+//
+// The scheduler (setTimeout/clearTimeout) is injected so the timer is testable
+// without real wall-clock. The timeout VALUE remains a master-dd design-call
+// (lethalConsent.DEFAULT_TIMEOUT_MS, PROPOSED); this only wires the firing.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../../apps/backend/services/coop/coopOrchestrator');
+const { createCoopStore } = require('../../../apps/backend/services/coop/coopStore');
+
+// Deterministic fake scheduler: setTimeoutFn records (cb, delay) and returns a
+// handle the test can fire/clear manually. unref() is a no-op stub so the
+// orchestrator's unref guard is exercised.
+function fakeScheduler() {
+  const timers = [];
+  return {
+    timers,
+    setTimeoutFn(cb, delay) {
+      const handle = { cb, delay, cleared: false, unrefed: false };
+      handle.unref = () => {
+        handle.unrefed = true;
+        return handle;
+      };
+      timers.push(handle);
+      return handle;
+    },
+    clearTimeoutFn(handle) {
+      if (handle) handle.cleared = true;
+    },
+    fire(handle) {
+      if (handle && !handle.cleared) handle.cb();
+    },
+  };
+}
+
+function listen(orch) {
+  const events = [];
+  orch._listeners.add((e) => events.push(e));
+  return events;
+}
+
+test('auto-timer: open schedules a one-shot timer at the round timeout_ms', () => {
+  const sched = fakeScheduler();
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => 0,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  orch.openLethalConsent(['p1', 'p2'], { timeoutMs: 5000 });
+  assert.equal(sched.timers.length, 1, 'one timer scheduled');
+  assert.equal(sched.timers[0].delay, 5000, 'delay = round timeout_ms');
+  assert.equal(sched.timers[0].unrefed, true, 'timer unref()ed so it never blocks process exit');
+});
+
+test('auto-timer: firing it auto-resolves a non-responsive round to timeout_soft', () => {
+  const clock = { t: 0 };
+  const sched = fakeScheduler();
+  const resolved = [];
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => clock.t,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  const events = listen(orch);
+  orch.openLethalConsent(['p1', 'p2'], {
+    timeoutMs: 1000,
+    onTimeout: (snapshot, outcome) => resolved.push({ snapshot, outcome }),
+  });
+  // Player never responds; wall-clock advances past the timeout, timer fires.
+  clock.t = 1000;
+  sched.fire(sched.timers[0]);
+
+  assert.equal(orch.lethalConsentSnapshot().status, 'timeout_soft');
+  assert.equal(orch.lethalConsentOutcome(), 'soft', 'lethal does NOT proceed');
+  assert.equal(resolved.length, 1, 'onTimeout fired exactly once');
+  assert.equal(resolved[0].outcome, 'soft');
+  assert.equal(resolved[0].snapshot.status, 'timeout_soft');
+  assert.ok(
+    events.some((e) => e.kind === 'lethal_consent_resolved'),
+    'emits lethal_consent_resolved',
+  );
+});
+
+test('auto-timer: all-confirm before the timer fires clears it (no soft override)', () => {
+  const clock = { t: 0 };
+  const sched = fakeScheduler();
+  const resolved = [];
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => clock.t,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  orch.openLethalConsent(['p1'], {
+    timeoutMs: 1000,
+    onTimeout: (snapshot, outcome) => resolved.push({ snapshot, outcome }),
+  });
+  orch.confirmLethalConsent('p1'); // last at-risk -> granted
+  assert.equal(orch.lethalConsentOutcome(), 'granted');
+  assert.equal(sched.timers[0].cleared, true, 'timer cleared on granted');
+
+  // Even a stray fire must NOT downgrade a granted round nor call onTimeout.
+  clock.t = 5000;
+  sched.fire(sched.timers[0]); // cleared -> fake no-op anyway
+  assert.equal(orch.lethalConsentOutcome(), 'granted');
+  assert.equal(resolved.length, 0, 'onTimeout never called after granted');
+});
+
+test('auto-timer: host cancel (delivery-fail) clears the timer', () => {
+  const sched = fakeScheduler();
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => 0,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  orch.openLethalConsent(['p1'], { timeoutMs: 1000 });
+  orch.evalLethalConsentTimeout({ deliveryFailed: true }); // cancel path
+  assert.equal(orch.lethalConsentOutcome(), 'soft');
+  assert.equal(sched.timers[0].cleared, true, 'timer cleared on cancel resolution');
+});
+
+test('auto-timer: starting a new run clears a dangling timer', () => {
+  const sched = fakeScheduler();
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => 0,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  orch.openLethalConsent(['p1'], { timeoutMs: 1000 });
+  orch.startRun({ scenarioStack: ['enc_a'] });
+  assert.equal(sched.timers[0].cleared, true, 'timer cleared on run reset');
+  assert.equal(orch.lethalConsentSnapshot(), null, 'consent round dropped on reset');
+});
+
+test('auto-timer: no at-risk players -> granted, no timer scheduled', () => {
+  const sched = fakeScheduler();
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => 0,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  const snap = orch.openLethalConsent([], { timeoutMs: 1000 });
+  assert.equal(snap.status, 'granted');
+  assert.equal(sched.timers.length, 0, 'no timer for a trivially-granted round');
+});
+
+test('auto-timer: re-opening clears the previous timer before scheduling a new one', () => {
+  const sched = fakeScheduler();
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => 0,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  orch.openLethalConsent(['p1'], { timeoutMs: 1000 });
+  orch.openLethalConsent(['p2'], { timeoutMs: 2000 });
+  assert.equal(sched.timers[0].cleared, true, 'first timer cleared on re-open');
+  assert.equal(sched.timers.length, 2, 'second timer scheduled');
+  assert.equal(sched.timers[1].delay, 2000);
+});
+
+test('auto-timer: stray fire on an already-soft round does not double-emit or call onTimeout', () => {
+  const clock = { t: 0 };
+  const sched = fakeScheduler();
+  const resolved = [];
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => clock.t,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  orch.openLethalConsent(['p1'], {
+    timeoutMs: 1000,
+    onTimeout: (snapshot, outcome) => resolved.push({ snapshot, outcome }),
+  });
+  // Resolve to soft via the cancel path first (clears the handle).
+  orch.evalLethalConsentTimeout({ deliveryFailed: true });
+  // Force-fire the (now cleared) handle to simulate a race; must be inert.
+  clock.t = 1000;
+  sched.timers[0].cb(); // bypass cleared guard to prove orchestrator-side guard
+  assert.equal(resolved.length, 0, 'onTimeout not called when round already resolved');
+});
+
+test('auto-timer: a sub-ms-early fire still resolves (deadline-pinned, no silent hang)', () => {
+  // Regression for the dual-clock race: libuv fires the timer ~1ms before
+  // Date.now() shows the full elapse. The orchestrator pins `now` to the exact
+  // deadline so the round resolves anyway (the "unattended fallback" must not
+  // silently fail). Without the fix evalTimeout would read elapsed < timeout_ms
+  // and leave the round stuck `pending` with the handle already nulled.
+  const clock = { t: 0 };
+  const sched = fakeScheduler();
+  const resolved = [];
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => clock.t,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  orch.openLethalConsent(['p1'], {
+    timeoutMs: 1000,
+    onTimeout: (snapshot, outcome) => resolved.push({ snapshot, outcome }),
+  });
+  clock.t = 999; // 1ms early relative to wall-clock at fire time
+  sched.fire(sched.timers[0]);
+  assert.equal(orch.lethalConsentSnapshot().status, 'timeout_soft', 'resolves despite early fire');
+  assert.equal(resolved.length, 1, 'onTimeout still fires');
+  assert.equal(resolved[0].outcome, 'soft');
+});
+
+test('auto-timer: advancing the scenario clears a dangling timer (per-scenario consent)', () => {
+  const sched = fakeScheduler();
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => 0,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  orch.startRun({ scenarioStack: ['enc_a', 'enc_b'] });
+  orch.openLethalConsent(['p1'], { timeoutMs: 1000 });
+  const armed = sched.timers[sched.timers.length - 1];
+  orch.advanceScenarioOrEnd(); // next_scenario branch
+  assert.equal(armed.cleared, true, 'timer cleared on scenario advance');
+  assert.equal(orch.lethalConsentSnapshot(), null, 'consent round dropped on advance');
+});
+
+test('auto-timer: coopStore.remove drains an armed timer before evicting the orchestrator', () => {
+  const sched = fakeScheduler();
+  const store = createCoopStore({
+    lobby: { getRoom: () => ({ hostId: 'h1' }) },
+    orchestratorOptions: {
+      now: () => 0,
+      setTimeoutFn: sched.setTimeoutFn,
+      clearTimeoutFn: sched.clearTimeoutFn,
+    },
+  });
+  const orch = store.getOrCreate('ABCD');
+  orch.openLethalConsent(['p1'], { timeoutMs: 1000 });
+  assert.equal(sched.timers.length, 1, 'timer armed');
+  store.remove('ABCD');
+  assert.equal(sched.timers[0].cleared, true, 'timer cleared on room teardown (no pinned orch)');
+});
+
+test('auto-timer: default scheduler wires real global timers (smoke)', () => {
+  // No injection -> the orchestrator must default to the real global timer fns
+  // and arm a genuine handle. We do NOT await the real fire here: the handle is
+  // unref()ed (so it never blocks process exit), and the firing path itself is
+  // already proven deterministically by the fake-scheduler tests above.
+  const orch = new CoopOrchestrator({ roomCode: 'ABCD', hostId: 'h1' });
+  assert.equal(orch._setTimeoutFn, setTimeout, 'defaults to global setTimeout');
+  assert.equal(orch._clearTimeoutFn, clearTimeout, 'defaults to global clearTimeout');
+  orch.openLethalConsent(['p1'], { timeoutMs: 60000 });
+  assert.ok(orch._lethalConsentTimer, 'a real timer handle is armed');
+  // Clean up: resolving the round must clear the real timer (no dangling timer).
+  orch.evalLethalConsentTimeout({ deliveryFailed: true });
+  assert.equal(orch._lethalConsentTimer, null, 'real timer cleared on resolution');
+});

--- a/tests/services/coop/coopOrchestratorLethalAutoTimer.test.js
+++ b/tests/services/coop/coopOrchestratorLethalAutoTimer.test.js
@@ -167,6 +167,24 @@ test('auto-timer: no at-risk players -> granted, no timer scheduled', () => {
   assert.equal(sched.timers.length, 0, 'no timer for a trivially-granted round');
 });
 
+test('auto-timer: a non-positive timeout_ms still arms a timer at the default (Codex P2)', () => {
+  // A host supplying timeout_ms: 0 must NOT disable the unattended fallback;
+  // the state machine normalizes it to DEFAULT_TIMEOUT_MS, so a pending round
+  // always gets an armed timer.
+  const sched = fakeScheduler();
+  const orch = new CoopOrchestrator({
+    roomCode: 'ABCD',
+    hostId: 'h1',
+    now: () => 0,
+    setTimeoutFn: sched.setTimeoutFn,
+    clearTimeoutFn: sched.clearTimeoutFn,
+  });
+  const snap = orch.openLethalConsent(['p1'], { timeoutMs: 0 });
+  assert.equal(snap.status, 'pending');
+  assert.equal(sched.timers.length, 1, 'timer armed despite timeoutMs=0');
+  assert.ok(sched.timers[0].delay > 0, 'armed at the normalized default, not 0');
+});
+
 test('auto-timer: re-opening clears the previous timer before scheduling a new one', () => {
   const sched = fakeScheduler();
   const orch = new CoopOrchestrator({

--- a/tests/services/coop/lethalConsent.test.js
+++ b/tests/services/coop/lethalConsent.test.js
@@ -34,6 +34,16 @@ test('open: default timeout is a finite proposed value (design-call param)', () 
   assert.ok(Number.isFinite(s.timeout_ms) && s.timeout_ms > 0);
 });
 
+test('open: a non-positive timeout falls back to the default (never disables the auto-fallback)', () => {
+  // Codex P2: timeout_ms 0 / negative would leave a pending round with no
+  // armable auto-timeout -> a non-responsive device could hang it. Normalize.
+  for (const bad of [0, -1, -5000]) {
+    const s = lc.open(['p1'], { now: 0, timeoutMs: bad });
+    assert.equal(s.status, 'pending');
+    assert.equal(s.timeout_ms, lc.DEFAULT_TIMEOUT_MS, `timeoutMs=${bad} -> default`);
+  }
+});
+
 // --- confirm -------------------------------------------------------------
 
 test('confirm: an at-risk player confirms; all confirmed -> granted', () => {


### PR DESCRIPTION
## Cosa

SPEC-J sez.5 **trigger-(a)** — timer automatico di timeout per il lethal-consent. Ultimo residuo SPEC-J buildable-autonomo (altri gated: durable cooldown=contracts, Godot UI=item-3, flip prod=master-dd).

Prima: round `pending` risolto solo se TUTTI gli at-risk confermano (`granted`), host abort via `POST /coop/lethal/cancel`, o `evalLethalConsentTimeout` manuale. Device **online ma senza risposta** = round pending fino ad azione host (trigger-(a) "device online ma nessuna risposta -> timeout" non wirato).

Ora: `openLethalConsent` arma timer one-shot a `timeout_ms`; allo scadere auto-risolve a `timeout_soft` (NON parte lethal) senza host ("mai loop bloccato").

## Design

- **Scheduler injectable** (`setTimeoutFn`/`clearTimeoutFn`, default globals) → TDD deterministico.
- **`onTimeout(snapshot, outcome)`** da `/coop/lethal/open` (closure `room.broadcast`). Fira SOLO dal timer → path manuali broadcastano da soli → **no double-broadcast**.
- Timer `.unref()`ed. Clear su: confirm→granted, eval-resolution, run reset, scenario advance, coopStore.remove.
- **Value-neutral**: VALORE timeout (`DEFAULT_TIMEOUT_MS=120000`, PROPOSED) = design-call master-dd; PR wira solo il firing.
- **Band-neutral / default-OFF**: dietro `LETHAL_MISSIONS_ENABLED` (default OFF); pull-only.

## Adversarial review (coop-phase-validator) — 3 fix pre-merge

| # | Finding | Fix |
|---|---------|-----|
| P1-B | sub-ms-early libuv fire vs Date.now elapsed → stuck pending (silent hang) | eval `now` pinnato al deadline (opened_at+timeout_ms) |
| P1-A | advanceScenarioOrEnd droppava lethalConsent senza clear (ended+next_scenario) | _clearLethalConsentTimer in cima |
| P2-A | coopStore.remove non drenava timer → orch+room pinnati ~120s | remove() drena prima del delete |

(4 invarianti HOLD: double-broadcast, F5 anonymity, granted-override, re-open race.)

## Test
- coopOrchestratorLethalAutoTimer.test.js — **12** (incl. early-fire / advance-clear / store-remove).
- coopLethalConsentOpen.test.js — +1 e2e (auto-timeout → broadcast soft, F5-anonymous).
- Coop **332/332**, AI **543/543** (≥382), prettier clean.

## Changelog
- feat: SPEC-J auto-timeout timer (coopOrchestrator + coop route + coopStore DI).

## Rollback (03A)
Revert commit unico. Zero schema/migration, zero deps, zero forbidden-path. Flag-gated (default OFF) → inerte fino a flip master-dd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)