### PR TITLE
fix(spec-h): keep scrubbing ALIENA sub-score leaves, drop only 'strength' (Codex P2 #2847)

### DIFF
--- a/apps/backend/services/codex/codexEntries.js
+++ b/apps/backend/services/codex/codexEntries.js
@@ -132,19 +132,27 @@ const PUBLIC_ENTRY_KEYS = [
 // exact-match set of the scorer's UNAMBIGUOUS container/score keys, scrubbed at
 // ANY depth.
 //
-// Scope (Codex P2 on #2841): only the score CONTAINERS + clearly-score-named keys
-// are listed. The sub-score LEAF names (plausibilita / coerenza_eco /
-// ancoraggio_narrativo) and `strength` are deliberately NOT here: they only ever
-// live under sub_scores / _aliena_enforcement (both removed wholesale), so listing
-// them standalone is redundant AND would drop legit public content (e.g. a synergy
-// `strength` or a creature stat). Exact match also keeps the dimension keys
-// A_ancoraggio_narrativo / E_ecologia untouched.
+// Scope (Codex P2 on #2841 + #2847): the score containers PLUS the score-specific
+// sub-score LEAF names -- but NOT the generic word `strength`.
+//   - Leaf names (plausibilita / coerenza_eco / ancoraggio_narrativo) are kept:
+//     they are scorer terms, never natural public codex content, and a future
+//     entry could place a raw score directly under a dimension
+//     (aliena_dimensions.E_ecologia.plausibilita) -- the HA2 gate does not reject
+//     extra dimension fields, so the scrub is the only guard. Exact match keeps
+//     the DIMENSION keys A_ancoraggio_narrativo / E_ecologia untouched (distinct
+//     from the leaf names ancoraggio_narrativo / coerenza_eco).
+//   - `strength` is NOT scrubbed: it is legit public content (a synergy strength,
+//     a creature stat) and only leaks as part of `_aliena_enforcement`, which is
+//     already removed wholesale.
 const SECRET_KEYS = new Set([
   'aggregate',
   'sub_scores',
   'coherence',
   'enforcement_factor',
   '_aliena_enforcement',
+  'plausibilita',
+  'coerenza_eco',
+  'ancoraggio_narrativo',
 ]);
 
 // Recursively delete any secret-named key at any depth (in place, on the clone).

--- a/tests/api/codexEntries.test.js
+++ b/tests/api/codexEntries.test.js
@@ -165,11 +165,12 @@ test('projectPublicEntry drops top-level unknown AND nested secret-named keys', 
         content: 'public lore',
         coherence: 0.8, // NESTED secret -> dropped by scrub
         sub_scores: { plausibilita: 1 }, // nested secret container -> dropped wholesale
+        coerenza_eco: 0.9, // bare score LEAF directly under a dimension -> scrubbed (#2847)
       },
       A_ancoraggio_narrativo: { heading: 'Anc', content: 'lore', story_hook_it: 'h' },
     },
-    // public 'strength' must SURVIVE (Codex P2 on #2841: scrub scoped to score
-    // containers, not the generic 'strength' / sub-score leaf names).
+    // public 'strength' must SURVIVE (Codex P2 on #2841: scrub scoped, 'strength'
+    // is a generic public word, not a scorer term).
     synergies: [{ id: 'echo_backstab', strength: 'high', note_it: 'public' }],
   };
   const projected = projectPublicEntry(crafted);
@@ -185,9 +186,16 @@ test('projectPublicEntry drops top-level unknown AND nested secret-named keys', 
     undefined,
     'nested sub_scores scrubbed (wholesale -> plausibilita gone too)',
   );
+  // bare score LEAF directly under a dimension is scrubbed (#2847 -- not only the
+  // container; the HA2 gate does not reject extra dimension fields).
+  assert.equal(
+    projected.aliena_dimensions.E_ecologia.coerenza_eco,
+    undefined,
+    'bare sub-score leaf under a dimension scrubbed',
+  );
   // public 'strength' under an allowlisted container survives (not over-scrubbed).
   assert.equal(projected.synergies[0].strength, 'high', "public 'strength' preserved");
-  for (const secret of ['alien_fit', 'coherence', 'sub_scores', 'plausibilita']) {
+  for (const secret of ['alien_fit', 'coherence', 'sub_scores', 'plausibilita', 'coerenza_eco']) {
     assert.ok(!blob.includes(secret), `secret '${secret}' must not survive projection`);
   }
   // public content survives + the dimension key A_ancoraggio_narrativo is NOT scrubbed.


### PR DESCRIPTION
Convergent fix for the two opposing Codex P2s on the codex secret scrub. **#2841**: a public 'strength' was over-scrubbed. **#2847**: dropping the sub-score leaf names let a raw score under a dimension (aliena_dimensions.E_ecologia.plausibilita) leak (HA2 gate does not reject extra dimension fields). SECRET_KEYS now keeps the score-specific leaf names (plausibilita/coerenza_eco/ancoraggio_narrativo -- scorer terms, exact-match so dimension keys untouched) and drops ONLY the generic 'strength' (legit public). Test asserts both: bare E_ecologia.coerenza_eco scrubbed + public synergy 'strength' survives. codexEntries 7/7, prettier clean. Codex thread #2847 resolved.