### PR TITLE
fix(spec-h): scrub nested secret-named keys in codex projection (Codex P2 #2839)

### DIFF
--- a/apps/backend/services/codex/codexEntries.js
+++ b/apps/backend/services/codex/codexEntries.js
@@ -126,15 +126,54 @@ const PUBLIC_ENTRY_KEYS = [
   'synergies',
 ];
 
-// Project an entry to the public allowlist + deep-clone, so the served object
-// (a) carries no unrecognized field and (b) cannot mutate the process-wide cache.
+// The top-level allowlist keeps PUBLIC containers (aliena_dimensions, variants...)
+// whole, so a secret embedded under a NESTED key (e.g. aliena_dimensions.
+// E_ecologia.coherence) would still serialize (Codex P2 on #2839). This is the
+// exact-match set of the scorer's secret field names (alienaCoherence.js sub_scores
+// + sez.8 enforcement signals); scrubbed at ANY depth. Exact match -> the dimension
+// keys A_ancoraggio_narrativo / E_ecologia are NOT touched (distinct from the
+// sub-score names ancoraggio_narrativo / coerenza_eco).
+const SECRET_KEYS = new Set([
+  'aggregate',
+  'sub_scores',
+  'coherence',
+  'enforcement_factor',
+  '_aliena_enforcement',
+  'plausibilita',
+  'coerenza_eco',
+  'ancoraggio_narrativo',
+  'strength',
+]);
+
+// Recursively delete any secret-named key at any depth (in place, on the clone).
+function _scrubSecrets(node) {
+  if (Array.isArray(node)) {
+    for (const item of node) _scrubSecrets(item);
+    return;
+  }
+  if (node && typeof node === 'object') {
+    for (const k of Object.keys(node)) {
+      if (SECRET_KEYS.has(k)) {
+        delete node[k];
+        continue;
+      }
+      _scrubSecrets(node[k]);
+    }
+  }
+}
+
+// Project an entry to the public allowlist + deep-clone + recursive secret scrub,
+// so the served object (a) carries no unrecognized TOP-LEVEL field, (b) carries no
+// secret-named field at ANY depth, and (c) cannot mutate the process-wide cache.
 function projectPublicEntry(entry) {
   if (!entry || typeof entry !== 'object') return entry;
   const out = {};
   for (const k of PUBLIC_ENTRY_KEYS) {
     if (k in entry) out[k] = entry[k];
   }
-  return structuredClone(out);
+  const cloned = structuredClone(out);
+  _scrubSecrets(cloned);
+  return cloned;
 }
 
 // Worktree vs deployed path candidates (mirror routes/meta.js + services/codex).
@@ -227,5 +266,6 @@ module.exports = {
   listCodexEntries,
   getCodexEntry,
   presenceDescriptor,
+  projectPublicEntry,
   _resetCache,
 };

--- a/tests/api/codexEntries.test.js
+++ b/tests/api/codexEntries.test.js
@@ -148,3 +148,47 @@ test('codex entries never leak a coherence score (SPEC-H sez.8 secret)', async (
     await close();
   }
 });
+
+// 2026-06-18 audit follow-up (Codex P2 on #2839): the top-level allowlist keeps
+// PUBLIC containers whole, so a secret under a NESTED key would still serialize.
+// projectPublicEntry now scrubs secret-named keys at ANY depth.
+test('projectPublicEntry drops top-level unknown AND nested secret-named keys', () => {
+  const { projectPublicEntry } = require('../../apps/backend/services/codex/codexEntries');
+  const crafted = {
+    id: 'x_test',
+    type: 'species',
+    display_name_it: 'Test',
+    alien_fit: 0.9, // top-level unknown -> dropped by allowlist
+    aliena_dimensions: {
+      E_ecologia: {
+        heading: 'Ecologia',
+        content: 'public lore',
+        coherence: 0.8, // NESTED secret -> dropped by scrub
+        sub_scores: { plausibilita: 1 }, // nested secret container -> dropped
+      },
+      A_ancoraggio_narrativo: { heading: 'Anc', content: 'lore', story_hook_it: 'h' },
+    },
+  };
+  const projected = projectPublicEntry(crafted);
+  const blob = JSON.stringify(projected);
+  assert.equal(projected.alien_fit, undefined, 'top-level unknown dropped');
+  assert.equal(
+    projected.aliena_dimensions.E_ecologia.coherence,
+    undefined,
+    'nested coherence scrubbed',
+  );
+  assert.equal(
+    projected.aliena_dimensions.E_ecologia.sub_scores,
+    undefined,
+    'nested sub_scores scrubbed',
+  );
+  for (const secret of ['alien_fit', 'coherence', 'sub_scores', 'plausibilita']) {
+    assert.ok(!blob.includes(secret), `secret '${secret}' must not survive projection`);
+  }
+  // public content survives + the dimension key A_ancoraggio_narrativo is NOT scrubbed.
+  assert.equal(projected.aliena_dimensions.E_ecologia.content, 'public lore');
+  assert.ok(
+    projected.aliena_dimensions.A_ancoraggio_narrativo,
+    'dimension key preserved (exact-match scrub)',
+  );
+});


### PR DESCRIPTION
## What

Follow-up to the Codex P2 review on #2839. The secret-hardening there was
**top-level only**: the `PUBLIC_ENTRY_KEYS` allowlist keeps public containers
(`aliena_dimensions`, `variants`, ...) whole, so a future authored entry that
embeds a score under a **nested** key (e.g. `aliena_dimensions.E_ecologia.coherence`)
would still serialize through `/api/v1/codex/entries/:id`.

`projectPublicEntry` now also runs a recursive **exact-match scrub** of the
scorer's secret field names at **any depth**, after the top-level projection:
`aggregate / sub_scores / coherence / enforcement_factor / _aliena_enforcement /
plausibilita / coerenza_eco / ancoraggio_narrativo / strength`.

Exact-match is deliberate: the dimension keys `A_ancoraggio_narrativo` /
`E_ecologia` are NOT touched (distinct from the sub-score names
`ancoraggio_narrativo` / `coerenza_eco`).

## Verification

New unit test crafts a nested-secret entry (`alien_fit` top-level + nested
`coherence` + nested `sub_scores`) and asserts: top-level unknown dropped, nested
secrets scrubbed, public content + the dimension key preserved. codexEntries 7/7,
prettier clean.

## Scope / rollback

`apps/backend/services/codex/codexEntries.js` + `tests/api/codexEntries.test.js`.
Pure revert restores the top-level-only guard.

Codex thread resolved: https://github.com/MasterDD-L34D/Game/pull/2839#discussion_r3435306503

🤖 Generated with [Claude Code](https://claude.com/claude-code)