### PR TITLE
feat(spec-h): serve A.L.I.E.N.A. 6-dim Codex entries (public lore)

### DIFF
--- a/apps/backend/routes/codex.js
+++ b/apps/backend/routes/codex.js
@@ -23,6 +23,7 @@
 const { Router } = require('express');
 const tunic = require('../services/codex/tunicGlyphs');
 const codexState = require('../services/codex/codexState');
+const codexEntries = require('../services/codex/codexEntries');
 
 function createCodexRouter() {
   const router = Router();
@@ -110,6 +111,26 @@ function createCodexRouter() {
       newly_added: added,
       content: page.content_clear || '',
     });
+  });
+
+  // ─── A.L.I.E.N.A. 6-dim Codex entries (SPEC-H sez.7) ─────────────────────
+  //
+  // Diegetic Codex content from data/codex/{id}.yaml. PUBLIC lore only: the
+  // coherence SCORE is `secret` (SPEC-H sez.8) and is NOT stored in these files,
+  // so nothing secret is served. Unlock-state is client-side (localStorage); the
+  // list carries unlock METADATA (triggers / locked_preview) for the obscured
+  // sidebar, not per-player progress.
+  router.get('/v1/codex/entries', (_req, res) => {
+    const entries = codexEntries.listCodexEntries();
+    res.json({ entries, total: entries.length });
+  });
+
+  router.get('/v1/codex/entries/:id', (req, res) => {
+    const entry = codexEntries.getCodexEntry(String(req.params.id));
+    if (!entry) {
+      return res.status(404).json({ error: `codex entry '${req.params.id}' non trovata` });
+    }
+    res.json({ entry });
   });
 
   return router;

--- a/apps/backend/services/codex/codexEntries.js
+++ b/apps/backend/services/codex/codexEntries.js
@@ -1,0 +1,103 @@
+// SPEC-H — A.L.I.E.N.A. 6-dim Codex entries loader.
+//
+// Serves the diegetic Codex content authored in data/codex/{id}.yaml. The 6-dim
+// schema (A.L.I.E.N.A.) is SHARED with the authoring gate (one source, no
+// prose-vs-data divergence — hades-schema doc 2026-04-27).
+//
+// SPEC-H sez.8 invariant: the coherence SCORE is `secret` (engine-only,
+// computed separately by services/authorial/alienaCoherence.js — it is NOT in
+// these YAML files). This loader therefore surfaces only PUBLIC lore. The HA5
+// diegetic proxy (qualitative descriptor derived from the secret score) is a
+// follow-up and is deliberately NOT computed here.
+//
+// Unlock-state is client-side (localStorage `evo:codex-seen-{id}`, SPEC-H sez.8
+// = private). This module serves entry CONTENT + unlock METADATA (triggers /
+// locked_preview); per-player unlock progress is not tracked server-side.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+// The 6 canonical A.L.I.E.N.A. dimensions (authoring gate + Codex share these).
+const ALIENA_DIMENSION_KEYS = [
+  'A_ambiente',
+  'L_linee_evolutive',
+  'I_impianto',
+  'E_ecologia',
+  'N_norme_socio',
+  'A_ancoraggio_narrativo',
+];
+
+// Worktree vs deployed path candidates (mirror routes/meta.js + services/codex).
+function candidateDirs() {
+  return [
+    path.resolve(__dirname, '../../../../data/codex'),
+    path.resolve(process.cwd(), 'data/codex'),
+  ];
+}
+
+let _cache = null;
+
+// Load + parse every data/codex/*.yaml entry. Best-effort: a malformed file is
+// skipped, never throws (a single bad authoring file must not 500 the Codex).
+function loadCodexEntries() {
+  if (_cache) return _cache;
+  const entries = [];
+  for (const dir of candidateDirs()) {
+    if (!fs.existsSync(dir)) continue;
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+    for (const file of files) {
+      try {
+        const raw = fs.readFileSync(path.join(dir, file), 'utf8');
+        const parsed = yaml.load(raw);
+        const entry = parsed && parsed.codex_entry;
+        if (entry && entry.id) entries.push(entry);
+      } catch {
+        /* skip malformed entry — best-effort */
+      }
+    }
+    if (entries.length) break; // first candidate dir that yields entries wins
+  }
+  _cache = entries;
+  return entries;
+}
+
+// Sidebar summary: id + display + type + unlock metadata (no full sections).
+function summarize(entry) {
+  const unlock = entry.unlock || {};
+  return {
+    id: entry.id,
+    type: entry.type || 'species',
+    display_name_it: entry.display_name_it || entry.id,
+    display_name_en: entry.display_name_en || '',
+    subtitle_it: entry.subtitle_it || '',
+    unlock: {
+      triggers: Array.isArray(unlock.triggers) ? unlock.triggers : [],
+      threshold: Number.isFinite(unlock.threshold) ? unlock.threshold : 1,
+      locked_preview: unlock.locked_preview || '',
+    },
+  };
+}
+
+function listCodexEntries() {
+  return loadCodexEntries().map(summarize);
+}
+
+function getCodexEntry(id) {
+  return loadCodexEntries().find((e) => e.id === id) || null;
+}
+
+// Test hook — clears the in-process cache (no production caller).
+function _resetCache() {
+  _cache = null;
+}
+
+module.exports = {
+  ALIENA_DIMENSION_KEYS,
+  loadCodexEntries,
+  listCodexEntries,
+  getCodexEntry,
+  _resetCache,
+};

