### PR TITLE
fix(spec-h): widen HA2 content band to 100-500 (audit P2, master-dd ratified)

### DIFF
--- a/tests/codex/validator.test.js
+++ b/tests/codex/validator.test.js
@@ -11,14 +11,14 @@ const SCRIPT = path.join(__dirname, '..', '..', 'tools', 'js', 'validate_codex_a
 const REPO_ROOT = path.join(__dirname, '..', '..');
 
 const SIX_DIMS = `
-    A_ambiente: { heading: Ambiente, content: '${'a'.repeat(150)}' }
-    L_linee_evolutive: { heading: Linee, content: '${'b'.repeat(150)}' }
-    I_impianto: { heading: Impianto, content: '${'c'.repeat(150)}' }
-    E_ecologia: { heading: Ecologia, content: '${'d'.repeat(150)}' }
-    N_norme_socio: { heading: Norme, content: '${'e'.repeat(150)}' }
+    A_ambiente: { heading: Ambiente, content: '${'a'.repeat(400)}' }
+    L_linee_evolutive: { heading: Linee, content: '${'b'.repeat(400)}' }
+    I_impianto: { heading: Impianto, content: '${'c'.repeat(400)}' }
+    E_ecologia: { heading: Ecologia, content: '${'d'.repeat(400)}' }
+    N_norme_socio: { heading: Norme, content: '${'e'.repeat(400)}' }
     A_ancoraggio_narrativo:
       heading: Ancoraggio
-      content: '${'f'.repeat(150)}'
+      content: '${'f'.repeat(400)}'
       story_hook_it: 'Un gancio narrativo.'`;
 
 function wellFormed(id) {
@@ -118,7 +118,7 @@ test('validator warns (non-strict pass, strict fail) on short content', () => {
     writeFixture(dir, 'short.yaml', body);
     const r = run(dir);
     assert.equal(r.status, 0, 'short content is a warning, not an error (non-strict)');
-    assert.match(r.stdout, /outside 100-300 char band/);
+    assert.match(r.stdout, /outside 100-500 char band/);
     const strict = run(dir, ['--strict']);
     assert.equal(strict.status, 1, 'strict mode fails on warnings');
   } finally {

--- a/tools/js/validate_codex_aliena.js
+++ b/tools/js/validate_codex_aliena.js
@@ -10,8 +10,9 @@
  *   HARD (error)  -- every data/codex/{id}.yaml entry declares all 6 keys
  *     (A_ambiente / L_linee_evolutive / I_impianto / E_ecologia / N_norme_socio /
  *     A_ancoraggio_narrativo) and each has non-empty `content`.
- *   SOFT (warn)   -- content length outside the spec's 100-300 char TV-readable
- *     band; A_ancoraggio lacks a narrative hook (story_hook_it / lore_seed_it /
+ *   SOFT (warn)   -- content length outside the 100-500 char TV-readable band
+ *     (max re-derived from the real corpus, 2026-06-18 audit); A_ancoraggio lacks
+ *     a narrative hook (story_hook_it / lore_seed_it /
  *     sistema_relation); unlock.triggers empty.
  *
  * This guard checks PRESENCE + quality of the authored data; it does NOT impose a
@@ -51,9 +52,13 @@ const ALIENA_DIMENSION_KEYS = [
   'A_ancoraggio_narrativo',
 ];
 
-// Spec sez.5: each dimension content is 100-300 char, TV-readable (SOFT band).
+// SOFT TV-readable length band. Spec sez.5 says 100-300, but the 2026-06-18 audit
+// showed the real authored corpus (dune_stalker dimensions 368-493 char) sits well
+// over that ceiling -- the band warned on 100% of real content (zero signal +
+// --strict footgun). CONTENT_MAX re-derived from the corpus to 500 (the actual
+// TV-readable ceiling); master-dd ratified. CONTENT_MIN keeps the spec floor.
 const CONTENT_MIN = 100;
-const CONTENT_MAX = 300;
+const CONTENT_MAX = 500;
 
 function parseArgs(argv) {
   const out = { codexDir: 'data/codex', strict: false };
@@ -91,10 +96,10 @@ function validateEntry(file, parsed, errors, warnings) {
       continue;
     }
     present += 1;
-    // SOFT: TV-readable length band (spec sez.5: 100-300 char).
+    // SOFT: TV-readable length band (100-500, corpus-derived -- see CONTENT_MAX).
     if (content.length < CONTENT_MIN || content.length > CONTENT_MAX) {
       warnings.push(
-        `${id}: dimension '${key}' content length ${content.length} outside 100-300 char band`,
+        `${id}: dimension '${key}' content length ${content.length} outside ${CONTENT_MIN}-${CONTENT_MAX} char band`,
       );
     }
   }


### PR DESCRIPTION
## What (2026-06-18 audit P2, master-dd ratified)

The HA2 validator's SOFT length band (`100-300`) warned on **100% of the real
authored corpus** -- `dune_stalker` dimensions are 368-493 char, all over the
ceiling. Zero discriminating signal + a latent `--strict` footgun (CI would fail
on the only canonical example).

`CONTENT_MAX` re-derived from the corpus to **500** (the actual TV-readable
ceiling). `CONTENT_MIN` keeps the spec floor. The over-length warn still fires for
genuinely-too-long content (>500).

## Verification
- Real `dune_stalker` now validates **errors=0 warnings=0** (was 6 length warnings).
- Validator test 6/6; the well-formed fixture bumped 150->400 char so the band is
  exercised against representative data; the short-content (<100) warn case still passes.

## Scope / rollback
`tools/js/validate_codex_aliena.js` + `tests/codex/validator.test.js`. No
forbidden-path. Pure revert restores the 100-300 band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)