### PR TITLE
docs(combat): currency-fix 2 stale Python rules-engine refs (Phase 3)

### DIFF
--- a/docs/combat/worker-bridge.md
+++ b/docs/combat/worker-bridge.md
@@ -14,7 +14,7 @@ review_cycle_days: 14
 
 > **Runtime status 2026-06-06.** This document predates the Python-to-Node combat migration. Treat implementation paths/tests that reference `services/rules/*`, `resolver.py`, `round_orchestrator.py`, `worker.py`, or old Python pytest commands as historical naming only. Current runtime authority is [combat-canon.md](combat-canon.md), `apps/backend/services/roundOrchestrator.js`, `apps/backend/routes/sessionRoundBridge.js`, `apps/backend/services/abilityExecutor.js`, and `apps/backend/services/combat/*`. Semantic notes may remain useful, but do not open build work from legacy paths without checking current code.
 
-Il rules engine è scritto in Python (`services/rules/resolver.py`, `hydration.py`) ma il backend dell'applicazione è Node (`apps/backend/`). La comunicazione avviene tramite `services/rules/worker.py`, un **worker persistente** che legge messaggi JSON-line da stdin e scrive risposte JSON-line su stdout.
+**[STORICO]** Il rules engine era scritto in Python (`services/rules/resolver.py`, `hydration.py`) e il backend dell'applicazione era Node (`apps/backend/`); la comunicazione avveniva tramite `services/rules/worker.py`, un **worker persistente** che leggeva messaggi JSON-line da stdin e scriveva risposte JSON-line su stdout. Dal 2026-05-05 (ADR-2026-04-19, Phase 3) `services/rules/` e' stato rimosso e l'engine e' migrato a Node nativo (`apps/backend/services/roundOrchestrator.js`, `apps/backend/services/abilityExecutor.js`, `apps/backend/services/combat/*`). Paragrafo conservato come riferimento storico del protocollo (vedi banner sopra).
 
 Il pattern è identico a `services/generation/worker.py` (Flow workstream) per coerenza operativa: ready → heartbeat → response loop → shutdown.
 

--- a/docs/hubs/combat.md
+++ b/docs/hubs/combat.md
@@ -68,7 +68,7 @@ Per una panoramica e mappa completa dei doc del workstream vedi [docs/combat/REA
 ### Tool di generazione
 
 - `tools/py/gen_trait_docs.py` — auto-genera `docs/generated/trait-reference.md` da YAML (O3 pattern)
-- `tools/py/gen_trait_types.py` — codegen TS + Python + JSON Schema da YAML (L1 pattern)
+- `tools/py/gen_trait_types.py` -- codegen TS + JSON Schema da YAML (L1 pattern; output Python rimosso in Phase 3, ADR-2026-04-19)
 
 ## Dati di bilanciamento
 


### PR DESCRIPTION
## Summary
Two doc-currency fixes surfaced by a **read-only stale-python audit** of the docs tree. Behavior-neutral (docs only); no code, no tests touched.

Audit funnel: `grep python docs/**` = ~359 hits -> 4 suspects -> **2 genuinely stale**. The other 2 suspects were verified **historically-correct** and left untouched:
- `docs/00-INDEX.md` (`game_cli.py validate` is active dataset tooling in CI, not the killed rules engine)
- `docs/adr/ADR-2025-12-07-generation-orchestrator.md` (`services/generation/orchestrator.py` confirmed live + tested today; distinct from the killed `services/rules/`)

## Fixes
- **`docs/hubs/combat.md`** -- `gen_trait_types.py` was listed as "codegen TS + Python + JSON Schema", but the Python output target was dropped in Phase 3 (commit `d0c86c60`). Removed "Python +" and noted the removal.
- **`docs/combat/worker-bridge.md`** -- a body line stated the rules engine `"e' scritto in Python"` in **present tense**, contradicting the doc's own `[STORICO]` banner; `services/rules/` was removed 2026-05-05 (ADR-2026-04-19, Phase 3). Reworded to past tense + migration note pointing at the Node-native engine.

## Verification vs current code (read-only)
- `services/generation/orchestrator.py` + `tools/py/game_cli.py` -> confirmed present/active.
- `services/rules/` -> confirmed deleted (Phase 3).
- Added lines verified pure-ASCII (ADR-0021 added-lines scope).

## Notes
- Draft; external-repo merge is Eduardo's call.
- ADR-0011 trailer on the commit (Coding-Agent + Trace-Id).