### PR TITLE
feat(coop): SPEC-K K-05 Nido next-mission readiness quorum (device-authority)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -101,6 +101,17 @@ function createCoopRouter({
         payload: orch.worldTally(quorumPids(room, orch, null), connectedQuorumPids(room, orch)),
       });
     }
+    // SPEC-K K-05 — re-surface the Nido next-mission readiness tally while in the hub
+    // (keeps phones in sync on any coop-state rebroadcast). Mirror of world_tally.
+    if (orch.phase === 'nido') {
+      room.broadcast({
+        type: 'mission_tally',
+        payload: orch.missionReadyTally(
+          quorumPids(room, orch, null),
+          connectedQuorumPids(room, orch),
+        ),
+      });
+    }
     // GAP-C fase-3 — re-surface an open meta-network route choice (phase-agnostic:
     // gated on open candidates, not a PHASES value). Keeps phones in sync on any
     // coop-state rebroadcast while a route vote is in progress.
@@ -244,6 +255,50 @@ function createCoopRouter({
       return res.json({ phase: orch.phase, tally });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'world_vote_failed' });
+    }
+  });
+
+  // SPEC-K K-05 — Nido next-mission readiness quorum (device-authority). Each
+  // connected player POSTs their ready state; when ALL connected players are ready
+  // the run auto-advances out of the Nido (no host action), mirroring the mating
+  // connected-quorum auto-resolve. The host fallback is /coop/mission/start below.
+  router.post('/coop/mission/ready', (req, res) => {
+    const { code, player_id: playerId, player_token: playerToken, ready = true } = req.body || {};
+    const auth = authPlayer(code, playerId, playerToken);
+    if (!auth) return res.status(403).json({ error: 'player_auth_failed' });
+    const { room } = auth;
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const tally = orch.markMissionReady(playerId, {
+        ready,
+        allPlayerIds: quorumPids(room, orch, playerId),
+        connectedPlayerIds: connectedQuorumPids(room, orch),
+      });
+      let advanced = null;
+      if (tally.all_connected_ready) advanced = orch.advanceScenarioOrEnd();
+      broadcastCoopState(room, orch);
+      return res.json({ phase: orch.phase, tally, advanced });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'mission_ready_failed' });
+    }
+  });
+
+  // SPEC-K K-05 — host anti-deadlock fallback: the host force-starts the next mission
+  // even if not every device marked ready (e.g. an AFK/offline peer).
+  router.post('/coop/mission/start', (req, res) => {
+    const { code, player_id: playerId, player_token: playerToken } = req.body || {};
+    const auth = authPlayer(code, playerId, playerToken);
+    if (!auth) return res.status(403).json({ error: 'player_auth_failed' });
+    const { room } = auth;
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const result = orch.startMissionFromNido(playerId, { hostId: room.hostId });
+      broadcastCoopState(room, orch);
+      return res.json({ phase: orch.phase, advance: result.advance });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'mission_start_failed' });
     }
   });
 

--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -150,6 +150,16 @@ function createCoopRouter({
     }
   }
 
+  // SPEC-K K-05 — broadcast a creature_named reveal carried by an advance result
+  // to the whole room (mirror wsSession.broadcastCreatureNamed). No-op when the
+  // advance carries no names. So a Nido-exit name/MBTI reveal reaches every phone,
+  // not only the REST responder.
+  function broadcastCreatureNamedReveal(room, advance) {
+    if (!room || typeof room.broadcast !== 'function') return;
+    const named = advance && Array.isArray(advance.creature_named) ? advance.creature_named : [];
+    if (named.length) room.broadcast({ type: 'creature_named', payload: { named } });
+  }
+
   // 2026-05-20 — readonly diagnostic per onboarding hint (A6 pattern
   // `listStarterBiomas` replicato; gap-fill Explore quick-win discovery).
   // Frontend onboarding HUD può preload role expectation per biome scelto.
@@ -278,6 +288,9 @@ function createCoopRouter({
       let advanced = null;
       if (tally.all_connected_ready) advanced = orch.advanceScenarioOrEnd();
       broadcastCoopState(room, orch);
+      // mirror the WS nido_start_mission path: a name/MBTI reveal carried by the
+      // advance must reach EVERY phone, not just this responder (Codex P2).
+      broadcastCreatureNamedReveal(room, advanced);
       return res.json({ phase: orch.phase, tally, advanced });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'mission_ready_failed' });
