### PR TITLE
fix(balance): widen badlands_elite band [0.15,0.30]->[0.10,0.30] (steep-lever variance)

### DIFF
--- a/data/core/balance/damage_curves.yaml
+++ b/data/core/balance/damage_curves.yaml
@@ -156,18 +156,24 @@ encounter_classes:
 
   badlands_elite:
     # S1 (2026-06-18): dedicated elite band for ferrimordax-rutilus (T3 apex anchor),
-    # scenario enc_badlands_elite_01. Band [0.15,0.30]. New/separate band.
+    # scenario enc_badlands_elite_01. Band [0.10,0.30] (widened 2026-06-19, see below).
     description: 'Badlands elite (ferrimordax-rutilus apex + escort).'
     target_bands:
-      win_rate: [0.15, 0.30]  # PROPOSAL pending N=40 ratify (elite range)
-      defeat_rate: [0.55, 0.85]
+      win_rate: [0.10, 0.30]  # RATIFIED edm 1.85 -> WR 0.16 (steep-lever, variance-robust)
+      defeat_rate: [0.55, 0.90]
       timeout_rate: [0.00, 0.15]
-    # RATIFIED 2026-06-18 N=100 seed 424242: WR 0.16 in-band [0.15,0.30] (1-apex
-    # ferrimordax solo-anchor + escort). STEEP LEVER (hc06-style cliff): 1.8 -> 0.29
-    # (ceiling) / 1.85 -> 0.16 / 1.9 -> 0.16 (floor plateau) -- the band mid is not
-    # reachable without falling off the cliff. Ratified on the stable 0.16 plateau (1.85
-    # == 1.9). FOLLOW-UP design-call (master-dd): widen the elite band or use a flatter
-    # knob (enemy HP) for margin -- mirrors the hc06 steep-lever open call.
+    # RATIFIED 2026-06-18 N=100 seed 424242: WR 0.16 (defeat 0.84) -- 1-apex ferrimordax
+    # solo-anchor + escort. STEEP LEVER (hc06-style cliff): 1.8 -> 0.29 (ceiling) /
+    # 1.85 -> 0.16 / 1.9 -> 0.16 (floor plateau); the band mid is not reachable without
+    # falling off the cliff. Ratified on the stable 0.16 plateau (1.85 == 1.9).
+    # BAND WIDENED 2026-06-19 (master-dd "procedi con l'ottimale"): win_rate
+    # [0.15,0.30] -> [0.10,0.30], defeat [0.55,0.85] -> [0.55,0.90]. Keeps the edm 1.85
+    # knob and absorbs the steep-lever N=100 CI variance (WR 0.16 has CI95 ~[0.10,0.24])
+    # so a same-knob re-run cannot read OOB-low on an unlucky seed. Mirrors the hc06
+    # steep-lever resolution (decision A: widen band asymmetrically toward the variance,
+    # keep knob). Flatter-knob (enemy HP) rejected: hc06 proved HP can cliff too (boss_hp
+    # WAS its steep lever) -> no guaranteed flatness + would need re-calibration that
+    # changes the ratified WR. Scenario is non-oracle (out of the gated suite).
     enemy_damage_multiplier: 1.85
     boss_enrage_threshold_hp: null
     turn_limit_defeat: 30  # decisive (shorter than ambient)

--- a/docs/playtest/2026-06-18-badlands-s1-calibration.md
+++ b/docs/playtest/2026-06-18-badlands-s1-calibration.md
@@ -45,13 +45,19 @@ Roster: ferrimordax-rutilus (T3 -> APEX, sole anchor) + ferrocolonia-magnetotatt
 | 1.85 | 100 | 0.16 | floor plateau (== 1.9)            |
 | 1.8  | 100 | 0.29 | pre-cliff (ceiling)               |
 
