### PR TITLE
docs(spec-h): accurate codex unlock comment + BACKLOG reachability gap

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -57,6 +57,13 @@ IMPLEMENTAZIONE (forward-work, NON doc-flip blocker):
   `enc_badlands_pilot_01` (win-rate in banda + no regressione) + propagazione
   `enforcement_factor` nel sample telemetria (sez.4). master-dd + harness G2. **Unico residuo
   sostanziale SPEC-H** (la machinery e la surface sono complete).
+- **Codex unlock-reachability gap (Gate-5)** — verify-first 2026-06-18 (#2851): l'unica codex
+  entry autorata (`dune_stalker`) e' `controlled_by:'player'` in OGNI wave wired -> non entra
+  mai nel set sistema-filtered dell'unlock hook; la sua unica apparizione non-player e'
+  `enc_savana_pack_clash` (`apex_neutral`), che nessun routing referenzia -> nel flow default ~0
+  entry sbloccabili. Fix = wire dell'encounter savana OPPURE aggiungere `dune_stalker` come nemico
+  sistema in una wave (content/balance, master-dd). Il guard namespace (#2851) cattura l'orphan;
+  questo gap = reachability del roster, separato.
 
 Doc-flip != runtime (precedent SPEC-I/K). item-1 = 17/17 a doc-level; questi residui = build.
 
@@ -74,6 +81,7 @@ completa -> i ticket sez.10 sono build-residue item-3 (cross-repo Game-Godot-v2)
 - **K-05** Next mission quorum — PENDING.
 - **K-06** Wording cleanup ("host drives" residui) — PENDING.
 - **K-07** Real-device smoke playtest (2 telefoni + TV: route-vote/recruit/mating/Nido/next) — PENDING (criterio sez.9.9 UNMET).
+- **Codex namespace cross-check (HA2 follow-up)** — **DONE 2026-06-18** (PR #2851 `d0d59923`): `validate_codex_aliena.js` orphan-id guard -- una codex entry il cui id non e' in alcun roster sistema/encounter (scenario builders + `data/encounters/*.yaml`) warna SOFT (mai sbloccabile). Reso require()-able, 5 test, CI-enforced. Scoperto il gap reachability di cui sopra (SPEC-H).
 
 Dipendenti gia' flippati che poggiano su questo seam: SPEC-J (consent UI #477) + SPEC-B (visibility).
 Runtime/surface = item-3 Godot, NON blocca il doc-flip (precedent SPEC-I/A/G).

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -290,12 +290,20 @@ function redraw() {
       //
       // CONTRACT (2026-06-18 audit P2): unlock keys on the unit's species slug
       // (species_id preferred, else species). A codex entry unlocks iff its id
-      // EQUALS that slug. Today only dune_stalker has an entry, and it appears as
-      // a sistema unit in the tutorial waves (species:'dune_stalker') -> it
-      // unlocks. Archetype-labelled enemies (apex_predatore, ...) have no entry,
-      // so their localStorage keys are harmless orphans. When authoring a new
-      // codex entry, its id MUST match the sistema unit's species slug or it will
-      // never unlock through play.
+      // EQUALS that slug. Archetype-labelled enemies (apex_predatore, ...) have
+      // no entry, so their localStorage keys are harmless orphans. When authoring
+      // a new codex entry, its id MUST match a sistema unit's species slug in a
+      // roster that is actually played, or it will never unlock. The HA2 validator
+      // (tools/js/validate_codex_aliena.js, SPEC-K namespace cross-check) warns on
+      // ids absent from every scenario/encounter roster.
+      //
+      // REACHABILITY GAP (SPEC-K, 2026-06-18 verify-first -- BACKLOG): the only
+      // authored entry, dune_stalker, is controlled_by:'player' in EVERY wired
+      // scenario wave, so it never enters this sistema-filtered set there. Its only
+      // non-player appearance is the enc_savana_pack_clash encounter (apex_neutral),
+      // which no routing references yet. So in the default flow ~0 codex entries are
+      // currently unlockable (Gate-5 gap). Fix = wire the savana encounter OR add
+      // dune_stalker as a sistema enemy in a wave (content/balance, master-dd).
       try {
         const encounteredSpecies = new Set(
           (state.world.units || [])


### PR DESCRIPTION
## Cosa

Follow-up del finding di #2851 (master-dd verdict = "fix commento + BACKLOG il gap").

Il commento-contratto unlock-on-encounter (`apps/play/src/main.js`) affermava che `dune_stalker` *"appears as a sistema unit in the tutorial waves -> it unlocks"*. **Falso** (verify-first): dune_stalker e' `controlled_by:'player'` in OGNI wave wired; unica apparizione non-player = `enc_savana_pack_clash` (`apex_neutral`), non referenziato da alcun routing -> nel flow default ~0 codex entry sbloccabili (gap Gate-5).

## Come
- `main.js`: rimpiazzo il claim impreciso con lo stato reale di reachability + puntatore al namespace cross-check HA2 (#2851). **No behavior change** (solo commento).
- `BACKLOG.md`: SPEC-H riceve il residuo "Codex unlock-reachability gap (Gate-5)" (fix = wire encounter savana O dune_stalker nemico sistema = content/balance master-dd); SPEC-K marca il namespace cross-check DONE #2851.

## Rollback (03A)
Revert `ac3ffcce`. Zero runtime (comment + backlog).

## Gates
- <50 righe, fuori forbidden-path, no deps, band-neutral. Comment/doc only.

Coding-Agent: claude-opus-4-8
