### PR TITLE
feat(spec-h): HA2 A.L.I.E.N.A. codex authoring-gate validator

### DIFF
--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -48,6 +48,12 @@ const steps = [
   // test runs the script against every real encounter (errors=0), so wiring this
   // glob makes the guard an enforced gate. Flat subtree -> single-* glob.
   'node --test tests/difficulty/*.test.js',
+  // tests/codex/** -- SPEC-H HA2 A.L.I.E.N.A. authoring-gate validator. Same
+  // anti-pattern #10 risk: the guard (validate_codex_aliena.js: 6-dim presence +
+  // content) only blocks mis-authored codex entries if its test runs at merge.
+  // The validator test runs the script against every real data/codex entry
+  // (errors=0), so wiring this glob makes the authoring gate an enforced check.
+  'node --test tests/codex/*.test.js',
 ];
 
 const baseEnv = {

--- a/tests/codex/validator.test.js
+++ b/tests/codex/validator.test.js
@@ -1,0 +1,127 @@
+// SPEC-H HA2 -- A.L.I.E.N.A. Codex authoring-gate validator CI test.
+// Mirrors tests/difficulty/validator.test.js (spawn the CLI against fixtures).
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'tools', 'js', 'validate_codex_aliena.js');
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+const SIX_DIMS = `
+    A_ambiente: { heading: Ambiente, content: '${'a'.repeat(150)}' }
+    L_linee_evolutive: { heading: Linee, content: '${'b'.repeat(150)}' }
+    I_impianto: { heading: Impianto, content: '${'c'.repeat(150)}' }
+    E_ecologia: { heading: Ecologia, content: '${'d'.repeat(150)}' }
+    N_norme_socio: { heading: Norme, content: '${'e'.repeat(150)}' }
+    A_ancoraggio_narrativo:
+      heading: Ancoraggio
+      content: '${'f'.repeat(150)}'
+      story_hook_it: 'Un gancio narrativo.'`;
+
+function wellFormed(id) {
+  return `codex_entry:
+  id: ${id}
+  type: species
+  display_name_it: Test
+  unlock:
+    triggers: [encounter_completed]
+    threshold: 1
+  aliena_dimensions:${SIX_DIMS}
+`;
+}
+
+function writeFixture(dir, name, body) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), body);
+}
+
+function run(dir, extra = []) {
+  return spawnSync('node', [SCRIPT, '--codex', dir, ...extra], {
+    encoding: 'utf8',
+    cwd: REPO_ROOT,
+  });
+}
+
+test('validator passes on the real data/codex without errors', () => {
+  const result = spawnSync('node', [SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+  if (result.status !== 0) {
+    assert.fail(`exit=${result.status}\n${result.stdout}\n${result.stderr}`);
+  }
+  assert.match(result.stdout, /errors=0/);
+  assert.match(result.stdout, /authoring-gate audit/);
+});
+
+test('validator accepts a well-formed fixture (errors=0)', () => {
+  const dir = path.join(__dirname, '_tmp_codex_ok');
+  try {
+    writeFixture(dir, 'good.yaml', wellFormed('good_one'));
+    const r = run(dir);
+    assert.equal(r.status, 0, r.stdout);
+    assert.match(r.stdout, /errors=0/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('validator flags a missing A.L.I.E.N.A. dimension as error', () => {
+  const dir = path.join(__dirname, '_tmp_codex_missing_dim');
+  try {
+    // Drop N_norme_socio (match the full 4-space-indented line).
+    const body = wellFormed('missing_dim').replace(/ {4}N_norme_socio: \{[^}]*\}\n/, '');
+    writeFixture(dir, 'bad.yaml', body);
+    const r = run(dir);
+    assert.equal(r.status, 1, r.stdout);
+    assert.match(r.stdout, /missing A\.L\.I\.E\.N\.A\. dimension 'N_norme_socio'/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('validator flags an empty-content dimension as error', () => {
+  const dir = path.join(__dirname, '_tmp_codex_empty');
+  try {
+    const body = wellFormed('empty_one').replace(
+      /A_ambiente: \{ heading: Ambiente, content: '[^']*' \}/,
+      "A_ambiente: { heading: Ambiente, content: '' }",
+    );
+    writeFixture(dir, 'bad.yaml', body);
+    const r = run(dir);
+    assert.equal(r.status, 1, r.stdout);
+    assert.match(r.stdout, /dimension 'A_ambiente' has no content/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('validator flags a missing codex_entry as error', () => {
+  const dir = path.join(__dirname, '_tmp_codex_noentry');
+  try {
+    writeFixture(dir, 'bad.yaml', 'not_codex_entry:\n  foo: 1\n');
+    const r = run(dir);
+    assert.equal(r.status, 1, r.stdout);
+    assert.match(r.stdout, /missing top-level codex_entry/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('validator warns (non-strict pass, strict fail) on short content', () => {
+  const dir = path.join(__dirname, '_tmp_codex_short');
+  try {
+    const body = wellFormed('short_one').replace(
+      /A_ambiente: \{ heading: Ambiente, content: '[^']*' \}/,
+      "A_ambiente: { heading: Ambiente, content: 'troppo corto' }",
+    );
+    writeFixture(dir, 'short.yaml', body);
+    const r = run(dir);
+    assert.equal(r.status, 0, 'short content is a warning, not an error (non-strict)');
+    assert.match(r.stdout, /outside 100-300 char band/);
+    const strict = run(dir, ['--strict']);
+    assert.equal(strict.status, 1, 'strict mode fails on warnings');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/js/validate_codex_aliena.js
+++ b/tools/js/validate_codex_aliena.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * A.L.I.E.N.A. Codex authoring-gate validator (SPEC-H HA2).
+ *
+ * HA2 is the authoring gate for the 6-dimension A.L.I.E.N.A. method
+ * (docs/design/evo-tactics-aliena-enforcement-lore.md sez.5). HA2 was ratified
+ * 2026-06-08 as HYBRID: HARD on PRESENCE of the 6 dimensions + their content,
+ * SOFT (warn) on editorial-rubric quality.
+ *
+ *   HARD (error)  -- every data/codex/{id}.yaml entry declares all 6 keys
+ *     (A_ambiente / L_linee_evolutive / I_impianto / E_ecologia / N_norme_socio /
+ *     A_ancoraggio_narrativo) and each has non-empty `content`.
+ *   SOFT (warn)   -- content length outside the spec's 100-300 char TV-readable
+ *     band; A_ancoraggio lacks a narrative hook (story_hook_it / lore_seed_it /
+ *     sistema_relation); unlock.triggers empty.
+ *
+ * This guard checks PRESENCE + quality of the authored data; it does NOT impose a
+ * coherence-score spawn threshold (anti-pattern, sez.5 -- the strength knob stays
+ * a continuous runtime value). The scorer's runtime-read fields
+ * (narrative_hooks / lore_ref / narrative_tag) live on the species/spawn entries,
+ * not these codex files; the cross-file species-side check is a follow-up.
+ *
+ * Usage:
+ *   node tools/js/validate_codex_aliena.js [--codex DIR] [--strict]
+ *
+ * Exit codes:
+ *   0: pass (0 errors; warnings allowed unless --strict)
+ *   1: errors, or warnings in --strict mode
+ */
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+let yaml;
+try {
+  yaml = require('js-yaml');
+} catch {
+  console.error('ERROR: js-yaml not installed. Run: npm install');
+  process.exit(1);
+}
+
+// The 6 canonical A.L.I.E.N.A. dimension keys (schema codex 2026-04-27).
+const ALIENA_DIMENSION_KEYS = [
+  'A_ambiente',
+  'L_linee_evolutive',
+  'I_impianto',
+  'E_ecologia',
+  'N_norme_socio',
+  'A_ancoraggio_narrativo',
+];
+
+// Spec sez.5: each dimension content is 100-300 char, TV-readable (SOFT band).
+const CONTENT_MIN = 100;
+const CONTENT_MAX = 300;
+
+function parseArgs(argv) {
+  const out = { codexDir: 'data/codex', strict: false };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--codex' && argv[i + 1]) {
+      out.codexDir = argv[++i];
+    } else if (argv[i] === '--strict') {
+      out.strict = true;
+    }
+  }
+  return out;
+}
+
+// Validate a single parsed codex file. Pushes into errors/warnings (mutated).
+function validateEntry(file, parsed, errors, warnings) {
+  const entry = parsed && parsed.codex_entry;
+  if (!entry || typeof entry !== 'object') {
+    errors.push(`${file}: missing top-level codex_entry`);
+    return { id: file, dims: 0 };
+  }
+  const id = entry.id || file;
+  if (!entry.id) errors.push(`${file}: codex_entry.id is required`);
+
+  const dims = entry.aliena_dimensions || {};
+  let present = 0;
+  for (const key of ALIENA_DIMENSION_KEYS) {
+    const dim = dims[key];
+    if (!dim || typeof dim !== 'object') {
+      errors.push(`${id}: missing A.L.I.E.N.A. dimension '${key}'`);
+      continue;
+    }
+    const content = typeof dim.content === 'string' ? dim.content.trim() : '';
+    if (!content) {
+      errors.push(`${id}: dimension '${key}' has no content`);
+      continue;
+    }
+    present += 1;
+    // SOFT: TV-readable length band (spec sez.5: 100-300 char).
+    if (content.length < CONTENT_MIN || content.length > CONTENT_MAX) {
+      warnings.push(
+        `${id}: dimension '${key}' content length ${content.length} outside 100-300 char band`,
+      );
+    }
+  }
+
+  // SOFT: A_ancoraggio should carry a narrative hook (the diegetic anchor the
+  // runtime ancoraggio sub-score rewards).
+  const anc = dims.A_ancoraggio_narrativo || {};
+  const hasHook = Boolean(anc.story_hook_it || anc.lore_seed_it || anc.sistema_relation);
+  if (anc && typeof anc === 'object' && anc.content && !hasHook) {
+    warnings.push(
+      `${id}: A_ancoraggio_narrativo lacks a narrative hook (story_hook_it / lore_seed_it / sistema_relation)`,
+    );
+  }
+
+  // SOFT: unlock triggers should be authored (QBN unlock, sez.7).
+  const triggers = entry.unlock && entry.unlock.triggers;
+  if (!Array.isArray(triggers) || triggers.length === 0) {
+    warnings.push(`${id}: unlock.triggers is empty (entry can never unlock)`);
+  }
+
+  return { id, dims: present };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const codexDir = path.resolve(repoRoot, args.codexDir);
+
+  if (!fs.existsSync(codexDir)) {
+    console.error(`ERROR: codex dir not found: ${codexDir}`);
+    process.exit(1);
+  }
+
+  const files = fs.readdirSync(codexDir).filter((f) => f.endsWith('.yaml') || f.endsWith('.yml'));
+  if (!files.length) {
+    console.log(`[codex-aliena] no codex entries found in ${codexDir}`);
+    process.exit(0);
+  }
+
+  const errors = [];
+  const warnings = [];
+  const rows = [];
+
+  for (const file of files.sort()) {
+    let parsed;
+    try {
+      parsed = yaml.load(fs.readFileSync(path.join(codexDir, file), 'utf8'));
+    } catch (err) {
+      errors.push(`${file}: YAML parse error: ${err.message}`);
+      continue;
+    }
+    rows.push(validateEntry(file, parsed, errors, warnings));
+  }
+
+  console.log('[codex-aliena] A.L.I.E.N.A. authoring-gate audit (HA2)');
+  console.log('  entry'.padEnd(34) + 'dims_present');
+  for (const r of rows) {
+    console.log('  ' + String(r.id).padEnd(32) + `${r.dims}/6`);
+  }
+  console.log(
+    `[codex-aliena] files=${files.length} errors=${errors.length} warnings=${warnings.length}`,
+  );
+  for (const e of errors) console.log(`  ERROR: ${e}`);
+  for (const w of warnings) console.log(`  WARN:  ${w}`);
+
+  if (errors.length) process.exit(1);
+  if (warnings.length && args.strict) process.exit(1);
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## What

The SPEC-H **HA2 authoring gate** (sez.5, ratified 2026-06-08 = hybrid: HARD on
presence, SOFT on rubric). New `tools/js/validate_codex_aliena.js` validates every
`data/codex/{id}.yaml`:

- **HARD (error)** -- all 6 A.L.I.E.N.A. dimensions present (`A_ambiente` /
  `L_linee_evolutive` / `I_impianto` / `E_ecologia` / `N_norme_socio` /
  `A_ancoraggio_narrativo`) + each has non-empty `content`.
- **SOFT (warn)** -- content outside the spec's 100-300 char TV-readable band;
  `A_ancoraggio` missing a narrative hook; `unlock.triggers` empty.

It does **not** impose a coherence-score spawn threshold (anti-pattern, sez.5 --
the strength knob stays a continuous runtime value).

## How

Mirrors the A2 author-guard (`validate_encounter_difficulty.js`) + its
`tests/difficulty` wiring. The validator test spawns the CLI against fixtures
(missing dim / empty content / no `codex_entry` / short-content warn -> strict
fail) and the **real `data/codex`** (`dune_stalker` 6/6, errors=0). Wired into
`scripts/run-test-api.cjs` so the gate is enforced at merge (avoids the
CI-orphaned anti-pattern #10).

## Location decision (resolved conservatively)

Built in `tools/js` (mirrors the existing JS author-guard), **not**
`packages/contracts` -- that keeps the forbidden-path schema formalization a
master-dd call. The HARD presence check does not need a contracts schema.

## Scope / notes

- Files: `tools/js/validate_codex_aliena.js` (new), `tests/codex/validator.test.js`
  (new), `scripts/run-test-api.cjs` (+6, wires the glob). +301 lines, all outside
  `apps/backend` (tooling + test, not runtime) -- flagged per the 50-line guardrail.
- No contract/forbidden-path/migration. The scorer's species-side runtime fields
  (`narrative_hooks`/`lore_ref`/`narrative_tag`) cross-check = follow-up.

## 03A rollback

Pure revert (additive: a tool + test + one runner glob). No data, no runtime, no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)