### PR TITLE
feat(calibration): PE_ratio PR2b -- extend instrumentation + multi-oracle run

### DIFF
--- a/docs/playtest/2026-06-19-pe-ratio-experiment-n100.md
+++ b/docs/playtest/2026-06-19-pe-ratio-experiment-n100.md
@@ -72,3 +72,36 @@ Consequences:
   the multi-oracle experiment for a confirmed selection; derive + ratify the composite
   band into `canonical-suite.yaml` (SDMG, human-ratified per CANONICAL sec 9); then
   flip P4 gate-2/4b + P5 to consume the real composite band.
+
+## Multi-oracle re-run (2026-06-19, instrumentation extended)
+
+The per-run pressure trajectory was extended to the `badlands_elite_01` and
+`foresta_pilot_01` batch modules (mirror hc06). Re-run N=40 seed-pinned, node 22, 3
+oracles -- the pe_ratio is now REAL on all three (no longer 0.0):
+
+| oracle            | win_rate | kd_ratio | pe_ratio | composite |
+| ----------------- | -------- | -------- | -------- | --------- |
+| hardcore_06       | 0.125    | 0.721    | 0.937    | 0.477     |
+| badlands_elite_01 | 0.150    | 0.513    | 0.809    | 0.405     |
+| foresta_pilot_01  | 0.550    | 0.778    | 0.903    | 0.695     |
+
+**Composite band PROPOSED (master-dd ratifies, SDMG):** mean 0.526, range [0.405, 0.695];
+k=2.0 -> **[0.236, 0.815]** (k=1.5 -> [0.309, 0.743]). Not yet written to the manifest.
+
+🔴 **Honest finding -- the PE-from-pressure signal is MARGINAL.** All three ratified
+balance oracles run at HIGH pressure (pe_ratio 0.81-0.94 everywhere), so the candidates
+near-SATURATE even multi-oracle. The |corr| ranking is then noise between near-flat
+candidates and is N-sensitive (B won the contaminated N=100 pool at 0.197; A won this
+clean N=40 pool at 0.092; differences are 0.09-0.24). No robust |corr| winner exists.
+`SELECTED_CANDIDATE` stays **B_time_avg** on a PRINCIPLED basis, not the noisy |corr|:
+B (time-averaged pressure) is the only CONTINUOUS candidate, so it carries real variance,
+whereas A (sustained-threat fraction) pins near 1.0 and C (apex-reach) is binary -- both
+degenerate on high-pressure oracles. Consequence for the composite: because pe_ratio is
+~0.8-0.94 for every in-band oracle, the PE term mostly shifts the composite up uniformly
+and adds little DISCRIMINATION between healthy and unhealthy balance.
+
+**Open for master-dd:** (a) ratify (or reject) the proposed composite band; (b) decide
+whether the marginal pressure-PE signal is worth keeping in the composite as-is, OR switch
+to the design's alternate tension source (turns-to-resolve + dmg_taken "contestedness",
+sec 4.5) which is telemetered on every oracle and may avoid the high-pressure saturation;
+(c) only after (a)+(b) flip P4 gate-2/4b + P5 to consume the real band.

--- a/tools/py/batch_calibrate_badlands_elite_01.py
+++ b/tools/py/batch_calibrate_badlands_elite_01.py
@@ -34,6 +34,7 @@ import urllib.error
 import urllib.request
 
 import calibrate_policies
+from pressure_stats import pressure_stats
 
 SCENARIO_ID = "enc_badlands_elite_01"
 ENCOUNTER_CLASS = "badlands_elite"  # sent in /session/start body (backend class mult resolution)
@@ -740,6 +741,9 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
         vc_status, vc = get(f"{host}/api/session/{sid}/vc")
         vc_data = vc if vc_status == 200 else {}
 
