### PR TITLE
feat(spec-k): enrich meta/npg with server-owned recruit/mating gates

### DIFF
--- a/apps/backend/routes/meta.js
+++ b/apps/backend/routes/meta.js
@@ -28,6 +28,7 @@ const {
   getTribeForUnit,
   recordOffspring,
   listLineageEntries,
+  evalNpcGates,
 } = require('../services/metaProgression');
 const { addFragments } = require('../services/rewards/skipFragmentStore');
 const { loadEpigenomeConfig, computeSpeciesMean } = require('../services/genetics/epigenome');
@@ -132,7 +133,11 @@ function createMetaRouter(opts = {}) {
   router.get('/npg', async (_req, res, next) => {
     try {
       const [npcs, nest] = await Promise.all([store.listNpcs(), store.getNest()]);
-      res.json({ npcs, nest });
+      // K-04 (SPEC-K device-authority): surface the recruit/mating gates per-npc
+      // so the Godot phone Nido view renders the server-owned gate instead of
+      // recomputing the thresholds client-side. Additive (raw fields preserved).
+      const enriched = (npcs || []).map((npc) => ({ ...npc, ...evalNpcGates(npc, nest) }));
+      res.json({ npcs: enriched, nest });
     } catch (err) {
       next(err);
     }

--- a/apps/backend/services/metaProgression.js
+++ b/apps/backend/services/metaProgression.js
@@ -35,6 +35,25 @@ const TRUST_MAX = 5;
 
 const MATING_THRESHOLD = 12; // DC base
 
+// K-04 (SPEC-K device-authority): pure recruit/mating gate eval over a plain
+// NPC row + nest state. Keeps the gates in ONE place (the constants above) so
+// they can be surfaced server-side on the /npg list. The Godot phone Nido view
+// used to recompute these gates client-side, duplicating the thresholds
+// verbatim (drift risk on re-tune) -- enriching /npg lets the device read the
+// gate the server owns. Matches the can_recruit flag already returned by
+// POST /affinity|/trust and the canRecruit()/canMate() store methods.
+function evalNpcGates(npc = {}, nest = {}) {
+  const affinity = Number(npc.affinity) || 0;
+  const trust = Number(npc.trust) || 0;
+  const recruited = Boolean(npc.recruited);
+  const mated = Boolean(npc.mated);
+  const cooldown = Number(npc.mating_cooldown) || 0;
+  const nestReady = Boolean(nest && nest.requirements_met);
+  const can_recruit = affinity >= RECRUIT_AFFINITY_MIN && trust >= RECRUIT_TRUST_MIN && !recruited;
+  const can_mate = recruited && trust >= MATING_TRUST_MIN && !mated && cooldown <= 0 && nestReady;
+  return { can_recruit, can_mate };
+}
+
 /**
  * D1: Creates a meta progression tracker for a party/campaign.
  * In-memory state — persist externally if needed.
@@ -1304,3 +1323,6 @@ module.exports.TIER_NO_GLOW = TIER_NO_GLOW;
 module.exports.TIER_GOLD = TIER_GOLD;
 module.exports.TIER_RAINBOW = TIER_RAINBOW;
 module.exports.TIER_VISUAL_HINTS = TIER_VISUAL_HINTS;
+
+// K-04 (SPEC-K) — server-side recruit/mating gate eval for /npg enrichment.
+module.exports.evalNpcGates = evalNpcGates;

--- a/tests/api/metaRoutes.test.js
+++ b/tests/api/metaRoutes.test.js
@@ -26,6 +26,43 @@ test('GET /api/meta/npg returns npcs + nest shape', async () => {
   }
 });
 
+// K-04 (SPEC-K device-authority): /npg must surface the recruit/mating gates
+// per-npc so the Godot phone Nido view reads the server-owned gate instead of
+// recomputing the thresholds client-side (drift risk). Mirrors the can_recruit
+// flag already returned by POST /affinity|/trust.
+test('GET /api/meta/npg enriches each npc with can_recruit + can_mate gates', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // Seed npc_a so it clears the recruit gate (affinity>=0, trust>=2, !recruited).
+    await request(app)
+      .post('/api/meta/affinity')
+      .send({ npc_id: 'npc_enrich_a', delta: 1 })
+      .expect(200);
+    await request(app)
+      .post('/api/meta/trust')
+      .send({ npc_id: 'npc_enrich_a', delta: 2 })
+      .expect(200);
+    // Seed npc_b below the trust gate (trust 0) -> not recruitable.
+    await request(app)
+      .post('/api/meta/affinity')
+      .send({ npc_id: 'npc_enrich_b', delta: 1 })
+      .expect(200);
+
+    const res = await request(app).get('/api/meta/npg').expect(200);
+    const a = res.body.npcs.find((n) => n.npc_id === 'npc_enrich_a');
+    const b = res.body.npcs.find((n) => n.npc_id === 'npc_enrich_b');
+    assert.ok(a, 'seeded npc_a present in npg list');
+    assert.ok(b, 'seeded npc_b present in npg list');
+    assert.equal(a.can_recruit, true); // affinity 1, trust 2, not recruited
+    assert.equal(a.can_mate, false); // not recruited yet -> mate gate closed
+    assert.equal(b.can_recruit, false); // trust 0 < RECRUIT_TRUST_MIN
+    assert.equal(typeof a.affinity, 'number');
+    assert.equal(typeof a.trust, 'number');
+  } finally {
+    await close();
+  }
+});
+
 test('POST /api/meta/affinity updates + returns can_recruit flag', async () => {
   const { app, close } = createApp({ databasePath: null });
   try {


### PR DESCRIPTION
## What

`GET /api/v1/meta/npg` now returns `can_recruit` + `can_mate` **per npc**,
computed server-side from the canonical gate constants
(`RECRUIT_AFFINITY_MIN=0`, `RECRUIT_TRUST_MIN=2`, `MATING_TRUST_MIN=3`).

New pure helper `metaProgression.evalNpcGates(npc, nest)` is the single source
for the gate; the `/npg` route maps each npc through it. Additive -- raw npc
fields are preserved and there is no contract schema for `npg`.

## Why (K-04, Track A prereq)

The Godot phone Nido view's `meta_relations_presenter.gd` currently recomputes
these gates client-side, with a comment admitting it mirrors the backend
constants *verbatim*:

> `listNpcs()` returns RAW rows, so the gates are computed client-side, mirroring
> metaProgression.js constants verbatim: RECRUIT_AFFINITY_MIN=0, RECRUIT_TRUST_MIN=2,
> MATING_TRUST_MIN=3.

That is a drift risk: any future re-tune of the recruit/mating gate would
silently desync the device. Surfacing the gate the server owns lets the phone
read it instead of hardcoding the thresholds -- the same read-enrich pattern as
the SPEC-J scars read (#2823) and the consent `timeout_ms` snapshot (#2803).

This unblocks the K-04 recruit-review surface on the device (the follow-up
Game-Godot-v2 chip switches the presenter to prefer the server fields and adds
the player-facing recruit action).

## Scope / safety

- Files: `apps/backend/routes/meta.js`, `apps/backend/services/metaProgression.js`,
  `tests/api/metaRoutes.test.js`. No forbidden-path touched.
- Backward-compatible: existing `npg` consumers (debrief recruit wire,
  v3MatingApi) keep working; fields are added, none removed.
- `evalNpcGates` matches the existing `canRecruit()`/`canMate()` store gates and
  the `POST /affinity|/trust` `can_recruit` response exactly.

## Tests

- New: `GET /api/meta/npg enriches each npc with can_recruit + can_mate gates`
  (true + below-gate false cases).
- `tests/api/metaRoutes.test.js` 9/9, `tests/ai/metaProgression.test.js` 50/50,
  `tests/api/v3MatingApi.test.js` 14/14, **AI suite 543/543**, prettier clean.

## Changelog

- meta: `GET /api/v1/meta/npg` enriched with per-npc `can_recruit` + `can_mate`
  server-owned gates (K-04 device-authority prereq).

## 03A rollback

Pure revert of this PR (single commit, additive 3-file change). No migration, no
data, no flag. Reverting restores the raw `npg` payload; the Godot client still
falls back to client-side gate compute (unchanged today), so no surface breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)