### PR TITLE
fix(spec-h): harden codex secret invariant + honest HA5 bands + audit P3s

### DIFF
--- a/apps/backend/services/codex/codexEntries.js
+++ b/apps/backend/services/codex/codexEntries.js
@@ -6,9 +6,10 @@
 //
 // SPEC-H sez.8 invariant: the coherence SCORE is `secret` (engine-only,
 // computed separately by services/authorial/alienaCoherence.js — it is NOT in
-// these YAML files). This loader therefore surfaces only PUBLIC lore. The HA5
-// diegetic proxy (qualitative descriptor derived from the secret score) is a
-// follow-up and is deliberately NOT computed here.
+// these YAML files). This loader surfaces only PUBLIC lore, and enforces that
+// structurally: getCodexEntry returns a PROJECTED clone with only an allowlist
+// of known public keys (fail-closed) so a future authored entry cannot leak a
+// novel score-bearing field (2026-06-18 audit hardening).
 //
 // Unlock-state is client-side (localStorage `evo:codex-seen-{id}`, SPEC-H sez.8
 // = private). This module serves entry CONTENT + unlock METADATA (triggers /
@@ -36,16 +37,21 @@ const ALIENA_DIMENSION_KEYS = [
 // `secret`). The runtime scorer (alienaCoherence.js) operates on combat
 // spawn-pool vs ecosystem-biome pairs, which do NOT align with a browse-time
 // codex species in its narrative home biome (the canonical biomes carry no
-// role_templates / species roster). So HA5 derives a codex-NATIVE coherence
-// proxy from the entry's own authored 6-dim data, reusing the method's frozen
-// 3-dim weights (plausibilita .4 / coerenza_eco .4 / ancoraggio .2). This
-// measures AUTHORING coherence -- the right lens for a Codex. The raw proxy
-// stays internal; only the band descriptor is surfaced. Bands ratified
-// 2026-06-18 (master-dd): >=0.66 endemica / >=0.33 adattata / else inattesa.
+// role_templates / species roster). So HA5 derives a codex-NATIVE proxy from the
+// entry's own authored 6-dim data, reusing the method's frozen 3-dim weights
+// (.4 / .4 / .2). The raw proxy stays internal; only the band descriptor surfaces.
+//
+// 2026-06-18 audit (master-dd ratified): the proxy actually measures AUTHORING
+// COMPLETENESS (which dimensions carry content + cross_ref + a narrative hook),
+// NOT ecological fit -- a content-rich species drops band purely by removing
+// link arrays, with no prose change. So the descriptors are ARCHIVAL-completeness
+// in-world language ("scheda completa/parziale/frammentaria"), honest about what
+// the proxy reads. They are NOT an ecological-belonging claim ("endemica" was
+// misleading -- renamed). Bands: >=0.66 completa / >=0.33 parziale / else frammentaria.
 const PRESENCE_BANDS = [
-  { min: 0.66, descriptor: 'specie endemica' },
-  { min: 0.33, descriptor: 'presenza adattata' },
-  { min: 0, descriptor: 'presenza inattesa' },
+  { min: 0.66, descriptor: 'scheda completa' },
+  { min: 0.33, descriptor: 'scheda parziale' },
+  { min: 0, descriptor: 'scheda frammentaria' },
 ];
 
 function _dimContent(dims, key) {
@@ -100,6 +106,37 @@ function presenceDescriptor(entry) {
   return PRESENCE_BANDS[PRESENCE_BANDS.length - 1].descriptor;
 }
 
+// SECRET invariant (sez.8) enforced structurally: the codex YAML is served only
+// through this allowlist. Any top-level key NOT listed here is dropped before
+// serialization (fail-closed), so a future entry that embeds a score-bearing
+// field under a novel key (alien_fit, coerenza_eco, ...) cannot leak. All six
+// listed keys are public lore (2026-06-18 audit hardening).
+const PUBLIC_ENTRY_KEYS = [
+  'id',
+  'type',
+  'display_name_it',
+  'display_name_en',
+  'subtitle_it',
+  'unlock',
+  'aliena_dimensions',
+  'skiv_instance_note',
+  'variants',
+  'traits_core',
+  'traits_optional',
+  'synergies',
+];
+
+// Project an entry to the public allowlist + deep-clone, so the served object
+// (a) carries no unrecognized field and (b) cannot mutate the process-wide cache.
+function projectPublicEntry(entry) {
+  if (!entry || typeof entry !== 'object') return entry;
+  const out = {};
+  for (const k of PUBLIC_ENTRY_KEYS) {
+    if (k in entry) out[k] = entry[k];
+  }
+  return structuredClone(out);
+}
+
 // Worktree vs deployed path candidates (mirror routes/meta.js + services/codex).
 function candidateDirs() {
   return [
@@ -111,9 +148,12 @@ function candidateDirs() {
 let _cache = null;
 
 // Load + parse every data/codex/*.yaml entry. Best-effort: a malformed file is
-// skipped, never throws (a single bad authoring file must not 500 the Codex).
-function loadCodexEntries() {
-  if (_cache) return _cache;
+// skipped, never throws (a single bad authoring file must not 500 the Codex) --
+// but the skip is now OBSERVABLE (structured warn), since the HA2 validator is
+// the only other thing that would catch it (2026-06-18 audit). `force` bypasses
+// the process cache (mirrors codexState.loadCodexPages) for in-process reload.
+function loadCodexEntries(force = false) {
+  if (_cache && !force) return _cache;
   const entries = [];
   for (const dir of candidateDirs()) {
     if (!fs.existsSync(dir)) continue;
@@ -123,9 +163,19 @@ function loadCodexEntries() {
         const raw = fs.readFileSync(path.join(dir, file), 'utf8');
         const parsed = yaml.load(raw);
         const entry = parsed && parsed.codex_entry;
-        if (entry && entry.id) entries.push(entry);
-      } catch {
-        /* skip malformed entry — best-effort */
+        if (entry && entry.id) {
+          entries.push(entry);
+        } else {
+          console.warn(
+            JSON.stringify({
+              evt: 'codex_entry_skip',
+              file,
+              reason: entry ? 'missing codex_entry.id' : 'no codex_entry',
+            }),
+          );
+        }
+      } catch (err) {
+        console.warn(JSON.stringify({ evt: 'codex_entry_skip', file, reason: err.message }));
       }
     }
     if (entries.length) break; // first candidate dir that yields entries wins
@@ -143,7 +193,9 @@ function summarize(entry) {
     display_name_it: entry.display_name_it || entry.id,
     display_name_en: entry.display_name_en || '',
     subtitle_it: entry.subtitle_it || '',
-    presence_descriptor: presenceDescriptor(entry),
+    // presence_descriptor is detail-only (the list view never renders it) -- not
+    // serialized on summaries to avoid carrying it into the locked/obscured
+    // sidebar context (2026-06-18 audit P3).
     unlock: {
       triggers: Array.isArray(unlock.triggers) ? unlock.triggers : [],
       threshold: Number.isFinite(unlock.threshold) ? unlock.threshold : 1,
@@ -156,8 +208,12 @@ function listCodexEntries() {
   return loadCodexEntries().map(summarize);
 }
 
+// Detail entry: allowlisted + deep-cloned (fail-closed secret guard + no cache
+// mutation). presenceDescriptor still resolves -- aliena_dimensions is public.
 function getCodexEntry(id) {
-  return loadCodexEntries().find((e) => e.id === id) || null;
+  const found = loadCodexEntries().find((e) => e.id === id);
+  if (!found) return null;
+  return projectPublicEntry(found);
 }
 
 // Test hook — clears the in-process cache (no production caller).

--- a/tests/api/codexEntries.test.js
+++ b/tests/api/codexEntries.test.js
@@ -41,26 +41,67 @@ test('GET /api/v1/codex/entries lists codex entry summaries', async () => {
   }
 });
 
-// HA5 (sez.7/8): the Codex surfaces a DIEGETIC presence descriptor derived from a
-// codex-native coherence proxy. The descriptor is public; the raw proxy stays
-// secret (never serialized). Bands ratified 2026-06-18.
-const VALID_DESCRIPTORS = ['specie endemica', 'presenza adattata', 'presenza inattesa'];
+// HA5 (sez.7/8): the Codex surfaces a DIEGETIC descriptor derived from a
+// codex-native proxy. It is DETAIL-ONLY (not on list summaries), the raw proxy
+// stays secret, and the bands are archival-completeness (renamed post-2026-06-18
+// audit: the proxy measures authoring completeness, not ecological fit).
+const VALID_DESCRIPTORS = ['scheda completa', 'scheda parziale', 'scheda frammentaria'];
+const PUBLIC_ENTRY_KEYS = [
+  'id',
+  'type',
+  'display_name_it',
+  'display_name_en',
+  'subtitle_it',
+  'unlock',
+  'aliena_dimensions',
+  'skiv_instance_note',
+  'variants',
+  'traits_core',
+  'traits_optional',
+  'synergies',
+];
 
-test('codex list + detail carry an HA5 presence_descriptor (diegetic, never the raw number)', async () => {
+test('HA5 descriptor is detail-only, archival-honest, and never leaks the raw score', async () => {
   const { app, close } = createApp({ databasePath: null });
   try {
     const list = await request(app).get('/api/v1/codex/entries').expect(200);
-    const dune = list.body.entries.find((e) => e.id === 'dune_stalker');
-    assert.ok(VALID_DESCRIPTORS.includes(dune.presence_descriptor), 'list descriptor is diegetic');
-    // dune_stalker is a richly authored, well-grounded entry -> endemic.
-    assert.equal(dune.presence_descriptor, 'specie endemica');
+    // Descriptor is detail-only -> must NOT appear on list summaries.
+    for (const e of list.body.entries) {
+      assert.equal(e.presence_descriptor, undefined, 'list summary carries no descriptor');
+    }
 
     const detail = await request(app).get('/api/v1/codex/entries/dune_stalker').expect(200);
-    assert.equal(detail.body.presence_descriptor, 'specie endemica');
-    // The raw proxy must NOT leak: no numeric coherence field on the response.
+    assert.ok(
+      VALID_DESCRIPTORS.includes(detail.body.presence_descriptor),
+      'descriptor is diegetic',
+    );
+    assert.equal(detail.body.presence_descriptor, 'scheda completa'); // fully authored
+
+    // Raw proxy must NOT leak under any field name (allowlist guard, both routes).
     const blob = JSON.stringify(list.body) + JSON.stringify(detail.body);
     for (const secret of ['aggregate', 'sub_scores', 'coherence', 'enforcement_factor']) {
       assert.ok(!blob.includes(secret), `secret '${secret}' must not be serialized`);
+    }
+  } finally {
+    await close();
+  }
+});
+
+test('detail entry is projected to the public allowlist (fail-closed secret guard)', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const list = await request(app).get('/api/v1/codex/entries').expect(200);
+    // Fetch the detail of EVERY listed entry and assert no unknown top-level key.
+    for (const summary of list.body.entries) {
+      const res = await request(app)
+        .get(`/api/v1/codex/entries/${encodeURIComponent(summary.id)}`)
+        .expect(200);
+      for (const key of Object.keys(res.body.entry)) {
+        assert.ok(
+          PUBLIC_ENTRY_KEYS.includes(key),
+          `entry '${summary.id}' exposes non-allowlisted key '${key}'`,
+        );
+      }
     }
   } finally {
     await close();

--- a/tests/api/metaRoutes.test.js
+++ b/tests/api/metaRoutes.test.js
@@ -133,6 +133,44 @@ test('POST /api/meta/nest/setup + GET /api/meta/nest roundtrip', async () => {
   }
 });
 
+// 2026-06-18 audit P3: the npg-enrich test covered can_recruit true/false + the
+// can_mate=false (not-recruited) path, but never the can_mate=TRUE positive nor
+// the nest-not-ready discriminator (the 5-condition mating gate had zero positive
+// coverage -> a re-tune of MATING_TRUST_MIN or a flipped sub-condition passed CI).
+test('GET /api/meta/npg can_mate true only when recruited + trust>=3 + nest ready', async () => {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    // Build an npc that clears recruit (affinity>=0, trust>=2) then mating trust (>=3).
+    await request(app)
+      .post('/api/meta/affinity')
+      .send({ npc_id: 'npc_mate_01', delta: 1 })
+      .expect(200);
+    await request(app)
+      .post('/api/meta/trust')
+      .send({ npc_id: 'npc_mate_01', delta: 3 })
+      .expect(200);
+    await request(app).post('/api/meta/recruit').send({ npc_id: 'npc_mate_01' }).expect(200);
+
+    // Nest NOT ready yet -> can_mate must stay false despite recruited + trust>=3.
+    let res = await request(app).get('/api/meta/npg').expect(200);
+    let npc = res.body.npcs.find((n) => n.npc_id === 'npc_mate_01');
+    assert.ok(npc, 'seeded npc present');
+    assert.equal(npc.can_recruit, false, 'already recruited -> not recruitable');
+    assert.equal(npc.can_mate, false, 'nest not ready -> mate gate closed');
+
+    // Make the nest ready -> can_mate flips true.
+    await request(app)
+      .post('/api/meta/nest/setup')
+      .send({ biome: 'savana', requirements_met: true })
+      .expect(200);
+    res = await request(app).get('/api/meta/npg').expect(200);
+    npc = res.body.npcs.find((n) => n.npc_id === 'npc_mate_01');
+    assert.equal(npc.can_mate, true, 'recruited + trust>=3 + nest ready -> can_mate');
+  } finally {
+    await close();
+  }
+});
+
 test('POST /api/meta/mating 400 on missing party_member', async () => {
   const { app, close } = createApp({ databasePath: null });
   try {


### PR DESCRIPTION
## What (2026-06-18 audit fixes -- backend)

The adversarial audit of the session's own PRs (Codex never reviewed this change class -- rate-limited) surfaced these. Fixes batched:

### P2 -- SECRET invariant now structural (covers #2828 + #2835)
`getCodexEntry` projects to a `PUBLIC_ENTRY_KEYS` allowlist + `structuredClone`s. The raw YAML is no longer served whole -> a future authored entry cannot leak a novel-named score field (`alien_fit`, `coerenza_eco`, ...), and the clone also closes the cache-by-reference mutation risk. New test fetches the detail of **every** listed entry and asserts **no non-allowlisted top-level key**.

### P2 -- HA5 honest bands (#2835, master-dd ratified)
The audit proved the proxy measures **authoring completeness**, not ecological fit (a content-rich species flips `endemica->frammentaria` purely by deleting `cross_ref` arrays, zero prose change). Renamed the player-facing descriptors ecological -> archival: **`scheda completa / scheda parziale / scheda frammentaria`**. No more misleading "endemica" claim; the descriptor now honestly maps to record completeness.

### P3 -- batched
- `presence_descriptor` is **detail-only** now (dropped from list summaries -- the list never rendered it; keeps it out of the locked/obscured sidebar).
- **Observability**: structured `console.warn({evt:'codex_entry_skip',...})` on a malformed/id-less codex file (was a silent total loss); `loadCodexEntries(force)` mirrors `codexState`.
- **Mating coverage** (#2826): npg `can_mate=TRUE` positive + nest-not-ready discriminator (the 5-condition gate had zero positive coverage).

## Verification
codexEntries 6/6, metaRoutes 10/10, codex regression 7/7, HA2 validator 6/6, **AI suite 543/543**, prettier clean. The frontend badge renders the new descriptor string with no client change.

## Scope / rollback
Files: `services/codex/codexEntries.js`, `tests/api/codexEntries.test.js`, `tests/api/metaRoutes.test.js` (apps/backend + tests). No contract/forbidden-path. Pure revert restores prior behavior (raw-YAML serve + ecological band names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)