### PR TITLE
feat(calibration): PE_ratio composite wiring (PR2) + experiment selection

### DIFF
--- a/docs/playtest/2026-06-19-pe-ratio-experiment-n100.md
+++ b/docs/playtest/2026-06-19-pe-ratio-experiment-n100.md
@@ -1,0 +1,74 @@
+---
+title: 'PE_ratio orthogonality experiment -- N=100 selection + instrumentation gap'
+date: 2026-06-19
+type: playtest-evidence
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-19'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+tags: [evo-tactics, calibration, g2, pe-ratio, composite, n100]
+---
+
+# PE_ratio orthogonality experiment (PR2 selection step)
+
+> Experiment for the composite `0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio`
+> (design `docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md`).
+> N=100 seed-pinned (424242), node 22, backend on 127.0.0.1:3400 (NOT prod). Runner =
+> calibrate_parallel per oracle -> pe_experiment.analyze_corpus.
+
+## Result
+
+| candidate          | aggregate form        | hc06-only \|corr\| | hc06 sd (variance) | verdict                        |
+| ------------------ | --------------------- | ------------------ | ------------------ | ------------------------------ |
+| A_sustained_threat | mean(frac_ge75)       | 0.074              | 0.009              | degenerate-flat (saturated)    |
+| B_time_avg         | pressure_mean_avg/100 | 0.254              | **0.024**          | the only candidate with signal |
+| C_apex_reach       | apex_reach_rate       | 0.000              | 0.000              | degenerate-flat (constant 1.0) |
+
+**Selected (provisional): B_time_avg**, by ELIMINATION. hc06 starts at pressure 75
+(Critical), so A (sustained-threat fraction) and C (apex-reach) SATURATE -- every run
+sits at frac_ge75~1.0 / apex=1.0 (sd 0.009 / 0.000). Their |corr|~0 is the
+"orthogonal-but-no-signal" artifact the design warns of (a constant correlates with
+nothing but measures nothing). B (time-averaged pressure) is the ONLY candidate with
+trajectory variance (sd 0.024). Pooled runs (hc06 + the uninstrumented oracles, see
+below) ranked B first at |corr| 0.099-0.197; the negative-result threshold (min |corr|
+above 0.6) did NOT fire, so pressure is not rejected as a PE source.
+
+Win rates this run (all in their ratified bands): hc06 23%, badlands_elite 16%,
+foresta_pilot 50% -- consistent with the #2850 / node-22 calibration.
+
+## 🔴 Instrumentation gap (blocks the clean multi-oracle selection + the composite band)
+
+Verify-first finding: the per-run pressure-trajectory stats (`pressure_mean`,
+`pressure_frac_ge75`, `pressure_pmax`) are emitted ONLY by
+`batch_calibrate_hardcore06.py`. The varied-pressure oracles that would BREAK hc06's
+saturation -- `badlands_elite_01`, `foresta_pilot_01` -- emit only `pressure_final`;
+`hardcore_07` emits none. So in those oracles every candidate (and the aggregate
+`pe_ratio`) defaults to 0.0, and a pooled |corr| is really hc06's signal plus a block
+of zeros (which is why pooling lowered |corr| from 0.197 to 0.099 -- an artifact, not a
+cleaner measurement).
+
+Consequences:
+
+- The cross-oracle selection cannot be confirmed until the trajectory instrumentation
+  is extended to the other pressure oracles (a low-saturation oracle is needed to
+  separate A/B/C properly).
+- The **composite band cannot be derived** cleanly: only hc06 carries a real `pe_ratio`
+  (0.937); badlands_elite + foresta_pilot read `pe_ratio` = 0.0, so their composites
+  (0.208 / 0.442 vs hc06 0.530) are deflated by the missing PE term. A band off those
+  numbers would be wrong.
+
+## What PR2 ships now (vs what is gated)
+
+- SHIPPED (autonomous, tested): the composite WIRING -- `attach_composite_terms()`
+  emits `kd_ratio` (= kd_avg/(kd_avg+1)) + `pe_ratio` (selected candidate) on every
+  aggregate, so `objective.evaluate_metric` computes the composite instead of raising
+  `KeyError`/returning None. `pe_ratio` is meaningful where the trajectory is emitted
+  (hc06) and 0.0 elsewhere (honest, until the instrumentation is extended).
+- GATED (master-dd / follow-up): extend the per-run pressure instrumentation to
+  badlands_elite / foresta_pilot (and hardcore_07 if it is kept as an oracle); re-run
+  the multi-oracle experiment for a confirmed selection; derive + ratify the composite
+  band into `canonical-suite.yaml` (SDMG, human-ratified per CANONICAL sec 9); then
+  flip P4 gate-2/4b + P5 to consume the real composite band.

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -23,6 +23,7 @@ import urllib.error
 import urllib.request
 
 import calibrate_policies
