### PR TITLE
fix(coop): emit world_confirm_accepted on REST vote auto-confirm (K-07 smoke)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -274,14 +274,24 @@ function createCoopRouter({
         allPlayerIds: quorumPids(room, orch, playerId),
         connectedPlayerIds: connectedQuorumPids(room, orch),
       });
-      broadcastCoopState(room, orch);
       const out = { phase: orch.phase, tally };
       if (auto) {
+        // K-07 smoke finding: emit world_confirm_accepted on the REST vote path
+        // too, so the device-quorum commit signals the SAME named event whether
+        // the closing vote arrived over WS (wsSession drain) or REST. Without
+        // this, a REST-driven auto-confirm only sent phase_change -- an
+        // event-contract asymmetry vs the WS path.
+        const confirmPayload = { scenario_id: auto.scenario_id, phase: orch.phase };
+        if (auto.enriched_world) Object.assign(confirmPayload, auto.enriched_world);
+        if (typeof room.broadcast === 'function') {
+          room.broadcast({ type: 'world_confirm_accepted', payload: confirmPayload });
+        }
         out.world_confirmed = true;
         out.scenario_id = auto.scenario_id;
         out.session_start_payload = orch.buildSessionStartPayload();
         if (auto.enriched_world) Object.assign(out, auto.enriched_world);
       }
+      broadcastCoopState(room, orch);
       return res.json(out);
     } catch (err) {
       return res.status(400).json({ error: err.message || 'world_vote_failed' });

--- a/tests/api/coopWorldConfirmQuorum.test.js
+++ b/tests/api/coopWorldConfirmQuorum.test.js
@@ -310,3 +310,44 @@ test('flag ON + co-op: host confirm PROPOSES, device quorum auto-commits', async
     delete process.env.WORLD_CONFIRM_QUORUM_ENABLED;
   }
 });
+
+test('flag ON + co-op: REST auto-confirm broadcasts world_confirm_accepted (K-07 smoke finding)', async () => {
+  process.env.WORLD_CONFIRM_QUORUM_ENABLED = 'true';
+  try {
+    const { app, lobby } = buildApp();
+    const { host, p1, p2 } = await bootstrapWorldSetup(app);
+    markConnected(lobby, host.code);
+    // Spy room.broadcast to capture the emitted event types.
+    const room = lobby.getRoom(host.code);
+    const seen = [];
+    const orig = room.broadcast.bind(room);
+    room.broadcast = (msg) => {
+      seen.push(msg);
+      return orig(msg);
+    };
+    await request(app)
+      .post('/api/coop/world/confirm')
+      .send({ code: host.code, host_token: host.host_token });
+    await request(app).post('/api/coop/world/vote').send({
+      code: host.code,
+      player_id: p1.player_id,
+      player_token: p1.player_token,
+      accept: true,
+    });
+    const v2 = await request(app).post('/api/coop/world/vote').send({
+      code: host.code,
+      player_id: p2.player_id,
+      player_token: p2.player_token,
+      accept: true,
+    });
+    assert.equal(v2.body.world_confirmed, true);
+    // The device-quorum commit must emit world_confirm_accepted on the REST vote
+    // path too, not just over WS -- same named event regardless of transport.
+    const confirm = seen.find((m) => m && m.type === 'world_confirm_accepted');
+    assert.ok(confirm, 'world_confirm_accepted broadcast on REST auto-confirm');
+    assert.equal(confirm.payload.phase, 'combat');
+    assert.equal(confirm.payload.scenario_id, v2.body.scenario_id);
+  } finally {
+    delete process.env.WORLD_CONFIRM_QUORUM_ENABLED;
+  }
+});


### PR DESCRIPTION
## K-07 AI smoke finding + fix

Ran a contract-level **K-07 AI smoke** of the SPEC-K K-02 device-quorum flow against a **running backend** (local PORT=3400 shared-WS, `WORLD_CONFIRM_QUORUM_ENABLED=true`, never prod) -- the first cross-stack exercise of the K-02 stack with the flag ON.

**Smoke 8/8** after fix: host propose -> 2-phone vote -> auto-confirm; `world_proposed` + `world_confirm_accepted` broadcasts; host `force:true` immediate commit; disconnect-of-last-voter completes quorum; solo (no connected voters) immediate commit.

**Bug it caught (now fixed):** the device-quorum auto-confirm emitted `world_confirm_accepted` only when the closing vote arrived over **WS** (wsSession drain); the **REST** `/coop/world/vote` path only broadcast `phase_change`. A client keying on `world_confirm_accepted` would miss a REST-driven commit. Now emitted on both transports -- a transport-agnostic event contract.

Regression test spies `room.broadcast` to assert the event fires on REST auto-confirm. coopWorldConfirmQuorum **18/18**, coop+WS **217/217**.

> Note: this is the **contract-level** AI smoke. K-07's real-device playtest (2 phones + TV, Godot rendering) remains master-dd hands -- this de-risks it.