### PR TITLE
docs(coop): SPEC-K K-06 reclassify world-confirm + combat-end comments

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -495,7 +495,11 @@ function createCoopRouter({
   });
 
   router.post('/coop/combat/end', (req, res) => {
-    // Host notifies combat ended (victory/defeat). MVP: host controls.
+    // Host notifies combat ended (victory/defeat). HOST_TECHNICAL (SPEC-K
+    // sez.6.1): the combat->debrief transition is an event-driven notify from
+    // the authoritative combat session, not a host CHOICE of a player-facing
+    // outcome -- so it stays host-arbiter by design, not a migratable gate.
+
     // 2026-05-15 Bundle C follow-up — optional `debrief_payload` carries
     // 4-layer profilo psicologico (per_actor sentience+conviction+ennea) for
     // phone DebriefView parity reveal. Computed by host-side combat resolver

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -542,7 +542,10 @@ class CoopOrchestrator {
 
   /**
    * Confirm scenario for this run. Moves phase world_setup → combat.
-   * Voting logic deferred to M17 (host confirm for MVP).
+   * SPEC-K K-02: under WORLD_CONFIRM_QUORUM_ENABLED this is the committing
+   * primitive the device quorum auto-fires (see tryAutoConfirmWorld); the host
+   * CTA that calls it directly is the marked DEV_FALLBACK / anti-deadlock path,
+   * NOT the production commit. Flag OFF = legacy host-confirm.
    */
   confirmWorld({ scenarioId, biomeId, formAxes, runSeed, trainerCanonical } = {}) {
     if (this.phase !== 'world_setup') throw new Error('not_in_world_setup');


### PR DESCRIPTION
K-06 wording cleanup from the [K-01 audit](https://github.com/MasterDD-L34D/Game/pull/2878). Comment-only:
- `confirmWorld` docstring: clarify it is the commit primitive the K-02 device quorum auto-fires; the host CTA calling it directly is the marked **DEV_FALLBACK**, not the production commit.
- `/coop/combat/end`: "MVP: host controls" -> **HOST_TECHNICAL** (event-driven combat->debrief notify, host-arbiter by design, not a migratable gate per the audit verdict).

(The `voteWorld` docstring was already updated in #2879.) No logic change; parse-verified.