### PR TITLE
feat(catalog): DB provenance marker on catalog-tier species (RFC #4 S2)

### DIFF
--- a/packs/evo_tactics_pack/docs/catalog/species/aurora-gull.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/aurora-gull.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "aurora-gull",
   "display_name": "Gabbiano d’Aurora",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/blight-micotico.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/blight-micotico.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "blight-micotico",
   "display_name": "Blight Micotico",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/cactus-weaver.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/cactus-weaver.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "cactus-weaver",
   "display_name": "Cactus Weaver",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/cryo-lynx.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/cryo-lynx.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "cryo-lynx",
   "display_name": "Cryo Lynx",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/dune-stalker.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/dune-stalker.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "dune-stalker",
   "display_name": "Dune Stalker",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/echo-wing.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/echo-wing.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "echo-wing",
   "display_name": "Echo Wing",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/ferrocolonia-magnetotattica.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/ferrocolonia-magnetotattica.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "ferrocolonia-magnetotattica",
   "display_name": "Ferrocolonia Magnetotattica",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/lupus-temperatus.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/lupus-temperatus.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "lupus-temperatus",
   "display_name": "Lupo della Foresta",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/nano-rust-bloom.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/nano-rust-bloom.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "nano-rust-bloom",
   "display_name": "Nano Rust Bloom",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/noctule-termico.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/noctule-termico.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "noctule-termico",
   "display_name": "Noctule Termico",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/rust-scavenger.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/rust-scavenger.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "rust-scavenger",
   "display_name": "Rust Scavenger",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/sand-burrower.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/sand-burrower.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "sand-burrower",
   "display_name": "Sand Burrower",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/sentinella-radice.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/sentinella-radice.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "sentinella-radice",
   "display_name": "Sentinella Radice",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/silica-bloom.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/silica-bloom.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "silica-bloom",
   "display_name": "Silica Bloom",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/steppe-bison-mini.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/steppe-bison-mini.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "steppe-bison-mini",
   "display_name": "Bisonte Nano della Steppa",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/thaw-rot.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/thaw-rot.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "thaw-rot",
   "display_name": "Thaw Rot",
   "biomes": [

--- a/packs/evo_tactics_pack/docs/catalog/species/thermo-raptor.json
+++ b/packs/evo_tactics_pack/docs/catalog/species/thermo-raptor.json
@@ -1,4 +1,6 @@
 {
+  "_generated_from": "Game-Database v1.1.0",
+  "generated_at": "2026-06-17T21:17:28.983Z",
   "id": "thermo-raptor",
   "display_name": "Thermo Raptor",
   "biomes": [


### PR DESCRIPTION
## What

First **DB -> Game species export** (RFC #4 "Species S2", execution ladder step 2). Stamps the top-level provenance marker on the 17 catalog-tier species:

```json
{ "_generated_from": "Game-Database v1.1.0", "generated_at": "<iso8601>", "id": "...", ... }
```

This declares Game-Database as the released-snapshot source for this taxonomy content -- the authority-map entry landed in [#2812](https://github.com/MasterDD-L34D/Game/pull/2812) (section 4.6, species = second wave after traits).

## How it was produced

Manual operator dispatch of Game-Database's `taxonomy-export.yml` against a released **v1.1.0** snapshot (OQ4 manual CLI / OQ5 local operator, no standing cross-repo PAT). The workflow rebuilds the DB from this repo's checkout, releases the snapshot, exports it back, and **fails closed unless fidelity is green** (0 divergent / 0 game_only_unexpected / 0 targetMissing). The operator downloaded the `taxonomy-export` artifact and opened this PR.

## Diff is marker-only

Every field other than the marker is **byte-faithful** to the hand-authored file -- the exporter preserves the template's key order, biome slug separators (underscore), accented names, and the Game-owned MODEL_GAP fields (`description` i18n keys, `last_synced_at`). So this PR adds **only** `_generated_from` + `generated_at` to each of the 17 files (34 insertions, 0 deletions); nothing is reformatted or deleted.

## Scope

Catalog-tier per-file species only (`sourceFiles` includes `species_catalog_file`). Ecosystem-derived species and the generated `index` / `canonical-index` stay Game-generated downstream.

## Gate

`evo-import-gate` validates the round-trip (import of these files = 0 errors). The importer reads only known fields, so the marker is dropped on re-import and never round-trips into the DB.

Source: Game-Database `docs/rfc/2026-06-11-bidirectional-sync.md` -> "Species S2".