--- a/tests/api/codexEntries.test.js
+++ b/tests/api/codexEntries.test.js
@@ -1,0 +1,83 @@
+// SPEC-H — A.L.I.E.N.A. 6-dim Codex entries API.
+//
+// Serves the diegetic Codex content from data/codex/{id}.yaml (shared 6-dim
+// schema with the authoring gate). SPEC-H sez.8 invariant: the coherence SCORE
+// is `secret` (engine-only, computed by alienaCoherence.js, NOT in these
+// files) -- this route must only surface PUBLIC lore. Unlock-state is
+// client-side (localStorage) per the hades-schema doc; the route serves
+// content + unlock metadata (triggers / locked_preview), not per-player state.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+const ALIENA_DIMENSION_KEYS = [
+  'A_ambiente',
+  'L_linee_evolutive',
+  'I_impianto',
+  'E_ecologia',
+  'N_norme_socio',
+  'A_ancoraggio_narrativo',
+];
+
+test('GET /api/v1/codex/entries lists codex entry summaries', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/v1/codex/entries').expect(200);
+    assert.ok(Array.isArray(res.body.entries), 'entries is an array');
+    assert.equal(typeof res.body.total, 'number');
+    const dune = res.body.entries.find((e) => e.id === 'dune_stalker');
+    assert.ok(dune, 'dune_stalker summary present');
+    assert.equal(dune.type, 'species');
+    assert.ok(dune.display_name_it, 'has display_name_it');
+    assert.ok(dune.unlock, 'has unlock block');
+    assert.ok(Array.isArray(dune.unlock.triggers), 'unlock.triggers is array');
+    assert.ok(dune.unlock.locked_preview, 'has locked_preview for the obscured state');
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/v1/codex/entries/:id returns the full 6-dim A.L.I.E.N.A. entry', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const res = await request(app).get('/api/v1/codex/entries/dune_stalker').expect(200);
+    const entry = res.body.entry;
+    assert.ok(entry, 'entry present');
+    assert.equal(entry.id, 'dune_stalker');
+    assert.ok(entry.aliena_dimensions, 'has aliena_dimensions');
+    for (const key of ALIENA_DIMENSION_KEYS) {
+      assert.ok(entry.aliena_dimensions[key], `dimension ${key} present`);
+      assert.ok(entry.aliena_dimensions[key].content, `dimension ${key} has content`);
+    }
+    assert.ok(entry.skiv_instance_note, 'has Skiv-instance note footer');
+  } finally {
+    await close();
+  }
+});
+
+test('GET /api/v1/codex/entries/:id 404 on unknown id', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    await request(app).get('/api/v1/codex/entries/not_a_real_entry').expect(404);
+  } finally {
+    await close();
+  }
+});
+
+test('codex entries never leak a coherence score (SPEC-H sez.8 secret)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const list = await request(app).get('/api/v1/codex/entries').expect(200);
+    const detail = await request(app).get('/api/v1/codex/entries/dune_stalker').expect(200);
+    const blob = JSON.stringify(list.body) + JSON.stringify(detail.body);
+    for (const secret of ['aggregate', 'sub_scores', 'coherence', 'enforcement_factor']) {
+      assert.ok(!blob.includes(secret), `secret field '${secret}' must not be serialized`);
+    }
+  } finally {
+    await close();
+  }
+});


### PR DESCRIPTION
## What

New backend slice for the SPEC-H Codex surface (item-3 build-residue):

- `GET /api/v1/codex/entries` -> `{ entries: [summaries], total }`
- `GET /api/v1/codex/entries/:id` -> `{ entry }` (full 6-dim) or 404

Serves the diegetic A.L.I.E.N.A. 6-dim Codex content authored in
`data/codex/{id}.yaml` (today: `dune_stalker`). New loader
`services/codex/codexEntries.js` (best-effort yaml glob, cached, a malformed
file is skipped and never throws). The 6-dim schema is shared with the
authoring gate -- one source, no prose-vs-data divergence (hades-schema doc
2026-04-27).

## Why

The Codex panel (`apps/play/src/codexPanel.js`) renders Tunic glyphs + pages but
has no A.L.I.E.N.A. species surface; the 6-dim entries had no endpoint. This is
the data source the frontend "Specie" tab will consume (follow-up).

## SPEC-H sez.8 secret invariant

The coherence SCORE is `secret` -- engine-only, computed by
`services/authorial/alienaCoherence.js`, and NOT present in these YAML files. So
this route surfaces only PUBLIC lore. A regression test asserts no
`aggregate` / `sub_scores` / `coherence` / `enforcement_factor` field is ever
serialized. Unlock-state stays client-side (localStorage, sez.8 `private`); the
list carries unlock METADATA only (triggers / locked_preview).

## Scope / deferred

- Files: `apps/backend/routes/codex.js`, `apps/backend/services/codex/codexEntries.js`,
  `tests/api/codexEntries.test.js`. Additive, no contract/forbidden-path.
- DEFERRED (follow-ups): frontend "Specie" tab render (50-line frontend change,
  flagged); HA5 diegetic proxy descriptor (needs the descriptor-band design-call);
  `species.yaml` fallback for entries without a codex yaml.

## Tests

- New `codexEntries.test.js` 4/4 (list summary, full 6-dim detail, 404, secret-leak guard).
- codex regression: `codexRoutes` + w55codex suites 23/23.
- **AI suite 543/543**, prettier clean.

## 03A rollback

Pure revert (single additive commit, 3 files). No migration, no data, no flag.
The new routes simply stop existing; nothing else consumes them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)