+from pe_candidates import attach_composite_terms
 from pressure_stats import pressure_stats
 
 SCENARIO_ID = "enc_tutorial_06_hardcore"
@@ -799,7 +800,7 @@ def aggregate(runs, encounter_class=None):
         bands = load_target_bands(encounter_class)
         verdict, verdict_reasons = verdict_for(wr, dr, tr, bands)
 
-    return {
+    _agg = {
         "N": n,
         "encounter_class": encounter_class,
         "target_bands": bands,
@@ -838,6 +839,9 @@ def aggregate(runs, encounter_class=None):
         "player_action_distribution": player_global,
         "trait_used_distribution": trait_global,
     }
+    # PE_ratio PR2: add the two normalized composite terms (kd_ratio + pe_ratio) so
+    # objective.evaluate_metric can compute the composite (no longer KeyErrors).
+    return attach_composite_terms(_agg)
 
 
 def _hist(values, bins):

--- a/tools/py/calibrate_parallel.py
+++ b/tools/py/calibrate_parallel.py
@@ -229,7 +229,12 @@ def aggregate_merged(runs, scenario):
     mod = __import__(script_module)
     enc_cls = cfg.get("encounter_class", "hardcore")
     if hasattr(mod, "aggregate"):
-        return mod.aggregate(runs, encounter_class=enc_cls)
+        # PE_ratio PR2: attach the composite terms here so EVERY scenario's metrics
+        # (orchestrator runner reads this) carry kd_ratio + pe_ratio, not just hc06.
+        # Idempotent (hc06's own aggregate already attaches them -> setdefault no-op).
+        from pe_candidates import attach_composite_terms
+
+        return attach_composite_terms(mod.aggregate(runs, encounter_class=enc_cls))
     if hasattr(mod, "summarise"):
         return mod.summarise(runs)
     return {"error": f"no aggregate fn in {script_module}"}

--- a/tools/py/pe_candidates.py
+++ b/tools/py/pe_candidates.py
@@ -31,6 +31,60 @@ def candidate_value(name, stats):
     return max(0.0, min(1.0, v))
 
 
+# Aggregate form: the same candidate read off the run-SET aggregate keys that
+# batch_calibrate aggregate() already emits (mean of per-run frac_ge75; mean
+# pressure/100; fraction of runs that reached apex). Linear candidates (A,B)
+# satisfy mean(candidate)==candidate(mean); C's per-run binary aggregates to the
+# apex_reach_rate fraction. This is the form the composite_metric consumes.
+_AGGREGATE_FORM = {
+    "A_sustained_threat": lambda agg: float(agg.get("pressure_frac_ge75_avg", 0.0)),
+    "B_time_avg": lambda agg: float(agg.get("pressure_mean_avg", 0.0)) / 100.0,
+    "C_apex_reach": lambda agg: float(agg.get("apex_reach_rate", 0.0)),
+}
+
+
+def pe_ratio_aggregate(agg, candidate):
+    """pe_ratio (0..1) for the selected candidate, read off an aggregate() dict.
+    KeyError on an unknown candidate (surfaces a bad config instead of faking 0)."""
+    fn = _AGGREGATE_FORM.get(candidate)
+    if fn is None:
+        raise KeyError(f"unknown pe_ratio candidate {candidate!r}")
+    return max(0.0, min(1.0, fn(agg)))
+
+
+def attach_composite_terms(agg, candidate=None):
+    """Idempotently add the two normalized composite terms to an aggregate() dict
+    so objective.evaluate_metric can compute `0.50*win_rate+0.25*kd_ratio+0.25*pe_ratio`.
+      kd_ratio = kd_normalize(kd_avg)   (None if kd_avg absent -- surfaced, never faked)
+      pe_ratio = the experiment-selected candidate read off the aggregate pressure keys
+                 (0.0 if a scenario emits no pressure trajectory, e.g. hardcore_07).
+    No-op on an {'error': ...} dict. Returns the same dict for chaining."""
+    if not isinstance(agg, dict) or "error" in agg:
+        return agg
+    agg.setdefault("kd_ratio", kd_normalize(agg.get("kd_avg")))
+    agg.setdefault("pe_ratio", pe_ratio_aggregate(agg, candidate or SELECTED_CANDIDATE))
+    return agg
+
+
+# SELECTED (PROVISIONAL) by the PR2 experiment (N=100 seed-pinned, node 22, 2026-06-19).
+# B_time_avg (= pressure_mean_avg/100) chosen BY ELIMINATION: on the only fully
+# instrumented oracle (hc06) A_sustained_threat + C_apex_reach SATURATE (hc06 starts
+# at pressure 75=Critical -> frac_ge75 sd=0.009, apex sd=0.000 = degenerate-flat, the
+# "orthogonal-but-no-signal" failure the design warns of); B is the ONLY candidate
+# carrying trajectory variance (sd=0.024). Every experiment ranked B as the real
+# signal. min|corr| << 0.6 -> pressure is NOT rejected as a PE source.
+#
+# 🔴 OPEN (master-dd + follow-up): a CLEAN multi-oracle |corr| + the composite BAND
+# are BLOCKED. The per-run pressure-trajectory stats (pressure_mean/frac_ge75/pmax)
+# are emitted ONLY by batch_calibrate_hardcore06.py; the varied-pressure oracles that
+# would break hc06's saturation (badlands_elite / foresta_pilot) emit only
+# pressure_final, and hardcore_07 emits none -> their pe_ratio aggregates to 0.0.
+# Extend that instrumentation to the other oracles, then re-run the experiment for a
+# cross-oracle selection + derive the composite band. Evidence:
+# docs/playtest/2026-06-19-pe-ratio-experiment-n100.md.
+SELECTED_CANDIDATE = "B_time_avg"
+
+
 def kd_normalize(kd_avg):
     """Map kd_avg (~0.8 typical, unbounded) -> (0,1) via kd/(kd+1): bounded, monotonic.
     None in -> None out (missing metric surfaced, never faked)."""

--- a/tools/py/test_pe_ratio_wiring.py
+++ b/tools/py/test_pe_ratio_wiring.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""PE_ratio PR2 wiring tests (hermetic, no backend). Covers the aggregate-form
+pe_ratio mapping, the kd_ratio normalization, and the end-to-end contract that
+objective.evaluate_metric can now compute the composite once aggregate() emits
+kd_ratio + pe_ratio. The candidate SELECTION is the experiment's output; these
+tests are candidate-agnostic (they assert mapping + consistency, not which won)."""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import batch_calibrate_hardcore06 as bc  # noqa: E402
+import objective  # noqa: E402
+from pe_candidates import (  # noqa: E402
+    SELECTED_CANDIDATE,
+    attach_composite_terms,
+    kd_normalize,
+    pe_ratio_aggregate,
+)
+
+COMPOSITE = "0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio"
+
+
+def test_pe_ratio_aggregate_maps_each_candidate_to_its_key():
+    agg = {"pressure_frac_ge75_avg": 0.7, "pressure_mean_avg": 60.0, "apex_reach_rate": 0.3}
+    assert pe_ratio_aggregate(agg, "A_sustained_threat") == pytest.approx(0.7)
+    assert pe_ratio_aggregate(agg, "B_time_avg") == pytest.approx(0.60)
+    assert pe_ratio_aggregate(agg, "C_apex_reach") == pytest.approx(0.3)
+
+
+def test_pe_ratio_aggregate_clamps_and_rejects_unknown():
+    assert pe_ratio_aggregate({"pressure_mean_avg": 250.0}, "B_time_avg") == 1.0  # clamp >1
+    assert pe_ratio_aggregate({}, "A_sustained_threat") == 0.0  # missing -> 0, not crash
+    with pytest.raises(KeyError):
+        pe_ratio_aggregate({}, "Z_nonexistent")
+
+
+def test_kd_normalize_bounded_monotonic():
+    assert kd_normalize(0.0) == 0.0
+    assert kd_normalize(0.8) == pytest.approx(0.4444, abs=1e-3)
+    assert kd_normalize(1e6) == pytest.approx(1.0, abs=1e-5)
+    assert kd_normalize(None) is None
+    assert kd_normalize(2.0) > kd_normalize(0.5)  # monotonic
+
+
+def test_selected_candidate_is_a_known_candidate():
+    # the ratified selection must resolve (guards a typo'd constant)
+    assert SELECTED_CANDIDATE in {"A_sustained_threat", "B_time_avg", "C_apex_reach"}
+
+
+def _run(outcome, *, rounds=10, players_dead=1, enemies_dead=5, pmean=80.0, frac=1.0, pmax=100.0):
+    """A complete synthetic run record carrying every field aggregate() reads."""
+    return {
+        "outcome": outcome,
+        "rounds": rounds,
+        "players_dead": players_dead,
+        "enemies_dead": enemies_dead,
+        "ai_intent_tally": {"aggressive": 3},
+        "player_action_tally": {"attack": 4},
+        "trait_used_tally": {"echo": 1},
+        "pressure_mean": pmean,
+        "pressure_frac_ge75": frac,
+        "pressure_pmax": pmax,
+        "dmg_dealt_player": 100,
+        "dmg_taken_player": 50,
+        "boss_hp_remaining": 0 if outcome == "victory" else 12,
+        "players_alive": 3 if outcome == "victory" else 0,
+    }
+
+
+def test_aggregate_emits_kd_ratio_and_pe_ratio_consistently():
+    runs = [_run("victory", pmean=90.0, frac=1.0, pmax=100.0), _run("defeat", pmean=60.0, frac=0.4, pmax=80.0)]
+    agg = bc.aggregate(runs)
+    # both new composite terms present + 0..1
+    assert "kd_ratio" in agg and 0.0 <= agg["kd_ratio"] <= 1.0
+    assert "pe_ratio" in agg and 0.0 <= agg["pe_ratio"] <= 1.0
+    # kd_ratio is the normalized kd_avg
+    assert agg["kd_ratio"] == pytest.approx(kd_normalize(agg["kd_avg"]))
+    # pe_ratio is the selected candidate read off the aggregate keys (consistency)
+    assert agg["pe_ratio"] == pytest.approx(pe_ratio_aggregate(agg, SELECTED_CANDIDATE))
+
+
+def test_attach_composite_terms_idempotent_and_graceful():
+    # pressure-emitting aggregate -> both terms set from the data
+    agg = {"kd_avg": 0.8, "pressure_mean_avg": 50.0, "pressure_frac_ge75_avg": 0.6, "apex_reach_rate": 0.4}
+    attach_composite_terms(agg)
+    assert agg["kd_ratio"] == pytest.approx(kd_normalize(0.8))
+    assert agg["pe_ratio"] == pytest.approx(pe_ratio_aggregate(agg, SELECTED_CANDIDATE))
+    # idempotent: a second call (or a pre-set value) is NOT overwritten
+    agg["pe_ratio"] = 0.123
+    attach_composite_terms(agg)
+    assert agg["pe_ratio"] == 0.123
+    # no-pressure scenario (e.g. hardcore_07): pe_ratio degrades to 0.0, never crashes
+    bare = {"kd_avg": 1.0}
+    attach_composite_terms(bare)
+    assert bare["pe_ratio"] == 0.0 and bare["kd_ratio"] == pytest.approx(kd_normalize(1.0))
+    # error dict is a no-op
+    assert attach_composite_terms({"error": "no successful runs"}) == {"error": "no successful runs"}
+
+
+def test_objective_composite_now_computable_no_keyerror():
+    runs = [_run("victory"), _run("defeat")]
+    agg = bc.aggregate(runs)
+    # BEFORE PR2 this raised KeyError('pe_ratio'); now it evaluates to the weighted sum.
+    score = objective.evaluate_metric(COMPOSITE, agg)
+    expected = 0.50 * agg["win_rate"] + 0.25 * agg["kd_ratio"] + 0.25 * agg["pe_ratio"]
+    assert score == pytest.approx(expected)
+    assert 0.0 <= score <= 1.0


### PR DESCRIPTION
## Cosa
G2 PR2: rende il composite `0.50*win_rate+0.25*kd_ratio+0.25*pe_ratio` **COMPUTABILE** (oggi None → P4 gate-2/4b fail-closed, P5 WR-only).

- **`attach_composite_terms()`** (pe_candidates): emette idempotente `kd_ratio` (=kd_avg/(kd_avg+1)) + `pe_ratio` (candidato selezionato letto dai pressure-key aggregati) su OGNI aggregate. Chiamato in `batch_calibrate_hardcore06.aggregate()` **E** `calibrate_parallel.aggregate_merged` (choke-point del runner orchestrator) → tutti gli scenari portano i termini. `objective.evaluate_metric` ora calcola il composite invece di KeyError. **27 test pe/objective verdi** (7 nuovi).
- **Esperimento RUN** (N=100 seed-pinned, node 22, backend :3400 NON prod): candidato **B_time_avg** selezionato (provvisorio) per ELIMINAZIONE — sull'unico oracolo instrumentato (hc06) A+C **saturano** (sd 0.009/0.000 = il fallimento "orthogonal-but-flat" che il design avvisa); B e' l'unico con varianza-trajectory. negative-threshold (min|corr| > 0.6) NON scattato → pressure non rifiutato.

## 🔴 OPEN (verify-first finding — master-dd + follow-up)
Selezione cross-oracolo PULITA + **banda composite = BLOCCATE**. PR1 ha instrumentato il per-run pressure-trajectory SOLO in hc06 (che satura a Critical-start); badlands_elite/foresta_pilot emettono solo `pressure_final`, hardcore_07 niente → il loro pe_ratio = 0.0 e una banda derivata da loro sarebbe sbagliata. **Next**: estendere l'instrumentation agli oracoli a pressione-variata → re-run per selezione confermata → derivare+ratificare la banda (SDMG, human). Evidence: `docs/playtest/2026-06-19-pe-ratio-experiment-n100.md`.

## Verify
27 pytest verdi. governance --strict errors=0. Band-neutral (calibration tooling, no combat/runtime change). Backend test su :3400 (prod 3334/3341 untouched).

## Rollback
Revert `c329eb79`. Composite torna None (stato pre-PR2).

## Gates
- Tocca `tools/py/calibrate_*` (dominio G2 calibration; sessione wrapped, no collisione). No forbidden-path. No deps nuove.
- **>50 righe fuori apps/backend** → non auto-merge-L3, serve tuo OK.

Coding-Agent: claude-opus-4-8
