### PR TITLE
feat(calibration): composite PE_ratio experiment-first design + PR1 harness

### DIFF
--- a/docs/superpowers/plans/2026-06-18-composite-pe-ratio-experiment-pr1.md
+++ b/docs/superpowers/plans/2026-06-18-composite-pe-ratio-experiment-pr1.md
@@ -1,0 +1,701 @@
+# Composite PE_ratio Experiment Harness (PR1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the experiment harness that lets the owner pick the PE_ratio formula by data (least collinear with WR), plus pressure-trajectory instrumentation -- no formula chosen yet, no composite wired (that is PR2).
+
+**Architecture:** Three pure, hermetically-tested modules (`pressure_stats`, `pe_candidates`, `pe_orthogonality`) + an analysis core that turns a calibrate_parallel runs-corpus into a candidate-selection report + a thin maintainer CLI/backend runner. The batch aggregate is instrumented to emit per-run pressure stats. No backend or network in any test; the real N=100 run is the owner's experiment step.
+
+**Tech Stack:** Python 3.12 (real interpreter `C:/Users/edusc/AppData/Local/Programs/Python/Python312/python.exe`; the `py` launcher is broken on this host), pytest `--import-mode=importlib`, PyYAML. Tests live in `tools/py/test_*.py`. Worktree: `C:/dev/game-wt/pe` (branch `feat/composite-pe-ratio-experiment`, off origin/main `24fbe86b`).
+
+**Conventions (MANDATORY):** ASCII-first (`--` not em-dash). Commits use Conventional Commits + the ADR-0011 trailer (`Coding-Agent: <model-id>` + `Trace-Id: <uuidv7>`, NO `Co-Authored-By`, NO `--no-verify`). Run the full suite with `python -m pytest -q --import-mode=importlib tools/py` after each task. Spec: `docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md`.
+
+---
+
+## File Structure
+
+- Create `tools/py/pressure_stats.py` -- pure trajectory -> {mean, frac_ge75, pmax}.
+- Create `tools/py/pe_candidates.py` -- candidate A/B/C from per-run stats + `kd_normalize`.
+- Create `tools/py/pe_orthogonality.py` -- Pearson + per-candidate analysis + selection report.
+- Create `tools/py/pe_experiment.py` -- analysis core (corpus -> report) + maintainer CLI/backend runner.
+- Modify `tools/py/batch_calibrate_hardcore06.py` -- emit per-run pressure stats + aggregate them.
+- Create the 5 matching `tools/py/test_*.py` files.
+
+---
+
+### Task 1: pressure_stats (pure trajectory helper)
+
+**Files:**
+- Create: `tools/py/pressure_stats.py`
+- Test: `tools/py/test_pressure_stats.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tools/py/test_pressure_stats.py
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+from pressure_stats import pressure_stats  # noqa: E402
+
+
+def test_basic_trajectory():
+    s = pressure_stats([75, 80, 95, 100])
+    assert s["pmax"] == 100
+    assert round(s["pressure_mean"], 2) == 87.5
+    assert s["frac_ge75"] == 1.0  # all >= 75
+
+
+def test_mixed_tiers():
+    s = pressure_stats([10, 50, 75, 90])  # 2 of 4 >= 75
+    assert s["frac_ge75"] == 0.5
+    assert s["pmax"] == 90
+
+
+def test_empty_is_zeroed_not_crash():
+    s = pressure_stats([])
+    assert s == {"pressure_mean": 0.0, "frac_ge75": 0.0, "pmax": 0.0}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pressure_stats.py`
+Expected: FAIL (ModuleNotFoundError: No module named 'pressure_stats').
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# tools/py/pressure_stats.py
+#!/usr/bin/env python3
+"""Pure pressure-trajectory stats for the PE_ratio experiment (G2 follow-up PR1)."""
+from __future__ import annotations
+
+
+def pressure_stats(samples, threshold=75):
+    """Compact per-run stats from a pressure sample list: mean, fraction of samples at or
+    above `threshold` (sustained-threat), and max. Empty -> zeros (defined, never crash)."""
+    if not samples:
+        return {"pressure_mean": 0.0, "frac_ge75": 0.0, "pmax": 0.0}
+    vals = [float(s) for s in samples]
+    return {
+        "pressure_mean": sum(vals) / len(vals),
+        "frac_ge75": sum(1 for v in vals if v >= threshold) / len(vals),
+        "pmax": max(vals),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pressure_stats.py`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/py/pressure_stats.py tools/py/test_pressure_stats.py
+git commit  # message: "feat(calibration): pressure-trajectory stats helper (PE experiment PR1)" + ADR-0011 trailer
+```
+
+---
+
+### Task 2: pe_candidates (A/B/C + kd_normalize)
+
+**Files:**
+- Create: `tools/py/pe_candidates.py`
+- Test: `tools/py/test_pe_candidates.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tools/py/test_pe_candidates.py
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+from pe_candidates import CANDIDATES, candidate_value, kd_normalize  # noqa: E402
+
+STATS = {"pressure_mean": 80.0, "frac_ge75": 0.6, "pmax": 96.0}
+
+
+def test_candidate_A_sustained_threat():
+    assert candidate_value("A_sustained_threat", STATS) == 0.6  # frac_ge75
+
+
+def test_candidate_B_time_avg():
+    assert candidate_value("B_time_avg", STATS) == 0.80  # pressure_mean/100
+
+
+def test_candidate_C_apex_reach():
+    assert candidate_value("C_apex_reach", STATS) == 1.0  # pmax 96 >= 95
+    assert candidate_value("C_apex_reach", {"pmax": 80.0}) == 0.0
+
+
+def test_all_candidates_return_0_1():
+    for name in CANDIDATES:
+        v = candidate_value(name, STATS)
+        assert 0.0 <= v <= 1.0
+
+
+def test_kd_normalize_bounded_monotonic():
+    assert kd_normalize(0.0) == 0.0
+    assert round(kd_normalize(0.8), 3) == 0.444
+    assert 0.0 < kd_normalize(0.8) < kd_normalize(5.0) < 1.0
+    assert kd_normalize(None) is None  # missing -> None, never a fake number
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pe_candidates.py`
+Expected: FAIL (ModuleNotFoundError: No module named 'pe_candidates').
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# tools/py/pe_candidates.py
+#!/usr/bin/env python3
+"""PE_ratio candidate formulas (G2 follow-up PR1). Each maps per-run pressure stats
+(from pressure_stats) -> a 0..1 tension value (higher = more sustained tension). The
+WINNER is chosen by the orthogonality experiment, NOT here -- new candidates are cheap."""
+from __future__ import annotations
+
+APEX = 95
+
+
+def candidate_A(stats):  # sustained-threat fraction
+    return float(stats.get("frac_ge75", 0.0))
+
+
+def candidate_B(stats):  # time-averaged pressure, normalized
+    return float(stats.get("pressure_mean", 0.0)) / 100.0
+
+
+def candidate_C(stats):  # apex-reach (touched >= 95)
+    return 1.0 if float(stats.get("pmax", 0.0)) >= APEX else 0.0
+
+
+CANDIDATES = {
+    "A_sustained_threat": candidate_A,
+    "B_time_avg": candidate_B,
+    "C_apex_reach": candidate_C,
+}
+
+
+def candidate_value(name, stats):
+    v = CANDIDATES[name](stats)
+    return max(0.0, min(1.0, v))
+
+
+def kd_normalize(kd_avg):
+    """Map kd_avg (~0.8 typical, unbounded) -> (0,1) via kd/(kd+1): bounded, monotonic.
+    None in -> None out (missing metric surfaced, never faked)."""
+    if kd_avg is None:
+        return None
+    kd = float(kd_avg)
+    return kd / (kd + 1.0)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pe_candidates.py`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/py/pe_candidates.py tools/py/test_pe_candidates.py
+git commit  # "feat(calibration): PE_ratio candidate formulas + kd_normalize (PE experiment PR1)" + ADR-0011 trailer
+```
+
+---
+
+### Task 3: pe_orthogonality (Pearson + selection report)
+
+**Files:**
+- Create: `tools/py/pe_orthogonality.py`
+- Test: `tools/py/test_pe_orthogonality.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tools/py/test_pe_orthogonality.py
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+from pe_orthogonality import pearson, analyze_candidate, selection_report  # noqa: E402
+
+
+def test_pearson_perfect_and_zero():
+    assert round(pearson([1, 2, 3, 4], [1, 2, 3, 4]), 6) == 1.0
+    assert round(pearson([1, 2, 3, 4], [4, 3, 2, 1]), 6) == -1.0
+    assert pearson([1, 1, 1], [1, 2, 3]) == 0.0  # zero variance -> 0 (no crash)
+
+
+def test_analyze_candidate_abs_corr():
+    # values perfectly track wins -> abs_corr ~ 1 (maximally collinear = WORST)
+    vals = [0.2, 0.9, 0.3, 0.95]
+    wons = [False, True, False, True]
+    a = analyze_candidate(vals, wons)
+    assert a["n"] == 4
+    assert a["abs_corr"] > 0.9
+
+
+def test_selection_report_ranks_least_collinear_first():
+    wons = [False, True, False, True, False, True]
+    per_candidate = {
+        "collinear": [0.1, 0.9, 0.1, 0.9, 0.1, 0.9],     # tracks wins -> high |corr|
+        "orthogonal": [0.5, 0.5, 0.6, 0.4, 0.55, 0.45],  # ~flat vs wins -> low |corr|
+    }
+    eased = {"collinear": 0.05, "orthogonal": 0.2}   # trivialized-run candidate values
+    ratified = {"collinear": 0.5, "orthogonal": 0.5}
+    rep = selection_report(per_candidate, wons, ratified_value=ratified, eased_value=eased)
+    assert rep["ranked"][0]["name"] == "orthogonal"   # least collinear first
+    assert rep["selected"] == "orthogonal"
+    # discrimination: ratified tension > eased tension (correct direction)
+    assert rep["ranked"][0]["discrimination"]["correct_direction"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pe_orthogonality.py`
+Expected: FAIL (ModuleNotFoundError: No module named 'pe_orthogonality').
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# tools/py/pe_orthogonality.py
+#!/usr/bin/env python3
+"""Orthogonality analysis for PE_ratio selection (G2 follow-up PR1). The PRIMARY criterion
+is |Pearson(candidate, won)| -- LOWER is better (less collinear with WR = better anti-false-
+balanced third axis). The SECONDARY check is discrimination (a trivialized run must score
+LOWER tension than the ratified run). Pure; hand-rolled Pearson (no numpy)."""
+from __future__ import annotations
+
+import math
+
+DEFAULT_MAX_CORR = 0.6  # negative-result threshold (sec 4.5): all candidates above -> reject source
+
+
+def pearson(xs, ys):
+    n = len(xs)
+    if n == 0 or n != len(ys):
+        return 0.0
+    mx, my = sum(xs) / n, sum(ys) / n
+    sx = sum((x - mx) ** 2 for x in xs)
+    sy = sum((y - my) ** 2 for y in ys)
+    if sx == 0 or sy == 0:
+        return 0.0  # zero variance -> undefined correlation -> 0
+    cov = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    return cov / math.sqrt(sx * sy)
+
+
+def analyze_candidate(values, wons):
+    wbin = [1.0 if w else 0.0 for w in wons]
+    return {
+        "n": len(values),
+        "abs_corr": abs(pearson(values, wbin)),
+        "mean": (sum(values) / len(values)) if values else 0.0,
+    }
+
+
+def selection_report(per_candidate, wons, *, ratified_value=None, eased_value=None,
+                     max_corr=DEFAULT_MAX_CORR):
+    ratified_value = ratified_value or {}
+    eased_value = eased_value or {}
+    rows = []
+    for name, values in per_candidate.items():
+        a = analyze_candidate(values, wons)
+        rv, ev = ratified_value.get(name), eased_value.get(name)
+        disc = None
+        if rv is not None and ev is not None:
+            disc = {"gap": rv - ev, "correct_direction": rv > ev}
+        rows.append({"name": name, **a, "discrimination": disc})
+    rows.sort(key=lambda r: r["abs_corr"])  # least collinear first
+    best = rows[0] if rows else None
+    # Negative-result branch (sec 4.5): if even the best is too collinear, reject the source.
+    if best is None or best["abs_corr"] > max_corr:
+        selected, verdict = None, f"negative-result: min abs_corr {best['abs_corr']:.3f} > {max_corr} -- reject pressure source" if best else "no candidates"
+    else:
+        selected, verdict = best["name"], f"selected {best['name']} (abs_corr {best['abs_corr']:.3f})"
+    return {"ranked": rows, "selected": selected, "verdict": verdict, "max_corr": max_corr}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pe_orthogonality.py`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/py/pe_orthogonality.py tools/py/test_pe_orthogonality.py
+git commit  # "feat(calibration): orthogonality analysis + selection report (PE experiment PR1)" + ADR-0011 trailer
+```
+
+---
+
+### Task 4: pe_experiment analysis core (corpus -> report)
+
+**Files:**
+- Create: `tools/py/pe_experiment.py`
+- Test: `tools/py/test_pe_experiment.py`
+
+The analysis core turns a list of per-run records (each carrying pressure stats + an outcome) into a selection report, with an optional eased-run record for the discrimination check. Pure; no backend.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tools/py/test_pe_experiment.py
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+from pe_experiment import run_to_stats, analyze_corpus  # noqa: E402
+
+
+def _run(frac, mean, pmax, won):
+    return {"outcome": "victory" if won else "defeat",
+            "pressure_frac_ge75": frac, "pressure_mean": mean, "pressure_pmax": pmax}
+
+
+def test_run_to_stats_maps_fields():
+    s, won = run_to_stats(_run(0.6, 80.0, 96.0, True))
+    assert s == {"frac_ge75": 0.6, "pressure_mean": 80.0, "pmax": 96.0}
+    assert won is True
+
+
+def test_analyze_corpus_selects_least_collinear():
+    # B tracks wins (collinear); A is flat vs outcome (orthogonal-ish).
+    corpus = [
+        _run(0.50, 30.0, 80.0, False),
+        _run(0.55, 95.0, 99.0, True),
+        _run(0.52, 28.0, 70.0, False),
+        _run(0.48, 96.0, 99.0, True),
+    ]
+    rep = analyze_corpus(corpus)
+    assert rep["selected"] in ("A_sustained_threat", "B_time_avg", "C_apex_reach")
+    # A (flat ~0.5) is far less win-correlated than B (30 vs 95) -> A ranks above B
+    names = [r["name"] for r in rep["ranked"]]
+    assert names.index("A_sustained_threat") < names.index("B_time_avg")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pe_experiment.py`
+Expected: FAIL (ModuleNotFoundError: No module named 'pe_experiment').
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# tools/py/pe_experiment.py
+#!/usr/bin/env python3
+"""PE_ratio orthogonality experiment (G2 follow-up PR1). Analysis core: a runs-corpus
+(per-run pressure stats + outcome) -> a candidate-selection report. The real N=100 run is
+the owner's maintainer step (make_corpus_from_backend, backend-dependent); the analysis is
+pure + hermetically tested. See docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from pe_candidates import CANDIDATES, candidate_value  # noqa: E402
+from pe_orthogonality import selection_report  # noqa: E402
+
+
+def run_to_stats(run):
+    """Map one calibrate_parallel run record -> (stats dict for candidates, won bool)."""
+    stats = {
+        "frac_ge75": run.get("pressure_frac_ge75", 0.0),
+        "pressure_mean": run.get("pressure_mean", 0.0),
+        "pmax": run.get("pressure_pmax", 0.0),
+    }
+    return stats, run.get("outcome") == "victory"
+
+
+def analyze_corpus(corpus, eased_run=None):
+    """Compute each candidate's per-run values + outcomes, then the selection report."""
+    per_candidate = {name: [] for name in CANDIDATES}
+    wons = []
+    for run in corpus:
+        stats, won = run_to_stats(run)
+        wons.append(won)
+        for name in CANDIDATES:
+            per_candidate[name].append(candidate_value(name, stats))
+    eased_value = ratified_value = None
+    if eased_run is not None:
+        es, _ = run_to_stats(eased_run)
+        eased_value = {n: candidate_value(n, es) for n in CANDIDATES}
+        # the ratified-run reference = the mean candidate value across the corpus
+        ratified_value = {n: (sum(v) / len(v) if v else 0.0) for n, v in per_candidate.items()}
+    return selection_report(per_candidate, wons, ratified_value=ratified_value,
+                            eased_value=eased_value)
+
+
+def main():
+    import argparse
+    import json
+
+    ap = argparse.ArgumentParser(description="PE_ratio orthogonality experiment (analysis)")
+    ap.add_argument("--corpus", required=True,
+                    help="JSON: a list of run records (pressure_frac_ge75/pressure_mean/"
+                         "pressure_pmax/outcome), e.g. the merged calibrate_parallel runs.")
+    ap.add_argument("--eased", help="optional JSON: one trivialized-knob run record (discrimination).")
+    args = ap.parse_args()
+    corpus = json.loads(Path(args.corpus).read_text(encoding="utf-8"))
+    if isinstance(corpus, dict):
+        corpus = corpus.get("runs", [])
+    eased = json.loads(Path(args.eased).read_text(encoding="utf-8")) if args.eased else None
+    print(json.dumps(analyze_corpus(corpus, eased_run=eased), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pe_experiment.py`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/py/pe_experiment.py tools/py/test_pe_experiment.py
+git commit  # "feat(calibration): PE experiment analysis core + CLI (PR1)" + ADR-0011 trailer
+```
+
+---
+
+### Task 5: Instrument the batch aggregate to emit per-run pressure stats
+
+The per-run result already carries `pressure_final` (`batch_calibrate_hardcore06.py:743`); the full `pressure_samples` exist locally in `run_one`. Surface compact per-run stats (so the experiment corpus has them) and aggregate them (additive, for the eventual composite).
+
+**Files:**
+- Modify: `tools/py/batch_calibrate_hardcore06.py` (the `run_one` return dict near line 743, and `aggregate()` return dict near lines 813-826)
+- Test: `tools/py/test_aggregate_pressure_instrumentation.py`
+
+- [ ] **Step 1: Write the failing test (fixture-driven, no backend)**
+
+```python
+# tools/py/test_aggregate_pressure_instrumentation.py
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+import batch_calibrate_hardcore06 as hc06  # noqa: E402
+
+
+def test_run_one_emits_per_run_pressure_stats(monkeypatch):
+    # run_one must add pressure_frac_ge75 / pressure_mean / pressure_pmax from the samples.
+    # We exercise the pure stat block by calling the helper the script now uses.
+    from pressure_stats import pressure_stats
+    s = pressure_stats([75, 80, 95, 100])
+    # the script stores these under the agreed keys:
+    assert set(s) == {"pressure_mean", "frac_ge75", "pmax"}
+
+
+def test_aggregate_surfaces_pressure_keys():
+    # aggregate() over synthetic per-run records must emit the 3 aggregate pressure keys.
+    runs = [
+        {"outcome": "victory", "turns": 10, "kd": 1.0, "dmg_dealt_player": 5,
+         "dmg_taken_player": 3, "boss_hp_remaining": 0, "pressure_final": 99,
+         "pressure_mean": 90.0, "pressure_frac_ge75": 0.9, "pressure_pmax": 99,
+         "players_alive": 2},
+        {"outcome": "defeat", "turns": 8, "kd": 0.5, "dmg_dealt_player": 2,
+         "dmg_taken_player": 6, "boss_hp_remaining": 12, "pressure_final": 60,
+         "pressure_mean": 62.0, "pressure_frac_ge75": 0.2, "pressure_pmax": 75,
+         "players_alive": 0},
+    ]
+    agg = hc06.aggregate(runs, "hardcore")
+    assert "pressure_mean_avg" in agg
+    assert "pressure_frac_ge75_avg" in agg
+    assert "apex_reach_rate" in agg
+    assert round(agg["pressure_frac_ge75_avg"], 2) == 0.55  # (0.9 + 0.2)/2
+    assert agg["apex_reach_rate"] == 0.5  # 1 of 2 runs pmax >= 95
+```
+
+NOTE: confirm `aggregate()`'s real per-run field names against the source before running (the
+fixture above mirrors the keys at `batch_calibrate_hardcore06.py:740-744`; adjust the non-pressure
+keys in the fixture if the real `aggregate()` requires more fields, but do NOT change the asserts
+on the pressure keys).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_aggregate_pressure_instrumentation.py`
+Expected: FAIL (`KeyError`/`AssertionError`: `pressure_mean_avg` not in agg).
+
+- [ ] **Step 3: Implement the instrumentation**
+
+In `run_one` (where the per-run result dict is built around line 740-744), import the helper at
+the top of the file (`from pressure_stats import pressure_stats`) and add the per-run stats:
+
+```python
+        # PE experiment (PR1): compact per-run pressure-trajectory stats.
+        **{f"pressure_{k}" if k != "pressure_mean" else k: v
+           for k, v in pressure_stats(pressure_samples).items()},
+```
+
+Simpler + explicit (preferred -- avoid the comprehension): add three keys to the result dict
+right after `"pressure_final": ...`:
+
+```python
+        "pressure_mean": pressure_stats(pressure_samples)["pressure_mean"],
+        "pressure_frac_ge75": pressure_stats(pressure_samples)["frac_ge75"],
+        "pressure_pmax": pressure_stats(pressure_samples)["pmax"],
+```
+
+(Compute once into a local `_ps = pressure_stats(pressure_samples)` and reference `_ps[...]` to
+avoid three calls.)
+
+In `aggregate()` (the returned dict near lines 813-826, alongside `kd_avg`), add:
+
+```python
+        "pressure_mean_avg": statistics.mean([r.get("pressure_mean", 0.0) for r in ok]),
+        "pressure_frac_ge75_avg": statistics.mean([r.get("pressure_frac_ge75", 0.0) for r in ok]),
+        "apex_reach_rate": (
+            sum(1 for r in ok if r.get("pressure_pmax", 0.0) >= 95) / len(ok) if ok else 0.0
+        ),
+```
+
+(`ok` is the existing list of completed runs used for the other aggregate stats; confirm its name
+in the function and reuse it.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_aggregate_pressure_instrumentation.py`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Run the FULL suite (no regressions in the existing calibration tests)**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py`
+Expected: PASS (all prior tests + the new ones; e.g. 120 + new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/py/batch_calibrate_hardcore06.py tools/py/test_aggregate_pressure_instrumentation.py
+git commit  # "feat(calibration): emit per-run + aggregate pressure-trajectory stats (PE experiment PR1)" + ADR-0011 trailer
+```
+
+---
+
+### Task 6: Maintainer backend runner + experiment CLI smoke
+
+The analysis core (Task 4) is complete. This task adds the backend-dependent corpus builder (a
+maintainer path, like the P2/P3/P4/P5 runners) so the owner can produce a real corpus, plus a
+`--dry-run` smoke that exercises the analysis end-to-end on a synthetic corpus with no backend.
+
+**Files:**
+- Modify: `tools/py/pe_experiment.py` (add `make_corpus_from_backend` + `--dry-run`)
+- Test: `tools/py/test_pe_experiment.py` (add a dry-run smoke assertion)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tools/py/test_pe_experiment.py`:
+
+```python
+def test_synthetic_corpus_smoke():
+    from pe_experiment import synthetic_corpus
+    corpus = synthetic_corpus(n=20, seed_bias=0.5)
+    assert len(corpus) == 20
+    rep = analyze_corpus(corpus)
+    assert "ranked" in rep and len(rep["ranked"]) == 3
+    assert "verdict" in rep
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pe_experiment.py::test_synthetic_corpus_smoke`
+Expected: FAIL (ImportError: cannot import name 'synthetic_corpus').
+
+- [ ] **Step 3: Implement `synthetic_corpus`, `make_corpus_from_backend`, and `--dry-run`**
+
+Add to `tools/py/pe_experiment.py` (above `main`):
+
+```python
+def synthetic_corpus(n=20, seed_bias=0.5):
+    """Deterministic synthetic corpus for the dry-run smoke (no backend, no randomness):
+    half wins / half losses, with pressure stats that mimic the real collinearity
+    (wins -> higher mean/pmax) so the analysis exercises end-to-end."""
+    corpus = []
+    for i in range(n):
+        won = (i % 2 == 0)
+        mean = 90.0 if won else 60.0
+        corpus.append({
+            "outcome": "victory" if won else "defeat",
+            "pressure_frac_ge75": 0.9 if won else 0.3,
+            "pressure_mean": mean,
+            "pressure_pmax": 99.0 if won else 80.0,
+        })
+    return corpus
+
+
+def make_corpus_from_backend(repo, scenario_key, *, seed=424242, n=100, shards=4):
+    """BACKEND-DEPENDENT maintainer path: run calibrate_parallel seed-pinned on node 22, read
+    the merged runs (each now carrying the per-run pressure stats from Task 5), return the
+    corpus. Validated by the maintainer on a real run; not unit-tested (no backend in CI)."""
+    import json
+    import subprocess
+    import tempfile
+    tmp = Path(tempfile.gettempdir())
+    cmd = [sys.executable, str(Path(repo) / "tools/py/calibrate_parallel.py"),
+           "--scenario", scenario_key, "--n", str(n), "--seed", str(seed),
+           "--shards", str(shards), "--out-dir", str(tmp), "--label", "pe-exp"]
+    subprocess.run(cmd, cwd=repo, check=True)
+    merged = sorted(tmp.glob("*pe-exp*.json"), key=lambda p: p.stat().st_mtime)
+    data = json.loads(merged[-1].read_text(encoding="utf-8")) if merged else {}
+    return data.get("runs", [])
+```
+
+Then extend `main` to support `--dry-run` (before the `--corpus` requirement):
+
+```python
+    ap.add_argument("--dry-run", action="store_true",
+                    help="analyze a deterministic synthetic corpus (no backend); smoke only")
+    ...
+    if args.dry_run:
+        print(json.dumps(analyze_corpus(synthetic_corpus()), indent=2))
+        return 0
+```
+
+(Make `--corpus` not-required when `--dry-run` is set: change `required=True` to `required=False`
+and add an explicit error if neither `--dry-run` nor `--corpus` is given.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q --import-mode=importlib tools/py/test_pe_experiment.py`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Dry-run smoke (output captured, QG Step-1)**
+
+Run: `python tools/py/pe_experiment.py --dry-run`
+Expected: prints a JSON report with `ranked` (3 candidates) + `verdict`; exit 0. (On the synthetic
+corpus B/C are collinear with wins and A is the least-collinear, so `selected` is typically
+`A_sustained_threat` -- but the smoke only asserts the harness runs + emits a report.)
+
+- [ ] **Step 6: Full suite + commit**
+
+```bash
+python -m pytest -q --import-mode=importlib tools/py   # all green
+git add tools/py/pe_experiment.py tools/py/test_pe_experiment.py
+git commit  # "feat(calibration): PE experiment backend runner + dry-run smoke (PR1)" + ADR-0011 trailer
+```
+
+---
+
+## After PR1
+
+The harness is shipped. The OWNER runs the experiment (maintainer step, backend, node 22):
+1. `python tools/py/calibrate_parallel.py --scenario hardcore_06 --n 100 --seed 424242` (now emits per-run pressure stats) -> merged runs JSON.
+2. (optional) one eased-knob run for discrimination.
+3. `python tools/py/pe_experiment.py --corpus <merged.json> [--eased <eased.json>]` -> selection report.
+4. Read the report: the least-collinear candidate (abs_corr) with correct discrimination is the PE_ratio. If `verdict` is negative-result (all abs_corr > 0.6), PR2 switches to the contestedness proxy (spec sec 4.5).
+
+**PR2** (separate spec/plan) wires the selected `pe_ratio` + `kd_normalize` into the aggregate/objective, derives + human-ratifies the composite band, and unblocks P4 gate-2/4b + P5 composite-drift.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** instrumentation (sec 3.1) = Task 5; candidates (3.2) = Task 2; orthogonality (3.3) = Task 3; experiment runner (3.4) = Tasks 4+6; kd_normalize (3.5) = Task 2; the composite band (3.6) + wiring (sec 5) are explicitly PR2, not PR1 (correct per delivery sec 8). Experiment protocol (sec 4) incl. negative-result threshold 0.6 = Task 3 `DEFAULT_MAX_CORR` + the "After PR1" run steps.
+- **Placeholder scan:** every code step has complete code; the one judgment call (real `aggregate()` field names) is flagged with an explicit confirm-against-source note in Task 5, not left as TBD.
+- **Type consistency:** per-run keys are `pressure_mean` / `pressure_frac_ge75` / `pressure_pmax` everywhere (run_one emit in Task 5, `run_to_stats` in Task 4, fixtures in Tasks 4-5). Candidate names `A_sustained_threat` / `B_time_avg` / `C_apex_reach` are identical in Tasks 2/3/4/6. `pressure_stats` returns `{pressure_mean, frac_ge75, pmax}` consistently (Task 1) and `run_to_stats` maps the per-run `pressure_frac_ge75`->`frac_ge75`, `pressure_pmax`->`pmax` (Task 4) -- the one rename point, intentional and tested.

--- a/docs/superpowers/plans/2026-06-18-composite-pe-ratio-experiment-pr1.md
+++ b/docs/superpowers/plans/2026-06-18-composite-pe-ratio-experiment-pr1.md
@@ -241,8 +241,8 @@ def test_analyze_candidate_abs_corr():
 def test_selection_report_ranks_least_collinear_first():
     wons = [False, True, False, True, False, True]
     per_candidate = {
-        "collinear": [0.1, 0.9, 0.1, 0.9, 0.1, 0.9],     # tracks wins -> high |corr|
-        "orthogonal": [0.5, 0.5, 0.6, 0.4, 0.55, 0.45],  # ~flat vs wins -> low |corr|
+        "collinear": [0.1, 0.9, 0.1, 0.9, 0.1, 0.9],   # tracks wins -> abs_corr 1.0
+        "orthogonal": [0.4, 0.4, 0.6, 0.6, 0.5, 0.5],   # equal win/loss means -> abs_corr 0.0
     }
     eased = {"collinear": 0.05, "orthogonal": 0.2}   # trivialized-run candidate values
     ratified = {"collinear": 0.5, "orthogonal": 0.5}

--- a/docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md
+++ b/docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md
@@ -53,6 +53,32 @@ orthogonal to WR (outcome) and KD (combat efficiency). Ground truth of the mecha
 - Only `pressure_final` is emitted per run today; the full per-round trajectory
   (`pressure_samples`) exists internally but is not surfaced (batch_calibrate_hardcore06.py:743).
 
+### 1.2 External standards alignment (last30days + literature, 2026-06-18)
+
+Grounded the design against external practice before committing (gap-audit ethos). The
+experiment-first composite is standard-aligned, and Evo is ahead on the load-bearing axis:
+
+- **AI/sim players to predict engagement + difficulty is the established method** (Roohi et
+  al., "Predicting Game Engagement and Difficulty Using AI Players", arXiv 2107.12061; "Difficulty
+  Modelling ... combining player analytics and simulated data", arXiv 2401.17436). Evo's
+  AI-driven batch-sim playtest IS this method -- not a gap.
+- **Engagement = challenge-skill balance (flow theory)** (game-engagement-theory; dynamic-
+  difficulty-balancing literature). Tension is operationalized as *sustained challenge relative
+  to skill*. PE-as-tension maps directly: a healthy encounter keeps the AI in the "flow channel"
+  (challenging but winnable). This reinforces candidates A/B (sustained engagement) over C
+  (apex-only), and gives PE an academic name (challenge-engagement, not a bespoke coinage).
+- **Win-rate alone is insufficient** -- the composite's whole premise. Community discourse
+  (r/gamedesign "tropes that look like depth but aren't"; "rewarding clever resource use vs
+  punishing safe hoarding") is exactly the degenerate-but-fine-looking play the anti-false-
+  balanced composite must catch.
+- **Load-bearing caveat:** most engagement metrics in the literature rely on REAL-player
+  telemetry (biometrics, churn, session length) -- NOT transferable to a deterministic AI-sim
+  gate. The standard that transfers is "AI players predict difficulty/engagement"; the one that
+  does NOT is "engagement via human telemetry". So PE MUST be a sim-derivable proxy
+  (pressure-trajectory) -- which is exactly this design's constraint, and the reason the
+  negative-result branch (sec 4.5) falls back to a sim-derivable contestedness proxy
+  (turns/dmg = a challenge-skill margin), itself flow-aligned.
+
 ## 2. Goal / scope
 
 Define `pe_ratio` (a 0..1, higher=healthier tension signal) **empirically** -- pick the

--- a/docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md
+++ b/docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md
@@ -97,12 +97,16 @@ CANONICAL sec 9); promoting any gate from advisory (separate SDMG track).
 ## 3. Design (design-for-isolation)
 
 ### 3.1 Sim instrumentation (additive, deterministic)
-`batch_calibrate_*.py aggregate()` gains per-scenario pressure-trajectory stats, aggregated
-over the run set (the per-run `pressure_samples` are surfaced, not just `pressure_final`):
-- `pressure_mean` (mean over all rounds of all runs),
-- `pressure_tier_fractions` (share of rounds in each tier: calm/alert/escalated/critical/apex),
-- `apex_reach_rate` (fraction of runs that touched pressure >= 95).
-Additive keys; no behavior change; seed-pinned -> deterministic.
+The per-run result gains compact pressure-trajectory stats (from `pressure_stats(pressure_samples)`):
+`pressure_mean`, `pressure_frac_ge75` (share of rounds in the dangerous Critical+Apex tiers,
+pressure >= 75), `pressure_pmax`. `batch_calibrate_*.py aggregate()` then surfaces the
+aggregated forms over the run set:
+- `pressure_mean_avg` (mean of per-run `pressure_mean`),
+- `pressure_frac_ge75_avg` (mean of per-run sustained-threat fraction),
+- `apex_reach_rate` (fraction of runs whose `pressure_pmax` reached >= 95).
+(As-shipped PR1 keys -- the per-run `pressure_frac_ge75` + `pressure_mean` + `pressure_pmax`
+are exactly what candidates A/B/C consume; a full per-tier histogram is YAGNI until a future
+candidate needs it.) Additive keys; no behavior change; seed-pinned -> deterministic.
 
 ### 3.2 PE candidates (`tools/py/pe_candidates.py`, pure)
 Each maps the trajectory stats -> a 0..1 value (higher = more sustained tension):

--- a/docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md
+++ b/docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md
@@ -1,0 +1,180 @@
+---
+title: 'Composite PE_ratio -- experiment-first definition + composite wiring'
+doc_status: draft
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-18'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# Composite PE_ratio -- experiment-first definition + composite wiring
+
+> Brainstormed 2026-06-18 (G2 follow-up, unblocks the deferred composite gate). The
+> per-template calibration composite `0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio`
+> (canonical-suite.yaml:29, CANONICAL-AI-PLAYTEST.md:79) is UNCOMPUTABLE today: `pe_ratio`
+> is undefined anywhere, `kd_ratio` is emitted only as an unnormalized `kd_avg`, and the
+> scalar composite has no band. That gap is why P4 gate-2/gate-4b fail-closed and P5 only
+> checks WR-band drift. This spec defines PE_ratio **by experiment, not by armchair**, then
+> wires the computable composite. Input to `writing-plans`.
+
+## 1. Problem / current state (verified on origin/main `24fbe86b`)
+
+- **`pe_ratio` is undefined.** It appears ONLY in the composite formula (manifest:29,
+  CANONICAL:79) and in G2 code comments noting its absence. No computation exists
+  (grep: no `pe_ratio` / `pressure_efficiency` / `pressure_ratio`).
+- **`kd_ratio` != what is emitted.** `batch_calibrate_*.py aggregate()` emits `kd_avg`
+  (mean of per-run kill/death), not a normalized `kd_ratio`; the orchestrator maps
+  `kd_avg -> kd_ratio` as a stopgap. `kd_avg` is ~0.8 typical, not 0..1.
+- **No composite band.** The scalar composite has no target range in the manifest (the
+  dimensional gap flagged in the P4 spec): "composite in-band" is undefined.
+- **Consequence:** `objective.evaluate_metric` raises `KeyError` on `pe_ratio`/`kd_ratio`,
+  so the composite is `None`; P4 gate-2/4b abort fail-closed, P5 degrades to WR-only.
+
+### 1.1 The `sistema_pressure` mechanic (grounded, 2026-06-18)
+
+PE was intended as **Pressure-Efficiency** (owner, 2026-06-18): a tension/engagement signal
+orthogonal to WR (outcome) and KD (combat efficiency). Ground truth of the mechanic:
+
+- `sistema_pressure` is a 0-100 AI-escalation threat gauge (start 75 = Critical). Tiers:
+  Calm(0-24)/Alert(25-49)/Escalated(50-74)/Critical(75-94)/Apex(95-100). Pressure controls
+  AI intents-per-round (1->4) and reinforcement budget (0->4). HIGH pressure = BAD for the
+  player (sessionHelpers.js:771-777).
+- Evolution per round: +20 player-kills-Sistema, -10 Sistema-kills-player, -1 natural decay,
+  +-biome multiplier, +-Defy (sessionRoundBridge.js:803-815, defyEngine.js).
+- **Load-bearing finding -- collinearity.** Because pressure rises +20 on player kills,
+  it is positively correlated with winning: empirically WINS end at ~99.6 pressure (apex),
+  LOSSES at ~69. So `pressure_final` (and any pressure-MAGNITUDE metric) partly re-measures
+  WR -- the opposite of the orthogonal third axis the composite wants. Perfect orthogonality
+  from pressure alone is NOT achievable; the extractable orthogonal signal is mainly the
+  "too-easy / low-engagement" case (pressure stays low = AI never threatened, trivial
+  encounter even at in-band WR).
+- Only `pressure_final` is emitted per run today; the full per-round trajectory
+  (`pressure_samples`) exists internally but is not surfaced (batch_calibrate_hardcore06.py:743).
+
+## 2. Goal / scope
+
+Define `pe_ratio` (a 0..1, higher=healthier tension signal) **empirically** -- pick the
+formula that is the LEAST collinear with WR on real run data, rather than guessing -- then
+make the composite computable and derive its band. Negative-result is a valid outcome: if
+every pressure-derived candidate is too collinear, say so and reconsider the signal source.
+
+**In scope:** pressure-trajectory instrumentation; candidate PE formulas; an orthogonality
+experiment + selection report; `kd_ratio` normalization; empirical composite-band derivation;
+wiring the computable composite into the existing P4/P5 consumers.
+
+**Out of scope (YAGNI):** changing the pressure mechanic (the +20-on-kill direction is an
+intentional AI-War contract, not a bug); auto-ratifying the composite band (human-only, per
+CANONICAL sec 9); promoting any gate from advisory (separate SDMG track).
+
+## 3. Design (design-for-isolation)
+
+### 3.1 Sim instrumentation (additive, deterministic)
+`batch_calibrate_*.py aggregate()` gains per-scenario pressure-trajectory stats, aggregated
+over the run set (the per-run `pressure_samples` are surfaced, not just `pressure_final`):
+- `pressure_mean` (mean over all rounds of all runs),
+- `pressure_tier_fractions` (share of rounds in each tier: calm/alert/escalated/critical/apex),
+- `apex_reach_rate` (fraction of runs that touched pressure >= 95).
+Additive keys; no behavior change; seed-pinned -> deterministic.
+
+### 3.2 PE candidates (`tools/py/pe_candidates.py`, pure)
+Each maps the trajectory stats -> a 0..1 value (higher = more sustained tension):
+- **A -- sustained-threat fraction:** share of rounds with pressure >= 75 (Critical+Apex).
+- **B -- time-averaged pressure:** `pressure_mean / 100` (trajectory, not endpoint-biased).
+- **C -- apex-reach rate:** fraction of runs that reached Apex (>= 95).
+Pure functions, unit-tested on synthetic trajectory dicts. New candidates are easy to add.
+
+### 3.3 Orthogonality analysis (`tools/py/pe_orthogonality.py`, pure)
+Given a per-run corpus `[(candidate_value, won_bool), ...]` for each candidate:
+- `abs(pearson(candidate, won))` -- the collinearity score; LOWER is better (more orthogonal).
+  This is the PRIMARY selection criterion.
+- a SECONDARY discrimination check: run each oracle once more at a deliberately-EASED knob
+  (low difficulty, e.g. boss_hp at its `knob_space` min) and confirm the candidate scores
+  LOWER tension on that trivialized run than on the ratified-knob run (correct direction +
+  a meaningful gap). This guards against a candidate that is orthogonal-but-flat (no signal).
+- emits a ranked **selection report** (each candidate's |corr|, discrimination gap, verdict).
+Pure (numpy-free; hand-rolled Pearson), unit-tested with synthetic correlated/uncorrelated data.
+
+### 3.4 Experiment runner (maintainer/backend)
+A thin CLI that, for each ratified balance-oracle, runs the existing seed-pinned N=100
+harness on **node 22** (CANONICAL sec 3 rule 8), collects per-run `(pressure trajectory,
+won)`, computes A/B/C via 3.2, and feeds 3.3 -> prints the selection report. BACKEND-DEPENDENT
+(needs the Game backend), so the actual run is owner/maintainer-validated; the tooling it
+calls is fully unit-tested without a backend.
+
+### 3.5 kd_ratio normalization
+`kd_ratio = kd_avg / (kd_avg + 1)` -- bounded (0,1), monotonic increasing, 0.8 -> ~0.44. Makes
+all three composite terms 0..1 and same-direction (higher=healthier). Pure + tested.
+
+### 3.6 Composite band (human-ratified)
+Once `pe_ratio` (the selected candidate) + normalized `kd_ratio` are emitted, compute the
+composite on the in-band ratified oracles at N=100; the band = `[mean - k*half, mean + k*half]`
+derived from those healthy values (proposed, with the numbers shown). The band is
+**human-ratified, never auto-derived in CI** (CANONICAL sec 9); the tool proposes, the owner
+ratifies into the manifest.
+
+## 4. Experiment protocol + selection criterion
+
+1. Run N=100 seed-pinned (canonical_seed 424242), node 22, on each ratified oracle (hc06, hc07).
+2. For each run capture the pressure trajectory + the won/lost outcome.
+3. For each candidate A/B/C compute the per-run value, then `|pearson(value, won)|` across runs.
+4. **Select** the candidate with the LOWEST `|corr|` (most orthogonal to WR) that also shows
+   positive discrimination (separates too-easy from balanced). Document all three numbers.
+5. **Negative-result branch:** if `min |corr| > 0.6` (all candidates strongly collinear),
+   record it (the experiment FALSIFIED pressure-as-PE-source) and PR2 switches the tension
+   signal to the alternate already-telemetered source (turns-to-resolve + dmg_taken
+   "contestedness"), re-running 3.2-3.4 with those candidates. `0.6` is a starting threshold,
+   ratified with the data.
+
+## 5. Wiring (PR2, post-selection)
+
+- Emit the selected `pe_ratio` + normalized `kd_ratio` in `aggregate()` (and surface them
+  through `calibrate_parallel` / the orchestrator runner -> `evaluate_metric` now computes the
+  composite instead of `None`).
+- Derive + propose the composite band (sec 3.6); owner ratifies into `canonical-suite.yaml`
+  (a new per-scenario `composite_band`, or a global default).
+- **Unblock:** P4 gate-2/gate-4b can now evaluate the composite (no longer fail-closed on
+  `None`); P5 can add composite-drift to its WR-drift check. Update those modules + their
+  tests to consume the real composite + band.
+- Update `CANONICAL-AI-PLAYTEST.md` + the calibration spec with the ratified PE_ratio
+  definition + the selection evidence.
+
+## 6. Testing (TDD)
+
+- `pe_candidates` unit tests: each formula on synthetic trajectory dicts; boundary (all-calm,
+  all-apex, empty) -> defined 0..1 outputs.
+- `pe_orthogonality` unit tests: a perfectly-correlated synthetic corpus -> |corr| ~ 1; an
+  uncorrelated one -> |corr| ~ 0; discrimination separates a seeded too-easy set.
+- kd normalization: monotonic, bounded, known points (0 -> 0, 0.8 -> ~0.444, large -> ~1).
+- aggregate instrumentation: a run-fixture -> the new pressure keys present + correct (no
+  backend; feed synthetic per-run `pressure_samples`).
+- No backend/network in any test; the real N=100 run is the owner's experiment step.
+
+## 7. Risks / open questions
+
+- **Collinearity (load-bearing):** pressure tracks kills/winning; the experiment may show even
+  the best candidate is materially collinear. The selection report makes this explicit and the
+  negative-result branch (sec 4.5) handles "PE-from-pressure rejected". Either outcome is a
+  result, not a failure.
+- **Composite band = a self-designed threshold on the balance authority (SDMG).** It is
+  human-ratified, never auto; the tool only proposes with the numbers. A harsh-review of the
+  band derivation precedes ratification.
+- **N=100 cost.** The experiment is one N=100 sweep per oracle on node 22 -- a maintainer run,
+  not per-PR.
+- **kd_ratio semantics.** Normalizing `kd_avg` (mean-of-per-run-ratios) is the chosen
+  definition; ratio-of-totals (sum kills / sum deaths) is a documented alternative if the
+  normalized mean proves unstable.
+
+## 8. Delivery (2 sequenced PRs)
+
+1. **PR1 -- experiment harness:** pressure-trajectory instrumentation in `aggregate()` +
+   `pe_candidates.py` + `pe_orthogonality.py` + the experiment-runner CLI + full hermetic
+   tests. Ships the harness; the owner runs the N=100 experiment + the selection report.
+2. **PR2 -- wire the winner:** emit the selected `pe_ratio` + normalized `kd_ratio`; derive +
+   ratify the composite band; unblock P4 gate-2/4b + P5 composite-drift; update CANONICAL +
+   spec with the ratified definition + evidence. (Or, on a negative result, switch the tension
+   source per sec 4.5.)
+
+Each PR is owner-gated (merge = Eduardo), TDD, and gets its own `writing-plans`. PR1 is the
+recommended first implementation; the formula choice is the EXPERIMENT's output, not a guess.

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -23,6 +23,7 @@ import urllib.error
 import urllib.request
 
 import calibrate_policies
+from pressure_stats import pressure_stats
 
 SCENARIO_ID = "enc_tutorial_06_hardcore"
 MAX_ROUNDS = 40
@@ -727,6 +728,9 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
         vc_status, vc = get(f"{host}/api/session/{sid}/vc")
         vc_data = vc if vc_status == 200 else {}
 
+    # PE_ratio experiment PR1: compact pressure-trajectory stats for this run.
+    _ps = pressure_stats(pressure_samples)
+
     return {
         "run": run_idx,
         "seed": seed,
@@ -741,6 +745,9 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
         "dmg_taken_player": dmg_taken_player,
         "boss_hp_remaining": boss_hp_remaining,
         "pressure_final": pressure_samples[-1] if pressure_samples else pstart,
+        "pressure_mean": _ps["pressure_mean"],
+        "pressure_frac_ge75": _ps["frac_ge75"],
+        "pressure_pmax": _ps["pmax"],
         "ai_intent_tally": {f"{t}|{a}": c for (t, a), c in ai_intent_tally.items()},
         # 2026-05-20 method F: player + trait telemetry (anti-pattern #8 close).
         "player_action_tally": dict(player_action_tally),
@@ -812,6 +819,12 @@ def aggregate(runs, encounter_class=None):
         "turns_hist": _hist(turns, bins=[(1,5),(6,10),(11,15),(16,20),(21,30),(31,40),(41,999)]),
         "kd_avg": statistics.mean(kd),
         "kd_median": statistics.median(kd),
+        # PE_ratio experiment PR1: aggregate pressure-trajectory stats.
+        "pressure_mean_avg": statistics.mean([r.get("pressure_mean", 0.0) for r in ok]),
+        "pressure_frac_ge75_avg": statistics.mean([r.get("pressure_frac_ge75", 0.0) for r in ok]),
+        "apex_reach_rate": (
+            sum(1 for r in ok if r.get("pressure_pmax", 0.0) >= 95) / len(ok) if ok else 0.0
+        ),
         "dmg_dealt_avg": statistics.mean(r["dmg_dealt_player"] for r in ok),
         "dmg_taken_avg": statistics.mean(r["dmg_taken_player"] for r in ok),
         "boss_hp_remaining_avg_on_loss": (

--- a/tools/py/pe_candidates.py
+++ b/tools/py/pe_candidates.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""PE_ratio candidate formulas (G2 follow-up PR1). Each maps per-run pressure stats
+(from pressure_stats) -> a 0..1 tension value (higher = more sustained tension). The
+WINNER is chosen by the orthogonality experiment, NOT here -- new candidates are cheap."""
+from __future__ import annotations
+
+APEX = 95
+
+
+def candidate_A(stats):  # sustained-threat fraction
+    return float(stats.get("frac_ge75", 0.0))
+
+
+def candidate_B(stats):  # time-averaged pressure, normalized
+    return float(stats.get("pressure_mean", 0.0)) / 100.0
+
+
+def candidate_C(stats):  # apex-reach (touched >= 95)
+    return 1.0 if float(stats.get("pmax", 0.0)) >= APEX else 0.0
+
+
+CANDIDATES = {
+    "A_sustained_threat": candidate_A,
+    "B_time_avg": candidate_B,
+    "C_apex_reach": candidate_C,
+}
+
+
+def candidate_value(name, stats):
+    v = CANDIDATES[name](stats)
+    return max(0.0, min(1.0, v))
+
+
+def kd_normalize(kd_avg):
+    """Map kd_avg (~0.8 typical, unbounded) -> (0,1) via kd/(kd+1): bounded, monotonic.
+    None in -> None out (missing metric surfaced, never faked)."""
+    if kd_avg is None:
+        return None
+    kd = float(kd_avg)
+    return kd / (kd + 1.0)

--- a/tools/py/pe_experiment.py
+++ b/tools/py/pe_experiment.py
@@ -25,7 +25,15 @@ def run_to_stats(run):
 
 
 def analyze_corpus(corpus, eased_run=None):
-    """Compute each candidate's per-run values + outcomes, then the selection report."""
+    """Compute each candidate's per-run values + outcomes, then the selection report.
+
+    The PRIMARY result is |corr(candidate, won)| (least collinear = selected) -- read this
+    as the decision. If an `eased_run` (a deliberately-trivialized-knob run) is given, an
+    ADVISORY `discrimination` field compares the eased run's tension against the MEAN tension
+    over this corpus (the corpus IS the ratified-knob runs, so its mean = mean ratified-knob
+    tension). NB this secondary check is itself susceptible to the WR/pressure collinearity
+    the experiment measures (an easy eased run can read HIGH pressure), so it can mislead --
+    advisory only, not the selection criterion."""
     per_candidate = {name: [] for name in CANDIDATES}
     wons = []
     for run in corpus:
@@ -42,10 +50,12 @@ def analyze_corpus(corpus, eased_run=None):
                             eased_value=eased_value)
 
 
-def synthetic_corpus(n=20, seed_bias=0.5):
+def synthetic_corpus(n=20):
     """Deterministic synthetic corpus for the dry-run smoke (no backend, no randomness):
     half wins / half losses, with pressure stats that mimic the real collinearity
-    (wins -> higher mean/pmax) so the analysis exercises end-to-end."""
+    (wins -> higher mean/pmax) so the analysis exercises end-to-end. Every candidate is
+    collinear with wins here BY CONSTRUCTION, so the dry-run correctly reports a
+    negative-result -- it only proves the harness runs end-to-end, not a real selection."""
     corpus = []
     for i in range(n):
         won = (i % 2 == 0)
@@ -66,14 +76,15 @@ def make_corpus_from_backend(repo, scenario_key, *, seed=424242, n=100, shards=4
     import json
     import subprocess
     import tempfile
-    tmp = Path(tempfile.gettempdir())
+    out_dir = Path(tempfile.mkdtemp(prefix="pe-exp-"))  # fresh dir: no stale-file masquerade
     cmd = [sys.executable, str(Path(repo) / "tools/py/calibrate_parallel.py"),
            "--scenario", scenario_key, "--n", str(n), "--seed", str(seed),
-           "--shards", str(shards), "--out-dir", str(tmp), "--label", "pe-exp"]
+           "--shards", str(shards), "--out-dir", str(out_dir), "--label", "pe-exp"]
     subprocess.run(cmd, cwd=repo, check=True)
-    merged = sorted(tmp.glob("*pe-exp*.json"), key=lambda p: p.stat().st_mtime)
-    data = json.loads(merged[-1].read_text(encoding="utf-8")) if merged else {}
-    return data.get("runs", [])
+    merged = sorted(out_dir.glob("*pe-exp*.json"), key=lambda p: p.stat().st_mtime)
+    if not merged:
+        raise RuntimeError(f"calibrate_parallel produced no output under {out_dir} -- cannot build corpus")
+    return json.loads(merged[-1].read_text(encoding="utf-8")).get("runs", [])
 
 
 def main():

--- a/tools/py/pe_experiment.py
+++ b/tools/py/pe_experiment.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""PE_ratio orthogonality experiment (G2 follow-up PR1). Analysis core: a runs-corpus
+(per-run pressure stats + outcome) -> a candidate-selection report. The real N=100 run is
+the owner's maintainer step (make_corpus_from_backend, backend-dependent); the analysis is
+pure + hermetically tested. See docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from pe_candidates import CANDIDATES, candidate_value  # noqa: E402
+from pe_orthogonality import selection_report  # noqa: E402
+
+
+def run_to_stats(run):
+    """Map one calibrate_parallel run record -> (stats dict for candidates, won bool)."""
+    stats = {
+        "frac_ge75": run.get("pressure_frac_ge75", 0.0),
+        "pressure_mean": run.get("pressure_mean", 0.0),
+        "pmax": run.get("pressure_pmax", 0.0),
+    }
+    return stats, run.get("outcome") == "victory"
+
+
+def analyze_corpus(corpus, eased_run=None):
+    """Compute each candidate's per-run values + outcomes, then the selection report."""
+    per_candidate = {name: [] for name in CANDIDATES}
+    wons = []
+    for run in corpus:
+        stats, won = run_to_stats(run)
+        wons.append(won)
+        for name in CANDIDATES:
+            per_candidate[name].append(candidate_value(name, stats))
+    eased_value = ratified_value = None
+    if eased_run is not None:
+        es, _ = run_to_stats(eased_run)
+        eased_value = {n: candidate_value(n, es) for n in CANDIDATES}
+        ratified_value = {n: (sum(v) / len(v) if v else 0.0) for n, v in per_candidate.items()}
+    return selection_report(per_candidate, wons, ratified_value=ratified_value,
+                            eased_value=eased_value)
+
+
+def main():
+    import argparse
+    import json
+
+    ap = argparse.ArgumentParser(description="PE_ratio orthogonality experiment (analysis)")
+    ap.add_argument("--corpus", required=True,
+                    help="JSON: a list of run records (pressure_frac_ge75/pressure_mean/"
+                         "pressure_pmax/outcome), e.g. the merged calibrate_parallel runs.")
+    ap.add_argument("--eased", help="optional JSON: one trivialized-knob run record (discrimination).")
+    args = ap.parse_args()
+    corpus = json.loads(Path(args.corpus).read_text(encoding="utf-8"))
+    if isinstance(corpus, dict):
+        corpus = corpus.get("runs", [])
+    eased = json.loads(Path(args.eased).read_text(encoding="utf-8")) if args.eased else None
+    print(json.dumps(analyze_corpus(corpus, eased_run=eased), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/py/pe_experiment.py
+++ b/tools/py/pe_experiment.py
@@ -42,16 +42,58 @@ def analyze_corpus(corpus, eased_run=None):
                             eased_value=eased_value)
 
 
+def synthetic_corpus(n=20, seed_bias=0.5):
+    """Deterministic synthetic corpus for the dry-run smoke (no backend, no randomness):
+    half wins / half losses, with pressure stats that mimic the real collinearity
+    (wins -> higher mean/pmax) so the analysis exercises end-to-end."""
+    corpus = []
+    for i in range(n):
+        won = (i % 2 == 0)
+        mean = 90.0 if won else 60.0
+        corpus.append({
+            "outcome": "victory" if won else "defeat",
+            "pressure_frac_ge75": 0.9 if won else 0.3,
+            "pressure_mean": mean,
+            "pressure_pmax": 99.0 if won else 80.0,
+        })
+    return corpus
+
+
+def make_corpus_from_backend(repo, scenario_key, *, seed=424242, n=100, shards=4):
+    """BACKEND-DEPENDENT maintainer path: run calibrate_parallel seed-pinned on node 22, read
+    the merged runs (each now carrying the per-run pressure stats), return the corpus.
+    Validated by the maintainer on a real run; not unit-tested (no backend in CI)."""
+    import json
+    import subprocess
+    import tempfile
+    tmp = Path(tempfile.gettempdir())
+    cmd = [sys.executable, str(Path(repo) / "tools/py/calibrate_parallel.py"),
+           "--scenario", scenario_key, "--n", str(n), "--seed", str(seed),
+           "--shards", str(shards), "--out-dir", str(tmp), "--label", "pe-exp"]
+    subprocess.run(cmd, cwd=repo, check=True)
+    merged = sorted(tmp.glob("*pe-exp*.json"), key=lambda p: p.stat().st_mtime)
+    data = json.loads(merged[-1].read_text(encoding="utf-8")) if merged else {}
+    return data.get("runs", [])
+
+
 def main():
     import argparse
     import json
 
     ap = argparse.ArgumentParser(description="PE_ratio orthogonality experiment (analysis)")
-    ap.add_argument("--corpus", required=True,
+    ap.add_argument("--corpus", required=False,
                     help="JSON: a list of run records (pressure_frac_ge75/pressure_mean/"
                          "pressure_pmax/outcome), e.g. the merged calibrate_parallel runs.")
     ap.add_argument("--eased", help="optional JSON: one trivialized-knob run record (discrimination).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="analyze a deterministic synthetic corpus (no backend); smoke only")
     args = ap.parse_args()
+    if args.dry_run:
+        print(json.dumps(analyze_corpus(synthetic_corpus()), indent=2))
+        return 0
+    if not args.corpus:
+        print("--corpus <runs.json> required (or --dry-run)", file=sys.stderr)
+        return 2
     corpus = json.loads(Path(args.corpus).read_text(encoding="utf-8"))
     if isinstance(corpus, dict):
         corpus = corpus.get("runs", [])

--- a/tools/py/pe_orthogonality.py
+++ b/tools/py/pe_orthogonality.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Orthogonality analysis for PE_ratio selection (G2 follow-up PR1). The PRIMARY criterion
+is |Pearson(candidate, won)| -- LOWER is better (less collinear with WR = better anti-false-
+balanced third axis). The SECONDARY check is discrimination (a trivialized run must score
+LOWER tension than the ratified run). Pure; hand-rolled Pearson (no numpy)."""
+from __future__ import annotations
+
+import math
+
+DEFAULT_MAX_CORR = 0.6  # negative-result threshold: all candidates above -> reject source
+
+
+def pearson(xs, ys):
+    n = len(xs)
+    if n == 0 or n != len(ys):
+        return 0.0
+    mx, my = sum(xs) / n, sum(ys) / n
+    sx = sum((x - mx) ** 2 for x in xs)
+    sy = sum((y - my) ** 2 for y in ys)
+    if sx == 0 or sy == 0:
+        return 0.0  # zero variance -> undefined correlation -> 0
+    cov = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    return cov / math.sqrt(sx * sy)
+
+
+def analyze_candidate(values, wons):
+    wbin = [1.0 if w else 0.0 for w in wons]
+    return {
+        "n": len(values),
+        "abs_corr": abs(pearson(values, wbin)),
+        "mean": (sum(values) / len(values)) if values else 0.0,
+    }
+
+
+def selection_report(per_candidate, wons, *, ratified_value=None, eased_value=None,
+                     max_corr=DEFAULT_MAX_CORR):
+    ratified_value = ratified_value or {}
+    eased_value = eased_value or {}
+    rows = []
+    for name, values in per_candidate.items():
+        a = analyze_candidate(values, wons)
+        rv, ev = ratified_value.get(name), eased_value.get(name)
+        disc = None
+        if rv is not None and ev is not None:
+            disc = {"gap": rv - ev, "correct_direction": rv > ev}
+        rows.append({"name": name, **a, "discrimination": disc})
+    rows.sort(key=lambda r: r["abs_corr"])  # least collinear first
+    best = rows[0] if rows else None
+    if best is None or best["abs_corr"] > max_corr:
+        selected, verdict = None, (
+            f"negative-result: min abs_corr {best['abs_corr']:.3f} > {max_corr} -- reject pressure source"
+            if best else "no candidates")
+    else:
+        selected, verdict = best["name"], f"selected {best['name']} (abs_corr {best['abs_corr']:.3f})"
+    return {"ranked": rows, "selected": selected, "verdict": verdict, "max_corr": max_corr}

--- a/tools/py/pressure_stats.py
+++ b/tools/py/pressure_stats.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Pure pressure-trajectory stats for the PE_ratio experiment (G2 follow-up PR1)."""
+from __future__ import annotations
+
+
+def pressure_stats(samples, threshold=75):
+    """Compact per-run stats from a pressure sample list: mean, fraction of samples at or
+    above `threshold` (sustained-threat), and max. Empty -> zeros (defined, never crash)."""
+    if not samples:
+        return {"pressure_mean": 0.0, "frac_ge75": 0.0, "pmax": 0.0}
+    vals = [float(s) for s in samples]
+    return {
+        "pressure_mean": sum(vals) / len(vals),
+        "frac_ge75": sum(1 for v in vals if v >= threshold) / len(vals),
+        "pmax": max(vals),
+    }

--- a/tools/py/test_aggregate_pressure_instrumentation.py
+++ b/tools/py/test_aggregate_pressure_instrumentation.py
@@ -1,0 +1,48 @@
+"""TDD for PE_ratio experiment PR1: per-run + aggregate pressure-trajectory stats
+instrumentation in batch_calibrate_hardcore06.py (G2 follow-up)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import batch_calibrate_hardcore06 as hc06  # noqa: E402
+
+
+def _base_run(outcome):
+    """Minimal per-run record with every field aggregate() reads, so the
+    function does not crash on a real-contract fixture."""
+    return {
+        "outcome": outcome,
+        "rounds": 10,
+        "players_alive": 2,
+        "players_dead": 1,
+        "enemies_alive": 0,
+        "enemies_dead": 3,
+        "dmg_dealt_player": 40,
+        "dmg_taken_player": 20,
+        "boss_hp_remaining": 0,
+        "ai_intent_tally": {},
+        "player_action_tally": {},
+        "trait_used_tally": {},
+    }
+
+
+def test_run_one_emits_per_run_pressure_stats():
+    from pressure_stats import pressure_stats
+
+    s = pressure_stats([75, 80, 95, 100])
+    assert set(s) == {"pressure_mean", "frac_ge75", "pmax"}
+
+
+def test_aggregate_surfaces_pressure_keys():
+    run1 = _base_run("victory")
+    run1.update({"pressure_mean": 90.0, "pressure_frac_ge75": 0.9, "pressure_pmax": 99})
+    run2 = _base_run("defeat")
+    run2.update({"pressure_mean": 62.0, "pressure_frac_ge75": 0.2, "pressure_pmax": 75})
+    runs = [run1, run2]
+
+    agg = hc06.aggregate(runs, "hardcore")
+    assert "pressure_mean_avg" in agg
+    assert "pressure_frac_ge75_avg" in agg
+    assert "apex_reach_rate" in agg
+    assert round(agg["pressure_frac_ge75_avg"], 2) == 0.55  # (0.9 + 0.2)/2
+    assert agg["apex_reach_rate"] == 0.5  # 1 of 2 runs pmax >= 95

--- a/tools/py/test_pe_candidates.py
+++ b/tools/py/test_pe_candidates.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+from pe_candidates import CANDIDATES, candidate_value, kd_normalize  # noqa: E402
+
+STATS = {"pressure_mean": 80.0, "frac_ge75": 0.6, "pmax": 96.0}
+
+
+def test_candidate_A_sustained_threat():
+    assert candidate_value("A_sustained_threat", STATS) == 0.6  # frac_ge75
+
+
+def test_candidate_B_time_avg():
+    assert candidate_value("B_time_avg", STATS) == 0.80  # pressure_mean/100
+
+
+def test_candidate_C_apex_reach():
+    assert candidate_value("C_apex_reach", STATS) == 1.0  # pmax 96 >= 95
+    assert candidate_value("C_apex_reach", {"pmax": 80.0}) == 0.0
+
+
+def test_all_candidates_return_0_1():
+    for name in CANDIDATES:
+        v = candidate_value(name, STATS)
+        assert 0.0 <= v <= 1.0
+
+
+def test_kd_normalize_bounded_monotonic():
+    assert kd_normalize(0.0) == 0.0
+    assert round(kd_normalize(0.8), 3) == 0.444
+    assert 0.0 < kd_normalize(0.8) < kd_normalize(5.0) < 1.0
+    assert kd_normalize(None) is None  # missing -> None, never a fake number

--- a/tools/py/test_pe_experiment.py
+++ b/tools/py/test_pe_experiment.py
@@ -26,3 +26,12 @@ def test_analyze_corpus_selects_least_collinear():
     assert rep["selected"] in ("A_sustained_threat", "B_time_avg", "C_apex_reach")
     names = [r["name"] for r in rep["ranked"]]
     assert names.index("A_sustained_threat") < names.index("B_time_avg")
+
+
+def test_synthetic_corpus_smoke():
+    from pe_experiment import synthetic_corpus
+    corpus = synthetic_corpus(n=20, seed_bias=0.5)
+    assert len(corpus) == 20
+    rep = analyze_corpus(corpus)
+    assert "ranked" in rep and len(rep["ranked"]) == 3
+    assert "verdict" in rep

--- a/tools/py/test_pe_experiment.py
+++ b/tools/py/test_pe_experiment.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+from pe_experiment import run_to_stats, analyze_corpus  # noqa: E402
+
+
+def _run(frac, mean, pmax, won):
+    return {"outcome": "victory" if won else "defeat",
+            "pressure_frac_ge75": frac, "pressure_mean": mean, "pressure_pmax": pmax}
+
+
+def test_run_to_stats_maps_fields():
+    s, won = run_to_stats(_run(0.6, 80.0, 96.0, True))
+    assert s == {"frac_ge75": 0.6, "pressure_mean": 80.0, "pmax": 96.0}
+    assert won is True
+
+
+def test_analyze_corpus_selects_least_collinear():
+    corpus = [
+        _run(0.50, 30.0, 80.0, False),
+        _run(0.55, 95.0, 99.0, True),
+        _run(0.52, 28.0, 70.0, False),
+        _run(0.48, 96.0, 99.0, True),
+    ]
+    rep = analyze_corpus(corpus)
+    assert rep["selected"] in ("A_sustained_threat", "B_time_avg", "C_apex_reach")
+    names = [r["name"] for r in rep["ranked"]]
+    assert names.index("A_sustained_threat") < names.index("B_time_avg")

--- a/tools/py/test_pe_experiment.py
+++ b/tools/py/test_pe_experiment.py
@@ -30,7 +30,7 @@ def test_analyze_corpus_selects_least_collinear():
 
 def test_synthetic_corpus_smoke():
     from pe_experiment import synthetic_corpus
-    corpus = synthetic_corpus(n=20, seed_bias=0.5)
+    corpus = synthetic_corpus(n=20)
     assert len(corpus) == 20
     rep = analyze_corpus(corpus)
     assert "ranked" in rep and len(rep["ranked"]) == 3

--- a/tools/py/test_pe_orthogonality.py
+++ b/tools/py/test_pe_orthogonality.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+from pe_orthogonality import pearson, analyze_candidate, selection_report  # noqa: E402
+
+
+def test_pearson_perfect_and_zero():
+    assert round(pearson([1, 2, 3, 4], [1, 2, 3, 4]), 6) == 1.0
+    assert round(pearson([1, 2, 3, 4], [4, 3, 2, 1]), 6) == -1.0
+    assert pearson([1, 1, 1], [1, 2, 3]) == 0.0  # zero variance -> 0 (no crash)
+
+
+def test_analyze_candidate_abs_corr():
+    vals = [0.2, 0.9, 0.3, 0.95]
+    wons = [False, True, False, True]
+    a = analyze_candidate(vals, wons)
+    assert a["n"] == 4
+    assert a["abs_corr"] > 0.9
+
+
+def test_selection_report_ranks_least_collinear_first():
+    wons = [False, True, False, True, False, True]
+    per_candidate = {
+        "collinear": [0.1, 0.9, 0.1, 0.9, 0.1, 0.9],   # tracks wins -> abs_corr 1.0
+        "orthogonal": [0.4, 0.4, 0.6, 0.6, 0.5, 0.5],   # equal win/loss means -> abs_corr 0.0
+    }
+    eased = {"collinear": 0.05, "orthogonal": 0.2}
+    ratified = {"collinear": 0.5, "orthogonal": 0.5}
+    rep = selection_report(per_candidate, wons, ratified_value=ratified, eased_value=eased)
+    assert rep["ranked"][0]["name"] == "orthogonal"
+    assert rep["selected"] == "orthogonal"
+    assert rep["ranked"][0]["discrimination"]["correct_direction"] is True

--- a/tools/py/test_pressure_stats.py
+++ b/tools/py/test_pressure_stats.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent))
+from pressure_stats import pressure_stats  # noqa: E402
+
+
+def test_basic_trajectory():
+    s = pressure_stats([75, 80, 95, 100])
+    assert s["pmax"] == 100
+    assert round(s["pressure_mean"], 2) == 87.5
+    assert s["frac_ge75"] == 1.0  # all >= 75
+
+
+def test_mixed_tiers():
+    s = pressure_stats([10, 50, 75, 90])  # 2 of 4 >= 75
+    assert s["frac_ge75"] == 0.5
+    assert s["pmax"] == 90
+
+
+def test_empty_is_zeroed_not_crash():
+    s = pressure_stats([])
+    assert s == {"pressure_mean": 0.0, "frac_ge75": 0.0, "pmax": 0.0}


### PR DESCRIPTION
## Composite PE_ratio -- experiment-first design + PR1 harness

G2 calibration follow-up: makes the composite `0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio` computable so it can unblock P4 gate-2/4b + P5 composite-drift. **PE_ratio is chosen BY EXPERIMENT** (least collinear with win-rate on real data), not by armchair -- this PR ships the design (spec + plan) + **PR1: the experiment harness**. The owner runs the N=100 experiment; **PR2** (separate) wires the winner + the human-ratified composite band.

This was driven through the full brainstorming -> spec -> plan -> subagent-driven-TDD pipeline, with external-standards grounding (last30days + literature) and a final harsh-review.

### Why experiment-first (the load-bearing finding)
`sistema_pressure` rises +20 on a player kill, so it is **collinear with winning** (empirically wins end ~99.6 pressure, losses ~69). A naive `pressure_final` PE would just re-measure WR -- defeating the composite's anti-false-balanced purpose. So the harness computes several PE candidates and **measures each candidate's `|Pearson(value, won)|`**, selecting the least-collinear (most orthogonal = best third axis). If all are too collinear (`> 0.6`) it reports a **negative-result** and PR2 switches the tension source to a contestedness proxy.

### What ships (PR1 -- pure analysis harness, NO production writes)
- `tools/py/pressure_stats.py` -- per-run trajectory -> `{pressure_mean, frac_ge75, pmax}`.
- `tools/py/pe_candidates.py` -- 3 candidates (A sustained-threat / B time-avg / C apex-reach) + `kd_normalize` (`kd/(kd+1)`, 0..1).
- `tools/py/pe_orthogonality.py` -- hand-rolled Pearson + selection report (ranks least-collinear first, 0.6 negative-result threshold).
- `tools/py/pe_experiment.py` -- analysis core (corpus -> report) + `--dry-run` smoke + a backend-dependent maintainer runner.
- `batch_calibrate_hardcore06.py` -- **additive** per-run + aggregate pressure-trajectory stats (no sim behavior change; verified zero regressions).
- `docs/superpowers/specs/2026-06-18-...-design.md` + `docs/superpowers/plans/2026-06-18-...-pr1.md`.

### Standards alignment (last30days + literature)
Evo's AI-driven batch-sim playtest IS the academic method for measuring engagement/difficulty (arXiv 2107.12061, 2401.17436); PE-as-tension maps to flow challenge-skill balance; win-rate-alone-insufficient is confirmed. Caveat: human-telemetry engagement metrics do NOT transfer to a deterministic AI-sim gate, so PE must be sim-derivable (pressure-trajectory) -- the design's constraint.

### Quality
- **TDD, 6 tasks, fresh subagent per task** (one caught a real plan-fixture bug -- an "orthogonal" test candidate that was actually r=-0.77; corrected). Full `tools/py` suite **136 green**; dry-run smoke runs end-to-end (correctly reports negative-result on the deliberately-collinear synthetic corpus).
- **Final harsh-review: SHIP-IT, zero P1.** P2/P3 findings addressed (discrimination field documented as advisory + collinearity-confounded; backend runner hardened with fresh mkdtemp + non-empty assert; spec keys reconciled; dead param dropped).
- Not in the per-PR gate; no runtime/data change; commits carry the ADR-0011 trailer.

**After merge (owner):** run `calibrate_parallel --scenario hardcore_06 --n 100 --seed 424242` (now emits pressure stats) -> `pe_experiment.py --corpus <merged.json>` -> read the selection report -> PR2 wires the chosen PE_ratio + composite band. Merge is owner-gated (Eduardo), conditional on CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
