### PR TITLE
feat(spec-h): unlock Codex species on encounter completion

### DIFF
--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -20,7 +20,12 @@ import { openReplay } from './replayPanel.js';
 import { sfx, setMuted, isMuted } from './sfx.js';
 import { initHelpPanel } from './helpPanel.js';
 import { showTip, buildRecoveryTipMessage, resetAllTips } from './tips.js';
-import { toggleCodex, setCodexSessionId, setCodexCampaignId } from './codexPanel.js';
+import {
+  toggleCodex,
+  setCodexSessionId,
+  setCodexCampaignId,
+  markCodexEntrySeen,
+} from './codexPanel.js';
 import { initFeedbackPanel } from './feedbackPanel.js';
 import { initCampaignPanel } from './campaignPanel.js';
 import { initLobbyBridgeIfPresent } from './lobbyBridge.js';
@@ -278,6 +283,21 @@ function redraw() {
       state.endgameShown = true;
       if (outcome === 'victory') sfx.win();
       else sfx.defeat();
+      // SPEC-H — QBN unlock: completing an encounter reveals the Codex entry of
+      // every enemy species faced (trigger `encounter_completed`). Any outcome
+      // counts (you encountered them). markCodexEntrySeen is a no-op for species
+      // without a codex entry, so this is safe for the whole sistema roster.
+      try {
+        const encounteredSpecies = new Set(
+          (state.world.units || [])
+            .filter((u) => u && u.controlled_by === 'sistema')
+            .map((u) => u.species_id || u.species)
+            .filter(Boolean),
+        );
+        encounteredSpecies.forEach((sid) => markCodexEntrySeen(sid, 'encounter_completed'));
+      } catch (err) {
+        console.warn('[codex] unlock-on-encounter', err);
+      }
       // M19 — if coop host, notify server to transition phase → debrief.
       if (lobbyBridge?.isHost && lobbyBridge.session?.code && lobbyBridge.session?.token) {
         const survivors = (state.world.units || [])
@@ -1345,7 +1365,10 @@ async function refresh() {
         round: state.world.round,
         active_id: state.world.active_unit,
         active_unit: state.world.active_unit,
-        phase: lobbyBridge._currentPhase && lobbyBridge._currentPhase !== 'idle' ? lobbyBridge._currentPhase : 'combat',
+        phase:
+          lobbyBridge._currentPhase && lobbyBridge._currentPhase !== 'idle'
+            ? lobbyBridge._currentPhase
+            : 'combat',
         units: state.world.units,
         events: state.world.events,
         pressure: state.world.pressure,


### PR DESCRIPTION
## What

Wires the SPEC-H QBN unlock trigger into the combat-end hook in `main.js`. When
an encounter finishes (any outcome), every enemy species faced (the `sistema`
roster) gets its Codex entry revealed:

```js
markCodexEntrySeen(species_id, 'encounter_completed')
```

This closes the SPEC-H Codex surface loop: species now unlock **through play**
instead of only showing the locked preview (#2828 backend + #2829 Specie tab).

## Details

- Dedup via `Set`; fallback `species_id || species`; player units excluded;
  no-species units filtered out.
- `markCodexEntrySeen` is a no-op for a species without a codex entry, so the
  whole `sistema` roster is safe to pass.
- Wrapped in `try/catch` — an unlock failure must never block the endgame flow.

## Verification

- `vite build` green (import resolves).
- Collection logic unit-checked in isolation: player excluded, `sistema`
  collected, `species_id`/`species` fallback, dedup, no-species filtered ->
  exactly the faced species, each with `encounter_completed`.
- The `markCodexEntrySeen` -> Specie-tab-unlocked effect was verified live in #2829.

## Scope / 03A rollback

- File: `apps/play/src/main.js` (+25/-2). Frontend only, no backend/forbidden-path.
- Rollback: pure revert. Without it the Specie tab still works (manual/locked
  preview) — this only adds the play-driven unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)