### PR TITLE
feat(calibration): G2 P2 -- per-template orchestrator (probe/ratify/bisection)

### DIFF
--- a/tools/py/calibrate_orchestrator.py
+++ b/tools/py/calibrate_orchestrator.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Per-template calibration orchestrator (G2 P2).
+
+State machine that tunes a scenario's KNOB to its band using an injectable
+`runner` (so the logic is testable without a backend). P2 scope:
+probe -> ratify -> single-knob bisection -> finalize (staging + report).
+NO Optuna (P3), NO production auto-ratify (P4). See
+docs/superpowers/specs/2026-06-17-per-template-calibration-design.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from objective import evaluate_metric  # noqa: E402
+
+
+def in_band(value, band):
+    return band[0] <= value <= band[1]
+
+
+def orchestrate(
+    *,
+    band,
+    knob_space,
+    start_knob,
+    objective_metric,
+    runner,
+    max_bisect=8,
+    probe_n=10,
+    ratify_n=40,
+):
+    """Tune a single knob to land WR in `band`, using `runner(knob_values, n) -> metrics`.
+
+    P2: probe -> ratify -> single-knob direction-aware bisection. Returns a result dict
+    {status, knob, metrics, composite, band, n_used, history}. status is 'in-band' if a
+    ratify run lands in band, else 'not-converged' (best-so-far reported).
+    """
+    history = []
+    if not knob_space:
+        return {"status": "not-converged", "knob": dict(start_knob), "metrics": {},
+                "composite": None, "band": band, "n_used": 0, "history": history}
+    name = next(iter(knob_space))
+    spec = knob_space[name]
+    lo, hi = float(spec["min"]), float(spec["max"])
+
+    def run(x, n, stage):
+        m = runner({**start_knob, name: x}, n)
+        wr = m["win_rate"]
+        # P2 gates on WR (in_band). Composite is best-effort for the report: if the
+        # runner did not emit every objective term (e.g. pe_ratio not yet wired in the
+        # batch aggregate), composite stays None rather than crashing. Composite-driven
+        # gating is a P3/P4 concern.
+        try:
+            comp = evaluate_metric(objective_metric, m) if objective_metric else None
+        except KeyError:
+            comp = None
+        history.append({"stage": stage, "knob": {name: x}, "win_rate": wr, "n": n})
+        return m, wr, comp
+
+    def result(status, x, m, comp):
+        return {"status": status, "knob": {name: x}, "metrics": m, "composite": comp,
+                "band": band, "n_used": ratify_n, "history": history}
+
+    # PROBE at the starting knob; if in band, RATIFY and finalize.
+    x0 = float(start_knob[name])
+    _m, wr, _c = run(x0, probe_n, "probe")
+    if in_band(wr, band):
+        m2, wr2, c2 = run(x0, ratify_n, "ratify")
+        if in_band(wr2, band):
+            return result("in-band", x0, m2, c2)
+
+    # BISECTION (single knob, L-070). Bracket [lo,hi]; monotonic WR.
+    _ml, wrlo, _ = run(lo, probe_n, "bisect")
+    _mh, wrhi, _ = run(hi, probe_n, "bisect")
+    target = (band[0] + band[1]) / 2.0
+    increasing = (wrhi - wrlo) >= 0
+    a, b = lo, hi
+    best = None
+    for _ in range(max_bisect):
+        mid = (a + b) / 2.0
+        m, wr, comp = run(mid, probe_n, "bisect")
+        if best is None or abs(wr - target) < abs(best[1] - target):
+            best = (mid, wr, m, comp)
+        if in_band(wr, band):
+            m2, wr2, c2 = run(mid, ratify_n, "ratify")
+            if in_band(wr2, band):
+                return result("in-band", mid, m2, c2)
+        if increasing:
+            a, b = (mid, b) if wr < target else (a, mid)
+        else:
+            a, b = (a, mid) if wr < target else (mid, b)
+
+    # Exhausted: ratify the best-so-far; report converged-or-not.
+    mid, _wr, _m, _comp = best
+    m2, wr2, c2 = run(mid, ratify_n, "ratify")
+    status = "in-band" if in_band(wr2, band) else "not-converged"
+    return result(status, mid, m2, c2)
+
+
+def orchestrate_scenario(scenario_id, *, manifest, runner, **kw):
+    """Resolve band / knob_space / start (ratified) / objective / escalation from the
+    suite manifest and run `orchestrate`. The tunable lever is the FIRST knob in the
+    scenario's knob_space (P2 single-knob); other ratified knobs are held fixed."""
+    from suite_manifest import (  # noqa: E402
+        get_scenario,
+        scenario_band,
+        scenario_knob_space,
+        scenario_objective,
+    )
+
+    band = scenario_band(manifest, scenario_id)
+    knob_space = scenario_knob_space(manifest, scenario_id)
+    if not knob_space:
+        raise ValueError(f"{scenario_id}: no knob_space in manifest")
+    objective = scenario_objective(manifest, scenario_id)
+    sc = get_scenario(manifest, scenario_id)
+    ratified = dict(sc.get("ratified_knob") or {})
+    esc = sc.get("escalation_policy") or {}
+    name = next(iter(knob_space))
+    start = dict(ratified)
+    if name not in start:
+        spec = knob_space[name]
+        start[name] = (float(spec["min"]) + float(spec["max"])) / 2.0
+    return orchestrate(
+        band=band,
+        knob_space=knob_space,
+        start_knob=start,
+        objective_metric=objective,
+        runner=runner,
+        probe_n=kw.pop("probe_n", esc.get("probe_n", 10)),
+        ratify_n=kw.pop("ratify_n", esc.get("ratify_n", 40)),
+        **kw,
+    )
+
+
+def write_staging(scenario_id, knob, *, path=None):
+    """Write the candidate knob to damage_curves.staging.yaml under scenario_overrides
+    (never production -- that is a P4 gated step). Merges into any existing staging file."""
+    import os
+
+    import yaml
+
+    if path is None:
+        path = str(
+            Path(__file__).resolve().parents[2] / "data/core/balance/damage_curves.staging.yaml"
+        )
+    data = {}
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    data.setdefault("scenario_overrides", {}).setdefault(scenario_id, {}).update(knob)
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, sort_keys=False, allow_unicode=True)
+    return path
+
+
+# Manifest scenario id -> calibrate_parallel SCENARIO_MAP key.
+_PARALLEL_KEY = {
+    "enc_tutorial_06_hardcore": "hardcore_06",
+    "enc_tutorial_07_hardcore_pod_rush": "hardcore_07",
+}
+
+
+def make_parallel_runner(scenario_id, *, seed=424242, shards=4):
+    """Production runner: applies the candidate knob via a staging file (env
+    DAMAGE_CURVES_PATH, the repro-contract mechanism), runs calibrate_parallel, and
+    parses the merged aggregate for metrics.
+
+    BACKEND-DEPENDENT: needs the Game backend (shards). The orchestrator is a
+    maintainer/nightly tool (NOT a per-PR gate), so this path is validated by the
+    maintainer on a real run; the merged-output glob should be confirmed on first use.
+    Composite term pe_ratio is not emitted by the batch aggregate yet -> composite stays
+    WR-only until wired (P3/P4)."""
+    import json
+    import os
+    import subprocess
+    import tempfile
+
+    repo = Path(__file__).resolve().parents[2]
+    scen = _PARALLEL_KEY.get(scenario_id, scenario_id)
+
+    def runner(knob_values, n):
+        tmp = Path(tempfile.gettempdir())
+        staging = tmp / f"orch_staging_{scen}.yaml"
+        for k, v in knob_values.items():
+            write_staging(scenario_id, {k: v}, path=str(staging))
+        env = {**os.environ, "DAMAGE_CURVES_PATH": str(staging)}
+        cmd = [
+            sys.executable,
+            str(repo / "tools/py/calibrate_parallel.py"),
+            "--scenario", scen, "--n", str(n), "--seed", str(seed),
+            "--shards", str(shards), "--out-dir", str(tmp), "--label", "orch",
+        ]
+        subprocess.run(cmd, cwd=str(repo), env=env, check=True)
+        merged = sorted(tmp.glob("*orch*.json"), key=lambda p: p.stat().st_mtime)
+        agg = json.loads(merged[-1].read_text(encoding="utf-8")) if merged else {}
+        return {"win_rate": agg.get("win_rate"), "kd_ratio": agg.get("kd_avg"), "n": n}
+
+    return runner
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    from suite_manifest import DEFAULT_MANIFEST_PATH, load_manifest  # noqa: E402
+
+    ap = argparse.ArgumentParser(description="Per-template calibration orchestrator (G2 P2)")
+    ap.add_argument("--scenario", required=True)
+    ap.add_argument("--max-bisect", type=int, default=8)
+    ap.add_argument("--dry-run", action="store_true", help="synthetic monotonic runner, no backend")
+    args = ap.parse_args()
+
+    manifest = load_manifest(DEFAULT_MANIFEST_PATH)
+    if args.dry_run:
+
+        def runner(knob_values, n):  # deterministic synthetic monotonic WR (smoke, no backend)
+            x = float(next(iter(knob_values.values())))
+            return {"win_rate": max(0.0, min(1.0, 0.90 - 0.55 * x)), "kd_ratio": 0.8, "n": n}
+
+    else:
+        runner = make_parallel_runner(args.scenario)
+
+    res = orchestrate_scenario(
+        args.scenario, manifest=manifest, runner=runner, max_bisect=args.max_bisect
+    )
+    write_staging(args.scenario, res["knob"])
+    report = {k: res[k] for k in ("status", "knob", "composite", "band", "n_used")}
+    print(json.dumps(report, indent=2))
+    sys.exit(0 if res["status"] == "in-band" else 1)