-**RATIFIED: edm 1.85 -> WR 0.16, N=100, in-band [0.15,0.30]** (defeat 0.84, kd 1.04).
+**RATIFIED: edm 1.85 -> WR 0.16, N=100, in-band [0.10,0.30]** (defeat 0.84, kd 1.04).
 Chosen on the stable 0.16 plateau (1.85 == 1.9 forensic).
 
 **STEEP LEVER (hc06-style cliff)**: ~13pp WR drop over 0.05 edm (1.8->0.29 vs
-1.85->0.16); the band mid (~0.22) is not reachable. Ratified value sits ~1pp from the
-0.15 floor. **FOLLOW-UP design-call (master-dd)**: widen the elite band (e.g. [0.10,0.30])
-or switch to a flatter knob (enemy HP) for margin -- mirrors the open hc06 steep-lever call.
+1.85->0.16); the band mid (~0.22) is not reachable. **RESOLVED 2026-06-19 (master-dd
+"procedi con l'ottimale") -- band widened [0.15,0.30] -> [0.10,0.30]** (+ defeat
+[0.55,0.85] -> [0.55,0.90]), edm 1.85 kept. The widen absorbs the steep-lever N=100 CI
+variance (WR 0.16 CI95 ~[0.10,0.24]) so a same-knob re-run cannot read OOB-low on an
+unlucky seed -- mirrors the hc06 steep-lever resolution (decision A: widen band
+asymmetrically toward the variance, keep knob). Flatter-knob (enemy HP) was rejected:
+hc06 proved HP can cliff too (boss_hp WAS its steep lever), so it offers no guaranteed
+flatness and would need a re-calibration that changes the ratified WR. The scenario is
+non-oracle (out of the gated suite), so a centered band is not required.
 
 ## enc_badlands_ambient_01 -- rubrospina + ferriscroba (DESIGNED-WINNABLE)
 

--- a/tools/py/calibrate_parallel.py
+++ b/tools/py/calibrate_parallel.py
@@ -69,7 +69,7 @@ SCENARIO_MAP = {
     # S1 (2026-06-18): dedicated per-role bands for the #2850 species.
     "badlands_elite_01": {
         "script": "batch_calibrate_badlands_elite_01.py",
-        "target_band": (0.15, 0.30),
+        "target_band": (0.10, 0.30),  # widened 2026-06-19 (steep-lever variance, edm 1.85 kept)
         "scenario_id": "enc_badlands_elite_01",
         "encounter_class": "badlands_elite",
         "extra_args": ["--encounter-class", "badlands_elite"],


### PR DESCRIPTION
## Context

Resolves the S1 elite steep-lever follow-up (master-dd: *"procedi con l'ottimale"*).

`enc_badlands_elite_01` is a **steep edm lever** (hc06-style cliff): 1.8 -> WR 0.29, 1.85 -> 0.16, 1.9 -> 0.16. The ratified WR 0.16 sat **~1pp from the [0.15,0.30] floor**, so a same-knob re-run could read OOB-low on an unlucky seed (N=100 CI95 ~[0.10,0.24]).

## Fix -- band-widen, keep the knob

- `win_rate`   `[0.15,0.30]` -> **`[0.10,0.30]`**
- `defeat_rate` `[0.55,0.85]` -> **`[0.55,0.90]`**
- `enemy_damage_multiplier` **unchanged (1.85)**

Touched: `data/core/balance/damage_curves.yaml` + `calibrate_parallel.py` SCENARIO_MAP + the S1 report.

## Why band-widen, not flatter-knob (enemy HP)

- **Precedent**: mirrors the hc06 steep-lever resolution (master-dd *decision A* 2026-06-17 -- widen the band asymmetrically toward the variance, keep the knob).
- **Flatter-knob unproven**: hc06 proved HP can cliff too (`boss_hp` *was* its steep lever), so a knob swap offers no guaranteed flatness -- and would need a re-calibration that **changes the ratified WR**.
- **Non-oracle**: the scenario is intentionally outside the gated suite, so a perfectly-centered band isn't required; it only needs to not sit at the cliff edge.

After widen: WR 0.16 sits **6pp from the floor** (was 1pp); defeat 0.84 sits **6pp from the ceiling** (was 1pp) -> variance-robust.

## Verification

Re-ran N=100 seed 424242 (node 22.22.3, greedy, base-port 3410, prod untouched):
- runner reads the new bands `win [0.1,0.3]` / `defeat [0.55,0.9]`
- WR **0.16** / defeat **0.84** / timeout **0** -> **verdict GREEN** (deterministic; knob unchanged)
- `validate-datasets`: 0 avvisi; prettier-clean.

## Rollback

Band-metadata only (3 files). Revert the commit; the edm knob is unchanged so combat behaviour and the ratified WR are identical -- only the verdict tolerance changes.

Coding-Agent: claude-opus-4-8