### PR TITLE
fix(spec-h): codex Specie tab resilience + a11y + unlock-contract doc (audit P2/P3)

### DIFF
--- a/apps/play/src/codexPanel.js
+++ b/apps/play/src/codexPanel.js
@@ -327,9 +327,15 @@ function isCodexEntryUnlocked(id) {
   }
 }
 
-// Mark a Codex entry discovered (QBN unlock). Called by gameplay events
-// (encounter_completed / mating_success / ...). Wiring the triggers into the
-// combat/debrief flow is a follow-up; this surface already reads the state.
+// Mark a Codex entry discovered (QBN unlock). `id` MUST equal a codex entry id
+// (== the unit's species slug; see main.js unlock hook). Called by gameplay
+// events (encounter_completed / mating_success / ...).
+//
+// BINARY unlock (2026-06-18 audit P3): the first matching trigger unlocks the
+// entry permanently; the served unlock.threshold (default 1) is NOT counted. All
+// authored entries are threshold:1 today, so this is correct -- a future
+// threshold>1 entry would still unlock on the first trigger. Documented here
+// rather than implemented since no entry needs counting yet.
 export function markCodexEntrySeen(id, trigger = 'encounter_completed') {
   if (!id) return;
   try {
@@ -364,7 +370,10 @@ function renderSpecieList(el) {
     .codexEntries()
     .then((r) => {
       if (!r.ok) {
-        el.innerHTML = `<p class="codex-intro">Errore caricamento specie: ${escHtml(r.data?.error || r.status)}</p>`;
+        // status 0 = network drop (jsonFetch resolves {ok:false,status:0}); show a
+        // human message instead of a bare "0" (2026-06-18 audit P3).
+        const reason = r.data?.error || (r.status ? `errore ${r.status}` : 'backend offline?');
+        el.innerHTML = `<p class="codex-intro">Errore caricamento specie: ${escHtml(reason)}</p>`;
         return;
       }
       const entries = Array.isArray(r.data?.entries) ? r.data.entries : [];
@@ -388,9 +397,18 @@ function renderSpecieList(el) {
           ${withState.map((e) => renderSpecieRow(e)).join('')}
         </ul>`;
       el.querySelectorAll('.codex-specie-row.unlocked').forEach((row) => {
-        row.addEventListener('click', () => {
+        const open = () => {
           _specieSelectedId = row.dataset.entryId;
           renderSpecieTab(el);
+        };
+        row.addEventListener('click', open);
+        // a11y (2026-06-18 audit P3): rows advertise role=button + tabindex=0, so
+        // honor keyboard activation (Enter / Space) -- not just mouse click.
+        row.addEventListener('keydown', (ev) => {
+          if (ev.key === 'Enter' || ev.key === ' ') {
+            ev.preventDefault();
+            open();
+          }
         });
       });
     })
@@ -414,13 +432,29 @@ function renderSpecieRow(e) {
   </li>`;
 }
 
+// Detail error escape (2026-06-18 audit P2): the error/catch branches used to
+// overwrite the container with no back button while leaving _specieSelectedId set
+// -> renderSpecieTab routes back to the same failing fetch (player stuck). Always
+// render a working "<- Bestiario" escape that resets the selection to the list.
+function _renderSpecieError(el, msg) {
+  el.innerHTML = `
+    <div class="codex-actions-row">
+      <button class="codex-btn" id="codex-specie-back">← Bestiario</button>
+    </div>
+    <p class="codex-intro">${escHtml(msg)}</p>`;
+  el.querySelector('#codex-specie-back')?.addEventListener('click', () => {
+    _specieSelectedId = null;
+    renderSpecieTab(el);
+  });
+}
+
 function renderSpecieDetail(el, id) {
   el.innerHTML = `<p class="codex-intro">Caricamento...</p>`;
   api
     .codexEntry(id)
     .then((r) => {
       if (!r.ok || !r.data?.entry) {
-        el.innerHTML = `<p class="codex-intro">Specie non trovata.</p>`;
+        _renderSpecieError(el, 'Specie non trovata.');
         return;
       }
       const entry = r.data.entry;
@@ -454,7 +488,7 @@ function renderSpecieDetail(el, id) {
       wireSkivFooter(el, entry);
     })
     .catch((err) => {
-      el.innerHTML = `<p class="codex-intro">Errore: ${escHtml(err?.message || err)}</p>`;
+      _renderSpecieError(el, `Errore: ${err?.message || err}`);
     });
 }
 

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -287,6 +287,15 @@ function redraw() {
       // every enemy species faced (trigger `encounter_completed`). Any outcome
       // counts (you encountered them). markCodexEntrySeen is a no-op for species
       // without a codex entry, so this is safe for the whole sistema roster.
+      //
+      // CONTRACT (2026-06-18 audit P2): unlock keys on the unit's species slug
+      // (species_id preferred, else species). A codex entry unlocks iff its id
+      // EQUALS that slug. Today only dune_stalker has an entry, and it appears as
+      // a sistema unit in the tutorial waves (species:'dune_stalker') -> it
+      // unlocks. Archetype-labelled enemies (apex_predatore, ...) have no entry,
+      // so their localStorage keys are harmless orphans. When authoring a new
+      // codex entry, its id MUST match the sistema unit's species slug or it will
+      // never unlock through play.
       try {
         const encounteredSpecies = new Set(
           (state.world.units || [])


### PR DESCRIPTION
## What (2026-06-18 audit fixes -- frontend codex Specie tab)

- **Detail dead-end (P2)**: the `renderSpecieDetail` error/catch branches overwrote
  the container with no back button while leaving `_specieSelectedId` set, so
  `renderSpecieTab` re-routed to the same failing fetch -> player stuck (offline /
  404 / 5xx). New `_renderSpecieError` always renders a working "<- Bestiario"
  escape that resets the selection back to the list.
- **'0' offline message (P3)**: the list `ok:false` branch now shows
  'backend offline?' on a status-0 network drop instead of a bare 'Errore ... 0'.
- **a11y (P3)**: unlocked rows advertise `role=button` + `tabindex=0` but only had a
  click listener; added Enter/Space keydown activation.
- **unlock contract (P2 namespace)**: documented in `main.js` that a codex entry
  unlocks iff its id == a `sistema` unit's species slug (today `dune_stalker` via
  the tutorial waves; archetype-labelled enemies write harmless orphan keys).
  Verify-first: the unlock already keys on the species slug, so this is a
  data/contract clarification (only 1 entry exists today), **not a code bug** -- no
  risky scenario-builder propagation.
- **binary unlock (P3)**: documented that `unlock.threshold` is not counted (all
  entries are threshold:1 today).

## Verification
prettier clean, syntax ok, `vite build` green. Browser preview skipped -- these are
error-branch + a11y + doc changes on the already-preview-verified Specie path (#2829).

## Scope / rollback
`apps/play/src/codexPanel.js` + `apps/play/src/main.js`. Frontend only, no
backend/forbidden-path. Pure revert restores the prior (stuck) error behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)