--- a/tools/py/test_calibrate_orchestrator.py
+++ b/tools/py/test_calibrate_orchestrator.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/py/calibrate_orchestrator.py (G2 P2).
+
+The state machine is tested with a deterministic FAKE runner (no backend):
+runner(knob_values, n) -> metrics dict. A monotonic synthetic WR lets the
+single-knob bisection converge deterministically.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from calibrate_orchestrator import in_band, orchestrate, orchestrate_scenario, write_staging  # noqa: E402
+from suite_manifest import DEFAULT_MANIFEST_PATH, load_manifest  # noqa: E402
+
+BAND = [0.15, 0.30]
+KNOB_SPACE = {"boss_hp_multiplier": {"type": "float", "min": 0.50, "max": 1.30}}
+OBJ = "1.0*win_rate"  # objective == WR for these tests
+
+
+def make_runner(slope=-0.55, intercept=0.90):
+    """WR = clamp(intercept + slope*boss_hp). Monotonic-decreasing in boss_hp."""
+
+    def runner(knob_values, n):
+        x = knob_values["boss_hp_multiplier"]
+        wr = max(0.0, min(1.0, intercept + slope * x))
+        return {"win_rate": wr, "kd_ratio": 0.8, "pe_ratio": 0.5, "n": n}
+
+    return runner
+
+
+def test_in_band():
+    assert in_band(0.20, BAND) is True
+    assert in_band(0.15, BAND) is True
+    assert in_band(0.30, BAND) is True
+    assert in_band(0.31, BAND) is False
+    assert in_band(0.10, BAND) is False
+
+
+def test_start_already_in_band_no_bisection():
+    # boss_hp 1.20 -> WR = 0.90 - 0.66 = 0.24 (in band) -> ratify, no bisection.
+    runner = make_runner()
+    r = orchestrate(
+        band=BAND, knob_space=KNOB_SPACE, start_knob={"boss_hp_multiplier": 1.20},
+        objective_metric=OBJ, runner=runner,
+    )
+    assert r["status"] == "in-band"
+    assert in_band(r["metrics"]["win_rate"], BAND)
+    # no bisection steps needed
+    assert sum(1 for h in r["history"] if h["stage"] == "bisect") == 0
+
+
+def test_oob_start_bisects_to_in_band():
+    # boss_hp 0.50 -> WR = 0.625 (OOB high) -> bisect down toward band.
+    runner = make_runner()
+    r = orchestrate(
+        band=BAND, knob_space=KNOB_SPACE, start_knob={"boss_hp_multiplier": 0.50},
+        objective_metric=OBJ, runner=runner, max_bisect=20,
+    )
+    assert r["status"] == "in-band"
+    assert in_band(r["metrics"]["win_rate"], BAND)
+    assert KNOB_SPACE["boss_hp_multiplier"]["min"] <= r["knob"]["boss_hp_multiplier"] <= KNOB_SPACE["boss_hp_multiplier"]["max"]
+
+
+def test_unreachable_band_reports_not_converged():
+    # Flat runner: WR always 0.90 regardless of knob -> band [0.15,0.30] unreachable.
+    def flat(knob_values, n):
+        return {"win_rate": 0.90, "kd_ratio": 0.8, "pe_ratio": 0.5, "n": n}
+
+    r = orchestrate(
+        band=BAND, knob_space=KNOB_SPACE, start_knob={"boss_hp_multiplier": 0.90},
+        objective_metric=OBJ, runner=flat, max_bisect=8,
+    )
+    assert r["status"] == "not-converged"
+    assert "knob" in r and "metrics" in r  # still reports best-so-far
+
+
+def test_orchestrate_scenario_resolves_from_real_manifest():
+    manifest = load_manifest(DEFAULT_MANIFEST_PATH)
+
+    def runner(knob_values, n):
+        x = knob_values.get("boss_hp_multiplier", 1.0)
+        wr = max(0.0, min(1.0, 0.90 - 0.55 * x))
+        return {"win_rate": wr, "kd_ratio": 0.8, "pe_ratio": 0.5, "n": n}
+
+    r = orchestrate_scenario(
+        "enc_tutorial_06_hardcore", manifest=manifest, runner=runner, max_bisect=20
+    )
+    assert r["band"] == [0.15, 0.30]  # resolved from manifest
+    assert "boss_hp_multiplier" in r["knob"]  # first knob_space lever
+    assert r["status"] == "in-band"
+
+
+def test_write_staging_emits_knob(tmp_path):
+    out = tmp_path / "damage_curves.staging.yaml"
+    write_staging("enc_tutorial_06_hardcore", {"boss_hp_multiplier": 1.15}, path=str(out))
+    import yaml
+
+    d = yaml.safe_load(out.read_text(encoding="utf-8"))
+    ov = d["scenario_overrides"]["enc_tutorial_06_hardcore"]
+    assert ov["boss_hp_multiplier"] == 1.15


