### PR TITLE
feat(coop): SPEC-K K-02 co-op world lock-in (host proposes, device quorum commits)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -27,6 +27,12 @@ const {
 } = require('../services/coop/vcLedgerReplay');
 const { isDeepStrictEqual } = require('node:util');
 
+// SPEC-K K-02 — co-op world lock-in flag. Default OFF preserves the legacy
+// host-confirm (immediate commit). ON: the host CTA PROPOSES the world and the
+// device quorum auto-commits (host CTA = marked DEV_FALLBACK). Read at call time
+// so tests + ops can toggle without re-instantiating the router.
+const worldConfirmQuorumEnabled = () => process.env.WORLD_CONFIRM_QUORUM_ENABLED === 'true';
+
 function createCoopRouter({
   lobby,
   coopStore,
@@ -261,8 +267,22 @@ function createCoopRouter({
         allPlayerIds: quorumPids(room, orch, playerId),
         connectedPlayerIds: connectedQuorumPids(room, orch),
       });
+      // SPEC-K K-02: if a world is proposed and this vote completes the device
+      // quorum, auto-commit confirmWorld() WITHOUT host action. No-op (null)
+      // when nothing is proposed (legacy path), so this is safe flag-OFF.
+      const auto = orch.tryAutoConfirmWorld({
+        allPlayerIds: quorumPids(room, orch, playerId),
+        connectedPlayerIds: connectedQuorumPids(room, orch),
+      });
       broadcastCoopState(room, orch);
-      return res.json({ phase: orch.phase, tally });
+      const out = { phase: orch.phase, tally };
+      if (auto) {
+        out.world_confirmed = true;
+        out.scenario_id = auto.scenario_id;
+        out.session_start_payload = orch.buildSessionStartPayload();
+        if (auto.enriched_world) Object.assign(out, auto.enriched_world);
+      }
+      return res.json(out);
     } catch (err) {
       return res.status(400).json({ error: err.message || 'world_vote_failed' });
     }
@@ -386,16 +406,35 @@ function createCoopRouter({
     if (!room) return res.status(403).json({ error: 'host_auth_failed' });
     const orch = coopStore.get(code);
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    const force = req.body?.force === true;
     try {
-      const result = orch.confirmWorld({
-        scenarioId,
-        biomeId,
-        formAxes,
-        runSeed,
-        trainerCanonical,
-      });
-      broadcastCoopState(room, orch);
-      // Return session-start payload so host can forward to /api/session/start.
+      const params = { scenarioId, biomeId, formAxes, runSeed, trainerCanonical };
+      let result;
+      if (worldConfirmQuorumEnabled()) {
+        // SPEC-K K-02: propose-in-coop. Stashes params + opens the device vote
+        // when there are connected voters; commits immediately for solo/dev or
+        // host force-confirm (anti-deadlock).
+        result = orch.proposeWorld(params, {
+          connectedQuorumPids: connectedQuorumPids(room, orch),
+          force,
+        });
+        broadcastCoopState(room, orch);
+        if (result.committed === false) {
+          // Proposed — awaiting the device quorum (no session start yet).
+          // Versioned event so device phones get an explicit "vote open"
+          // trigger (broadcastCoopState already re-sent world_tally; this is
+          // the named signal the Godot K-02 surface consumes).
+          if (typeof room.publishEvent === 'function') {
+            room.publishEvent('world_proposed', { scenario_id: result.scenario_id });
+          }
+          return res.json({ proposed: true, scenario_id: result.scenario_id, phase: orch.phase });
+        }
+      } else {
+        result = orch.confirmWorld(params);
+        broadcastCoopState(room, orch);
+      }
+      // Committed (legacy OR solo/force). Return session-start payload so host
+      // can forward to /api/session/start.
       const startPayload = orch.buildSessionStartPayload();
       const response = {
         scenario_id: result.scenario_id,

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -612,6 +612,10 @@ class CoopOrchestrator {
       return { committed: true, ...this.confirmWorld(params) };
     }
     // co-op: stash proposed params + open the device vote (no phase change).
+    // Codex P2 #2879 — reset prior votes so the quorum applies to THIS proposal
+    // only. Without this, an accept cast against an earlier proposal would carry
+    // over and let a re-proposed (different) world auto-commit without re-vote.
+    this.worldVotes.clear();
     this.proposedWorld = { ...params };
     const sid = params.scenarioId || this.run?.scenarioStack?.[this.run.currentIndex] || null;
     this._emit('world_proposed', { scenario_id: sid, biome_id: params.biomeId || null });

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -123,6 +123,11 @@ class CoopOrchestrator {
     this.run = null; // populated by startRun()
     this.characters = new Map(); // player_id → character spec
     this.worldVotes = new Map(); // player_id → scenario_id|null
+    // SPEC-K K-02 — co-op world lock-in. When the host PROPOSES the world (rich
+    // params it computed: biome/seed/form_axes) the params are stashed here so a
+    // later device-quorum (worldTally.all_connected_accepted) can auto-commit
+    // confirmWorld() WITHOUT a host action. null = legacy host-confirm path.
+    this.proposedWorld = null;
     this.missionReadyVotes = new Map(); // player_id → {ready,ts} (SPEC-K K-05 nido next-mission quorum)
     // S22-B -- per-player mating pair vote { player_id -> { pair_id, ts } }.
     this.matingVotes = new Map();
@@ -285,6 +290,7 @@ class CoopOrchestrator {
     };
     this.characters.clear();
     this.worldVotes.clear();
+    this.proposedWorld = null; // SPEC-K K-02 — drop stale world proposal
     this.missionReadyVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();
@@ -331,6 +337,7 @@ class CoopOrchestrator {
     };
     this.characters.clear();
     this.worldVotes.clear();
+    this.proposedWorld = null; // SPEC-K K-02 — drop stale world proposal
     this.missionReadyVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();
@@ -575,6 +582,7 @@ class CoopOrchestrator {
     }
     this._emit('world_confirmed', { scenario_id: sid, biome_id: biomeId || null });
     this._setPhase('combat');
+    this.proposedWorld = null; // committed — drop any pending proposal
     return {
       scenario_id: sid,
       enriched_world: enrichedWorld,
@@ -582,8 +590,57 @@ class CoopOrchestrator {
   }
 
   /**
+   * SPEC-K K-02 — co-op world lock-in (host proposes, device quorum commits).
+   * In co-op (>=1 connected voter) the host CTA PROPOSES the world: the rich
+   * params it computed are stashed and the device vote opens, but the phase
+   * does NOT advance — confirmWorld fires only when worldTally reaches
+   * all_connected_accepted (see tryAutoConfirmWorld). Solo/dev (zero connected
+   * voters) OR `force` (host anti-deadlock) commit immediately = legacy
+   * behavior. The host CTA is the marked DEV_FALLBACK; production commit is the
+   * device quorum (spec sez.6.3 / matrix 131-132 / criterion 9.4).
+   *
+   * @param params — { scenarioId, biomeId, formAxes, runSeed, trainerCanonical }
+   * @param connectedQuorumPids — host-excluded connected voter ids (route helper)
+   * @param force — host force-confirm (skip quorum, anti-deadlock fallback)
+   * @returns { committed:true, ...confirmResult } | { committed:false, proposed:true, scenario_id }
+   */
+  proposeWorld(params = {}, { connectedQuorumPids = [], force = false } = {}) {
+    if (this.phase !== 'world_setup') throw new Error('not_in_world_setup');
+    const voters = (connectedQuorumPids || []).filter(Boolean);
+    if (force || voters.length === 0) {
+      // immediate commit: solo/dev (no device voters) OR host force-confirm.
+      return { committed: true, ...this.confirmWorld(params) };
+    }
+    // co-op: stash proposed params + open the device vote (no phase change).
+    this.proposedWorld = { ...params };
+    const sid = params.scenarioId || this.run?.scenarioStack?.[this.run.currentIndex] || null;
+    this._emit('world_proposed', { scenario_id: sid, biome_id: params.biomeId || null });
+    return { committed: false, proposed: true, scenario_id: sid };
+  }
+
+  /**
+   * SPEC-K K-02 — auto-commit a PROPOSED world once the device vote reaches
+   * all_connected_accepted. No-op (returns null) when no world is proposed
+   * (legacy host-confirm path) OR quorum not yet met, so callers may invoke it
+   * after every world vote / disconnect unconditionally (mirror of the K-05
+   * mission-ready auto-advance). Re-fires confirmWorld with the stashed params.
+   *
+   * @returns confirmWorld result (phase -> combat) | null
+   */
+  tryAutoConfirmWorld({ allPlayerIds = [], connectedPlayerIds } = {}) {
+    if (!this.proposedWorld) return null;
+    if (this.phase !== 'world_setup') return null;
+    const tally = this.worldTally(allPlayerIds, connectedPlayerIds);
+    if (!tally.all_connected_accepted) return null;
+    const params = this.proposedWorld;
+    this.proposedWorld = null;
+    return this.confirmWorld(params);
+  }
+
+  /**
    * M18 — Player casts vote on proposed scenario. accept=true/false.
-   * Host remains arbiter and must still confirmWorld() to commit.
+   * Host remains arbiter for the LEGACY path; under WORLD_CONFIRM_QUORUM_ENABLED
+   * the device quorum auto-commits via tryAutoConfirmWorld (SPEC-K K-02).
    */
   voteWorld(playerId, { scenarioId, accept = true, allPlayerIds = [], connectedPlayerIds } = {}) {
     if (this.phase !== 'world_setup') throw new Error('not_in_world_setup');
@@ -799,6 +856,15 @@ class CoopOrchestrator {
    * indefinitely when 2nd player WS dropped mid-vote. Now: caller may use
    * `all_connected_accepted` flag to advance phase even with offline peers.
    * Backward compat: when `connectedPlayerIds` omitted, behaves as before.
+   *
+   * SPEC-K K-02 design property (mirror of missionReadyTally / B-NEW-1): the
+   * connected-only quorum is computed over the CURRENT connected set, so a
+   * player who casts `reject` and then DISCONNECTS no longer counts toward
+   * `all_connected_accepted` (their stored reject survives in `reject`/`per_player`
+   * but not in `connected_reject`). A rejecter can therefore abandon their veto
+   * by leaving — intentional, identical to how a not-ready peer dropping
+   * completes the Nido readiness quorum. Consumers must read `connected_*`, not
+   * the raw `reject`, to reason about advance.
    */
   worldTally(allPlayerIds = [], connectedPlayerIds) {
     let accept = 0;
@@ -1437,6 +1503,7 @@ class CoopOrchestrator {
     });
     this.debriefChoices.clear();
     this.worldVotes.clear();
+    this.proposedWorld = null; // SPEC-K K-02 — drop stale world proposal
     this.missionReadyVotes.clear();
     this.sessionId = null;
     this.matingVotes.clear();

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1584,13 +1584,52 @@ function createWsServer({
                 );
                 return;
               }
-              const result = orch.confirmWorld({
+              const params = {
                 scenarioId: msg.payload?.scenario_id,
                 biomeId: msg.payload?.biome_id,
                 formAxes: msg.payload?.form_axes,
                 runSeed: msg.payload?.run_seed,
                 trainerCanonical: msg.payload?.trainer_canonical,
-              });
+              };
+              // SPEC-K K-02 — flag ON: host CTA PROPOSES (co-op) or commits
+              // (solo/force); flag OFF: legacy immediate confirm. Mirror of the
+              // REST /coop/world/confirm branch.
+              if (process.env.WORLD_CONFIRM_QUORUM_ENABLED === 'true') {
+                const connectedPids = Array.from(room.players.values())
+                  .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
+                  .map((p) => p.id);
+                const proposeResult = orch.proposeWorld(params, {
+                  connectedQuorumPids: connectedPids,
+                  force: msg.payload?.force === true,
+                });
+                if (proposeResult.committed === false) {
+                  // Proposed — open the device vote (re-surface world_tally),
+                  // broadcast a named "vote open" trigger to all devices, and
+                  // ack the host. No phase change (still world_setup).
+                  rebroadcastCoopState(room, orch);
+                  if (typeof room.publishEvent === 'function') {
+                    room.publishEvent('world_proposed', {
+                      scenario_id: proposeResult.scenario_id,
+                    });
+                  }
+                  socket.send(
+                    JSON.stringify({
+                      type: 'world_proposed',
+                      payload: { scenario_id: proposeResult.scenario_id, phase: orch.phase },
+                    }),
+                  );
+                  return;
+                }
+                room.publishPhaseChange(orch.phase);
+                const ackPayloadF = { scenario_id: proposeResult.scenario_id, phase: orch.phase };
+                if (proposeResult.enriched_world)
+                  Object.assign(ackPayloadF, proposeResult.enriched_world);
+                socket.send(
+                  JSON.stringify({ type: 'world_confirm_accepted', payload: ackPayloadF }),
+                );
+                return;
+              }
+              const result = orch.confirmWorld(params);
               room.publishPhaseChange(orch.phase);
               const ackPayload = { scenario_id: result.scenario_id, phase: orch.phase };
               if (result.enriched_world) Object.assign(ackPayload, result.enriched_world);
@@ -1660,6 +1699,18 @@ function createWsServer({
                 all_connected_accepted: tally.all_connected_accepted,
               });
               room.broadcast({ type: 'world_tally', payload: tally });
+              // SPEC-K K-02 — auto-commit a proposed world when this vote
+              // completes the device quorum (no-op flag-OFF / nothing proposed).
+              const autoWs = orch.tryAutoConfirmWorld({
+                allPlayerIds: allPids,
+                connectedPlayerIds: connectedPids,
+              });
+              if (autoWs) {
+                room.publishPhaseChange(orch.phase);
+                const confirmPayload = { scenario_id: autoWs.scenario_id, phase: orch.phase };
+                if (autoWs.enriched_world) Object.assign(confirmPayload, autoWs.enriched_world);
+                room.broadcast({ type: 'world_confirm_accepted', payload: confirmPayload });
+              }
               socket.send(JSON.stringify({ type: 'world_vote_accepted', payload: { tally } }));
             } catch (err) {
               socket.send(
@@ -2274,6 +2325,37 @@ function createWsServer({
               const advance = orch.advanceScenarioOrEnd();
               rebroadcastCoopState(room, orch);
               broadcastCreatureNamed(room, advance);
+            }
+          }
+          // SPEC-K K-02: a disconnect can COMPLETE the world-confirm device
+          // quorum (the departed peer was the last not-yet-accepted connected
+          // voter). Re-surface the tally; if a world is proposed and every
+          // REMAINING connected voter accepted, auto-commit (mirror the K-05
+          // Nido branch above). No-op when nothing is proposed.
+          if (orch && orch.phase === 'world_setup' && orch.proposedWorld) {
+            const allPidsW = Array.from(room.players.values())
+              .filter((p) => p.id !== room.hostId && p.role !== 'host')
+              .map((p) => p.id);
+            const connectedPidsW = Array.from(room.players.values())
+              .filter((p) => p.connected && p.id !== room.hostId && p.role !== 'host')
+              .map((p) => p.id);
+            room.broadcast({
+              type: 'world_tally',
+              payload: orch.worldTally(allPidsW, connectedPidsW),
+            });
+            const autoW = orch.tryAutoConfirmWorld({
+              allPlayerIds: allPidsW,
+              connectedPlayerIds: connectedPidsW,
+            });
+            if (autoW) {
+              room.publishPhaseChange(orch.phase);
+              // Symmetry with the vote-drain auto-commit path: emit
+              // world_confirm_accepted so event-driven clients see the same
+              // sequence whether the quorum closed by a vote or a disconnect.
+              const confirmPayloadW = { scenario_id: autoW.scenario_id, phase: orch.phase };
+              if (autoW.enriched_world) Object.assign(confirmPayloadW, autoW.enriched_world);
+              room.broadcast({ type: 'world_confirm_accepted', payload: confirmPayloadW });
+              rebroadcastCoopState(room, orch);
             }
           }
         } catch {

--- a/tests/api/coopWorldConfirmQuorum.test.js
+++ b/tests/api/coopWorldConfirmQuorum.test.js
@@ -162,14 +162,20 @@ test('confirmWorld clears any pending proposedWorld', () => {
   assert.equal(co.phase, 'combat');
 });
 
-test('re-propose overwrites the pending proposal; the second params commit', () => {
+test('re-propose clears prior votes; quorum applies to the new proposal only (Codex P2)', () => {
   const co = worldOrch();
   co.proposeWorld({ biomeId: 'foresta' }, { connectedQuorumPids: ['p1'] });
+  // p1 approved proposal A
+  co.voteWorld('p1', { accept: true, allPlayerIds: ['p1'], connectedPlayerIds: ['p1'] });
+  // host changes mind -> re-propose B. p1's accept on A must NOT carry over.
   co.proposeWorld({ biomeId: 'badlands' }, { connectedQuorumPids: ['p1'] });
   assert.equal(co.proposedWorld.biomeId, 'badlands'); // latest wins
+  assert.equal(co.worldVotes.size, 0); // votes reset
+  assert.equal(co.tryAutoConfirmWorld({ allPlayerIds: ['p1'], connectedPlayerIds: ['p1'] }), null); // no auto-commit on the stale vote
+  assert.equal(co.phase, 'world_setup');
+  // p1 re-votes on B -> quorum -> commit
   co.voteWorld('p1', { accept: true, allPlayerIds: ['p1'], connectedPlayerIds: ['p1'] });
-  const r = co.tryAutoConfirmWorld({ allPlayerIds: ['p1'], connectedPlayerIds: ['p1'] });
-  assert.ok(r);
+  assert.ok(co.tryAutoConfirmWorld({ allPlayerIds: ['p1'], connectedPlayerIds: ['p1'] }));
   assert.equal(co.phase, 'combat');
 });
 

--- a/tests/api/coopWorldConfirmQuorum.test.js
+++ b/tests/api/coopWorldConfirmQuorum.test.js
@@ -1,0 +1,306 @@
+// SPEC-K K-02 — co-op world lock-in (host proposes, device quorum commits).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function worldOrch() {
+  const co = new CoopOrchestrator({ roomCode: 'WRLD', hostId: 'p_h' });
+  co.startRun({ scenarioStack: ['enc_test_01'] });
+  co._setPhase('world_setup');
+  return co;
+}
+
+// ---- orchestrator (direct, flag-agnostic) ----
+
+test('proposeWorld throws outside world_setup', () => {
+  const co = new CoopOrchestrator({ roomCode: 'WRLD', hostId: 'p_h' }); // lobby
+  assert.throws(() => co.proposeWorld({}, {}), /not_in_world_setup/);
+});
+
+test('proposeWorld with zero connected voters commits immediately (solo/dev)', () => {
+  const co = worldOrch();
+  const r = co.proposeWorld({}, { connectedQuorumPids: [] });
+  assert.equal(r.committed, true);
+  assert.equal(co.phase, 'combat');
+  assert.equal(co.proposedWorld, null);
+});
+
+test('proposeWorld force:true commits immediately even with connected voters', () => {
+  const co = worldOrch();
+  const r = co.proposeWorld({}, { connectedQuorumPids: ['p1', 'p2'], force: true });
+  assert.equal(r.committed, true);
+  assert.equal(co.phase, 'combat');
+  assert.equal(co.proposedWorld, null);
+});
+
+test('proposeWorld co-op (>=1 connected voter) stashes proposal, no commit', () => {
+  const co = worldOrch();
+  const r = co.proposeWorld({ biomeId: 'foresta' }, { connectedQuorumPids: ['p1'] });
+  assert.equal(r.committed, false);
+  assert.equal(r.proposed, true);
+  assert.equal(r.scenario_id, 'enc_test_01');
+  assert.ok(co.proposedWorld);
+  assert.equal(co.proposedWorld.biomeId, 'foresta');
+  assert.equal(co.phase, 'world_setup'); // NOT advanced
+});
+
+test('tryAutoConfirmWorld returns null when nothing proposed', () => {
+  const co = worldOrch();
+  assert.equal(co.tryAutoConfirmWorld({ allPlayerIds: ['p1'], connectedPlayerIds: ['p1'] }), null);
+  assert.equal(co.phase, 'world_setup');
+});
+
+test('tryAutoConfirmWorld returns null when proposed but quorum not met', () => {
+  const co = worldOrch();
+  co.proposeWorld({}, { connectedQuorumPids: ['p1', 'p2'] });
+  // only p1 accepted -> p2 connected still pending
+  co.voteWorld('p1', {
+    accept: true,
+    allPlayerIds: ['p1', 'p2'],
+    connectedPlayerIds: ['p1', 'p2'],
+  });
+  const r = co.tryAutoConfirmWorld({
+    allPlayerIds: ['p1', 'p2'],
+    connectedPlayerIds: ['p1', 'p2'],
+  });
+  assert.equal(r, null);
+  assert.equal(co.phase, 'world_setup');
+  assert.ok(co.proposedWorld); // still pending
+});
+
+test('propose -> all connected accept -> tryAutoConfirmWorld commits + clears', () => {
+  const co = worldOrch();
+  co.proposeWorld({}, { connectedQuorumPids: ['p1', 'p2'] });
+  co.voteWorld('p1', {
+    accept: true,
+    allPlayerIds: ['p1', 'p2'],
+    connectedPlayerIds: ['p1', 'p2'],
+  });
+  co.voteWorld('p2', {
+    accept: true,
+    allPlayerIds: ['p1', 'p2'],
+    connectedPlayerIds: ['p1', 'p2'],
+  });
+  const r = co.tryAutoConfirmWorld({
+    allPlayerIds: ['p1', 'p2'],
+    connectedPlayerIds: ['p1', 'p2'],
+  });
+  assert.ok(r);
+  assert.equal(r.scenario_id, 'enc_test_01');
+  assert.equal(co.phase, 'combat');
+  assert.equal(co.proposedWorld, null);
+});
+
+test('a reject vote keeps the run in world_setup (no auto-confirm)', () => {
+  const co = worldOrch();
+  co.proposeWorld({}, { connectedQuorumPids: ['p1', 'p2'] });
+  co.voteWorld('p1', {
+    accept: true,
+    allPlayerIds: ['p1', 'p2'],
+    connectedPlayerIds: ['p1', 'p2'],
+  });
+  co.voteWorld('p2', {
+    accept: false,
+    allPlayerIds: ['p1', 'p2'],
+    connectedPlayerIds: ['p1', 'p2'],
+  });
+  assert.equal(
+    co.tryAutoConfirmWorld({ allPlayerIds: ['p1', 'p2'], connectedPlayerIds: ['p1', 'p2'] }),
+    null,
+  );
+  assert.equal(co.phase, 'world_setup');
+});
+
+test('a disconnect dropping the last not-accepted voter completes the quorum', () => {
+  const co = worldOrch();
+  co.proposeWorld({}, { connectedQuorumPids: ['p1', 'p2'] });
+  co.voteWorld('p1', {
+    accept: true,
+    allPlayerIds: ['p1', 'p2'],
+    connectedPlayerIds: ['p1', 'p2'],
+  });
+  // p2 never voted; p2 disconnects -> connected = {p1}, p1 accepted -> quorum
+  const r = co.tryAutoConfirmWorld({ allPlayerIds: ['p1', 'p2'], connectedPlayerIds: ['p1'] });
+  assert.ok(r);
+  assert.equal(co.phase, 'combat');
+});
+
+test('proposedWorld cleared on advanceScenarioOrEnd', () => {
+  const co = worldOrch();
+  // 2-scenario stack so advance lands in next world_setup, not ended.
+  co.run.scenarioStack = ['enc_test_01', 'enc_test_02'];
+  co.proposeWorld({}, { connectedQuorumPids: ['p1'] });
+  assert.ok(co.proposedWorld);
+  co._setPhase('debrief');
+  co.advanceScenarioOrEnd();
+  assert.equal(co.proposedWorld, null);
+});
+
+test('proposedWorld cleared on startRun', () => {
+  const co = worldOrch();
+  co.proposeWorld({}, { connectedQuorumPids: ['p1'] });
+  assert.ok(co.proposedWorld);
+  co._setPhase('ended');
+  co.startRun({ scenarioStack: ['enc_test_01'] });
+  assert.equal(co.proposedWorld, null);
+});
+
+test('confirmWorld clears any pending proposedWorld', () => {
+  const co = worldOrch();
+  co.proposeWorld({}, { connectedQuorumPids: ['p1'] });
+  assert.ok(co.proposedWorld);
+  co.confirmWorld({});
+  assert.equal(co.proposedWorld, null);
+  assert.equal(co.phase, 'combat');
+});
+
+test('re-propose overwrites the pending proposal; the second params commit', () => {
+  const co = worldOrch();
+  co.proposeWorld({ biomeId: 'foresta' }, { connectedQuorumPids: ['p1'] });
+  co.proposeWorld({ biomeId: 'badlands' }, { connectedQuorumPids: ['p1'] });
+  assert.equal(co.proposedWorld.biomeId, 'badlands'); // latest wins
+  co.voteWorld('p1', { accept: true, allPlayerIds: ['p1'], connectedPlayerIds: ['p1'] });
+  const r = co.tryAutoConfirmWorld({ allPlayerIds: ['p1'], connectedPlayerIds: ['p1'] });
+  assert.ok(r);
+  assert.equal(co.phase, 'combat');
+});
+
+// ---- route (flag-gated) ----
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app, lobby };
+}
+
+async function bootstrapWorldSetup(app) {
+  const { body: h } = await request(app).post('/api/lobby/create').send({ host_name: 'H' });
+  const { body: j1 } = await request(app)
+    .post('/api/lobby/join')
+    .send({ code: h.code, player_name: 'Alice' });
+  const { body: j2 } = await request(app)
+    .post('/api/lobby/join')
+    .send({ code: h.code, player_name: 'Bruno' });
+  await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+  await request(app).post('/api/coop/character/create').send({
+    code: h.code,
+    player_id: j1.player_id,
+    player_token: j1.player_token,
+    name: 'Aria',
+    form_id: 'istj',
+  });
+  await request(app).post('/api/coop/character/create').send({
+    code: h.code,
+    player_id: j2.player_id,
+    player_token: j2.player_token,
+    name: 'Bruno',
+    form_id: 'enfp',
+  });
+  return { host: h, p1: j1, p2: j2 };
+}
+
+function markConnected(lobby, code) {
+  const room = lobby.getRoom(code);
+  for (const p of room.players.values()) {
+    if (p.id !== room.hostId && p.role !== 'host') p.connected = true;
+  }
+  return room;
+}
+
+test('flag OFF: POST /coop/world/confirm commits immediately (legacy)', async () => {
+  delete process.env.WORLD_CONFIRM_QUORUM_ENABLED;
+  const { app, lobby } = buildApp();
+  const { host } = await bootstrapWorldSetup(app);
+  markConnected(lobby, host.code);
+  const res = await request(app)
+    .post('/api/coop/world/confirm')
+    .send({ code: host.code, host_token: host.host_token });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.phase, 'combat');
+  assert.ok(res.body.session_start_payload);
+  assert.equal(res.body.proposed, undefined);
+});
+
+test('flag ON + solo (no connected voters): /coop/world/confirm commits immediately', async () => {
+  process.env.WORLD_CONFIRM_QUORUM_ENABLED = 'true';
+  try {
+    const { app } = buildApp();
+    const { host } = await bootstrapWorldSetup(app); // players NOT marked connected
+    const res = await request(app)
+      .post('/api/coop/world/confirm')
+      .send({ code: host.code, host_token: host.host_token });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.phase, 'combat');
+    assert.ok(res.body.session_start_payload);
+  } finally {
+    delete process.env.WORLD_CONFIRM_QUORUM_ENABLED;
+  }
+});
+
+test('flag ON + force: /coop/world/confirm commits immediately despite voters', async () => {
+  process.env.WORLD_CONFIRM_QUORUM_ENABLED = 'true';
+  try {
+    const { app, lobby } = buildApp();
+    const { host } = await bootstrapWorldSetup(app);
+    markConnected(lobby, host.code);
+    const res = await request(app)
+      .post('/api/coop/world/confirm')
+      .send({ code: host.code, host_token: host.host_token, force: true });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.phase, 'combat');
+    assert.ok(res.body.session_start_payload);
+  } finally {
+    delete process.env.WORLD_CONFIRM_QUORUM_ENABLED;
+  }
+});
+
+test('flag ON + co-op: host confirm PROPOSES, device quorum auto-commits', async () => {
+  process.env.WORLD_CONFIRM_QUORUM_ENABLED = 'true';
+  try {
+    const { app, lobby } = buildApp();
+    const { host, p1, p2 } = await bootstrapWorldSetup(app);
+    markConnected(lobby, host.code);
+    // host confirm -> proposes (no commit, no session_start_payload)
+    const propose = await request(app)
+      .post('/api/coop/world/confirm')
+      .send({ code: host.code, host_token: host.host_token });
+    assert.equal(propose.status, 200);
+    assert.equal(propose.body.proposed, true);
+    assert.equal(propose.body.phase, 'world_setup');
+    assert.equal(propose.body.session_start_payload, undefined);
+    // p1 accepts -> still pending (p2 connected, not voted)
+    const v1 = await request(app).post('/api/coop/world/vote').send({
+      code: host.code,
+      player_id: p1.player_id,
+      player_token: p1.player_token,
+      accept: true,
+    });
+    assert.equal(v1.body.phase, 'world_setup');
+    assert.equal(v1.body.world_confirmed, undefined);
+    // p2 accepts -> quorum -> auto-commit
+    const v2 = await request(app).post('/api/coop/world/vote').send({
+      code: host.code,
+      player_id: p2.player_id,
+      player_token: p2.player_token,
+      accept: true,
+    });
+    assert.equal(v2.status, 200);
+    assert.equal(v2.body.world_confirmed, true);
+    assert.equal(v2.body.phase, 'combat');
+    assert.ok(v2.body.session_start_payload);
+  } finally {
+    delete process.env.WORLD_CONFIRM_QUORUM_ENABLED;
+  }
+});


### PR DESCRIPTION
## SPEC-K K-02 — world confirm device quorum

Moves the **final world commit** from a host-only CTA to a **device quorum**, per the active K-spec (matrix 131-132, criterion 9.4, ticket K-02 — the host CTA was a documented `dev fallback` to be "sostituito con device quorum"). Surfaced by the [K-01 audit (#2878)](https://github.com/MasterDD-L34D/Game/pull/2878).

**Flag-gated `WORLD_CONFIRM_QUORUM_ENABLED` default OFF** → legacy host-confirm is byte-identical and **prod is untouched**. Flip gated on the Godot K-02 surface + K-07 real-device playtest + master-dd.

### Mechanism A1 (master-dd approved)
Verify-first found the backend has **no server-side world params** (biome/seed are host-computed Godot `WorldSetupState`, passed fresh to `/confirm`). So a pure "auto-confirm on quorum" can't replay them. A1: the host CTA still **computes + proposes** the world; under the flag it **proposes** (stores params + opens the device vote) instead of committing; the device quorum auto-commits.

- `coopOrchestrator.proposeWorld(params, {connectedQuorumPids, force})` — `force` OR zero connected voters → immediate `confirmWorld` (solo/dev + host anti-deadlock); else stash `proposedWorld` + emit `world_proposed`, **no phase change**.
- `coopOrchestrator.tryAutoConfirmWorld({allPlayerIds, connectedPlayerIds})` — auto-fires `confirmWorld` when `worldTally.all_connected_accepted`; no-op (null) otherwise so callers invoke it unconditionally (safe flag-OFF / nothing proposed).
- `proposedWorld` cleared on startRun / startOnboarding / advanceScenarioOrEnd / confirmWorld.

### Surface parity (mirror K-05)
REST `/coop/world/confirm` (propose) + `/coop/world/vote` (auto-confirm on quorum) + WS `world_confirm` intent + `world_vote` drain + a **world_setup disconnect re-eval branch** (a departing last-pending voter completes the quorum, mirror of the K-05 Nido branch). Host CTA stays as the marked **DEV_FALLBACK** anti-deadlock force path (`force:true`).

### Adversarial review (`coop-phase-validator`)
**No P1.** Phase integrity, empty-set guard (`connected_total>0`), stale-proposal clear, host-gate parity (flag-OFF byte-identical), double-fire protection (`phase!==world_setup` guard), fail-closed — all hold. **4 P2/P3 consistency fixes folded in**: `world_proposed` versioned broadcast (device vote-open trigger), `world_confirm_accepted` broadcast on the disconnect-commit path (symmetry with vote-drain), overwrite-proposal test, `worldTally` JSDoc documents the connected-only veto property.

### Tests
`coopWorldConfirmQuorum` **17/17** (11 orchestrator + 6 route incl. flag-OFF regression, solo/force commit, co-op propose→quorum→auto-confirm, overwrite). Regression: **coop+WS 212/212**, **AI 554/554**, lobby/ws green. `prettier --check` clean.

### Scope / follow-up
- All changes inside `apps/backend/` + `tests/` (no forbidden path).
- **Godot K-02 surface** (host propose UX + phone world-ready + TV recap consuming `world_proposed`/`world_confirm_accepted`) = follow-up cross-repo chip.
- Flip = ops env var + restart, **gated** on the Godot surface + K-07 + master-dd.

### Rollback
Single flag (default OFF). Revert = unset / revert commit; legacy path is the untouched default.