### PR TITLE
feat(a2): encounter floor author-guard + ratify SPEC-J/A2 design-call verdicts

### DIFF
--- a/apps/backend/services/coop/lethalConsent.js
+++ b/apps/backend/services/coop/lethalConsent.js
@@ -21,9 +21,14 @@
 
 'use strict';
 
-// PROPOSED default (master-dd to ratify). 120s: long enough for a player to read
-// the non-silenceable prompt + confirm on their device, short enough to not
-// stall the table. Tuning value, not a balance lever.
+// RATIFIED-PROVISIONAL (master-dd verdict 2026-06-17). 120s: long enough for a
+// player to read the non-silenceable prompt + confirm on their device, short
+// enough to not stall the table. Tuning value, not a balance lever. Consistent
+// with the coop WS ghost-timeout (120s). NOTE: the round resolves the instant
+// EVERY at-risk player confirms (see confirm() -> _allConfirmed -> granted), so
+// this timeout only bites the NON-RESPONDER path; the value is observable only
+// once the Godot client renders the consent countdown (item-3). Re-tune (likely
+// down toward ~90s) only with device-roundtrip latency + co-op playtest data.
 const DEFAULT_TIMEOUT_MS = 120000;
 
 const SOFT_STATUSES = new Set(['pending', 'timeout_soft', 'fallback_soft']);

--- a/docs/design/evo-tactics-lethal-wounds-rituals.md
+++ b/docs/design/evo-tactics-lethal-wounds-rituals.md
@@ -233,3 +233,27 @@ SPEC-J e' implementabile/chiudibile quando:
    tutte A; J2 chiuso da canon); resta a Eduardo il flip `review_needed` -> `accepted`;
 8. coerenza con SPEC-B (3.10/F5), SPEC-K (6.4), SPEC-E (E2/E6), SPEC-F (Custode), SPEC-A
    (risk_posture secret), SPEC-D (death beat).
