### PR TITLE
feat(spec-j): carry timeout_ms in lethal-consent snapshot (item-3 J2)

### DIFF
--- a/apps/backend/services/coop/lethalConsent.js
+++ b/apps/backend/services/coop/lethalConsent.js
@@ -115,7 +115,13 @@ function evalTimeout(state, { now = 0 } = {}) {
   return state;
 }
 
-/** Anonymous aggregate (F5): counts only, never the per-player roster. */
+/**
+ * Anonymous aggregate (F5): counts only, never the per-player roster.
+ * `timeout_ms` is the round's configured duration (a constant, NOT a roster ->
+ * F5-safe): SPEC-J item-3 J2 -- the Godot client renders the consent countdown
+ * from it instead of hardcoding DEFAULT_TIMEOUT_MS, so a future re-tune of the
+ * value does not desync the client. 0 when no round is open.
+ */
 function snapshot(state) {
   if (!state)
     return {
@@ -124,6 +130,7 @@ function snapshot(state) {
       pending_count: 0,
       all_confirmed: false,
       status: 'pending',
+      timeout_ms: 0,
     };
   const total = state.at_risk.length;
   const confirmed_count = state.at_risk.filter((id) => _hasConfirmed(state, id)).length;
@@ -133,6 +140,7 @@ function snapshot(state) {
     pending_count: Math.max(0, total - confirmed_count),
     all_confirmed: total > 0 && confirmed_count === total,
     status: state.status,
+    timeout_ms: state.timeout_ms,
   };
 }
 

--- a/tests/api/coopLethalConsentOpen.test.js
+++ b/tests/api/coopLethalConsentOpen.test.js
@@ -65,6 +65,9 @@ test('POST /coop/lethal/open: broadcasts anonymous lethal_consent_open snapshot'
   assert.ok(ev, 'lethal_consent_open must be broadcast');
   assert.equal(ev.msg.payload.total, 2);
   assert.equal(ev.msg.payload.status, 'pending');
+  // SPEC-J item-3 J2: the open broadcast carries the round timeout_ms so the
+  // Godot client drives its countdown without hardcoding the design value.
+  assert.equal(ev.msg.payload.timeout_ms, 5000);
   // F5: the broadcast must NOT leak the per-player roster.
   assert.equal(ev.msg.payload.at_risk, undefined);
 });

--- a/tests/services/coop/lethalConsent.test.js
+++ b/tests/services/coop/lethalConsent.test.js
@@ -123,6 +123,20 @@ test('snapshot: anonymous counts only, no player ids/names leaked', () => {
   assert.equal(snap.confirmed, undefined);
 });
 
+test('snapshot: carries timeout_ms (round duration) for the client countdown', () => {
+  // SPEC-J item-3 J2: the Godot client renders a countdown but must NOT hardcode
+  // the design value. The anonymous snapshot carries the round timeout_ms (a
+  // duration constant, not a roster -> F5-safe) so open/waiting broadcasts let
+  // the device drive its countdown.
+  const s = lc.open(['p1', 'p2'], { now: 0, timeoutMs: 5000 });
+  assert.equal(lc.snapshot(s).timeout_ms, 5000);
+  // A non-positive timeoutMs normalized to the default still surfaces it.
+  const d = lc.open(['p1'], { now: 0, timeoutMs: 0 });
+  assert.equal(lc.snapshot(d).timeout_ms, lc.DEFAULT_TIMEOUT_MS);
+  // Empty/no-round snapshot is shape-stable (timeout_ms present, 0).
+  assert.equal(lc.snapshot(null).timeout_ms, 0);
+});
+
 // --- outcome / isGranted -------------------------------------------------
 
 test('isGranted: true only on granted, false on every soft state', () => {


### PR DESCRIPTION
J2 backend enrichment per la frontiera **item-3 Godot SPEC-J consent surface** (master-dd verdict). Il client Godot deve renderizzare il countdown del consenso ma non aveva modo di sapere la durata del round.

## Cosa
- `snapshot()` (lethalConsent.js) ora porta `timeout_ms` (durata del round = costante, NON roster -> F5-safe). Cavalca ogni broadcast che usa lo snapshot (`lethal_consent_open` / `_waiting`) -> il device guida il proprio countdown dall'evento open senza hardcodare `DEFAULT_TIMEOUT_MS` (che e' RATIFIED-PROVISIONAL e probabilmente si muovera' verso ~90s). No-round snapshot shape-stable (`timeout_ms: 0`).

## Perche'
Senza, il client hardcoderebbe 120000 e desync-erebbe a ogni re-tune del valore.

## Test
- `lethalConsent.test.js`: snapshot timeout_ms (5000 / default-on-0 / null->0). `coopLethalConsentOpen.test.js`: assertion e2e payload.timeout_ms===5000.
- coop **335/335**, AI **543/543**, prettier clean.

## Changelog
- feat: SPEC-J consent snapshot carries timeout_ms (item-3 J2 enrichment).

## Rollback (03A)
Revert commit unico. F5-safe (durata, non roster). Zero forbidden-path/deps/schema. La UI Godot che lo consuma = chip cross-repo separata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)