@@ -296,6 +309,7 @@ function createCoopRouter({
     try {
       const result = orch.startMissionFromNido(playerId, { hostId: room.hostId });
       broadcastCoopState(room, orch);
+      broadcastCreatureNamedReveal(room, result.advance); // reveal -> every phone (Codex P2)
       return res.json({ phase: orch.phase, advance: result.advance });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'mission_start_failed' });

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -123,6 +123,7 @@ class CoopOrchestrator {
     this.run = null; // populated by startRun()
     this.characters = new Map(); // player_id → character spec
     this.worldVotes = new Map(); // player_id → scenario_id|null
+    this.missionReadyVotes = new Map(); // player_id → {ready,ts} (SPEC-K K-05 nido next-mission quorum)
     // S22-B -- per-player mating pair vote { player_id -> { pair_id, ts } }.
     this.matingVotes = new Map();
     // GAP-C fase-3 -- per-player meta-network route vote { player_id ->
@@ -284,6 +285,7 @@ class CoopOrchestrator {
     };
     this.characters.clear();
     this.worldVotes.clear();
+    this.missionReadyVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();
     this.routeVotes.clear();
@@ -329,6 +331,7 @@ class CoopOrchestrator {
     };
     this.characters.clear();
     this.worldVotes.clear();
+    this.missionReadyVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();
     this.routeVotes.clear();
@@ -1222,6 +1225,61 @@ class CoopOrchestrator {
   }
 
   /**
+   * SPEC-K K-05 — Nido next-mission readiness QUORUM (device-authority). Each
+   * connected player marks ready on their OWN device instead of the host gating
+   * the start; `startMissionFromNido()` stays as the host anti-deadlock fallback.
+   * Mirrors voteWorld/worldTally. Phase must be 'nido'. Idempotent re-mark.
+   *
+   * @param playerId
+   * @param ready — true (ready to leave) | false (retracts)
+   * @returns missionReadyTally
+   */
+  markMissionReady(playerId, { ready = true, allPlayerIds = [], connectedPlayerIds } = {}) {
+    if (this.phase !== 'nido') throw new Error('not_in_nido');
+    if (!playerId) throw new Error('player_id_required');
+    this.missionReadyVotes.set(playerId, { ready: Boolean(ready), ts: this.now() });
+    this._emit('mission_ready', { player_id: playerId, ready: Boolean(ready) });
+    return this.missionReadyTally(allPlayerIds, connectedPlayerIds);
+  }
+
+  /**
+   * SPEC-K K-05 — readiness tally. `all_connected_ready` is the device-authority
+   * advance signal (every connected player marked ready). Mirror of worldTally:
+   * `connectedPlayerIds` omitted -> connected_* fields absent (legacy callers).
+   */
+  missionReadyTally(allPlayerIds = [], connectedPlayerIds) {
+    let ready = 0;
+    const perPlayer = {};
+    for (const [pid, v] of this.missionReadyVotes.entries()) {
+      if (v.ready) ready += 1;
+      perPlayer[pid] = v;
+    }
+    const cast = this.missionReadyVotes.size;
+    const tally = {
+      ready,
+      total: allPlayerIds.length || cast,
+      pending: Math.max(allPlayerIds.length - cast, 0),
+      per_player: perPlayer,
+    };
+    if (Array.isArray(connectedPlayerIds)) {
+      const connected = connectedPlayerIds.filter(Boolean);
+      const connectedTotal = connected.length;
+      let connectedReady = 0;
+      for (const pid of connected) {
+        const v = this.missionReadyVotes.get(pid);
+        if (v && v.ready) connectedReady += 1;
+      }
+      tally.connected_total = connectedTotal;
+      tally.connected_ready = connectedReady;
+      tally.connected_pending = Math.max(connectedTotal - connectedReady, 0);
+      // Advance signal: every connected player ready (empty set -> false, no
+      // auto-advance with zero participants -- mirrors worldTally).
+      tally.all_connected_ready = connectedTotal > 0 && connectedReady === connectedTotal;
+    }
+    return tally;
+  }
+
+  /**
    * Build the /session/start payload from current characters.
    * Used by M17+ host handler that forwards to existing session route.
    */
@@ -1367,6 +1425,7 @@ class CoopOrchestrator {
     });
     this.debriefChoices.clear();
     this.worldVotes.clear();
+    this.missionReadyVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();
     this.routeVotes.clear();

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -1218,7 +1218,10 @@ class CoopOrchestrator {
    * @returns { phase, advance, run_state }
    */
   startMissionFromNido(playerId, { hostId } = {}) {
-    if (hostId && playerId !== hostId) throw new Error('host_only');
+    // Fail-closed: a null hostId (e.g. a host-transfer gap) must NOT silently
+    // skip the host gate and let any player force-start (coop-phase-validator P2).
+    if (!hostId) throw new Error('no_host');
+    if (playerId !== hostId) throw new Error('host_only');
     if (this.phase !== 'nido') throw new Error('not_in_nido');
     const advance = this.advanceScenarioOrEnd();
     return { phase: this.phase, advance, run_state: this.run };
@@ -1265,13 +1268,17 @@ class CoopOrchestrator {
       const connected = connectedPlayerIds.filter(Boolean);
       const connectedTotal = connected.length;
       let connectedReady = 0;
+      let connectedCast = 0;
       for (const pid of connected) {
         const v = this.missionReadyVotes.get(pid);
-        if (v && v.ready) connectedReady += 1;
+        if (!v) continue;
+        connectedCast += 1; // cast = acted (ready OR retracted), mirror worldTally connectedVoted
+        if (v.ready) connectedReady += 1;
       }
       tally.connected_total = connectedTotal;
       tally.connected_ready = connectedReady;
-      tally.connected_pending = Math.max(connectedTotal - connectedReady, 0);
+      // pending = NOT-yet-acted (a ready:false retract has acted -> not pending).
+      tally.connected_pending = Math.max(connectedTotal - connectedCast, 0);
       // Advance signal: every connected player ready (empty set -> false, no
       // auto-advance with zero participants -- mirrors worldTally).
       tally.all_connected_ready = connectedTotal > 0 && connectedReady === connectedTotal;

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1076,6 +1076,14 @@ function rebroadcastCoopState(room, orch) {
   if (orch.phase === 'world_setup' && typeof orch.worldTally === 'function') {
     room.broadcast({ type: 'world_tally', payload: orch.worldTally(allIds, connectedIds) });
   }
+  // SPEC-K K-05 — re-surface the Nido readiness tally after a host transfer (mirror
+  // world_tally), so phones keep the correct connected_total/pending.
+  if (orch.phase === 'nido' && typeof orch.missionReadyTally === 'function') {
+    room.broadcast({
+      type: 'mission_tally',
+      payload: orch.missionReadyTally(allIds, connectedIds),
+    });
+  }
   // GAP-C fase-3 — re-surface an open route choice after host transfer (mirror
   // the reconnect snapshot above). Phase-agnostic: gated on open candidates.
   if (
@@ -2249,6 +2257,24 @@ function createWsServer({
               type: 'route_tally',
               payload: orch.routeTally(allPids, connectedPids),
             });
+          }
+          // SPEC-K K-05: a disconnect can COMPLETE the Nido readiness quorum (the
+          // departed peer was the last not-ready connected player). Re-broadcast the
+          // tally; if every REMAINING connected player is ready, auto-advance out of
+          // the Nido + push the reveal (mirror POST /coop/mission/ready). Without
+          // this the run waits forever for a gone player.
+          if (orch && orch.phase === 'nido' && typeof orch.missionReadyTally === 'function') {
+            const allPids = Array.from(room.players.values()).map((p) => p.id);
+            const connectedPids = Array.from(room.players.values())
+              .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
+              .map((p) => p.id);
+            const tally = orch.missionReadyTally(allPids, connectedPids);
+            room.broadcast({ type: 'mission_tally', payload: tally });
+            if (tally.all_connected_ready) {
+              const advance = orch.advanceScenarioOrEnd();
+              rebroadcastCoopState(room, orch);
+              broadcastCreatureNamed(room, advance);
+            }
           }
         } catch {
           // swallow -- best-effort re-broadcast.

--- a/tests/api/coopMissionReady.test.js
+++ b/tests/api/coopMissionReady.test.js
@@ -86,6 +86,19 @@ test('connected_pending counts a ready:false retract as ACTED (not pending)', ()
   assert.equal(t.all_connected_ready, false);
 });
 
+test('a disconnect dropping the last not-ready connected player completes the quorum', () => {
+  // The WS disconnect handler acts on exactly this: re-tally with the shrunk
+  // connected set; all_connected_ready -> auto-advance (Codex P2).
+  const co = nidoOrch();
+  const all = ['p_h', 'p1', 'p2'];
+  co.markMissionReady('p1', { ready: true, allPlayerIds: all, connectedPlayerIds: all });
+  let t = co.markMissionReady('p_h', { ready: true, allPlayerIds: all, connectedPlayerIds: all });
+  assert.equal(t.all_connected_ready, false); // p2 connected + not ready
+  // p2 disconnects -> connected = {p_h, p1}, both ready -> quorum completes
+  t = co.missionReadyTally(all, ['p_h', 'p1']);
+  assert.equal(t.all_connected_ready, true);
+});
+
 test('missionReadyVotes cleared on startRun (mirror worldVotes)', () => {
   const co = nidoOrch();
   co.markMissionReady('p1', { ready: true, allPlayerIds: ['p1'] });

--- a/tests/api/coopMissionReady.test.js
+++ b/tests/api/coopMissionReady.test.js
@@ -1,0 +1,122 @@
+// SPEC-K K-05 — Nido next-mission readiness quorum.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function nidoOrch() {
+  const co = new CoopOrchestrator({ roomCode: 'QUOR', hostId: 'p_h' });
+  co._setPhase('nido');
+  return co;
+}
+
+// ---- orchestrator (direct) ----
+
+test('markMissionReady throws outside nido', () => {
+  const co = new CoopOrchestrator({ roomCode: 'QUOR', hostId: 'p_h' }); // phase = lobby
+  assert.throws(() => co.markMissionReady('p1', {}), /not_in_nido/);
+});
+
+test('markMissionReady records ready + tally; idempotent re-mark', () => {
+  const co = nidoOrch();
+  const all = ['p_h', 'p1'];
+  let t = co.markMissionReady('p1', { ready: true, allPlayerIds: all });
+  assert.equal(t.ready, 1);
+  assert.equal(t.total, 2);
+  assert.equal(t.pending, 1); // p_h not yet
+  // re-mark same player -> still one entry (replaces)
+  t = co.markMissionReady('p1', { ready: true, allPlayerIds: all });
+  assert.equal(t.ready, 1);
+  assert.equal(Object.keys(t.per_player).length, 1);
+});
+
+test('ready=false retracts (not counted ready, but cast)', () => {
+  const co = nidoOrch();
+  const all = ['p_h', 'p1'];
+  co.markMissionReady('p1', { ready: true, allPlayerIds: all });
+  const t = co.markMissionReady('p1', { ready: false, allPlayerIds: all });
+  assert.equal(t.ready, 0);
+  assert.equal(t.pending, 1); // p1 cast (not pending), p_h still pending
+});
+
+test('all_connected_ready: true only when every CONNECTED player is ready', () => {
+  const co = nidoOrch();
+  const all = ['p_h', 'p1', 'p2'];
+  // p2 offline (connected = host + p1). p1 ready, host not yet -> false
+  let t = co.markMissionReady('p1', {
+    ready: true,
+    allPlayerIds: all,
+    connectedPlayerIds: ['p_h', 'p1'],
+  });
+  assert.equal(t.all_connected_ready, false);
+  assert.equal(t.connected_pending, 1);
+  // host ready -> both connected ready -> true (p2 offline does not block)
+  t = co.markMissionReady('p_h', {
+    ready: true,
+    allPlayerIds: all,
+    connectedPlayerIds: ['p_h', 'p1'],
+  });
+  assert.equal(t.all_connected_ready, true);
+  assert.equal(t.connected_ready, 2);
+});
+
+test('all_connected_ready false with zero connected participants', () => {
+  const co = nidoOrch();
+  const t = co.missionReadyTally(['p_h', 'p1'], []);
+  assert.equal(t.all_connected_ready, false);
+});
+
+test('missionReadyVotes cleared on startRun (mirror worldVotes)', () => {
+  const co = nidoOrch();
+  co.markMissionReady('p1', { ready: true, allPlayerIds: ['p1'] });
+  assert.equal(co.missionReadyVotes.size, 1);
+  // startRun only runs from lobby|ended; force 'ended' to exercise its reset.
+  co._setPhase('ended');
+  co.startRun({ scenarioStack: ['enc_tutorial_01'] });
+  assert.equal(co.missionReadyVotes.size, 0);
+});
+
+// ---- route error paths ----
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app };
+}
+
+async function createAndJoin(app) {
+  const { body: h } = await request(app).post('/api/lobby/create').send({ host_name: 'H' });
+  const { body: j } = await request(app)
+    .post('/api/lobby/join')
+    .send({ code: h.code, player_name: 'Alice' });
+  return { h, j };
+}
+
+test('POST /coop/mission/ready -> 403 bad token', async () => {
+  const { app } = buildApp();
+  const { h, j } = await createAndJoin(app);
+  const res = await request(app)
+    .post('/api/coop/mission/ready')
+    .send({ code: h.code, player_id: j.player_id, player_token: 'bad' });
+  assert.equal(res.status, 403);
+});
+
+test('POST /coop/mission/ready -> 409 run not started', async () => {
+  const { app } = buildApp();
+  const { h, j } = await createAndJoin(app);
+  const res = await request(app)
+    .post('/api/coop/mission/ready')
+    .send({ code: h.code, player_id: j.player_id, player_token: j.player_token });
+  assert.equal(res.status, 409);
+});

--- a/tests/api/coopMissionReady.test.js
+++ b/tests/api/coopMissionReady.test.js
@@ -73,6 +73,19 @@ test('all_connected_ready false with zero connected participants', () => {
   assert.equal(t.all_connected_ready, false);
 });
 
+test('connected_pending counts a ready:false retract as ACTED (not pending)', () => {
+  const co = nidoOrch();
+  const conn = ['p_h', 'p1'];
+  const t = co.markMissionReady('p1', {
+    ready: false,
+    allPlayerIds: conn,
+    connectedPlayerIds: conn,
+  });
+  assert.equal(t.connected_ready, 0);
+  assert.equal(t.connected_pending, 1); // p1 acted (retract) -> only p_h pending, NOT 2
+  assert.equal(t.all_connected_ready, false);
+});
+
 test('missionReadyVotes cleared on startRun (mirror worldVotes)', () => {
   const co = nidoOrch();
   co.markMissionReady('p1', { ready: true, allPlayerIds: ['p1'] });
@@ -119,4 +132,16 @@ test('POST /coop/mission/ready -> 409 run not started', async () => {
     .post('/api/coop/mission/ready')
     .send({ code: h.code, player_id: j.player_id, player_token: j.player_token });
   assert.equal(res.status, 409);
+});
+
+test('POST /coop/mission/start -> 400 host_only for a non-host', async () => {
+  const { app } = buildApp();
+  const { h, j } = await createAndJoin(app);
+  // run started so the orch exists; host gate fires before the phase check.
+  await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+  const res = await request(app)
+    .post('/api/coop/mission/start')
+    .send({ code: h.code, player_id: j.player_id, player_token: j.player_token });
+  assert.equal(res.status, 400);
+  assert.equal(res.body.error, 'host_only');
 });


### PR DESCRIPTION
## Cosa
Lo start della prossima missione dal Nido era **host-only** (`startMissionFromNido` throwava `host_only`) + non wirato. K-05 aggiunge il **quorum device-authority**: ogni player connesso marca ready sul proprio device; il run auto-avanza fuori dal Nido quando TUTTI i connessi sono ready. Host force-start resta come anti-deadlock fallback. = ultimo chokepoint host-only del loop co-op rimosso (pattern route-vote #2597).

## Come
- `coopOrchestrator`: `missionReadyVotes` Map (reset su startRun/startOnboarding/advanceScenarioOrEnd, mirror worldVotes) + `markMissionReady()` + `missionReadyTally()` — mirror ESATTO di voteWorld/worldTally (connected-quorum, `all_connected_ready` advance-signal, pending, idempotent re-mark, guard `not_in_nido`).
- route: `POST /coop/mission/ready` (quorum → auto-advance quando all_connected_ready, mirror dell'auto-resolve mating) + `POST /coop/mission/start` (host anti-deadlock → startMissionFromNido) + broadcast `mission_tally` in fase nido (mirror world_tally).
- **8 test** (orchestrator quorum/connected/retract/reset + route auth/run-not-started); **coop regression 200/200**.

## Verify
8/8 + coop 200/200 + parse OK + prettier clean. Band-neutral. Surface-dead finche' chip GGv2 (lo spawno).

## Rollback
Revert `5e4cb32a`.

## Gates
- orchestrator + route = `apps/backend` (esente 50-line); test ~120 righe in `tests/` (fuori apps/backend) → non auto-merge-L3, tuo OK. No forbidden-path, no deps.

Coding-Agent: claude-opus-4-8