+
+## 11. Verdetti master-dd 2026-06-17 (consent-timeout + flip)
+
+Backend SPEC-J COMPLETE end-to-end (death-model #2789 + ritual #2790 + consent #2792 +
+bridge #2794 + auto-timer sez.5 trigger-a #2798), flag `LETHAL_MISSIONS_ENABLED` default OFF.
+Due design-call decise (evidence: workflow ricerca 5-finder + synth-critic, vedi handoff
+2026-06-17 continuazione-3):
+
+- **Consent auto-timeout value = `DEFAULT_TIMEOUT_MS` 120000 RATIFIED-PROVISIONAL.** Tuning
+  value, non balance-lever; consistente con il ghost-timeout coop 120s. L'early-confirm
+  esiste gia' (round -> `granted` appena TUTTI confermano), quindi il timeout morde SOLO il
+  path non-responder ed e' osservabile solo quando il client Godot renderizza la countdown
+  (item-3). Re-tune (probabile verso ~90s, UX-evidence) SOLO con dati device-roundtrip +
+  playtest co-op reale. Per un consent-gate di permadeath err-long e' la scelta sicura
+  (clock stretto = soft-resolve non voluto sotto pressione sociale).
+- **Flip `LETHAL_MISSIONS_ENABLED=true` = DEFERRED** (NON flippare ora). Gate-5 surface-dead:
+  0 encounter `lethal: true` in data + 0 handler `lethal_consent_*` nel client Godot-v2
+  (broadcast unversioned -> silent drop) + backend inerte. Flip gated su TUTTI: (1) >=1
+  encounter lethal authored, (2) Godot consent UI [prompt + countdown + handler
+  open/waiting/resolved + confirm-sender + fallen/death surface + host-cancel], (3)
+  lethal-mission N=40 / co-op playtest che prova la choreography end-to-end, (4) verdetto
+  master-dd. Stesso pattern del defer `META_NETWORK_ROUTING` (validate-then-flip). NB: il
+  lavoro Godot lato item-3 NON e' ancora tracciato in `Game-Godot-v2/docs/godot-v2/`.
+- Reversibile: il flip e' env + restart; nessuna urgenza, validate-then-flip.

--- a/docs/reports/2026-06-16-a2-pressure-tier-n40-evidence.md
+++ b/docs/reports/2026-06-16-a2-pressure-tier-n40-evidence.md
@@ -250,3 +250,23 @@ node tools/sim/pressure-floor-probe.js --aggregate --out $OUT
 - Bande: `data/core/balance/damage_curves.yaml`.
 - Godot canonical: `Game-Godot-v2/docs/godot-v2/design/tkt-pressure-tier-encounter.md` (PR #221).
 - Pattern N=40 ratify-grade: `docs/reports/2026-06-11-spec-i-er6-overrun-n40-evidence.md`.
+
+## Verdetto master-dd 2026-06-17 -- floor magnitude RATIFIED-PROVISIONAL
+
+Decisione (evidence: workflow ricerca + synth-critic, vedi handoff 2026-06-17 cont-3).
+A2 e' gia' LIVE in prod (flag flippato ON 2026-06-17) -> "defer" sarebbe non-protettivo
+(lascerebbe valori attivi non-ratificati). Verdetto:
+
+- **Magnitudini floor RATIFIED-PROVISIONAL** (tutorial=1 no-op / standard=2 Alert@25 /
+  elite-solo=3 Escalated@50 / hardcore=4 Critical@75). Il N=40 prova SAFETY non OPTIMALITY:
+  delta WR ON-vs-OFF nel rumore (flag-OFF byte-identical), unico bite robusto =
+  `enc_hardcore_reinf_01` (floor 4, sola pool reinforcement: spawn 0->4, defeat->timeout
+  +8.1pp). La policy greedy del sim SATURA sopra il target umano -> "provisional", non
+  "final".
+- **Re-tune solo UPWARD, pending dati umani** (zero evidenza per downward; sim semmai
+  indica valori conservativi). Ratifica finale = playtest umano, non sim.
+- **Author-guard SHIPPED** (`tools/js/validate_encounter_difficulty.js`): `pressure_tier_floor`
+  deve essere intero [0,5] (range schema) E `<= difficulty_rating` -- impedisce di authorare
+  un encounter early/low-difficulty con floor alto (P6 first-encounter fairness). Regola
+  meccanica derivata dai valori ratificati (tutti i 14 encounter attuali la rispettano);
+  blocca solo mis-authoring futuro. Test: `tests/difficulty/validator.test.js`.

--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -41,6 +41,13 @@ const steps = [
   // subtree -> single-* glob suffices (no nesting). Verified passing standalone
   // + in-batch (2026-06-17).
   'node --test tests/worldgen/*.test.js',
+  // tests/difficulty/** was also CI-orphaned (anti-pattern #10): calculator +
+  // validator specs never matched a glob above, so the A2 encounter author-guard
+  // (validate_encounter_difficulty.js: pressure_tier_floor <= difficulty_rating)
+  // would NOT actually block a mis-authored encounter at merge. The validator
+  // test runs the script against every real encounter (errors=0), so wiring this
+  // glob makes the guard an enforced gate. Flat subtree -> single-* glob.
+  'node --test tests/difficulty/*.test.js',
 ];
 
 const baseEnv = {

--- a/tests/difficulty/validator.test.js
+++ b/tests/difficulty/validator.test.js
@@ -146,3 +146,127 @@ waves:
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+// A2 author-guard (master-dd verdict 2026-06-17, ratify-provisional + author guard):
+// an early / low-difficulty encounter must NOT be authored with a high
+// pressure_tier_floor. Mechanical rule: floor <= difficulty_rating. All current
+// encounters satisfy it (tutorial diff1/floor1 .. hardcore diff5/floor4); the
+// guard only blocks FUTURE mis-authoring (e.g. a tutorial starting at Critical).
+test('validator flags pressure_tier_floor > difficulty_rating as error (A2 author-guard)', () => {
+  const tmpDir = path.join(__dirname, '_tmp_enc_floor_high');
+  fs.mkdirSync(tmpDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, 'enc_floor_high.yaml'),
+    `
+encounter_id: enc_floor_high
+name: 'Floor too high for an easy encounter'
+biome_id: savana
+grid_size: [8, 8]
+difficulty_rating: 2
+pressure_tier_floor: 5
+objective:
+  type: elimination
+player_spawn:
+  - [0, 0]
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [5, 5]
+    units:
+      - species: predoni_nomadi
+        count: 1
+        tier: base
+`.trim(),
+  );
+  try {
+    const result = spawnSync('node', [SCRIPT, '--encounters', tmpDir], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+    });
+    assert.equal(result.status, 1, 'floor > difficulty must be an error');
+    assert.match(result.stdout, /pressure_tier_floor \(5\) exceeds difficulty_rating \(2\)/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('validator flags out-of-range pressure_tier_floor as error', () => {
+  const tmpDir = path.join(__dirname, '_tmp_enc_floor_oob');
+  fs.mkdirSync(tmpDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, 'enc_floor_oob.yaml'),
+    `
+encounter_id: enc_floor_oob
+name: 'Floor out of range'
+biome_id: savana
+grid_size: [8, 8]
+difficulty_rating: 5
+pressure_tier_floor: 9
+objective:
+  type: elimination
+player_spawn:
+  - [0, 0]
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [5, 5]
+    units:
+      - species: predoni_nomadi
+        count: 2
+        tier: base
+`.trim(),
+  );
+  try {
+    const result = spawnSync('node', [SCRIPT, '--encounters', tmpDir], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+    });
+    assert.equal(result.status, 1, 'out-of-range floor must be an error');
+    assert.match(result.stdout, /invalid pressure_tier_floor/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('validator accepts floor == difficulty_rating and an absent floor', () => {
+  const tmpDir = path.join(__dirname, '_tmp_enc_floor_ok');
+  fs.mkdirSync(tmpDir, { recursive: true });
+  // floor == difficulty (boundary OK) + a no-floor encounter (back-compat).
+  fs.writeFileSync(
+    path.join(tmpDir, 'enc_floor_ok.yaml'),
+    `
+encounter_id: enc_floor_ok
+name: 'Floor at the cap'
+biome_id: savana
+grid_size: [8, 8]
+difficulty_rating: 3
+pressure_tier_floor: 3
+objective:
+  type: elimination
+player_spawn:
+  - [0, 0]
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [5, 5]
+    units:
+      - species: predoni_nomadi
+        count: 2
+        tier: base
+`.trim(),
+  );
+  try {
+    const result = spawnSync('node', [SCRIPT, '--encounters', tmpDir], {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+    });
+    // No floor-guard error (drift may warn, but must not error on the floor rule).
+    assert.doesNotMatch(result.stdout, /pressure_tier_floor \(3\) exceeds/);
+    assert.doesNotMatch(result.stdout, /invalid pressure_tier_floor/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tools/js/validate_encounter_difficulty.js
+++ b/tools/js/validate_encounter_difficulty.js
@@ -89,6 +89,26 @@ function main() {
       continue;
     }
 
+    // A2 author-guard (master-dd verdict 2026-06-17, ratify-provisional + author
+    // guard). The per-encounter pressure_tier_floor raises the *starting* Sistema
+    // pressure tier; an early / low-difficulty encounter must NOT be authored
+    // with a high floor (P6 first-encounter fairness). Mechanical rule, derived
+    // from the ratified values (all current encounters satisfy floor <=
+    // difficulty_rating): floor must be an integer in [0,5] (schema range) AND
+    // not exceed the encounter's own difficulty_rating.
+    if (enc.pressure_tier_floor !== undefined && enc.pressure_tier_floor !== null) {
+      const floor = Number(enc.pressure_tier_floor);
+      if (!Number.isInteger(floor) || floor < 0 || floor > 5) {
+        errors.push(
+          `${file}: invalid pressure_tier_floor (${enc.pressure_tier_floor}) -- must be an integer 0-5`,
+        );
+      } else if (floor > declared) {
+        errors.push(
+          `${file}: pressure_tier_floor (${floor}) exceeds difficulty_rating (${declared}) -- early/low-difficulty encounter cannot start at a high Sistema pressure tier (A2 author-guard)`,
+        );
+      }
+    }
+
     // Biome lookup: default difficulty_base=1.0 (biome registry integration futura)
     const biomeData = { difficulty_base: 1.0 };
     const computed = calculateDifficultyRating(enc, biomeData, config);


### PR DESCRIPTION
Esegue i 3 verdetti master-dd (2026-06-17) sulle design-call SPEC-J/A2. Evidence = workflow ricerca 5-finder + synth-critic (handoff cont-3).

## Q3 -- A2 floor magnitude = RATIFY-PROVISIONAL + author-guard (unica parte di codice)
- **`tools/js/validate_encounter_difficulty.js`**: `pressure_tier_floor` deve essere intero [0,5] (range schema) E `<= difficulty_rating`. Blocca authoring di un encounter early/low-difficulty con floor alto (P6 first-encounter fairness). Regola meccanica derivata dai valori ratificati; **tutti i 14 encounter attuali la rispettano** -> blocca solo mis-authoring futuro.
- N=40 prova SAFETY non OPTIMALITY (sim greedy satura sopra la banda umana) -> provisional; re-tune solo UPWARD pending playtest umano.

## Q1 -- consent auto-timeout = RATIFY-PROVISIONAL 120000ms
- `lethalConsent.js` comment PROPOSED -> RATIFIED-PROVISIONAL. Tuning value, consistente col ghost-timeout coop 120s. L'early-confirm short-circuita l'happy-path -> il timeout morde SOLO il path non-responder; osservabile solo quando Godot renderizza la countdown (item-3). Re-tune verso ~90s solo con dati device-roundtrip + playtest.

## Q2 -- flip LETHAL_MISSIONS_ENABLED = DEFERRED
- Registrato nella spec lethal-wounds (sez.11). Gate-5 surface-dead: 0 encounter `lethal:true` + 0 handler `lethal_consent_*` in Godot-v2. Flip gated su Godot consent UI + lethal data + N=40/playtest + master-dd. Mirror del defer META_NETWORK_ROUTING.

## Test
- validator **7/7** (floor>difficulty + out-of-range + boundary-ok); difficulty+lethalConsent **60/60**; AI **543/543**; prettier + docs-governance (errors=0) clean.

## Changelog
- feat: A2 encounter pressure_tier_floor author-guard (validator).
- docs: ratify-provisional verdicts (consent-timeout 120s, A2 floor magnitude) + flip-defer record.

## Rollback (03A)
Revert commit unico. Guard = solo ERROR su mis-authoring futuro (dati attuali passano). Comment/doc-only per Q1/Q2. Zero forbidden-path, zero deps, zero schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)