### PR TITLE
test(coop): use createWsServer close wrapper in finally (Codex P2 #2884 follow-up)

### DIFF
--- a/tests/api/coopReconnectPreservesVotes.test.js
+++ b/tests/api/coopReconnectPreservesVotes.test.js
@@ -208,6 +208,9 @@ test('WS e2e: world-vote survives a real disconnect + reconnect (same token)', a
     aWs.close();
     bWs.close();
   } finally {
-    wsHandle.wss.close();
+    // Use the createWsServer wrapper (clears the heartbeat interval + terminates
+    // any still-connected clients) -- a bare wss.close() leaks the heartbeat and
+    // open sockets if an assertion above throws (Codex P2 #2884).
+    await wsHandle.close();
   }
 });


### PR DESCRIPTION
Codex P2 from [#2884](https://github.com/MasterDD-L34D/Game/pull/2884) that missed the merge window (the PR merged before this fix pushed). The WS e2e test's `finally` called a bare `wss.close()` (only the listener) -> leaks the heartbeat interval + leaves clients connected if an assertion throws, so CI can hang/leak handles on a failure path. Now awaits the `createWsServer().close()` wrapper (clears heartbeat + terminates clients) for deterministic cleanup. Test 4/4 green.