### PR TITLE
docs(planning): name species as 2nd export wave in authority map (RFC #4 S2)

### DIFF
--- a/docs/planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md
+++ b/docs/planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md
@@ -86,8 +86,9 @@ la versione piu recente e canonica vince.
 
 ### 4.6 Provenienza del taxonomy content (Game-Database, RFC #4 -- ratificato 2026-06-11)
 
-Game-Database e' la source-of-truth UPSTREAM del taxonomy content (prima ondata: traits)
-che alimenta `packs/evo_tactics_pack/docs/catalog/*` e i derivati `data/core/traits/*`:
+Game-Database e' la source-of-truth UPSTREAM del taxonomy content (prima ondata: traits;
+seconda ondata: species, RFC #4 "Species S2") che alimenta
+`packs/evo_tactics_pack/docs/catalog/*` e i derivati `data/core/traits/*`:
 una `TaxonomyVersion` con status `released` (immutabile, versionata, auditata) e' l'origine
 canonica del contenuto; i file in questo repo restano la verita' meccanica A2 per il runtime.
 Attivazione a fasi (RFC Game-Database `docs/rfc/2026-06-11-bidirectional-sync.md`):
@@ -99,6 +100,14 @@ Attivazione a fasi (RFC Game-Database `docs/rfc/2026-06-11-bidirectional-sync.md
   (header `GENERATED FROM Game-Database <tag>`), passano `evo-import-gate` (round-trip
   errori=0) e il merge resta umano (Eduardo). Un edit manuale a un file generato = drift:
   va riportato nel DB, non difeso nel file.
+- **Seconda ondata -- species (RFC #4 "Species S2", ratificato 2026-06-17)**: superficie
+  export = SOLO i file per-slug `packs/evo_tactics_pack/docs/catalog/species/<slug>.json`
+  del catalog-tier (sourceFiles include `species_catalog_file`). Le species
+  ecosystem-derived e i file `index` / `canonical-index` NON sono esportati: restano
+  rigenerati downstream dal tooling Game. Il marker per le species e' la chiave JSON
+  top-level `_generated_from: "Game-Database <tag>"` (+ `generated_at`), non lo header
+  testuale dei traits; per il resto vale lo stesso gate S2 (trigger CLI manuale, branch+PR
+  dall'operatore locale, `evo-import-gate` round-trip errori=0, merge Eduardo).
 - In conflitto sul CONTENUTO taxonomy tra un released snapshot DB e un file pack non
   generato/non aggiornato: vince la released version DB; la correzione passa da un nuovo
   export PR, mai da edit divergenti su entrambi i lati.


### PR DESCRIPTION
## What

Extend `docs/planning/EVO_FINAL_DESIGN_SOURCE_AUTHORITY_MAP.md` section 4.6 to name **species** as the second wave (after traits) under Game-Database SoT for released taxonomy content.

## Why

Resolves RFC #4 **S2-Q3 / Q8** (Game canon-authority for species). This authority-map entry is the ratified **prerequisite** for the first species export PR (S2 execution ladder, step 1).

## Scope (ratified 2026-06-17 -- Game-Database RFC #4 "Species S2")

- **Surface**: per-file `packs/evo_tactics_pack/docs/catalog/species/<slug>.json`, catalog-tier only (`sourceFiles` includes `species_catalog_file`). Ecosystem-derived species and the generated `index` / `canonical-index` stay Game-generated downstream.
- **Marker**: top-level JSON `_generated_from: "Game-Database <tag>"` (+ `generated_at`) -- distinct from the trait text header form.
- **Gate**: manual CLI trigger, branch+PR opened by the local operator, `evo-import-gate` round-trip errori=0, Eduardo merges.

Doc-only change. No runtime / data impact. Source: Game-Database `docs/rfc/2026-06-11-bidirectional-sync.md` -> section "Species S2: export-on-release".
