### PR TITLE
fix(validation): declare echo-wing bridge species for ATOLLO_OBSIDIANA (last 2 warnings)

### DIFF
--- a/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
+++ b/packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml
@@ -182,6 +182,9 @@ network:
     - DESERTO_CALDO
     - ROVINE_PLANARI
     - CRYOSTEPPE
+    # ATOLLO_OBSIDIANA: completes the #2587 6th-node bridge coverage
+    # (CRYOSTEPPE->ATOLLO + ATOLLO->ROVINE_PLANARI edges). master-dd ratified 2026-06-19.
+    - ATOLLO_OBSIDIANA
   - species_id: ferrocolonia-magnetotattica
     roles:
     - sentinella


### PR DESCRIPTION
## Problem

The final 2 `validate-datasets` warnings (`network.bridge.missing_species`):
- `CRYOSTEPPE -> ATOLLO_OBSIDIANA` (seasonal_bridge)
- `ATOLLO_OBSIDIANA -> ROVINE_PLANARI` (corridor)

[#2587](https://github.com/MasterDD-L34D/Game/pull/2587) added `ATOLLO_OBSIDIANA` as the 6th meta-network node + its edges, but never extended `bridge_species_map` -> neither edge had a declared bridge species.

## Fix

`echo-wing` is the canonical `dispersore_ponte` already present in 5/6 biomes, including **both** new-edge endpoints (`CRYOSTEPPE` and `ROVINE_PLANARI`). Adding `ATOLLO_OBSIDIANA` to its `present_in_nodes` satisfies both edges (the validator requires a bridge entry whose `present_in_nodes` contains both `from` and `to`).

**master-dd ratified the canon** (echo-wing bridges the obsidian atoll) 2026-06-19.

- Authoritative file only: `packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml` (the validator's input per `run_all_validators.py:49`). The divergent legacy `data/ecosistemi/meta_ecosistema_alpha.yaml` copy is not validator-read and left untouched (out of scope).

## Result

`validate-datasets`: **2 -> 0 avvisi** (combined with [#2872](https://github.com/MasterDD-L34D/Game/pull/2872) role fix, the pack validator is now fully clean: 14 controlli, 0 avvisi).

## Verification

- `run_all_validators.py`: 0 WARNING lines.
- `py -m pytest tests/ tools/py`: 998 passed (the 1 failure = pre-existing Windows `charmap` crash in the unrelated `trait_template_validator.py`; UTF-8 CI green).
- prettier-clean.

## Rollback

Single additive 3-line change (1 node id + comment) to a meta-network registry. Revert the commit; zero runtime/schema impact (validator data only; bridge_species_map is informational connectivity metadata).

Coding-Agent: claude-opus-4-8