### PR TITLE
docs(spec-k): resolve K-01 design-calls (DC#1/2/4 + 9.5)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -373,6 +373,12 @@ class CoopOrchestrator {
    * @param choice — { option_key, trait_id, label, narrative, auto_selected }
    * @param opts.allPlayerIds — expected device players (enables per-player readiness)
    * @param opts.hostId — host player id (legacy host-only gate when no allPlayerIds)
+   *
+   * SPEC-K K-01 design-call DC#2 (RESOLVED 2026-06-20): the per-player-vs-aggregate
+   * AUTHORITY for onboarding is deferred to SPEC-A/B (K-spec matrix line 129), NOT a
+   * K migration. The per-player device branch already exists here (pass allPlayerIds);
+   * the host-only path is the explicit legacy fallback until SPEC-A/B rules the model
+   * and the Godot client sends per-player onboarding_choice. Not a K build gap.
    */
   submitOnboardingChoice(playerId, choice, { allPlayerIds = [], hostId } = {}) {
     if (this.phase !== 'onboarding') throw new Error('not_in_onboarding');
@@ -1218,6 +1224,13 @@ class CoopOrchestrator {
    * {advance, branch, retreat}. Phase must be `debrief` or `ended` (post
    * debrief auto-advance). Records in `run.lastMacro` for telemetry +
    * downstream UI surface.
+   *
+   * SPEC-K K-01 design-call DC#1 (RESOLVED 2026-06-20, master-dd default):
+   * KEEP host-arbiter (HOST_TECHNICAL), NOT a device quorum. Rationale: this is
+   * run-shell navigation, not a player-facing route choice -- route-vote (K-03)
+   * already owns the node choice, and `retreat` is destructive (ends the run for
+   * everyone), so a bare quorum would be wrong; a migration would need per-player
+   * consent (sez.6.4), not a vote. Not a migration gap.
    *
    * Semantics:
    *  - `advance` — proceed to next scenario in stack. Delegates to

--- a/docs/design/evo-tactics-godot-device-authority-reconciliation.md
+++ b/docs/design/evo-tactics-godot-device-authority-reconciliation.md
@@ -585,3 +585,12 @@ laundering): criterio 3 (route-vote distinzione, PR #2597) e 7 (per-device actio
 Il completamento sez.9 = **item-3 Godot build-residue**, tracciato come K-01..K-07 (sez.10) in
 `BACKLOG.md`. Precedent: SPEC-I/A/G flippate active con forward-work esplicito + runtime/surface
 gated separatamente. Nessuna superficie non-costruita e' spacciata per fatta.
+
+> **Update 2026-06-20 (K-01 design-call 9.5 reconcile, audit PR #2878).** Currency Gate
+> (git > marker): **criterio 5 (Nido phone actions) = MET** -- K-04 DONE e2e 2026-06-18
+> (recruit GGv2 #481 `200ac70` + wound-ritual #479 `eac9232`; `phone_nido_view.gd` ha azioni
+> player-facing). **criterio 4 (world confirm device/quorum) = MET-buildable** -- K-02 DONE
+> (backend #2879 + Godot surface #513, mechanism A1 host-propose/device-commit, flag
+> `WORLD_CONFIRM_QUORUM_ENABLED` OFF). Resta **UNMET solo il criterio 9 (real-device playtest
+> TV+telefoni)** = K-07. SPEC-K item-3 = **6/7 DONE**; surface_role table (criterio 1) anche
+> depositata (GGv2 #516 registry+map). Sez.13 sopra preservata come snapshot 2026-06-17.

--- a/docs/reports/2026-06-19-spec-k-01-device-authority-surface-audit.md
+++ b/docs/reports/2026-06-19-spec-k-01-device-authority-surface-audit.md
@@ -128,6 +128,14 @@ Authority metadata (sez.8.1) per backend action: `confirmWorld` authority=dev_fa
 4. **Enum mismatch 8.2 (4) vs 9.1 (6)**: quale canonico per la K-01 table? **Default: adotta 9.1 (6 valori)** + patch snippet 8.2.
 5. **Route-vote disconnected-voter persistence** (invariante P1-B ereditato): ratify-or-prune? **Default: prune su disconnect** (mirror world/mission re-eval; un player andato non tiene aperto un quorum), salvo intenzionalita' per reconnect.
 
+### Resolutions (2026-06-20, master-dd "risolvo le 5")
+
+- **DC#1 RESOLVED** -- keep `submitNextMacro` host-arbiter (HOST_TECHNICAL); verdict recorded as a code comment at `coopOrchestrator.submitNextMacro`. Not a migration gap (run-shell nav; route-vote owns node choice; `retreat` would need per-player consent, not a quorum).
+- **DC#2 RESOLVED** -- onboarding per-player-vs-aggregate authority deferred to SPEC-A/B (K-spec matrix 129); the device branch already exists. Comment recorded at `submitOnboardingChoice`. Not a K build.
+- **DC#3 RESOLVED (superseded during K-02 build)** -- the audit's "reuse worldVotes + auto-confirm" default was corrected by a verify-first finding: the backend has NO server-side world params (biome/seed are host-computed), so a propose/lock-in step is required. Master-dd chose **mechanism A1** (host proposes, device quorum commits); shipped in #2879.
+- **DC#4 RESOLVED** -- 6-value enum (crit 9.1) adopted; implemented in the GGv2 registry `scripts/coop/surface_role_registry.gd` (#516).
+- **DC#5 PRESENTED (subjective, code-flagged "Eduardo's call")** -- `routeTally` raw `leading_node_id` still counts a departed voter (the `connected_*` quorum already self-heals). Ratify (persist for reconnect) vs prune (present players decide) is a route-vote outcome semantic + flag-OFF (META_NETWORK_ROUTING) = no current effect. Awaiting master-dd.
+
 ## Contraddizione 9.5 (doc-vs-BACKLOG, anti-pattern #19)
 
 Il criterion **9.5** (phone_nido_view action surface) e' **contraddittorio**: la spec sez.13 (flip-verdict) legge "5 = UNMET", ma il BACKLOG dice **K-04 DONE e2e 2026-06-18** (9.5 MET via recruit GGv2 #481 + wound-ritual #479, merged). Per Currency Gate il git-met (BACKLOG) e' autoritativo -> 9.5 = **MET**, spec sez.13 = **stale**. [master-dd: ratifica patch sez.13 spec -> MET, oppure conferma il gap residuo se sez.13 intende altro]


### PR DESCRIPTION
Resolves 4 of the 5 K-01 design-calls from the [audit #2878](https://github.com/MasterDD-L34D/Game/pull/2878) (master-dd 'risolvo le 5'). Comment + doc only.

- **DC#1** -> keep `submitNextMacro` host-arbiter (HOST_TECHNICAL); not a migration gap (run-shell nav; route-vote owns node choice; `retreat` is destructive). Verdict comment.
- **DC#2** -> onboarding per-player-vs-aggregate authority deferred to **SPEC-A/B** (matrix 129); device branch already exists. Verdict comment.
- **DC#4** -> 6-value enum already adopted + implemented (GGv2 #516 registry).
- **9.5** -> spec sez.13 **reconcile** (additive note, 2026-06-17 snapshot preserved): criterio 5 (Nido phone) = MET (K-04 #481/#479), criterio 4 (world confirm) = MET-buildable (K-02 #2879/#513); **only criterio 9 (real-device playtest) = UNMET** (K-07). SPEC-K item-3 = 6/7 DONE.
- **DC#3** noted superseded (verify-first found no server world-params -> A1 propose/lock-in, shipped #2879).

**DC#5 PRESENTED separately** (route-vote disconnected-voter persistence) -- the code comment flags it 'Eduardo's call' + it is a subjective route-vote outcome semantic, flag-OFF (META_NETWORK_ROUTING). Awaiting master-dd: ratify (persist for reconnect) vs prune (present players decide).

errors=0 docs-governance; coopOrchestrator comment-only (parse-verified).