### PR TITLE
fix(ci): run HA2 codex authoring-gate on codex-only PRs (audit P1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
               # skipped stack-quality, allowing schema regressions to slip
               # (e.g. on_hit_status.status_id enum violation in #2223).
               - 'data/core/**/*.yaml'
+              # 2026-06-18 audit — same blind spot for the SPEC-H HA2 codex
+              # authoring-gate (validate_codex_aliena via tests/codex/*, run in
+              # test:api). A codex-only edit matched 'data' (-> dataset-checks)
+              # but not 'stack', so the authoring gate it polices never ran.
+              - 'data/codex/**/*.yaml'
               - 'packs/**/*.yaml'
               - 'packages/contracts/schemas/**'
               # OD-038 — sim bridge JS must hit stack-quality (Prettier).


### PR DESCRIPTION
## What (2026-06-18 audit P1)

The SPEC-H HA2 codex authoring-gate (`tools/js/validate_codex_aliena.js` via
`tests/codex/*`, run in `npm run test:api` -> `stack-quality` job) **never ran on
codex-only PRs**. The `stack` paths-filter listed `data/core/**/*.yaml` but not
`data/codex/**/*.yaml`, so an edit touching only `data/codex/**` matched the
`data` filter (-> `dataset-checks`, which does not run `test:api`) and **skipped
the gate it exists to police**. Identical blind spot fixed for `data/core` post-#2223.

This adds `data/codex/**/*.yaml` to the `stack` filter. Now a codex-only PR
triggers `stack-quality` and actually runs the authoring gate.

## Why it matters

Surfaced by the adversarial audit of the session's own PRs. #2833 shipped the
HA2 validator + wired it into `run-test-api.cjs`, but the CI never reached it for
the exact change class (mis-authored `data/codex/*.yaml`) the gate targets.
Anti-pattern #10 (CI-orphaned gate) was not actually closed.

## Scope

- 1 line + comment in `.github/workflows/ci.yml` (forbidden-path; **master-dd
  authorized** 2026-06-18). No logic change.

## Rollback

Pure revert. Reverting only narrows which PRs trigger `stack-quality` back to the
pre-fix set.