### PR DESCRIPTION
P2 of the 5-PR G2 per-template calibration delivery (spec #2806; builds on P1 #2809).

## What
`tools/py/calibrate_orchestrator.py` -- state machine that tunes a scenario's KNOB to its band:
- **probe -> ratify -> direction-aware single-knob bisection (L-070) -> finalize**, via an **injectable runner** (the state machine is fully unit-tested with a deterministic fake runner -- no backend needed).
- WR-gated (`in_band`); composite is **best-effort** for the report (None if a term like pe_ratio isn't emitted by the batch aggregate yet -> P3/P4).
- `orchestrate_scenario`: resolves band / knob_space / ratified-start / objective / escalation from the P1 suite manifest.
- `write_staging`: candidate -> `damage_curves.staging.yaml` (never production -- P4 gates that).
- CLI: `--dry-run` (synthetic monotonic runner, smoke) | default `make_parallel_runner`.

## Backend runner
`make_parallel_runner` wires `calibrate_parallel` via env `DAMAGE_CURVES_PATH` (the repro-contract knob-application mechanism). **BACKEND-DEPENDENT -> maintainer-validated** on a real run (the orchestrator is a maintainer/nightly tool, not a per-PR gate; confirm the merged-output glob on first use).

## Tests
6 orchestrator tests (DI fake runner: converge / short-circuit / not-converged / manifest-resolve / staging-write) + **dry-run smoke** (hc06 bisects boss_hp -> in-band). 17 tests total, TDD.

NO Optuna (P3), NO production auto-ratify (P4). Merge = Eduardo.