### PR TITLE
feat(spec-j): GET nido/scars read for phone ritual UI (item-3 Track A prereq)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -3366,6 +3366,32 @@ function createSessionRouter(options = {}) {
     }
   });
 
+  // GET /api/session/:id/nido/scars — SPEC-J item-3 (Track A prereq for the phone
+  // Nido ritual UI). Lists, per unit, the `grave` scars available for a ritual
+  // (heal/transform). The public session state does not carry this, so the device
+  // needs this read to know WHICH creature + WHICH location to offer. Only units
+  // with >=1 grave scar are returned (the ritual-able set). Mirrors the ritual
+  // POST's data source (nidoRitual.graveWoundsOf on session.units).
+  router.get('/:id/nido/scars', (req, res) => {
+    const { error, session } = resolveSession(req.params.id);
+    if (error) return res.status(error.status).json(error.body);
+    const nidoRitual = require('../services/combat/nidoRitual');
+    const units = (session.units || [])
+      .map((u) => ({
+        unit_id: u && u.id,
+        name: (u && u.name) || null,
+        species_id: (u && u.species_id) || null,
+        scars: nidoRitual.graveWoundsOf(u).map((w) => ({
+          location: w.location,
+          severity: w.severity,
+          ...(w.stat ? { stat: w.stat } : {}),
+          ...(w.malus != null ? { malus: w.malus } : {}),
+        })),
+      }))
+      .filter((u) => u.unit_id && u.scars.length > 0);
+    return res.json({ session_id: session.session_id, units });
+  });
+
   // POST /api/session/:id/nido/ritual — SPEC-J sez.6 Nido wound ritual (J3).
   // Heal or transform a creature's `grave` scar. The ritual ACTION is `private`
   // (device-owned, SPEC-K 7.6); its esito is `public` (chronicle scar_healed /

--- a/tests/api/nidoRitualWire.test.js
+++ b/tests/api/nidoRitualWire.test.js
@@ -77,6 +77,37 @@ test('nido/ritual: no scar at location -> 409 ritual_unavailable (no_scar)', asy
   assert.equal(res.body.reason, 'no_scar');
 });
 
+test('GET nido/scars: lists grave scars per unit (drives the ritual UI)', async (t) => {
+  // SPEC-J item-3 (Track A prereq): the phone Nido ritual UI must know WHICH
+  // creatures have a grave scar + at WHICH location to offer heal/transform. The
+  // public session state does not carry that list, so this read exposes it. Only
+  // units WITH >=1 grave scar are listed (the ritual-able set).
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid, pgId } = await startWithScar(app, 'torso');
+  const res = await request(app).get(`/api/session/${sid}/nido/scars`);
+  assert.equal(res.status, 200, JSON.stringify(res.body).slice(0, 200));
+  assert.equal(res.body.session_id, sid);
+  const u = res.body.units.find((x) => x.unit_id === pgId);
+  assert.ok(u, 'unit with a grave scar is listed');
+  assert.equal(u.scars.length, 1);
+  assert.equal(u.scars[0].location, 'torso');
+  assert.equal(u.scars[0].severity, 'grave');
+  // every listed unit is ritual-able (>=1 grave scar) -- no scar-free noise.
+  assert.ok(res.body.units.every((x) => Array.isArray(x.scars) && x.scars.length > 0));
+});
+
+test('GET nido/scars: unknown session -> 404', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).get('/api/session/no_such_session/nido/scars');
+  assert.equal(res.status, 404);
+});
+
 test('nido/ritual: invalid kind -> 400; unknown unit -> 404', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {


### PR DESCRIPTION
Track A slice-1 prereq (Game-repo) per la SPEC-J Nido ritual UI (chip Godot a seguire).

## Perche'
La ritual UI (heal/transform) deve sapere QUALE creatura ha una grave-scar + DOVE, ma il public session state non lo porta. Stesso pattern del `timeout_ms` (#2803) che ha sbloccato la consent UI (#477).

## Cosa
`GET /api/session/:id/nido/scars` -> per unit le grave-scar (location/severity/stat/malus); solo unit con >=1 grave-scar (set ritual-able). Read-only, riusa `nidoRitual.graveWoundsOf`. 404 su sessione ignota.

## Test
+2 (scars list + 404); nido ritual suite **6/6**, AI **543/543**, prettier clean.

## Prossimo
Chip Godot: ritual UI su PhoneNidoView che consuma `nido/scars` + `POST /nido/ritual`. (K-04 broader: recruit/mating/party/tri-sorgente/custode = slice successive.)

## Rollback
Revert commit unico (read additivo, no state-change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)