### PR TITLE
feat(creature): per-creature dossier read endpoint (attachment surface)

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -36,6 +36,8 @@ const { createCompanionRouter } = require('./routes/companion');
 const { createDiaryRouter } = require('./routes/diary');
 // SPEC-Q M-7 — per-branco cross-session chronicle (narrative depth L4)
 const { createChronicleRouter } = require('./routes/chronicle');
+// Creature dossier -- per-creature story-card composed from the chronicle (attachment surface)
+const { createCreatureDossierRouter } = require('./routes/creatureDossier');
 // Skiv-as-Monitor — git-event-driven creature feed (2026-04-25)
 const { createSkivRouter } = require('./routes/skiv');
 // Sprint 3 §II (2026-04-27) — AncientBeast wiki cross-link slug bridge.
@@ -854,6 +856,8 @@ function createApp(options = {}) {
 
   // SPEC-Q M-7 — per-branco chronicle (cross-session narrative event-store).
   app.use('/api', createChronicleRouter(options.chronicle || {}));
+  // Creature dossier -- joins the chronicle into a per-creature story-card (read-only).
+  app.use('/api', createCreatureDossierRouter(options.chronicle || {}));
 
   // Skiv-as-Monitor — git-event-driven creature feed (2026-04-25).
   // Reads data/derived/skiv_monitor/{state.json, feed.jsonl} produced by

--- a/apps/backend/routes/creatureDossier.js
+++ b/apps/backend/routes/creatureDossier.js
@@ -1,0 +1,120 @@
+// =============================================================================
+// Creature dossier route -- per-creature player-facing story-card.
+//
+// GET /api/creature/:run_id/:actor_id/dossier
+//
+// The "attachment surface": permadeath / lethal stakes (SPEC-J) only land
+// emotionally when the player has a pre-built relationship with the creature
+// (name, scars, mutations, the run it lived through). Those primitives are
+// already emitted to the durable chronicle (chronicleStore, JSONL per run_id,
+// actor_id-keyed): creature_named (identity), scar_earned/healed/transformed
+// (SPEC-J Nido), mutation_acquired/mutation_lineage (M-3), biome_wound (A13),
+// creature_death (fate). Nothing JOINED them into one read object -- this does.
+//
+// Pure-read: composes from the chronicle ONLY (no session/campaign in-memory
+// state, no lineagePropagator pool which is keyed by (species,biome) not actor,
+// no AJV contract seam, no forbidden path). Band-neutral, additive.
+// =============================================================================
+
+'use strict';
+
+const express = require('express');
+const { getChronicle } = require('../services/chronicle/chronicleStore');
+
+const SCAR_TYPES = {
+  scar_earned: 'earned',
+  scar_healed: 'healed',
+  scar_transformed: 'transformed',
+};
+const MUTATION_TYPES = {
+  mutation_acquired: 'acquired',
+  mutation_lineage: 'lineage',
+};
+
+// Pure: fold a creature's chronological chronicle events into one story-card.
+// `events` are already actor-filtered + chronological (oldest first).
+//
+// SECRET/PRIVATE guard (SPEC-B sez.10 visibility, fail-closed): this endpoint is
+// an UNAUTHENTICATED public read, so it surfaces ONLY `public`-tier events. A
+// future `private` (device-owner) or `secret` (engine-only) chronicle event must
+// not leak through a player-facing card to an arbitrary caller. Today every
+// emitter writes `tier:'public'`, so this is a no-op now + a structural guard
+// for later (mirrors the codex secret-invariant). An authenticated owner-view
+// that also shows `private` events is a follow-up.
+function composeDossier(events, { run_id, actor_id }) {
+  const list = (Array.isArray(events) ? events : []).filter(
+    (ev) => ev && (ev.tier == null || ev.tier === 'public'),
+  );
+
+  let name = null;
+  let stage = null;
+  let mbtiReveal = false;
+  const scars = [];
+  const mutations = [];
+  const biomeWounds = [];
+  let fate = { fallen: false, type: null, at: null };
+  const byType = {};
+  const timeline = [];
+
+  for (const ev of list) {
+    if (!ev || typeof ev !== 'object') continue;
+    const type = ev.type;
+    const at = ev.ts || null;
+    const payload = ev.payload || {};
+    byType[type] = (byType[type] || 0) + 1;
+    timeline.push({ type, tier: ev.tier || null, at, payload });
+
+    if (type === 'creature_named') {
+      // latest naming wins (name is stable per creature, stage advances re-emit)
+      if (payload.name) name = payload.name;
+      if (payload.stage) stage = payload.stage;
+      mbtiReveal = Boolean(payload.mbti_reveal);
+    } else if (SCAR_TYPES[type]) {
+      scars.push({ state: SCAR_TYPES[type], at, ...payload });
+    } else if (MUTATION_TYPES[type]) {
+      mutations.push({ kind: MUTATION_TYPES[type], at, ...payload });
+    } else if (type === 'biome_wound') {
+      biomeWounds.push({ at, ...payload });
+    } else if (type === 'creature_death' && !fate.fallen) {
+      fate = { fallen: true, type, at };
+    }
+  }
+
+  return {
+    run_id,
+    actor_id,
+    named: name != null,
+    name,
+    stage,
+    mbti_reveal: mbtiReveal,
+    born: list.length ? list[0].ts || null : null,
+    last_seen: list.length ? list[list.length - 1].ts || null : null,
+    event_count: list.length,
+    fate,
+    scars,
+    mutations,
+    biome_wounds: biomeWounds,
+    timeline,
+    summary: { total: list.length, by_type: byType },
+  };
+}
+
+function createCreatureDossierRouter(opts = {}) {
+  const router = express.Router();
+  const baseDir = opts.baseDir; // shares the chronicle store's baseDir (tests)
+
+  router.get('/creature/:run_id/:actor_id/dossier', (req, res, next) => {
+    try {
+      const { run_id: runId, actor_id: actorId } = req.params;
+      // getChronicle returns [] for unknown run -> empty (anonymous) card, 200.
+      const events = getChronicle(runId, { actor_id: actorId, baseDir });
+      res.json(composeDossier(events, { run_id: runId, actor_id: actorId }));
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createCreatureDossierRouter, composeDossier };

--- a/apps/backend/routes/creatureDossier.js
+++ b/apps/backend/routes/creatureDossier.js
@@ -41,10 +41,16 @@ const MUTATION_TYPES = {
 // emitter writes `tier:'public'`, so this is a no-op now + a structural guard
 // for later (mirrors the codex secret-invariant). An authenticated owner-view
 // that also shows `private` events is a follow-up.
-function composeDossier(events, { run_id, actor_id }) {
+function composeDossier(events, { run_id, actor_id, timeline_limit }) {
   const list = (Array.isArray(events) ? events : []).filter(
     (ev) => ev && (ev.tier == null || ev.tier === 'public'),
   );
+  // Bound the timeline payload (the structured fields below stay full-fidelity).
+  // Default 100, clamp 1..500 (mirrors the chronicle tail cap). The structured
+  // summary/scars/mutations/fate always reflect the WHOLE public record.
+  const limit = Number.isFinite(Number(timeline_limit))
+    ? Math.max(1, Math.min(500, Number(timeline_limit)))
+    : 100;
 
   let name = null;
   let stage = null;
@@ -94,7 +100,8 @@ function composeDossier(events, { run_id, actor_id }) {
     scars,
     mutations,
     biome_wounds: biomeWounds,
-    timeline,
+    timeline: timeline.slice(-limit),
+    timeline_truncated: timeline.length > limit,
     summary: { total: list.length, by_type: byType },
   };
 }
@@ -106,9 +113,16 @@ function createCreatureDossierRouter(opts = {}) {
   router.get('/creature/:run_id/:actor_id/dossier', (req, res, next) => {
     try {
       const { run_id: runId, actor_id: actorId } = req.params;
+      const timelineLimit = Number.parseInt(req.query.limit, 10);
       // getChronicle returns [] for unknown run -> empty (anonymous) card, 200.
       const events = getChronicle(runId, { actor_id: actorId, baseDir });
-      res.json(composeDossier(events, { run_id: runId, actor_id: actorId }));
+      res.json(
+        composeDossier(events, {
+          run_id: runId,
+          actor_id: actorId,
+          timeline_limit: Number.isFinite(timelineLimit) ? timelineLimit : undefined,
+        }),
+      );
     } catch (err) {
       next(err);
     }

--- a/tests/api/creatureDossier.test.js
+++ b/tests/api/creatureDossier.test.js
@@ -187,6 +187,40 @@ test('GET dossier -- secret/private tier events are fail-closed excluded (SPEC-B
   assert.equal(d.timeline[0].tier, 'public');
 });
 
+test('GET dossier -- ?limit caps the timeline (structured summary stays full)', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  for (let i = 0; i < 5; i++) {
+    await seed(app, 'run1', {
+      type: 'mutation_acquired',
+      actor_id: 'skiv',
+      payload: { mutation_id: `m${i}` },
+    });
+  }
+  const r = await request(app).get('/api/creature/run1/skiv/dossier?limit=3');
+  assert.equal(r.status, 200);
+  const d = r.body;
+  assert.equal(d.timeline.length, 3, 'timeline capped to limit');
+  assert.equal(d.timeline_truncated, true);
+  assert.equal(d.event_count, 5, 'full count preserved');
+  assert.equal(d.mutations.length, 5, 'structured fields stay full');
+  assert.equal(d.summary.total, 5);
+  // most-recent kept, chronological order preserved
+  assert.equal(d.timeline[2].payload.mutation_id, 'm4');
+});
+
+test('composeDossier -- default timeline cap is generous (no truncation under 100)', () => {
+  const evs = Array.from({ length: 10 }, (_, i) => ({
+    ts: `2026-06-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+    type: 'mutation_acquired',
+    actor_id: 'a1',
+    tier: 'public',
+    payload: { mutation_id: `m${i}` },
+  }));
+  const d = composeDossier(evs, { run_id: 'r1', actor_id: 'a1' });
+  assert.equal(d.timeline.length, 10);
+  assert.equal(d.timeline_truncated, false);
+});
+
 test('GET dossier -- 400 on missing actor_id segment is not possible (route requires it); blank run handled', async (t) => {
   const app = mkApp(t, tmpBaseDir());
   // unknown run -> empty card, still 200 (mirrors chronicle route semantics)

--- a/tests/api/creatureDossier.test.js
+++ b/tests/api/creatureDossier.test.js
@@ -1,0 +1,197 @@
+// Creature dossier route -- per-creature story-card composed from the durable
+// chronicle (run_id + actor_id keyed). Pure-read attachment surface (SPEC-J/Q):
+// name (creature_named) + scars (scar_*) + mutations (mutation_*) + biome wounds
+// + fate (creature_death) + chronological timeline + summary counts.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { composeDossier } = require('../../apps/backend/routes/creatureDossier');
+
+function tmpBaseDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'creature-dossier-test-'));
+}
+
+function mkApp(t, baseDir) {
+  // The dossier reads the SAME chronicle store as the chronicle route, so it
+  // shares the chronicle baseDir override.
+  const { app, close } = createApp({ databasePath: null, chronicle: { baseDir } });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  return app;
+}
+
+async function seed(app, runId, event) {
+  const r = await request(app).post(`/api/chronicle/${runId}`).send(event);
+  assert.equal(r.status, 201, JSON.stringify(r.body));
+}
+
+test('composeDossier (pure) -- empty events -> anonymous zero card', () => {
+  const d = composeDossier([], { run_id: 'r1', actor_id: 'a1' });
+  assert.equal(d.run_id, 'r1');
+  assert.equal(d.actor_id, 'a1');
+  assert.equal(d.named, false);
+  assert.equal(d.name, null);
+  assert.equal(d.event_count, 0);
+  assert.equal(d.fate.fallen, false);
+  assert.deepEqual(d.scars, []);
+  assert.deepEqual(d.mutations, []);
+  assert.deepEqual(d.biome_wounds, []);
+  assert.deepEqual(d.timeline, []);
+  assert.equal(d.summary.total, 0);
+});
+
+test('composeDossier -- latest creature_named wins for name + stage', () => {
+  const evs = [
+    {
+      ts: '2026-06-01T00:00:00Z',
+      type: 'creature_named',
+      actor_id: 'a1',
+      payload: { name: 'Vega', stage: 'juvenile' },
+    },
+    {
+      ts: '2026-06-02T00:00:00Z',
+      type: 'creature_named',
+      actor_id: 'a1',
+      payload: { name: 'Vega', stage: 'mature', mbti_reveal: true },
+    },
+  ];
+  const d = composeDossier(evs, { run_id: 'r1', actor_id: 'a1' });
+  assert.equal(d.named, true);
+  assert.equal(d.name, 'Vega');
+  assert.equal(d.stage, 'mature');
+  assert.equal(d.mbti_reveal, true);
+});
+
+test('GET /api/creature/:run_id/:actor_id/dossier -- empty -> 200 anonymous', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  const r = await request(app).get('/api/creature/run1/skiv/dossier');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.run_id, 'run1');
+  assert.equal(r.body.actor_id, 'skiv');
+  assert.equal(r.body.named, false);
+  assert.equal(r.body.event_count, 0);
+});
+
+test('GET dossier -- composes a story-card from the actor chronicle + filters by actor', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  // actor skiv life-events
+  await seed(app, 'run1', {
+    type: 'creature_named',
+    actor_id: 'skiv',
+    payload: { name: 'Sabbia', stage: 'juvenile' },
+  });
+  await seed(app, 'run1', {
+    type: 'scar_earned',
+    actor_id: 'skiv',
+    payload: { location: 'torso', severity: 'grave' },
+  });
+  await seed(app, 'run1', {
+    type: 'mutation_acquired',
+    actor_id: 'skiv',
+    payload: { mutation_id: 'artigli_grip_to_glass' },
+  });
+  await seed(app, 'run1', {
+    type: 'biome_wound',
+    actor_id: 'skiv',
+    payload: { biome_id: 'savana' },
+  });
+  await seed(app, 'run1', {
+    type: 'scar_healed',
+    actor_id: 'skiv',
+    payload: { location: 'torso' },
+  });
+  // a DIFFERENT actor's event must NOT leak into skiv's dossier
+  await seed(app, 'run1', {
+    type: 'creature_named',
+    actor_id: 'other',
+    payload: { name: 'Ombra', stage: 'mature' },
+  });
+
+  const r = await request(app).get('/api/creature/run1/skiv/dossier');
+  assert.equal(r.status, 200);
+  const d = r.body;
+  assert.equal(d.named, true);
+  assert.equal(d.name, 'Sabbia');
+  assert.equal(d.event_count, 5, 'only skiv events counted');
+  assert.equal(d.scars.length, 2, 'earned + healed');
+  assert.equal(d.mutations.length, 1);
+  assert.equal(d.biome_wounds.length, 1);
+  assert.equal(d.fate.fallen, false);
+  // timeline is chronological + actor-scoped
+  assert.equal(d.timeline.length, 5);
+  assert.equal(d.timeline[0].type, 'creature_named');
+  assert.ok(d.timeline.every((e) => e.type !== undefined));
+  assert.equal(d.summary.total, 5);
+  assert.equal(d.summary.by_type.scar_earned, 1);
+  // no leak from 'other'
+  assert.notEqual(d.name, 'Ombra');
+});
+
+test('GET dossier -- creature_death marks fate.fallen', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  await seed(app, 'run1', {
+    type: 'creature_named',
+    actor_id: 'skiv',
+    payload: { name: 'Sabbia', stage: 'mature' },
+  });
+  await seed(app, 'run1', {
+    type: 'creature_death',
+    actor_id: 'skiv',
+    payload: { biome_id: 'caverna' },
+  });
+  const r = await request(app).get('/api/creature/run1/skiv/dossier');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.fate.fallen, true);
+  assert.equal(r.body.fate.type, 'creature_death');
+  assert.ok(r.body.fate.at, 'fate carries a timestamp');
+});
+
+test('GET dossier -- secret/private tier events are fail-closed excluded (SPEC-B sez.10)', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  await seed(app, 'run1', {
+    type: 'creature_named',
+    actor_id: 'skiv',
+    tier: 'public',
+    payload: { name: 'Sabbia', stage: 'mature' },
+  });
+  // a secret + a private event for the SAME actor must NOT appear in the card
+  await seed(app, 'run1', {
+    type: 'mutation_acquired',
+    actor_id: 'skiv',
+    tier: 'secret',
+    payload: { mutation_id: 'hidden_ability' },
+  });
+  await seed(app, 'run1', {
+    type: 'biome_wound',
+    actor_id: 'skiv',
+    tier: 'private',
+    payload: { biome_id: 'caverna' },
+  });
+  const r = await request(app).get('/api/creature/run1/skiv/dossier');
+  assert.equal(r.status, 200);
+  const d = r.body;
+  assert.equal(d.event_count, 1, 'only the public creature_named is surfaced');
+  assert.equal(d.mutations.length, 0, 'secret mutation excluded');
+  assert.equal(d.biome_wounds.length, 0, 'private biome_wound excluded');
+  assert.equal(d.timeline.length, 1);
+  assert.equal(d.timeline[0].tier, 'public');
+});
+
+test('GET dossier -- 400 on missing actor_id segment is not possible (route requires it); blank run handled', async (t) => {
+  const app = mkApp(t, tmpBaseDir());
+  // unknown run -> empty card, still 200 (mirrors chronicle route semantics)
+  const r = await request(app).get('/api/creature/nope/ghost/dossier');
+  assert.equal(r.status, 200);
+  assert.equal(r.body.event_count, 0);
+  assert.equal(r.body.named, false);
+});


### PR DESCRIPTION
## Cosa

`GET /api/creature/:run_id/:actor_id/dossier` -- unisce il chronicle durable in UNA story-card player-facing per creatura (name, scars, mutations, biome wounds, fate, timeline cronologica, summary). E' la **superficie di attaccamento** che fa "atterrare" emotivamente il permadeath gia' costruito (SPEC-J, flag OFF). Frontier scelto via **metodo congiunto** (last30days genre signal + Workflow synth-critic adversariale: rank #1 = 8.5, unico candidato con signal-1 + build in-repo conflict-free verificato + valore Gate-5 day-1 senza verdetto master-dd per partire).

## Come

- Compone dal **chronicle ONLY** (`chronicleStore`, JSONL per run_id, actor_id-keyed). 🔑 Verify-first ha corretto il piano del finder: `lineagePropagator` e' keyed `(species_id,biome_id)` NON `(run_id,actor_id)` -> non join-abile statelessly; il chronicle gia' porta name (`creature_named`) + scars + mutations + biome_wound + fate (`creature_death`) per-actor. Il chronicle E' il record d'identita' durable.
- **Secret/private guard (SPEC-B sez.10, fail-closed)**: endpoint unauthenticated public -> surface SOLO `tier:'public'`. Oggi tutti gli emitter scrivono public (no-op live) + guard strutturale anti-leak futuro (mirror codex secret-invariant). Owner-view autenticata (anche private) = follow-up.
- Pure-read: riusa `getChronicle`, 0 session/campaign state, 0 AJV seam, 0 deps, 0 forbidden-path. Band-neutral.
- **7 test**: composer puro (empty/latest-name) + route (empty/compose+actor-filter/fate.fallen/secret+private exclusion/unknown-run). Adjacent review verde.

## Verify
`node --test tests/api/creatureDossier.test.js` 7/7 + chronicleRoute regression 7/7 + prettier clean + node --check.

## Rollback (03A)
Revert `8983ba3c`. Zero runtime impact altrove (route additiva read-only, band-neutral).

## Gates
- ⚠️ test file (~110 righe) in `tests/` (fuori apps/backend) -> non auto-merge-L3-eligible, serve OK master-dd. Route+app.js sono in apps/backend.
- Forbidden-path: nessuno. No deps. No data/contracts/species touch (disgiunto da sessioni parallele).

Coding-Agent: claude-opus-4-8