+    # PE_ratio (PR2 follow-up): per-run pressure-trajectory stats so this oracle's
+    # composite carries a real pe_ratio (mirror batch_calibrate_hardcore06).
+    _ps = pressure_stats(pressure_samples)
     return {
         "run": run_idx,
         "seed": seed,
@@ -754,6 +758,9 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
         "dmg_taken_player": dmg_taken_player,
         "boss_hp_remaining": boss_hp_remaining,
         "pressure_final": pressure_samples[-1] if pressure_samples else pstart,
+        "pressure_mean": _ps["pressure_mean"],
+        "pressure_frac_ge75": _ps["frac_ge75"],
+        "pressure_pmax": _ps["pmax"],
         "ai_intent_tally": {f"{t}|{a}": c for (t, a), c in ai_intent_tally.items()},
         # 2026-05-20 method F: player + trait telemetry (anti-pattern #8 close).
         "player_action_tally": dict(player_action_tally),
@@ -824,6 +831,12 @@ def aggregate(runs, encounter_class=None):
         "turns_max": max(turns),
         "turns_hist": _hist(turns, bins=[(1,5),(6,10),(11,15),(16,20),(21,30),(31,40),(41,999)]),
         "kd_avg": statistics.mean(kd),
+        # PE_ratio PR2 follow-up: aggregate pressure-trajectory (composite pe_ratio source).
+        "pressure_mean_avg": statistics.mean([r.get("pressure_mean", 0.0) for r in ok]),
+        "pressure_frac_ge75_avg": statistics.mean([r.get("pressure_frac_ge75", 0.0) for r in ok]),
+        "apex_reach_rate": (
+            sum(1 for r in ok if r.get("pressure_pmax", 0.0) >= 95) / len(ok) if ok else 0.0
+        ),
         "kd_median": statistics.median(kd),
         "dmg_dealt_avg": statistics.mean(r["dmg_dealt_player"] for r in ok),
         "dmg_taken_avg": statistics.mean(r["dmg_taken_player"] for r in ok),

--- a/tools/py/batch_calibrate_foresta_pilot_01.py
+++ b/tools/py/batch_calibrate_foresta_pilot_01.py
@@ -34,6 +34,7 @@ import urllib.error
 import urllib.request
 
 import calibrate_policies
+from pressure_stats import pressure_stats
 
 SCENARIO_ID = "enc_foresta_pilot_01"
 ENCOUNTER_CLASS = "foresta_pilot"  # sent in /session/start body (backend class mult resolution)
@@ -740,6 +741,9 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
         vc_status, vc = get(f"{host}/api/session/{sid}/vc")
         vc_data = vc if vc_status == 200 else {}
 
+    # PE_ratio (PR2 follow-up): per-run pressure-trajectory stats so this oracle's
+    # composite carries a real pe_ratio (mirror batch_calibrate_hardcore06).
+    _ps = pressure_stats(pressure_samples)
     return {
         "run": run_idx,
         "seed": seed,
@@ -754,6 +758,9 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
         "dmg_taken_player": dmg_taken_player,
         "boss_hp_remaining": boss_hp_remaining,
         "pressure_final": pressure_samples[-1] if pressure_samples else pstart,
+        "pressure_mean": _ps["pressure_mean"],
+        "pressure_frac_ge75": _ps["frac_ge75"],
+        "pressure_pmax": _ps["pmax"],
         "ai_intent_tally": {f"{t}|{a}": c for (t, a), c in ai_intent_tally.items()},
         # 2026-05-20 method F: player + trait telemetry (anti-pattern #8 close).
         "player_action_tally": dict(player_action_tally),
@@ -824,6 +831,12 @@ def aggregate(runs, encounter_class=None):
         "turns_max": max(turns),
         "turns_hist": _hist(turns, bins=[(1,5),(6,10),(11,15),(16,20),(21,30),(31,40),(41,999)]),
         "kd_avg": statistics.mean(kd),
+        # PE_ratio PR2 follow-up: aggregate pressure-trajectory (composite pe_ratio source).
+        "pressure_mean_avg": statistics.mean([r.get("pressure_mean", 0.0) for r in ok]),
+        "pressure_frac_ge75_avg": statistics.mean([r.get("pressure_frac_ge75", 0.0) for r in ok]),
+        "apex_reach_rate": (
+            sum(1 for r in ok if r.get("pressure_pmax", 0.0) >= 95) / len(ok) if ok else 0.0
+        ),
         "kd_median": statistics.median(kd),
         "dmg_dealt_avg": statistics.mean(r["dmg_dealt_player"] for r in ok),
         "dmg_taken_avg": statistics.mean(r["dmg_taken_player"] for r in ok),

--- a/tools/py/pe_candidates.py
+++ b/tools/py/pe_candidates.py
@@ -66,21 +66,23 @@ def attach_composite_terms(agg, candidate=None):
     return agg
 
 
-# SELECTED (PROVISIONAL) by the PR2 experiment (N=100 seed-pinned, node 22, 2026-06-19).
-# B_time_avg (= pressure_mean_avg/100) chosen BY ELIMINATION: on the only fully
-# instrumented oracle (hc06) A_sustained_threat + C_apex_reach SATURATE (hc06 starts
-# at pressure 75=Critical -> frac_ge75 sd=0.009, apex sd=0.000 = degenerate-flat, the
-# "orthogonal-but-no-signal" failure the design warns of); B is the ONLY candidate
-# carrying trajectory variance (sd=0.024). Every experiment ranked B as the real
-# signal. min|corr| << 0.6 -> pressure is NOT rejected as a PE source.
+# SELECTED (PROVISIONAL) by the PR2 experiment (seed-pinned, node 22, 2026-06-19).
+# B_time_avg (= pressure_mean_avg/100) chosen on a PRINCIPLED basis, NOT the noisy
+# |corr| ranking: on every ratified balance oracle pressure runs HIGH (pe_ratio
+# 0.81-0.94 multi-oracle), so the candidates near-SATURATE and the |corr| ranking is
+# noise between near-flat values (N-sensitive: B@N=100 0.197, A@N=40 0.092). B is the
+# only CONTINUOUS candidate (real variance); A (sustained-threat fraction) pins ~1.0
+# and C (apex-reach) is binary -- both degenerate on high-pressure oracles. min|corr|
+# << 0.6 so pressure is not formally rejected, but the signal is MARGINAL.
 #
-# 🔴 OPEN (master-dd + follow-up): a CLEAN multi-oracle |corr| + the composite BAND
-# are BLOCKED. The per-run pressure-trajectory stats (pressure_mean/frac_ge75/pmax)
-# are emitted ONLY by batch_calibrate_hardcore06.py; the varied-pressure oracles that
-# would break hc06's saturation (badlands_elite / foresta_pilot) emit only
-# pressure_final, and hardcore_07 emits none -> their pe_ratio aggregates to 0.0.
-# Extend that instrumentation to the other oracles, then re-run the experiment for a
-# cross-oracle selection + derive the composite band. Evidence:
+# 🔴 OPEN (master-dd, NOT a blocker for this wiring): the per-run trajectory was
+# extended to badlands_elite + foresta_pilot (PR2b) so pe_ratio is now REAL on all 3
+# oracles (no longer 0.0). The composite BAND is PROPOSED ([0.236, 0.815] at k=2.0,
+# mean 0.526) but NOT written to the manifest (SDMG, human-ratified). Because pe_ratio
+# is ~0.8-0.94 everywhere it adds little DISCRIMINATION -> master-dd may instead switch
+# to the design's alternate tension source (turns-to-resolve + dmg_taken contestedness,
+# sec 4.5), telemetered on every oracle, which avoids the high-pressure saturation.
+# Evidence:
 # docs/playtest/2026-06-19-pe-ratio-experiment-n100.md.
 SELECTED_CANDIDATE = "B_time_avg"
 


### PR DESCRIPTION
## Cosa
Follow-up di PR2 (#2867). Estende il per-run pressure-trajectory (mean/frac_ge75/pmax + forme aggregate) a `badlands_elite_01` + `foresta_pilot_01` (mirror hc06) → il composite `pe_ratio` e' ora **REALE** su quegli oracoli invece di 0.0. Additivo, nessun cambio calibrazione (seed-pinned). pe test 18/18.

## Risultato multi-oracolo (N=40 seed-pinned, node 22, backend :3400 NON prod)
| oracle | WR | kd_ratio | pe_ratio | composite |
|---|---|---|---|---|
| hardcore_06 | 0.125 | 0.721 | **0.937** | 0.477 |
| badlands_elite_01 | 0.150 | 0.513 | **0.809** | 0.405 |
| foresta_pilot_01 | 0.550 | 0.778 | **0.903** | 0.695 |

**Banda composite PROPOSTA** (master-dd ratifica, SDMG): mean 0.526, k=2.0 **[0.236, 0.815]**. NON scritta nel manifest.

## 🔴 Finding onesto (master-dd)
Il segnale **PE-from-pressure e' MARGINALE**: tutti gli oracoli balance girano high-pressure → i candidati near-saturano (pe_ratio 0.81-0.94 ovunque) → il ranking |corr| e' rumore + N-sensitive (B@N100 0.197, A@N40 0.092, nessun winner robusto). `SELECTED_CANDIDATE` resta **B_time_avg** per argomento PRINCIPLED (unico continuo → varianza reale; A pin ~1.0, C binario). Poiche' pe_ratio e' quasi-costante aggiunge poca discriminazione al composite.

**Aperto per te**: (a) ratifica/rifiuta la banda proposta; (b) tieni il pressure-PE marginale cosi' com'e' OPPURE passa alla sorgente-tensione alternativa del design (turns-to-resolve + dmg_taken "contestedness", sec 4.5 — telemetrata su ogni oracolo, evita la saturazione); (c) solo dopo (a)+(b) flippa P4 gate-2/4b + P5 sul composite reale.

## Verify
18 pytest verdi, moduli parse OK, governance --strict errors=0, band-neutral, prod 3334/3341 untouched. Rollback = revert `6c78d0f2`.

## Gates
- tocca `tools/py` (dominio G2, sessione wrapped). No forbidden-path, no deps. >50-line → non auto-merge, tuo OK.

Coding-Agent: claude-opus-4-8
