### PR TITLE
feat(schema): Phase D biome + ecosystem JSON schemas (+ Phase C skip rationale)

### DIFF
--- a/docs/planning/2026-06-18-taxonomy-reconciliation-plan.md
+++ b/docs/planning/2026-06-18-taxonomy-reconciliation-plan.md
@@ -46,7 +46,7 @@ industry standard converges on five rules:
 1. **One canonical source per entity; GENERATE the derived views, never
    hand-author them.** (DRY / SSOT: "every piece of knowledge [has] a single,
    unambiguous, authoritative representation"; the "imposed duplication" fix is
-   an *active* build-time generator.)
+   an _active_ build-time generator.)
 2. **Mark generated files DO-NOT-EDIT and enforce generation in CI** -- a
    `regenerate && git diff --exit-code` (golden-file) gate makes drift between
    source and derived **impossible by construction**. Determinism required (no
@@ -81,12 +81,12 @@ the shape gate; `tests/scripts/speciesTraitReferences.test.js` (species
 
 ## 3. Gap inventory (all entities, worst -> best)
 
-| Entity | Representations | Real gaps found | Risk |
-| --- | --- | --- | --- |
-| **Biomes** | 4 (`data/core/biomes.yaml`, `biomes_expansion.yaml`, `biome_aliases.yaml`, `packs/.../data/biomes.yaml`) | `biomes_expansion.yaml` (20 biomes) unregistered in pack enrollment; alias mapping without merge enforcement; no equivalence gate; schema v1.0 vs v2.0 | **Critical** |
-| **Ecosystems** | 3-4 (`data/ecosystems/*.ecosystem.yaml`, `packs/.../data/ecosystems/*`, orphan `docs/planning/ecosystems-draft/`) | REAL roster divergence (badlands 5 -> 8 species between core and pack); orphan draft folder | **High** |
-| **Species** | 3 (`data/core/species/species_catalog.json` 75, `catalog_data.json` roster 21, per-file `docs/catalog/species/*.json` 21) | `role_tags:'playable'` (8 legacy, undeployed) vs `playable_unit:true` (8 deployed) overload = two answers to "playable"; 4 `evento_*` roster-only (is_event, generator-filtered); cross-layer parity unchecked | **High** |
-| **Traits** | 3 primary + 5 derived (auto-synced via `traits-sync.yml`) | single auto-synced SoT (cleanest); 60+ per-biome trait-keeper sidecars lack back-concordance to glossary | **Medium** |
+| Entity         | Representations                                                                                                           | Real gaps found                                                                                                                                                                                                | Risk         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| **Biomes**     | 4 (`data/core/biomes.yaml`, `biomes_expansion.yaml`, `biome_aliases.yaml`, `packs/.../data/biomes.yaml`)                  | `biomes_expansion.yaml` (20 biomes) unregistered in pack enrollment; alias mapping without merge enforcement; no equivalence gate; schema v1.0 vs v2.0                                                         | **Critical** |
+| **Ecosystems** | 3-4 (`data/ecosystems/*.ecosystem.yaml`, `packs/.../data/ecosystems/*`, orphan `docs/planning/ecosystems-draft/`)         | REAL roster divergence (badlands 5 -> 8 species between core and pack); orphan draft folder                                                                                                                    | **High**     |
+| **Species**    | 3 (`data/core/species/species_catalog.json` 75, `catalog_data.json` roster 21, per-file `docs/catalog/species/*.json` 21) | `role_tags:'playable'` (8 legacy, undeployed) vs `playable_unit:true` (8 deployed) overload = two answers to "playable"; 4 `evento_*` roster-only (is_event, generator-filtered); cross-layer parity unchecked | **High**     |
+| **Traits**     | 3 primary + 5 derived (auto-synced via `traits-sync.yml`)                                                                 | single auto-synced SoT (cleanest); 60+ per-biome trait-keeper sidecars lack back-concordance to glossary                                                                                                       | **Medium**   |
 
 Note: species per-file == roster (21==21, identical ids) -- no orphan files. The
 58 catalog species not in the roster are designed-but-undeployed backlog (by
@@ -131,12 +131,14 @@ Each phase is a separate worktree-isolated PR through `evo-import-gate` +
 ## 6. Decisions
 
 **Ratified (this session):**
+
 - DB-as-SoT for taxonomy authoring is DEFERRED to S3+ (a single Game-led
   authoring migration; not now). File = authoring SoT, DB = downstream shadow +
   trait-export-SoT.
 - Reconciliation is file-side (generator + checker + schema), per the standard.
 
 **Pending (Eduardo):**
+
 - **Tier semantics** -- the canonical partition: full-catalog (75 designed) /
   deployed (21 roster = per-file) / events (`is_event`, catalog_data-only) /
   playable. Confirm the field + meaning.
@@ -164,3 +166,33 @@ Each phase is a separate worktree-isolated PR through `evo-import-gate` +
   `tests/scripts/speciesTraitReferences.test.js`, `schemas/evo/species_catalog.schema.json`.
 - Generator: `scripts/update_evo_pack_catalog.js` + `scripts/sync_evo_pack_assets.js` (`npm run sync:evo-pack`).
 - Standards: see section 2 source list.
+
+## 8. Outcome (2026-06-18)
+
+- **Phase A -- SHIPPED** (#2832): species generation-enforcement (DO-NOT-EDIT
+  `_generated` marker + regenerate-and-diff gate via `git status --porcelain`).
+- **Phase B -- SHIPPED** (#2837): added `roster-species-canon` (inv1, clean) +
+  `ecosystem-roster-parity` (inv3) rules to `check-canon-consistency.cjs`.
+  Recon DROPPED inv2 (biome enrollment = dead-def S3 debt, overlaps `biome-refs`)
+  and inv4 (trait-keeper = empty stub sidecars; the "violations" were
+  `services_links` ecosystem-service refs, not traits -- already covered).
+- **5 ghost species -- DEPLOYED honest-stub** (#2850): the legacy `ecosystem-roster-parity`
+  baseline ghosts were brought into the game as honest uncalibrated stubs
+  (encounter_role only + empty vc + canon-truth traits); baseline shrunk to `[]`.
+  Real balance/vc deferred to AI-playtest calibration.
+- **Phase C -- SKIPPED.** The "playable overload" premise does not hold: the
+  three "playable" signals are near-disjoint distinct concepts, not a redundant
+  double-authoring -- (a) `clade_tag: Playable` (7, a taxonomy clade), (b)
+  `role_tags: 'playable'` (8 canon, a design-intent/backlog tag), (c)
+  `playable_unit: true` (8 roster, a deploy flag). The `role_tags:'playable'`
+  and `playable_unit` sets have ZERO overlap; the deployed playable_unit set has clade=null and
+  role_tags-playable=false. Collapsing them would conflate taxonomy + intent +
+  deploy-state (over-unify, plan rule 5). The "tier" is already derivable
+  (deployed = in roster; backlog = canon-not-roster; event = `is_event` /
+  `flags.event`), so a stored `tier` field is YAGNI. No conflation/drift exists
+  today. A stored tier field + collapse is NOT pursued.
+- **Phase D -- SHIPPED**: per-entity shape schemas `schemas/evo/biome.schema.json`
+  - `schemas/evo/ecosystem.schema.json`, validated in `validate_datasets.py`
+    (`validate_biome_schema` + `validate_ecosystem_schema`, mirroring the
+    species_catalog full-schema gate). Required fields = the set present on all
+    current records; `additionalProperties: true` permits per-record extras.

--- a/docs/planning/2026-06-18-taxonomy-reconciliation-plan.md
+++ b/docs/planning/2026-06-18-taxonomy-reconciliation-plan.md
@@ -192,7 +192,14 @@ Each phase is a separate worktree-isolated PR through `evo-import-gate` +
   `flags.event`), so a stored `tier` field is YAGNI. No conflation/drift exists
   today. A stored tier field + collapse is NOT pursued.
 - **Phase D -- SHIPPED**: per-entity shape schemas `schemas/evo/biome.schema.json`
-  - `schemas/evo/ecosystem.schema.json`, validated in `validate_datasets.py`
-    (`validate_biome_schema` + `validate_ecosystem_schema`, mirroring the
-    species_catalog full-schema gate). Required fields = the set present on all
-    current records; `additionalProperties: true` permits per-record extras.
+  and `schemas/evo/ecosystem.schema.json`, validated in `validate_datasets.py`
+  (`validate_biome_schema` and `validate_ecosystem_schema`, mirroring the
+  species_catalog full-schema gate). Required fields = the set present on all
+  current records; `additionalProperties: true` permits per-record extras.
+  SCOPE: the biome schema guards top-level record completeness only (nested
+  shapes are enforced by the procedural `validate_biomes()`); the ecosystem
+  schema governs the `data/ecosystems/*.ecosystem.yaml` shape only (the
+  `packs/.../data/ecosystems/` files have a different shape, governed by
+  `run_all_validators.py`). Negative-control (bad docs caught: 13 biome / 8
+  ecosystem) verified with the real jsonschema; a committed regression test is
+  deferred to the repo-root `jsonschema/` shadow cleanup (else it would no-op).

--- a/schemas/evo/biome.schema.json
+++ b/schemas/evo/biome.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.example.com/schemas/evo/biome.schema.json",
+  "title": "Evo Tactics Biome Catalog (data/core/biomes.yaml)",
+  "$comment": "Phase D / L4 per-entity shape schema for the canonical biome catalog. Validates the per-biome record shape under the `biomes` map; the vc_adapt/mutations/frequencies config sections are permitted (additionalProperties) but not constrained here. Required fields = the set present on ALL current biome records; additionalProperties:true permits per-biome extras (aliases, magnetic_field_strength, future).",
+  "type": "object",
+  "required": ["biomes"],
+  "properties": {
+    "biomes": {
+      "type": "object",
+      "description": "Map keyed by biome id; each value is a biome record.",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "legacy_slug",
+          "biome_class",
+          "display_name_it",
+          "display_name_en",
+          "label",
+          "summary",
+          "diff_base",
+          "mod_biome",
+          "affixes",
+          "hazard",
+          "npc_archetypes",
+          "stresswave",
+          "narrative"
+        ],
+        "properties": {
+          "legacy_slug": { "type": "string" },
+          "biome_class": { "type": "string" },
+          "display_name_it": { "type": "string" },
+          "display_name_en": { "type": "string" },
+          "label": { "type": "string" },
+          "summary": { "type": "string" },
+          "diff_base": { "type": "number" },
+          "mod_biome": { "type": "number" },
+          "affixes": { "type": "array", "items": { "type": "string" } },
+          "aliases": { "type": "array", "items": { "type": "string" } },
+          "magnetic_field_strength": { "type": "number", "minimum": 0, "maximum": 1 },
+          "hazard": {
+            "type": "object",
+            "properties": {
+              "description": { "type": "string" },
+              "severity": { "type": "string" },
+              "stress_modifiers": { "type": "object" }
+            },
+            "additionalProperties": true
+          },
+          "npc_archetypes": { "type": "object", "additionalProperties": true },
+          "stresswave": {
+            "type": "object",
+            "properties": {
+              "baseline": { "type": "number" },
+              "escalation_rate": { "type": "number" },
+              "event_thresholds": { "type": "object" }
+            },
+            "additionalProperties": true
+          },
+          "narrative": { "type": "object", "additionalProperties": true }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/evo/biome.schema.json
+++ b/schemas/evo/biome.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://game.example.com/schemas/evo/biome.schema.json",
   "title": "Evo Tactics Biome Catalog (data/core/biomes.yaml)",
-  "$comment": "Phase D / L4 per-entity shape schema for the canonical biome catalog. Validates the per-biome record shape under the `biomes` map; the vc_adapt/mutations/frequencies config sections are permitted (additionalProperties) but not constrained here. Required fields = the set present on ALL current biome records; additionalProperties:true permits per-biome extras (aliases, magnetic_field_strength, future).",
+  "$comment": "Phase D / L4 per-entity shape schema for the canonical biome catalog (data/core/biomes.yaml). SCOPE: guards TOP-LEVEL record completeness only -- each biome record must carry the set of fields present on ALL current records; additionalProperties:true permits per-biome extras (aliases, magnetic_field_strength, future), and the vc_adapt/mutations/frequencies config sections are permitted but not constrained. The NESTED shapes (hazard/narrative/npc_archetypes/stresswave sub-fields) are intentionally NOT required here -- their internal structure is enforced by the procedural validate_biomes() in tools/py/validate_datasets.py. (A separate, stricter config/schemas/biome.schema.yaml exists but is only meta-validated, not run against the data.)",
   "type": "object",
   "required": ["biomes"],
   "properties": {

--- a/schemas/evo/ecosystem.schema.json
+++ b/schemas/evo/ecosystem.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://game.example.com/schemas/evo/ecosystem.schema.json",
   "title": "Evo Tactics Ecosystem (data/ecosystems/*.ecosystem.yaml)",
-  "$comment": "Phase D / L4 per-entity shape schema for the canonical ecosystem files. Required fields = the set present on ALL current ecosystem files; additionalProperties:true permits extras (e.g. links.npg_dir). The trofico roster shape is validated loosely (cross-file roster equivalence is enforced by the ecosystem-roster-parity rule in check-canon-consistency.cjs, not here).",
+  "$comment": "Phase D / L4 per-entity shape schema for the canonical ecosystem files. SCOPE: governs the data/ecosystems/*.ecosystem.yaml shape ONLY (the small set of core authored ecosystems). The packs/evo_tactics_pack/data/ecosystems/ files have a DIFFERENT shape (no receipt/links/rules, plus a _provenance block) and are governed by the pack validator (run_all_validators.py via validate_ecosystem_pack), NOT this schema. Required fields = the set present on ALL current data/ecosystems files; additionalProperties:true permits extras (e.g. links.npg_dir). The trofico roster shape is validated loosely (cross-file roster equivalence is enforced by the ecosystem-roster-parity rule in check-canon-consistency.cjs, not here).",
   "type": "object",
   "required": ["schema_version", "receipt", "ecosistema", "links", "rules"],
   "properties": {

--- a/schemas/evo/ecosystem.schema.json
+++ b/schemas/evo/ecosystem.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://game.example.com/schemas/evo/ecosystem.schema.json",
+  "title": "Evo Tactics Ecosystem (data/ecosystems/*.ecosystem.yaml)",
+  "$comment": "Phase D / L4 per-entity shape schema for the canonical ecosystem files. Required fields = the set present on ALL current ecosystem files; additionalProperties:true permits extras (e.g. links.npg_dir). The trofico roster shape is validated loosely (cross-file roster equivalence is enforced by the ecosystem-roster-parity rule in check-canon-consistency.cjs, not here).",
+  "type": "object",
+  "required": ["schema_version", "receipt", "ecosistema", "links", "rules"],
+  "properties": {
+    "schema_version": { "type": ["number", "string"] },
+    "receipt": { "type": "object", "additionalProperties": true },
+    "ecosistema": {
+      "type": "object",
+      "required": [
+        "id",
+        "biome_id",
+        "label",
+        "clima",
+        "composizione_aria",
+        "abiotico",
+        "trofico",
+        "note"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "biome_id": { "type": "string" },
+        "label": { "type": "string" },
+        "clima": { "type": "object", "additionalProperties": true },
+        "composizione_aria": { "type": "object", "additionalProperties": true },
+        "abiotico": { "type": "object", "additionalProperties": true },
+        "trofico": {
+          "type": "object",
+          "properties": {
+            "produttori": { "type": "array", "items": { "type": "string" } },
+            "consumatori": {
+              "type": "object",
+              "properties": {
+                "primari": { "type": "array", "items": { "type": "string" } },
+                "secondari": { "type": "array", "items": { "type": "string" } },
+                "terziari": { "type": "array", "items": { "type": "string" } }
+              },
+              "additionalProperties": true
+            },
+            "decompositori": { "type": "array", "items": { "type": "string" } }
+          },
+          "additionalProperties": true
+        },
+        "note": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "links": { "type": "object", "additionalProperties": true },
+    "rules": { "type": "object", "additionalProperties": true }
+  },
+  "additionalProperties": true
+}

--- a/tools/py/validate_datasets.py
+++ b/tools/py/validate_datasets.py
@@ -40,6 +40,8 @@ def main() -> int:
     errors.extend(validate_telemetry())
     errors.extend(validate_species_ecology())
     errors.extend(validate_species_catalog_schema())
+    errors.extend(validate_biome_schema())
+    errors.extend(validate_ecosystem_schema())
 
     if errors:
         sys.stderr.write("\n".join(errors) + "\n")
@@ -738,6 +740,81 @@ def validate_species_catalog_schema() -> List[str]:
     for err in sorted(validator.iter_errors(catalog), key=lambda e: list(e.absolute_path)):
         loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
         errors.append(f"{catalog_path}: /{loc}: {err.message}")
+    return errors
+
+
+# === biome / ecosystem per-entity shape validation (Phase D / L4) ============
+# Extends the species_catalog full-schema gate to the canonical biome catalog
+# (data/core/biomes.yaml) and ecosystem files (data/ecosystems/*.ecosystem.yaml)
+# against schemas/evo/biome.schema.json + ecosystem.schema.json. These schemas
+# are self-contained (no cross-file $ref) so no referencing Registry is needed.
+
+def _self_contained_validator(schema_path: Path):
+    import jsonschema
+
+    with schema_path.open("r", encoding="utf-8") as fh:
+        schema = json.load(fh)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def validate_biome_schema() -> List[str]:
+    schema_path = _repo_root() / "schemas" / "evo" / "biome.schema.json"
+    biomes_path = _core_data_dir() / "biomes.yaml"
+    if not (schema_path.exists() and biomes_path.exists()):
+        return []  # nothing to validate in this layout
+
+    try:
+        import jsonschema  # noqa: F401
+    except ImportError:
+        return [
+            "tools/py/requirements.txt: 'jsonschema>=4.18.0' richiesto per validare "
+            "biomes.yaml contro lo schema (pip install jsonschema)"
+        ]
+
+    try:
+        validator = _self_contained_validator(schema_path)
+        with biomes_path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except (json.JSONDecodeError, yaml.YAMLError, OSError) as exc:
+        return [f"{biomes_path}: impossibile leggere schema/dataset ({exc})"]
+
+    errors: List[str] = []
+    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path)):
+        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        errors.append(f"{biomes_path}: /{loc}: {err.message}")
+    return errors
+
+
+def validate_ecosystem_schema() -> List[str]:
+    schema_path = _repo_root() / "schemas" / "evo" / "ecosystem.schema.json"
+    eco_dir = _data_dir() / "ecosystems"
+    if not (schema_path.exists() and eco_dir.exists()):
+        return []  # nothing to validate in this layout
+
+    try:
+        import jsonschema  # noqa: F401
+    except ImportError:
+        return [
+            "tools/py/requirements.txt: 'jsonschema>=4.18.0' richiesto per validare "
+            "gli ecosystem contro lo schema (pip install jsonschema)"
+        ]
+
+    try:
+        validator = _self_contained_validator(schema_path)
+    except (json.JSONDecodeError, OSError) as exc:
+        return [f"{schema_path}: impossibile leggere lo schema ({exc})"]
+
+    errors: List[str] = []
+    for eco_path in sorted(eco_dir.glob("*.ecosystem.yaml")):
+        try:
+            with eco_path.open("r", encoding="utf-8") as fh:
+                data = yaml.safe_load(fh)
+        except (yaml.YAMLError, OSError) as exc:
+            errors.append(f"{eco_path}: impossibile leggere ({exc})")
+            continue
+        for err in sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path)):
+            loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+            errors.append(f"{eco_path}: /{loc}: {err.message}")
     return errors
 
 


### PR DESCRIPTION
## Phase D / L4 -- per-entity shape schemas for biome + ecosystem

Closes the taxonomy reconciliation plan (#2827). Adds the per-record JSON Schema coverage the plan deferred to L4 (species already had it).

### What
- `schemas/evo/biome.schema.json` -- validates the per-biome record shape under `data/core/biomes.yaml`'s `biomes` map.
- `schemas/evo/ecosystem.schema.json` -- validates `data/ecosystems/*.ecosystem.yaml` files.
- `tools/py/validate_datasets.py`: `validate_biome_schema()` + `validate_ecosystem_schema()` wired into `main()`, mirroring the existing `validate_species_catalog_schema()` full-schema gate. Self-contained schemas (no cross-file `$ref`).
- Required fields = the set present on ALL current records (biome: 13/13 records; ecosystem: 5 file-level + 8 `ecosistema`-level, all 4 files); `additionalProperties: true` permits per-record extras (aliases, magnetic_field_strength, npg_dir, future).

### Verification (real jsonschema 4.26)
- Real data PASSES: `biomes.yaml` 0 errors; all 4 `*.ecosystem.yaml` 0 errors.
- Non-vacuous: injected bad docs caught (13 biome / 8 ecosystem errors).
- `validate_datasets.py` script-mode: "Tutti i dataset YAML sono validi".
- No new dependency (`jsonschema>=4.18` already required for species). prettier clean; added lines ASCII.

### Phase C -- SKIPPED (premise does not hold)
Recon found the "playable overload" is NOT a redundant double-authoring. The three "playable" signals are near-disjoint distinct concepts:
- `clade_tag: Playable` (7) -- a taxonomy clade
- `role_tags: 'playable'` (8 canon) -- a design-intent/backlog tag
- `playable_unit: true` (8 roster) -- a deploy flag

`role_tags:'playable'` and `playable_unit` have **ZERO overlap**; the deployed `playable_unit` set has `clade=null` + `role_tags`-playable=false. Collapsing them would conflate taxonomy + intent + deploy-state (over-unify, plan rule 5). The "tier" is already derivable (deployed = in roster; backlog = canon-not-roster; event = `is_event`/`flags.event`), so a stored `tier` field is YAGNI. No conflation/drift exists today. Documented in plan section 8.

### Gotcha noted (pre-existing, not fixed here)
A tracked repo-root `jsonschema/` directory shadows the real `jsonschema` lib when an interpreter has cwd on `sys.path` (e.g. `python -c`). CI runs `validate_datasets.py` in script mode (sys.path[0] = `tools/py`), so the real lib is used and this gate works -- but interactive `python -c`/`-m` from repo root silently no-ops jsonschema. Flagged for a separate cleanup.