### PR TITLE
fix(spec-h): scope codex secret scrub to score containers + correct audit report

### DIFF
--- a/apps/backend/services/codex/codexEntries.js
+++ b/apps/backend/services/codex/codexEntries.js
@@ -129,20 +129,22 @@ const PUBLIC_ENTRY_KEYS = [
 // The top-level allowlist keeps PUBLIC containers (aliena_dimensions, variants...)
 // whole, so a secret embedded under a NESTED key (e.g. aliena_dimensions.
 // E_ecologia.coherence) would still serialize (Codex P2 on #2839). This is the
-// exact-match set of the scorer's secret field names (alienaCoherence.js sub_scores
-// + sez.8 enforcement signals); scrubbed at ANY depth. Exact match -> the dimension
-// keys A_ancoraggio_narrativo / E_ecologia are NOT touched (distinct from the
-// sub-score names ancoraggio_narrativo / coerenza_eco).
+// exact-match set of the scorer's UNAMBIGUOUS container/score keys, scrubbed at
+// ANY depth.
+//
+// Scope (Codex P2 on #2841): only the score CONTAINERS + clearly-score-named keys
+// are listed. The sub-score LEAF names (plausibilita / coerenza_eco /
+// ancoraggio_narrativo) and `strength` are deliberately NOT here: they only ever
+// live under sub_scores / _aliena_enforcement (both removed wholesale), so listing
+// them standalone is redundant AND would drop legit public content (e.g. a synergy
+// `strength` or a creature stat). Exact match also keeps the dimension keys
+// A_ancoraggio_narrativo / E_ecologia untouched.
 const SECRET_KEYS = new Set([
   'aggregate',
   'sub_scores',
   'coherence',
   'enforcement_factor',
   '_aliena_enforcement',
-  'plausibilita',
-  'coerenza_eco',
-  'ancoraggio_narrativo',
-  'strength',
 ]);
 
 // Recursively delete any secret-named key at any depth (in place, on the clone).

--- a/docs/reports/2026-06-18-session-audit.md
+++ b/docs/reports/2026-06-18-session-audit.md
@@ -11,7 +11,7 @@ review_cycle_days: 30
 
 # Session audit -- 2026-06-18 build-residui (post-merge adversarial review)
 
-> Method: Workflow 7 adversarial reviewers (1/PR, refute-by-default, ground-truth git show) + synth-critic (verify/dedup/cross-cutting/fix-plan). 8 agents, 19 raw findings -> 18 verified (1 refuted). Codex did NOT review the 6 Game PRs (rate-limit); GGv2 #481 yes (2 P2 fixed pre-merge). All confirmed findings have since been FIXED -- see Resolution at the bottom.
+> Method: Workflow 7 adversarial reviewers (1/PR, refute-by-default, ground-truth git show) + synth-critic (verify/dedup/cross-cutting/fix-plan). 8 agents, 19 raw findings -> 18 verified (1 refuted). Codex did NOT review the 6 Game PRs (rate-limit); GGv2 #481 yes (2 P2 fixed pre-merge). All confirmed findings have since been RESOLVED -- mostly fixed in code, one (the #2830 namespace) documentation-only / accepted-risk; see Resolution at the bottom.
 
 ## Verdict
 
@@ -150,13 +150,14 @@ The 2026-06-18 session work is largely sound and SPEC-faithful. I adversarially 
 11. P3 (mechanical, frontend) -- #2829 a11y + #2830 threshold: add a keydown(Enter/Space) handler to unlocked rows (or drop role=button/tabindex); and either drop unlock.threshold from served metadata or implement counting in markCodexEntrySeen with a hook-comment documenting the binary semantics. Both latent/benign today; batch into a frontend-polish PR.
 12. No action -- #2826 '9/9' provenance: REFUTED. The suite genuinely has 9 tests on origin/main; the commit count is correct.
 
-## Resolution (2026-06-18 -- all shipped)
+## Resolution (2026-06-18)
 
 - P1 CI gate gap -> PR #2838 (data/codex/** added to stack paths-filter).
-- P2 secret allowlist (#2828/#2835) -> PR #2839 (projection + clone) + PR #2841 (recursive nested scrub, Codex P2 follow-up).
+- P2 secret allowlist (#2828/#2835) -> PR #2839 (projection + clone) + PR #2841 (recursive nested scrub, Codex P2 follow-up) + a follow-up PR scoping the scrub to the score containers only (Codex P2 on #2841: a generic public 'strength' was over-scrubbed).
 - P2 HA5 semantics -> PR #2839 (bands renamed ecological -> archival: scheda completa/parziale/frammentaria).
 - P2 HA2 band -> PR #2843 (CONTENT_MAX 300 -> 500, corpus-derived).
-- P2 frontend detail dead-end + '0' msg + a11y + unlock-contract + threshold doc -> PR #2842.
-- P2 GGv2 freed-view guard (#481) -> chip task_66e248f4 (cross-repo).
+- P2 frontend detail dead-end + '0' msg + a11y + threshold doc -> PR #2842.
+- P2 #2830 namespace -> **DOCUMENTATION-ONLY / accepted risk** (PR #2842). Verify-first superseded the original "propagate species_hint -> unit.species_id" plan: the unlock already keys on the unit's species slug, and only 1 codex entry (dune_stalker) exists today + unlocks via the tutorial waves. The contract (codex id == sistema unit species slug) is documented in the main.js hook. NOT propagated in the scenario builders -- a future codex entry whose id does not match a sistema unit's species slug would silently fail to unlock; revisit when authoring more entries (Codex P2 on #2844).
+- P2 GGv2 freed-view guard (#481) -> GGv2 #486 (caller + inside-method guards, Codex P2 caught + fixed in-PR).
 - P3 observability / force-param / mating coverage / dead list field -> PR #2839.
 - Refuted: #2826 '9/9' provenance (the commit count was correct).

--- a/tests/api/codexEntries.test.js
+++ b/tests/api/codexEntries.test.js
@@ -164,10 +164,13 @@ test('projectPublicEntry drops top-level unknown AND nested secret-named keys', 
         heading: 'Ecologia',
         content: 'public lore',
         coherence: 0.8, // NESTED secret -> dropped by scrub
-        sub_scores: { plausibilita: 1 }, // nested secret container -> dropped
+        sub_scores: { plausibilita: 1 }, // nested secret container -> dropped wholesale
       },
       A_ancoraggio_narrativo: { heading: 'Anc', content: 'lore', story_hook_it: 'h' },
     },
+    // public 'strength' must SURVIVE (Codex P2 on #2841: scrub scoped to score
+    // containers, not the generic 'strength' / sub-score leaf names).
+    synergies: [{ id: 'echo_backstab', strength: 'high', note_it: 'public' }],
   };
   const projected = projectPublicEntry(crafted);
   const blob = JSON.stringify(projected);
@@ -180,8 +183,10 @@ test('projectPublicEntry drops top-level unknown AND nested secret-named keys', 
   assert.equal(
     projected.aliena_dimensions.E_ecologia.sub_scores,
     undefined,
-    'nested sub_scores scrubbed',
+    'nested sub_scores scrubbed (wholesale -> plausibilita gone too)',
   );
+  // public 'strength' under an allowlisted container survives (not over-scrubbed).
+  assert.equal(projected.synergies[0].strength, 'high', "public 'strength' preserved");
   for (const secret of ['alien_fit', 'coherence', 'sub_scores', 'plausibilita']) {
     assert.ok(!blob.includes(secret), `secret '${secret}' must not survive projection`);
   }


### PR DESCRIPTION
## What (two Codex P2s on the audit fix-PRs)

Codex came back un-rate-limited and reviewed my own audit fixes:

### #2841 P2 -- secret scrub over-scoped
The recursive scrub listed generic leaf names (`strength` + the sub-score names
`plausibilita`/`coerenza_eco`/`ancoraggio_narrativo`). `strength` is legit public
content (a synergy strength, a creature stat), and the leaf names only ever live
under `sub_scores` / `_aliena_enforcement` (both removed wholesale), so listing
them standalone was redundant AND silently dropped valid codex content.
`SECRET_KEYS` reduced to the unambiguous score containers
`{aggregate, sub_scores, coherence, enforcement_factor, _aliena_enforcement}` --
still catches the nested leak vectors. The test now asserts a public `strength`
under `synergies` **survives** while nested `coherence`/`sub_scores` are scrubbed.

### #2844 P2 -- audit report over-claimed
The report's resolution trail listed the #2830 namespace as fixed; PR #2842 only
**documented** the contract (verify-first deferred the `species_hint -> species_id`
propagation as unnecessary for the single codex entry today). Corrected to
**documentation-only / accepted-risk**, with the residual + when-to-revisit noted.

## Verification
codexEntries 7/7, AI suite 543/543, prettier + docs-governance (--strict errors=0).

## Scope / rollback
`apps/backend/services/codex/codexEntries.js`, `tests/api/codexEntries.test.js`,
`docs/reports/2026-06-18-session-audit.md`. Pure revert restores the broader scrub.

Codex threads resolved: #2841 + #2844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)