### PR TITLE
feat(spec-h): HA5 diegetic presence descriptor (codex-native proxy)

### DIFF
--- a/apps/backend/routes/codex.js
+++ b/apps/backend/routes/codex.js
@@ -130,7 +130,9 @@ function createCodexRouter() {
     if (!entry) {
       return res.status(404).json({ error: `codex entry '${req.params.id}' non trovata` });
     }
-    res.json({ entry });
+    // HA5 (sez.7): diegetic presence descriptor (public); the raw coherence proxy
+    // stays secret. Sibling of `entry` so the cached entry object is not mutated.
+    res.json({ entry, presence_descriptor: codexEntries.presenceDescriptor(entry) });
   });
 
   return router;

--- a/apps/backend/services/codex/codexEntries.js
+++ b/apps/backend/services/codex/codexEntries.js
@@ -19,6 +19,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const yaml = require('js-yaml');
+const { ALIENA_WEIGHTS } = require('../authorial/alienaCoherence');
 
 // The 6 canonical A.L.I.E.N.A. dimensions (authoring gate + Codex share these).
 const ALIENA_DIMENSION_KEYS = [
@@ -29,6 +30,75 @@ const ALIENA_DIMENSION_KEYS = [
   'N_norme_socio',
   'A_ancoraggio_narrativo',
 ];
+
+// HA5 (sez.7, ratified 2026-06-08 = B): the Codex surfaces a DIEGETIC qualitative
+// descriptor derived from a coherence assessment -- never the raw number (sez.8
+// `secret`). The runtime scorer (alienaCoherence.js) operates on combat
+// spawn-pool vs ecosystem-biome pairs, which do NOT align with a browse-time
+// codex species in its narrative home biome (the canonical biomes carry no
+// role_templates / species roster). So HA5 derives a codex-NATIVE coherence
+// proxy from the entry's own authored 6-dim data, reusing the method's frozen
+// 3-dim weights (plausibilita .4 / coerenza_eco .4 / ancoraggio .2). This
+// measures AUTHORING coherence -- the right lens for a Codex. The raw proxy
+// stays internal; only the band descriptor is surfaced. Bands ratified
+// 2026-06-18 (master-dd): >=0.66 endemica / >=0.33 adattata / else inattesa.
+const PRESENCE_BANDS = [
+  { min: 0.66, descriptor: 'specie endemica' },
+  { min: 0.33, descriptor: 'presenza adattata' },
+  { min: 0, descriptor: 'presenza inattesa' },
+];
+
+function _dimContent(dims, key) {
+  const d = dims[key];
+  return d && typeof d.content === 'string' ? d.content.trim() : '';
+}
+
+function _dimHasCrossRef(dims, key) {
+  const d = dims[key];
+  return Boolean(d && Array.isArray(d.cross_ref) && d.cross_ref.length);
+}
+
+// Codex-native 3-dim coherence proxy in [0,1]. INTERNAL -- never serialized.
+function _coherenceProxy(entry) {
+  const dims = (entry && entry.aliena_dimensions) || {};
+
+  // ancoraggio (.2): does A_ancoraggio carry a narrative hook? (mirror of the
+  // scorer's _scoreAncoraggioNarrativo: hook -> 1.0, content-only -> 0.5).
+  const anc = dims.A_ancoraggio_narrativo || {};
+  const hasHook = Boolean(
+    anc.story_hook_it || anc.lore_seed_it || anc.sistema_relation || anc.theme_it,
+  );
+  const n = _dimContent(dims, 'A_ancoraggio_narrativo') ? (hasHook ? 1.0 : 0.5) : 0;
+
+  // plausibilita (.4): a declared home habitat consistent with a biome cross_ref.
+  const eco = dims.E_ecologia || {};
+  const habitat = eco.habitat_primary;
+  const habitatGrounded =
+    _dimHasCrossRef(dims, 'E_ecologia') || _dimHasCrossRef(dims, 'A_ambiente');
+  let p = 0;
+  if (habitat && habitatGrounded) p = 1.0;
+  else if (habitat) p = 0.5;
+
+  // coerenza_eco (.4): the bio-eco-morpho dimensions are grounded + cross-linked.
+  const ecoDims = ['E_ecologia', 'I_impianto', 'L_linee_evolutive'];
+  const grounded = ecoDims.filter((k) => _dimContent(dims, k) && _dimHasCrossRef(dims, k)).length;
+  const e = grounded / ecoDims.length;
+
+  return (
+    p * ALIENA_WEIGHTS.plausibilita +
+    e * ALIENA_WEIGHTS.coerenza_eco +
+    n * ALIENA_WEIGHTS.ancoraggio_narrativo
+  );
+}
+
+// HA5 diegetic descriptor (PUBLIC). The raw proxy value stays secret.
+function presenceDescriptor(entry) {
+  const v = _coherenceProxy(entry);
+  for (const band of PRESENCE_BANDS) {
+    if (v >= band.min) return band.descriptor;
+  }
+  return PRESENCE_BANDS[PRESENCE_BANDS.length - 1].descriptor;
+}
 
 // Worktree vs deployed path candidates (mirror routes/meta.js + services/codex).
 function candidateDirs() {
@@ -73,6 +143,7 @@ function summarize(entry) {
     display_name_it: entry.display_name_it || entry.id,
     display_name_en: entry.display_name_en || '',
     subtitle_it: entry.subtitle_it || '',
+    presence_descriptor: presenceDescriptor(entry),
     unlock: {
       triggers: Array.isArray(unlock.triggers) ? unlock.triggers : [],
       threshold: Number.isFinite(unlock.threshold) ? unlock.threshold : 1,
@@ -99,5 +170,6 @@ module.exports = {
   loadCodexEntries,
   listCodexEntries,
   getCodexEntry,
+  presenceDescriptor,
   _resetCache,
 };

--- a/apps/play/src/codexPanel.js
+++ b/apps/play/src/codexPanel.js
@@ -428,6 +428,11 @@ function renderSpecieDetail(el, id) {
       const sections = ALIENA_DIM_ORDER.filter((k) => dims[k])
         .map((k) => renderDimSection(dims[k]))
         .join('');
+      // HA5 -- diegetic presence descriptor (server-derived; never a raw score).
+      const descriptor = r.data.presence_descriptor;
+      const descriptorBadge = descriptor
+        ? `<span class="codex-presence-badge">${escHtml(descriptor)}</span>`
+        : '';
       el.innerHTML = `
         <div class="codex-actions-row">
           <button class="codex-btn" id="codex-specie-back">← Bestiario</button>
@@ -436,6 +441,7 @@ function renderSpecieDetail(el, id) {
           <div class="codex-specie-detail-head">
             <strong class="codex-specie-title">${escHtml(entry.display_name_it)}</strong>
             <span class="codex-specie-en">${escHtml(entry.display_name_en || '')}</span>
+            ${descriptorBadge}
             <div class="codex-specie-subtitle">${escHtml(entry.subtitle_it || '')}</div>
           </div>
           ${sections}

--- a/apps/play/src/style.css
+++ b/apps/play/src/style.css
@@ -1563,6 +1563,19 @@ canvas#grid:hover {
   opacity: 0.8;
   margin-top: 2px;
 }
+/* HA5 -- diegetic presence descriptor badge (qualitative, never a raw score). */
+.codex-presence-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 0.74em;
+  font-style: italic;
+  vertical-align: middle;
+  color: #d8c9a8;
+  background: rgba(200, 170, 120, 0.14);
+  border: 1px solid rgba(200, 170, 120, 0.4);
+}
 .codex-dim {
   margin: 6px 0;
   border: 1px solid rgba(139, 111, 176, 0.2);

--- a/tests/api/codexEntries.test.js
+++ b/tests/api/codexEntries.test.js
@@ -41,6 +41,32 @@ test('GET /api/v1/codex/entries lists codex entry summaries', async () => {
   }
 });
 
+// HA5 (sez.7/8): the Codex surfaces a DIEGETIC presence descriptor derived from a
+// codex-native coherence proxy. The descriptor is public; the raw proxy stays
+// secret (never serialized). Bands ratified 2026-06-18.
+const VALID_DESCRIPTORS = ['specie endemica', 'presenza adattata', 'presenza inattesa'];
+
+test('codex list + detail carry an HA5 presence_descriptor (diegetic, never the raw number)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const list = await request(app).get('/api/v1/codex/entries').expect(200);
+    const dune = list.body.entries.find((e) => e.id === 'dune_stalker');
+    assert.ok(VALID_DESCRIPTORS.includes(dune.presence_descriptor), 'list descriptor is diegetic');
+    // dune_stalker is a richly authored, well-grounded entry -> endemic.
+    assert.equal(dune.presence_descriptor, 'specie endemica');
+
+    const detail = await request(app).get('/api/v1/codex/entries/dune_stalker').expect(200);
+    assert.equal(detail.body.presence_descriptor, 'specie endemica');
+    // The raw proxy must NOT leak: no numeric coherence field on the response.
+    const blob = JSON.stringify(list.body) + JSON.stringify(detail.body);
+    for (const secret of ['aggregate', 'sub_scores', 'coherence', 'enforcement_factor']) {
+      assert.ok(!blob.includes(secret), `secret '${secret}' must not be serialized`);
+    }
+  } finally {
+    await close();
+  }
+});
+
 test('GET /api/v1/codex/entries/:id returns the full 6-dim A.L.I.E.N.A. entry', async () => {
   const { app, close } = createApp({ databasePath: null });
   try {


### PR DESCRIPTION
## What

HA5=B (ratified 2026-06-08): the Codex shows a **diegetic qualitative descriptor**
of a species' ecological coherence -- never the raw score (sez.8 `secret`). Bands
ratified 2026-06-18: `>=0.66` **specie endemica** / `>=0.33` **presenza adattata** /
else **presenza inattesa**.

## Verify-first finding (why a codex-native proxy)

The runtime scorer (`alienaCoherence.js`) scores **combat spawn-pool vs
ecosystem-biome** pairs. The 8 spawn pools are exotic ecosystems with **no codex
species** in them, and the canonical biomes (`biomes.yaml` savana/caverna) carry **no
`role_templates` / species roster** -- so the scorer cannot meaningfully score a
browse-time codex species in its narrative home biome. Per master-dd verdict, HA5
derives a **codex-native coherence proxy** from the entry's own authored 6-dim data,
reusing the method's frozen 3-dim weights (plausibilita .4 / coerenza_eco .4 /
ancoraggio .2). This measures **authoring coherence** -- the right lens for a Codex.

## How

- Backend `codexEntries.presenceDescriptor()` -- internal proxy in [0,1], mapped to
  the 3-band descriptor. Attached to list summaries + the detail route as a sibling
  of `entry` (no cache mutation). The raw proxy is **never serialized**; the field is
  `presence_descriptor` (no `coherence`/`aliena` substring -> the #2828 secret-leak
  guard still holds, and a new test asserts no leak).
- Frontend: descriptor badge in the Specie detail head.
- `dune_stalker` (richly authored, well-grounded) -> **specie endemica**.

## Verification

codexEntries 6/6 (+HA5 descriptor + no-leak), codex regression 12/12, AI suite
543/543, prettier clean, `vite build` green. Full browser preview skipped -- the
descriptor is server-tested end-to-end and the badge is a trivial server-field render
on the already-preview-verified Specie detail path (#2829).

## Scope / 03A rollback

- Files: `services/codex/codexEntries.js`, `routes/codex.js`, `tests/api/codexEntries.test.js`
  (apps/backend) + `apps/play/src/{codexPanel.js, style.css}` (frontend badge, <50 lines).
  No contract/forbidden-path. Bands + the codex-native-proxy approach are master-dd-ratified.
- Rollback: pure revert. The descriptor field disappears; nothing else depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)