### PR TITLE
fix(canon): resolve 5 ghost species in pack ecosystem rosters

### DIFF
--- a/data/core/canon-consistency-baseline.json
+++ b/data/core/canon-consistency-baseline.json
@@ -1,31 +1,5 @@
 {
   "generated_at": null,
   "note": "Accepted known violations -- gate enforces NO NEW. Shrink as debt closes.",
-  "baseline": [
-    {
-      "rule": "ecosystem-roster-parity",
-      "entity": "badlands",
-      "ref": "rubrospina-velox"
-    },
-    {
-      "rule": "ecosystem-roster-parity",
-      "entity": "badlands",
-      "ref": "ferrimordax-rutilus"
-    },
-    {
-      "rule": "ecosystem-roster-parity",
-      "entity": "badlands",
-      "ref": "ferriscroba-detrita"
-    },
-    {
-      "rule": "ecosystem-roster-parity",
-      "entity": "foresta_temperata",
-      "ref": "nebulocornis-mollis"
-    },
-    {
-      "rule": "ecosystem-roster-parity",
-      "entity": "foresta_temperata",
-      "ref": "arboryxis-lenis"
-    }
-  ]
+  "baseline": []
 }

--- a/packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml
@@ -40,14 +40,11 @@ ecosistema:
       secondari:
       - ferrocolonia-magnetotattica
       - echo-wing
-      - rubrospina-velox
       terziari:
       - dune-stalker
-      - ferrimordax-rutilus
     decompositori:
     - nano-rust-bloom
     - evento-tempesta-ferrosa
-    - ferriscroba-detrita
   note: Ecosistema desertico magnetizzato con pulse detritici stagionali.
 links:
   species_dir: packs/evo_tactics_pack/data/species/badlands

--- a/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml
@@ -37,8 +37,6 @@ ecosistema:
       primari:
       - cervidi_erborivori
       - impollinatori_misti
-      - nebulocornis-mollis
-      - arboryxis-lenis
       secondari:
       - lupus-temperatus
       terziari:


### PR DESCRIPTION
## Cosa

Chiude il debito `ecosystem-roster-parity` (Phase B canon checker,
`scripts/check-canon-consistency.cjs`) risolvendo i 5 ghost species presenti
nel roster trofico del PACK ma assenti dal roster CORE autoritativo.

I 5 ghost erano `legacy_slug` deprecati, senza alcun file species YAML di
supporto, baselined come known-debt in `data/core/canon-consistency-baseline.json`.

## Analisi per ghost (legacy_slug -> esito)

| ecosistema | ghost (legacy_slug) | species_id corrente | nel core roster? | esito |
|---|---|---|---|---|
| badlands | `rubrospina-velox` | `sp_rubrospina_velox` | no | rimosso |
| badlands | `ferrimordax-rutilus` | `sp_ferrimordax_rutilus` | no | rimosso |
| badlands | `ferriscroba-detrita` | `sp_ferriscroba_detrita` | no | rimosso |
| foresta_temperata | `nebulocornis-mollis` | `sp_nebulocornis_mollis` | no | rimosso |
| foresta_temperata | `arboryxis-lenis` | `sp_arboryxis_lenis` | no | rimosso |

Ogni `legacy_slug` mappa a un `species_id` corrente (`sp_*`) in
`species_catalog.json` (rename a livello catalogo), MA:

- nessuno ha un file species YAML di supporto (`packs/.../data/species/**`);
- ne' la forma `sp_*` ne' lo slug legacy compaiono nel roster CORE
  (`data/ecosystems/<id>.ecosystem.yaml`);
- core e' la source-of-truth e questo PR tocca solo i file PACK.

Quindi sono ghost solo-pack: aggiungere la forma `sp_*` al pack creerebbe una
NUOVA violazione di parita' in direzione opposta (core-but-not-pack). La
risoluzione corretta che porta `pack == core` e' la **rimozione**.

## Modifiche

- `packs/evo_tactics_pack/data/ecosystems/badlands.ecosystem.yaml` -- rimossi 3
  ghost da `consumatori.secondari` / `consumatori.terziari` / `decompositori`.
- `packs/evo_tactics_pack/data/ecosystems/foresta_temperata.ecosystem.yaml` --
  rimossi 2 ghost da `consumatori.primari`.
- `data/core/canon-consistency-baseline.json` -- baseline 5 -> 0 (vuota); il gate
  ora ENFORCE quei 5, niente piu' regressioni di parita'.

## Verifica

- `node scripts/check-canon-consistency.cjs` -> `total=0 baselined=0 new=0`, OK.
- `node --test tests/api/canon-consistency.test.js` -> 30 pass / 0 fail
  (inclusi i negative-control non-vacui).
- `prettier --check` sui 3 file -> clean.
- Grep: i 5 slug non sono referenziati in foodwebs/npg/core-ecosystems (nessun
  dangling-ref residuo). I role-count validator risolvono le specie dai YAML;
  i ghost (senza YAML) non contribuivano ruoli risolti -> `rules.at_least` intatto.

## Rollback (03A)

Revert del singolo commit: ripristina i 5 ghost nei 2 pack YAML e ri-popola la
baseline con le 5 entry. Nessuna migrazione, nessun dato runtime toccato.

## Changelog

- fix(canon): ecosystem-roster-parity baseline 5 -> 0 (debt paydown, G3).
