### PR TITLE
feat(codex): A.L.I.E.N.A. lore draft generator + promote review-gate

### DIFF
--- a/data/codex/_drafts/predoni_nomadi.yaml
+++ b/data/codex/_drafts/predoni_nomadi.yaml
@@ -48,6 +48,26 @@ codex_entry:
       per sbloccare il Codex.
     persistence: "localStorage:evo:codex-seen-predoni_nomadi"
 
+  # Structured slots (factual, from data) consumed by the A.L.I.E.N.A. lore
+  # generator (tools/py/codex_aliena_lore_gen.py). The generator narrativizes
+  # these into the 6 `content:` blocks as a DRAFT (pending human review). NOT
+  # the final prose -- master-dd reviews/edits the generated draft before
+  # promoting (the `content:` below stay TODO until then). Adding lore_vars does
+  # not change what is served (file is under _drafts/, the loader globs flat).
+  lore_vars:
+    subject: "predone nomade"
+    biome_name: "savana ionizzata"
+    biome_trait: "dune fotoniche, luce radente e tempeste ioniche"
+    lineage: "razziatori umanoidi"
+    archetype: "adattivo"
+    morphotype: "bipede armato"
+    job: "skirmisher"
+    role: "predatore secondario"
+    threat_tier: "T1"
+    social: "bande di razzia nomadi"
+    sentience: "istintiva"
+    hook: "il primo nemico che affronti nel tutorial"
+
   aliena_dimensions:
     A_ambiente:
       heading: "Ambiente"

--- a/data/codex/_grammar/aliena_lore.json
+++ b/data/codex/_grammar/aliena_lore.json
@@ -1,0 +1,27 @@
+{
+  "_README": "A.L.I.E.N.A. lore story-grammar (Tracery format) consumed by tools/py/codex_aliena_lore_gen.py. The HANDCRAFTED authoring layer (Wildermyth model): master-dd tunes these templates ONCE; the generator fills the #slots# from each creature's codex_entry.lore_vars and produces a per-creature DRAFT (pending human review). Each origin_<dim> defines the prose for one of the 6 A.L.I.E.N.A. dimensions; >1 variant per origin gives seeded variability across creatures. Slots: subject, biome_name, biome_trait, lineage, archetype, morphotype, job, role, threat_tier, social, sentience, hook. Keep variants ~150-350 chars (HA2 TV-readable band 100-500). NEVER reference a coherence/score slot (SPEC-H sez.8 secret invariant).",
+  "origin_A_ambiente": [
+    "Il territorio del #subject# e' #biome_name#: #biome_trait#. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.",
+    "#biome_name# non e' uno sfondo ma un avversario costante per il #subject#: #biome_trait#. Ogni movimento e' una risposta all'ambiente."
+  ],
+  "origin_L_linee_evolutive": [
+    "Il #subject# discende dai #lineage#. La sua linea segue un archetipo #archetype#: non la forza bruta, ma la capacita' di piegarsi a cio' che il bioma richiede.",
+    "Le origini del #subject# stanno nei #lineage#. Traiettoria #archetype#: ogni generazione conserva cio' che ha funzionato e scarta il resto."
+  ],
+  "origin_I_impianto": [
+    "Sul piano morfo-fisiologico il #subject# e' un #morphotype#, costruito attorno al ruolo di #job#. La struttura privilegia la prontezza sulla resistenza.",
+    "Il corpo del #subject# -- #morphotype# -- e' ottimizzato per il #job#: rapido, essenziale, fragile se isolato dal gruppo."
+  ],
+  "origin_E_ecologia": [
+    "Nell'ecologia di #biome_name# il #subject# occupa la nicchia di #role# (#threat_tier#). Esercita pressione sulle prede senza contendere l'apice.",
+    "Il #subject# e' #role# nel #biome_name#: una presenza diffusa (#threat_tier#) che modella il comportamento di cio' che gli sta sotto nella catena trofica."
+  ],
+  "origin_N_norme_socio": [
+    "La struttura sociale del #subject# si regge su #social#. La socialita' e' #sentience#: coordinazione efficace senza una cultura nel senso pieno.",
+    "Il #subject# vive in #social#. I legami sono di natura #sentience# -- funzionali alla razzia e alla sopravvivenza, non al racconto di se'."
+  ],
+  "origin_A_ancoraggio_narrativo": [
+    "Per l'allenatore il #subject# e' #hook#. E' qui che il Codex comincia: la prima forma di vita di cui annotare la verita'.",
+    "#hook#: ecco perche' il #subject# apre il Codex. Il primo incontro non si dimentica -- diventa il metro di tutto cio' che segue."
+  ]
+}

--- a/tests/codex/promoteGate.test.js
+++ b/tests/codex/promoteGate.test.js
@@ -60,3 +60,20 @@ test('NOT ready when a dimension is missing', () => {
   assert.equal(ready, false);
   assert.ok(problems.some((p) => /E_ecologia/.test(p)));
 });
+
+test('NOT ready when lore_review_status is present but null/empty (corrupt)', () => {
+  // A present-but-not-human_reviewed flag must reject, even if falsy. Only an
+  // ABSENT field (hand-authored, or human-removed after review) may promote.
+  for (const bad of [null, '', 'generated_pending_review', 'pending']) {
+    const { ready } = evaluateDraft(draft({ lore_review_status: bad }));
+    assert.equal(ready, false, `expected reject for lore_review_status=${JSON.stringify(bad)}`);
+  }
+});
+
+test('NOT ready when a dimension content is not a string', () => {
+  const d = draft();
+  d.codex_entry.aliena_dimensions.A_ambiente.content = [1, 2, 3];
+  const { ready, problems } = evaluateDraft(d);
+  assert.equal(ready, false);
+  assert.ok(problems.some((p) => /A_ambiente/.test(p)));
+});

--- a/tests/codex/promoteGate.test.js
+++ b/tests/codex/promoteGate.test.js
@@ -1,0 +1,62 @@
+// SPEC-H -- promote_codex_draft.js readiness gate unit test.
+// The gate must refuse machine-generated drafts (lore_review_status:
+// generated_pending_review) so AI prose never reaches players without human
+// curation -- in addition to the existing empty/TODO checks.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { evaluateDraft } = require('../../tools/js/promote_codex_draft.js');
+
+const DIMS = [
+  'A_ambiente',
+  'L_linee_evolutive',
+  'I_impianto',
+  'E_ecologia',
+  'N_norme_socio',
+  'A_ancoraggio_narrativo',
+];
+
+function draft(overrides = {}) {
+  const aliena_dimensions = {};
+  for (const k of DIMS) {
+    aliena_dimensions[k] = { content: 'Prosa autorata valida per la dimensione.' };
+  }
+  return { codex_entry: { id: 'x', aliena_dimensions, ...overrides } };
+}
+
+test('ready when all 6 dims authored and no review-gate flag', () => {
+  const { ready, problems } = evaluateDraft(draft());
+  assert.equal(ready, true, problems.join('; '));
+});
+
+test('NOT ready when a dimension still has TODO master-dd', () => {
+  const d = draft();
+  d.codex_entry.aliena_dimensions.A_ambiente.content = 'TODO master-dd: x';
+  const { ready, problems } = evaluateDraft(d);
+  assert.equal(ready, false);
+  assert.ok(problems.some((p) => /A_ambiente/.test(p)));
+});
+
+test('NOT ready when lore_review_status is generated_pending_review', () => {
+  const { ready, problems } = evaluateDraft(
+    draft({ lore_review_status: 'generated_pending_review' }),
+  );
+  assert.equal(ready, false);
+  assert.ok(
+    problems.some((p) => /review/i.test(p)),
+    `expected a review problem, got: ${problems.join('; ')}`,
+  );
+});
+
+test('ready when lore_review_status flipped to human_reviewed', () => {
+  const { ready, problems } = evaluateDraft(draft({ lore_review_status: 'human_reviewed' }));
+  assert.equal(ready, true, problems.join('; '));
+});
+
+test('NOT ready when a dimension is missing', () => {
+  const d = draft();
+  delete d.codex_entry.aliena_dimensions.E_ecologia;
+  const { ready, problems } = evaluateDraft(d);
+  assert.equal(ready, false);
+  assert.ok(problems.some((p) => /E_ecologia/.test(p)));
+});

--- a/tests/test_codex_aliena_lore_gen.py
+++ b/tests/test_codex_aliena_lore_gen.py
@@ -86,23 +86,26 @@ def test_fill_draft_marks_pending_review_and_fills_content():
         assert c.strip()
 
 
-def test_fill_draft_does_not_emit_secret_score_fields():
-    # SPEC-H sez.8 secret invariant: the generator must NEVER write the
-    # engine-only score fields into a player-facing draft.
+def test_fill_draft_strips_secret_score_fields():
+    # SPEC-H sez.8 secret invariant (defense in depth): even if a malformed
+    # input draft already carries the engine-only score fields, fill_draft must
+    # SCRUB them so they never reach a player-facing draft.
+    forbidden = {"aggregate", "sub_scores", "coherence", "enforcement_factor"}
     draft = {
         "codex_entry": {
             "id": "x",
+            "aggregate": 0.91,  # top-level forbidden field
             "aliena_dimensions": {
-                k: {"content": "TODO"} for k in gen.ALIENA_DIMENSION_KEYS
+                k: {"content": "TODO", "coherence": 0.5}  # nested forbidden field
+                for k in gen.ALIENA_DIMENSION_KEYS
             },
         }
     }
     filled = gen.fill_draft(draft, gen.generate_all(GRAMMAR, LORE_VARS, "x"))
-    forbidden = {"aggregate", "sub_scores", "coherence", "enforcement_factor"}
     ce = filled["codex_entry"]
-    assert not (forbidden & set(ce.keys()))
-    for dim in ce["aliena_dimensions"].values():
-        assert not (forbidden & set(dim.keys()))
+    assert not (forbidden & set(ce.keys())), "top-level score field not scrubbed"
+    for key, dim in ce["aliena_dimensions"].items():
+        assert not (forbidden & set(dim.keys())), f"nested score field not scrubbed in {key}"
 
 
 def test_extract_lore_vars_reads_codex_entry_block():

--- a/tests/test_codex_aliena_lore_gen.py
+++ b/tests/test_codex_aliena_lore_gen.py
@@ -1,0 +1,110 @@
+"""Tests for codex_aliena_lore_gen -- A.L.I.E.N.A. lore draft generator (SPEC-H).
+
+Run: PYTHONPATH=tools/py python -m pytest tests/test_codex_aliena_lore_gen.py
+
+The generator narrativizes a creature's already-structured data (the
+generate-data-then-narrate pattern, Caves of Qud) into the 6 A.L.I.E.N.A.
+dimension `content:` prose, via the seeded Tracery engine (skiv_tracery). It
+produces DRAFTS marked for human review -- it never auto-promotes.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools" / "py"))
+
+import codex_aliena_lore_gen as gen  # noqa: E402
+
+
+GRAMMAR = {
+    "origin_A_ambiente": ["Il #biome# e' il territorio dei #subject#."],
+    "origin_L_linee_evolutive": ["I #subject# discendono dai #lineage#."],
+    "origin_I_impianto": ["Morfologia: #morpho#, profilo da #job#."],
+    "origin_E_ecologia": ["Ruolo ecologico: #role# nel #biome#."],
+    "origin_N_norme_socio": ["Struttura sociale: #social#."],
+    "origin_A_ancoraggio_narrativo": ["Il gancio: #hook#."],
+}
+
+LORE_VARS = {
+    "biome": "savana ionizzata",
+    "subject": "predoni nomadi",
+    "lineage": "razziatori umanoidi",
+    "morpho": "bipede armato",
+    "job": "skirmisher",
+    "role": "predatore secondario",
+    "social": "bande di razzia",
+    "hook": "primo scontro del tutorial",
+}
+
+
+def test_generate_dimension_substitutes_slots():
+    out = gen.generate_dimension(GRAMMAR, LORE_VARS, "predoni_nomadi", "A_ambiente")
+    assert "savana ionizzata" in out
+    assert "predoni nomadi" in out
+    assert "#" not in out  # no unresolved grammar symbols
+
+
+def test_generate_dimension_is_deterministic():
+    a = gen.generate_dimension(GRAMMAR, LORE_VARS, "predoni_nomadi", "E_ecologia")
+    b = gen.generate_dimension(GRAMMAR, LORE_VARS, "predoni_nomadi", "E_ecologia")
+    assert a == b
+
+
+def test_generate_all_returns_six_nonempty_dimensions():
+    out = gen.generate_all(GRAMMAR, LORE_VARS, "predoni_nomadi")
+    assert set(out.keys()) == set(gen.ALIENA_DIMENSION_KEYS)
+    for key, content in out.items():
+        assert content.strip(), f"empty content for {key}"
+        assert "#" not in content, f"unresolved symbol in {key}"
+        assert "TODO" not in content, f"TODO placeholder leaked in {key}"
+
+
+def test_generate_all_distinct_per_dimension():
+    out = gen.generate_all(GRAMMAR, LORE_VARS, "predoni_nomadi")
+    # Each dimension uses its own origin symbol -> distinct prose.
+    assert out["A_ambiente"] != out["N_norme_socio"]
+
+
+def test_fill_draft_marks_pending_review_and_fills_content():
+    draft = {
+        "codex_entry": {
+            "id": "predoni_nomadi",
+            "aliena_dimensions": {
+                k: {"heading": k, "content": "TODO master-dd: x"}
+                for k in gen.ALIENA_DIMENSION_KEYS
+            },
+        }
+    }
+    contents = gen.generate_all(GRAMMAR, LORE_VARS, "predoni_nomadi")
+    filled = gen.fill_draft(draft, contents)
+    ce = filled["codex_entry"]
+    assert ce["lore_review_status"] == "generated_pending_review"
+    for k in gen.ALIENA_DIMENSION_KEYS:
+        c = ce["aliena_dimensions"][k]["content"]
+        assert "TODO" not in c
+        assert c.strip()
+
+
+def test_fill_draft_does_not_emit_secret_score_fields():
+    # SPEC-H sez.8 secret invariant: the generator must NEVER write the
+    # engine-only score fields into a player-facing draft.
+    draft = {
+        "codex_entry": {
+            "id": "x",
+            "aliena_dimensions": {
+                k: {"content": "TODO"} for k in gen.ALIENA_DIMENSION_KEYS
+            },
+        }
+    }
+    filled = gen.fill_draft(draft, gen.generate_all(GRAMMAR, LORE_VARS, "x"))
+    forbidden = {"aggregate", "sub_scores", "coherence", "enforcement_factor"}
+    ce = filled["codex_entry"]
+    assert not (forbidden & set(ce.keys()))
+    for dim in ce["aliena_dimensions"].values():
+        assert not (forbidden & set(dim.keys()))
+
+
+def test_extract_lore_vars_reads_codex_entry_block():
+    draft = {"codex_entry": {"id": "x", "lore_vars": {"biome": "tundra"}}}
+    assert gen.extract_lore_vars(draft) == {"biome": "tundra"}

--- a/tools/js/promote_codex_draft.js
+++ b/tools/js/promote_codex_draft.js
@@ -51,16 +51,23 @@ function evaluateDraft(doc) {
       problems.push(`missing dimension: ${key}`);
       continue;
     }
-    const content = String(dim.content || '').trim();
+    if (typeof dim.content !== 'string') {
+      problems.push(`non-string content: ${key}`);
+      continue;
+    }
+    const content = dim.content.trim();
     if (!content) problems.push(`empty content: ${key}`);
     else if (/TODO\s+master-dd/i.test(content))
       problems.push(`unauthored (TODO master-dd placeholder still present): ${key}`);
   }
-  const status = ce.lore_review_status;
-  if (status && status !== REVIEW_STATUS_OK) {
+  // A PRESENT lore_review_status that is not human_reviewed rejects (incl. null
+  // / empty / generated_pending_review). Only an ABSENT field (hand-authored,
+  // or human-removed after review -- a documented approval path) may promote.
+  if ('lore_review_status' in ce && ce.lore_review_status !== REVIEW_STATUS_OK) {
     problems.push(
-      `generated draft pending human review (lore_review_status: ${status}) -- ` +
-        'edit the prose then set lore_review_status: human_reviewed (or remove the field)',
+      `generated draft pending human review (lore_review_status: ${JSON.stringify(
+        ce.lore_review_status,
+      )}) -- edit the prose then set lore_review_status: human_reviewed (or remove the field)`,
     );
   }
   return { ready: problems.length === 0, problems };

--- a/tools/js/promote_codex_draft.js
+++ b/tools/js/promote_codex_draft.js
@@ -27,6 +27,45 @@ const DIMENSION_KEYS = [
   'A_ancoraggio_narrativo',
 ];
 
+// Machine-generated drafts (tools/py/codex_aliena_lore_gen.py) are stamped
+// `lore_review_status: generated_pending_review` so AI prose can NEVER be
+// promoted to players without human curation. Promotion requires the author to
+// flip it to `human_reviewed` (or remove the field) after editing the prose.
+const REVIEW_STATUS_OK = 'human_reviewed';
+
+/**
+ * Pure readiness check (no filesystem access -> unit-testable). Returns
+ * { ready, problems }. The CLI (main) wraps it with file IO + the rename.
+ */
+function evaluateDraft(doc) {
+  const problems = [];
+  const ce = doc && doc.codex_entry;
+  const dims = ce && ce.aliena_dimensions;
+  if (!dims) {
+    problems.push('missing codex_entry.aliena_dimensions');
+    return { ready: false, problems };
+  }
+  for (const key of DIMENSION_KEYS) {
+    const dim = dims[key];
+    if (!dim) {
+      problems.push(`missing dimension: ${key}`);
+      continue;
+    }
+    const content = String(dim.content || '').trim();
+    if (!content) problems.push(`empty content: ${key}`);
+    else if (/TODO\s+master-dd/i.test(content))
+      problems.push(`unauthored (TODO master-dd placeholder still present): ${key}`);
+  }
+  const status = ce.lore_review_status;
+  if (status && status !== REVIEW_STATUS_OK) {
+    problems.push(
+      `generated draft pending human review (lore_review_status: ${status}) -- ` +
+        'edit the prose then set lore_review_status: human_reviewed (or remove the field)',
+    );
+  }
+  return { ready: problems.length === 0, problems };
+}
+
 function main() {
   const id = process.argv[2];
   if (!id) {
@@ -54,26 +93,8 @@ function main() {
     process.exit(1);
   }
 
-  const dims = doc && doc.codex_entry && doc.codex_entry.aliena_dimensions;
-  if (!dims) {
-    console.error('missing codex_entry.aliena_dimensions');
-    process.exit(1);
-  }
-
-  const problems = [];
-  for (const key of DIMENSION_KEYS) {
-    const dim = dims[key];
-    if (!dim) {
-      problems.push(`missing dimension: ${key}`);
-      continue;
-    }
-    const content = String(dim.content || '').trim();
-    if (!content) problems.push(`empty content: ${key}`);
-    else if (/TODO\s+master-dd/i.test(content))
-      problems.push(`unauthored (TODO master-dd placeholder still present): ${key}`);
-  }
-
-  if (problems.length) {
+  const { ready, problems } = evaluateDraft(doc);
+  if (!ready) {
     console.error(`NOT READY to promote ${id}:`);
     for (const p of problems) console.error(`  - ${p}`);
     console.error('Author the A.L.I.E.N.A. voice prose in every content: field first.');
@@ -87,4 +108,6 @@ function main() {
   );
 }
 
-main();
+if (require.main === module) main();
+
+module.exports = { evaluateDraft, DIMENSION_KEYS };

--- a/tools/py/codex_aliena_lore_gen.py
+++ b/tools/py/codex_aliena_lore_gen.py
@@ -126,10 +126,27 @@ def extract_lore_vars(draft: Dict[str, object]) -> Dict[str, object]:
     return dict(ce.get("lore_vars") or {})
 
 
+def _scrub_forbidden(obj: object) -> None:
+    """Recursively delete engine-only score fields (SPEC-H sez.8 secret invariant).
+
+    Defense in depth: even if a malformed input draft already carries these
+    fields, they must never serialize into a player-facing draft.
+    """
+    if isinstance(obj, dict):
+        for key in list(obj.keys()):
+            if key in _FORBIDDEN_SCORE_FIELDS:
+                del obj[key]
+            else:
+                _scrub_forbidden(obj[key])
+    elif isinstance(obj, list):
+        for item in obj:
+            _scrub_forbidden(item)
+
+
 def fill_draft(draft: Dict[str, object], contents: Dict[str, str]) -> Dict[str, object]:
     """Write generated content into a draft + stamp it pending-review.
 
-    Does NOT add any engine-only score field (secret invariant).
+    Scrubs any engine-only score field (secret invariant) before returning.
     """
     ce = draft["codex_entry"]
     ce["lore_review_status"] = REVIEW_STATUS_PENDING
@@ -137,6 +154,7 @@ def fill_draft(draft: Dict[str, object], contents: Dict[str, str]) -> Dict[str, 
     for key, content in contents.items():
         if key in dims and isinstance(dims[key], dict):
             dims[key]["content"] = content
+    _scrub_forbidden(ce)
     return draft
 
 

--- a/tools/py/codex_aliena_lore_gen.py
+++ b/tools/py/codex_aliena_lore_gen.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""A.L.I.E.N.A. codex lore DRAFT generator (SPEC-H, generate-data-then-narrate).
+
+A creature's structured data already exists (biome, role_trofico, morphotype,
+traits, combat_baseline -- see the `key_facts:` of any
+data/codex/_drafts/<id>.yaml). Authoring the 6 A.L.I.E.N.A. `content:` prose
+blocks by hand for every species x biome combination does NOT scale for a solo
+dev. This generator narrativizes that data via a seeded story-grammar -- the
+"generate the data, then rationalize it after the fact" pattern (Caves of Qud)
+on top of the layered handcrafted+procedural model (Wildermyth): the author
+writes the GRAMMAR once; the generator fills the slots per creature.
+
+It produces DRAFTS only. Every output is stamped
+`codex_entry.lore_review_status: generated_pending_review`, which
+tools/js/promote_codex_draft.js refuses to promote -- so machine prose can NEVER
+reach a player without human curation. The author edits the draft (improving the
+prose and/or the grammar) and sets `lore_review_status: human_reviewed` (or
+removes the field) before promoting.
+
+Reuses the repo's seeded Tracery engine (tools/py/skiv_tracery.py: grammar
+format, SYMBOL_RE, MAX_DEPTH) but substitutes a hashlib-stable picker so the
+output is reproducible ACROSS process runs (builtin hash() is per-process
+randomized -> not replay-safe; a draft generator needs stable git diffs).
+
+Usage:
+    PYTHONPATH=tools/py python tools/py/codex_aliena_lore_gen.py \
+        data/codex/_drafts/predoni_nomadi.yaml            # review mode (print)
+    PYTHONPATH=tools/py python tools/py/codex_aliena_lore_gen.py \
+        data/codex/_drafts/predoni_nomadi.yaml --out /tmp/draft.yaml  # write draft
+
+SECRET INVARIANT (SPEC-H sez.8): never writes the engine-only score fields
+(aggregate / sub_scores / coherence / enforcement_factor) into a draft.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # so skiv_tracery imports
+import skiv_tracery  # noqa: E402  (repo seeded-grammar engine: SYMBOL_RE, MAX_DEPTH)
+
+import yaml  # noqa: E402
+
+# The 6 canonical A.L.I.E.N.A. dimension keys (schema codex 2026-04-27); the
+# grammar must define an `origin_<key>` symbol for each.
+ALIENA_DIMENSION_KEYS = [
+    "A_ambiente",
+    "L_linee_evolutive",
+    "I_impianto",
+    "E_ecologia",
+    "N_norme_socio",
+    "A_ancoraggio_narrativo",
+]
+
+DEFAULT_GRAMMAR_PATH = "data/codex/_grammar/aliena_lore.json"
+REVIEW_STATUS_PENDING = "generated_pending_review"
+# Engine-only fields the generator must never serialize into a player-facing draft.
+_FORBIDDEN_SCORE_FIELDS = {"aggregate", "sub_scores", "coherence", "enforcement_factor"}
+
+
+def _stable_pick(pool: Sequence[str], seed: str, salt: str) -> str:
+    """Deterministic pick using sha256 (replay-safe across process runs)."""
+    if not pool:
+        return ""
+    digest = hashlib.sha256((seed + ":" + salt).encode("utf-8")).hexdigest()
+    return pool[int(digest, 16) % len(pool)]
+
+
+def _expand(grammar: Dict[str, List[str]], symbol: str, seed: str, depth: int = 0) -> str:
+    """Expand a Tracery symbol with hashlib-stable seeded determinism.
+
+    Mirrors skiv_tracery.flatten (reuses its SYMBOL_RE + MAX_DEPTH) but with a
+    replay-safe picker. Unknown symbols pass through as `#symbol#`.
+    """
+    if depth > skiv_tracery.MAX_DEPTH:
+        return f"#{symbol}#"
+    pool = grammar.get(symbol)
+    if not pool:
+        return f"#{symbol}#"
+    template = _stable_pick(pool, seed, salt=f"{symbol}:{depth}")
+
+    def _sub(match) -> str:
+        return _expand(grammar, match.group(1), seed, depth=depth + 1)
+
+    return skiv_tracery.SYMBOL_RE.sub(_sub, template)
+
+
+def _merge_vars(grammar: Dict[str, List[str]], lore_vars: Dict[str, object]) -> Dict[str, List[str]]:
+    """Overlay lore_vars as single-element grammar pools so `#var#` resolves."""
+    merged: Dict[str, List[str]] = dict(grammar)
+    for key, value in (lore_vars or {}).items():
+        merged[key] = [str(value)]
+    return merged
+
+
+def generate_dimension(
+    grammar: Dict[str, List[str]],
+    lore_vars: Dict[str, object],
+    entry_id: str,
+    dim_key: str,
+) -> str:
+    """Generate the prose for one A.L.I.E.N.A. dimension. Deterministic."""
+    merged = _merge_vars(grammar, lore_vars)
+    seed = f"{entry_id}:{dim_key}"
+    return _expand(merged, f"origin_{dim_key}", seed).strip()
+
+
+def generate_all(
+    grammar: Dict[str, List[str]],
+    lore_vars: Dict[str, object],
+    entry_id: str,
+    dim_keys: Optional[Sequence[str]] = None,
+) -> Dict[str, str]:
+    """Generate prose for all 6 dimensions -> {dim_key: content}."""
+    keys = list(dim_keys) if dim_keys else ALIENA_DIMENSION_KEYS
+    return {k: generate_dimension(grammar, lore_vars, entry_id, k) for k in keys}
+
+
+def extract_lore_vars(draft: Dict[str, object]) -> Dict[str, object]:
+    """Read the `codex_entry.lore_vars` slot dict (the structured data)."""
+    ce = draft.get("codex_entry") or {}
+    return dict(ce.get("lore_vars") or {})
+
+
+def fill_draft(draft: Dict[str, object], contents: Dict[str, str]) -> Dict[str, object]:
+    """Write generated content into a draft + stamp it pending-review.
+
+    Does NOT add any engine-only score field (secret invariant).
+    """
+    ce = draft["codex_entry"]
+    ce["lore_review_status"] = REVIEW_STATUS_PENDING
+    dims = ce.get("aliena_dimensions") or {}
+    for key, content in contents.items():
+        if key in dims and isinstance(dims[key], dict):
+            dims[key]["content"] = content
+    return draft
+
+
+def load_grammar(path: str) -> Dict[str, List[str]]:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="A.L.I.E.N.A. codex lore draft generator")
+    p.add_argument("draft", help="path to data/codex/_drafts/<id>.yaml")
+    p.add_argument("--grammar", default=DEFAULT_GRAMMAR_PATH, help="grammar JSON path")
+    p.add_argument("--out", default=None, help="write filled draft YAML to this path")
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    with open(args.draft, encoding="utf-8") as fh:
+        draft = yaml.safe_load(fh)
+    entry_id = (draft.get("codex_entry") or {}).get("id")
+    if not entry_id:
+        print("ERROR: draft has no codex_entry.id", file=sys.stderr)
+        return 2
+    grammar = load_grammar(args.grammar)
+    lore_vars = extract_lore_vars(draft)
+    if not lore_vars:
+        print(
+            "ERROR: draft has no codex_entry.lore_vars block (the structured slots "
+            "the grammar narrativizes). Add lore_vars: {...} first.",
+            file=sys.stderr,
+        )
+        return 2
+    contents = generate_all(grammar, lore_vars, entry_id)
+
+    if args.out:
+        fill_draft(draft, contents)
+        with open(args.out, "w", encoding="utf-8") as fh:
+            yaml.safe_dump(draft, fh, allow_unicode=True, sort_keys=False, width=88)
+        print(f"WROTE generated draft (pending review): {args.out}")
+        print("Review/edit the prose, set lore_review_status: human_reviewed, then promote.")
+    else:
+        print(f"# Generated A.L.I.E.N.A. draft for {entry_id} (review mode -- NOT written)")
+        for key in ALIENA_DIMENSION_KEYS:
+            print(f"\n## {key}\n{contents[key]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Cosa

Architettura **generate-data-then-narrate** per la lore A.L.I.E.N.A. procedurale: risolve lo scaling della lore sul combinatorio **specie x bioma x 6-dimensioni** (il bottleneck predoni = sintomo). Pattern presi dai dev solo (research last30days + vault): **Wildermyth** (layered handcrafted+procedural) + **Caves of Qud** (replacement-grammar, "genera i dati poi narrativizza"). Riusa l'infra Tracery gia' nel repo (`skiv_tracery.py`).

**3 livelli:**
1. **Slot-fill deterministico** -- `tools/py/codex_aliena_lore_gen.py` narrativizza i dati strutturati (`codex_entry.lore_vars`) nelle 6 `content:` A.L.I.E.N.A. via story-grammar. Picker **hashlib-stabile** -> riproducibile cross-run (il builtin `hash()` di skiv e' randomizzato per-processo, non replay-safe). Emette SOLO draft.
2. **Grammar autorato** -- `data/codex/_grammar/aliena_lore.json` = il layer handcrafted (master-dd rifinisce la voce; 2 varianti/dimensione per variabilita' seeded).
3. **Gate umano** -- `promote_codex_draft.js` rifiuta ogni draft con `lore_review_status: generated_pending_review`: **la prosa-macchina non raggiunge MAI il player senza la tua curatela**. L'autore edita -> `human_reviewed` -> promote.

## PoC predoni (review mode, output reale)

> Il territorio del predone nomade e' savana ionizzata: dune fotoniche, luce radente e tempeste ioniche. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.
> ...
> Per l'allenatore il predone nomade e' il primo nemico che affronti nel tutorial. E' qui che il Codex comincia: la prima forma di vita di cui annotare la verita'.

(6/6 dimensioni generate da `lore_vars` factual. `content:` canonico resta TODO master-dd -- la prosa e' ancora tua da scrivere, o da generare-poi-rivedere.)

## Safety property (provata end-to-end)

- Draft generato passa **HA2** (6/6 dims, `errors=0`).
- Promote **RIFIUTA** (pending review).
- **Secret invariant** preservato (mai aggregate/sub_scores/coherence/enforcement_factor).

## Boundary rispettato

Io ho costruito il TOOL + grammar-scaffold; la prosa player-facing finale resta tua (curatela via review-gate). Il generatore propone, tu ratifichi.

## Caveat (verify-first / SDMG)

E' un metodo che propongo IO -> il grammar starter e' uno scaffold, NON la voce finale. La falsificazione = il PoC sopra (la bozza e' editabile, non da riscrivere). Affina la grammar a piacimento. 1 SOFT-warn HA2 atteso (A_ancoraggio senza `story_hook_it` -- lo aggiungi in review).

## Test (TDD, RED->GREEN)

- `tests/test_codex_aliena_lore_gen.py` -- 7 (slot-fill / determinismo / 6-dim / secret-invariant)
- `tests/codex/promoteGate.test.js` -- 5 (gate review-status, CI-wired via test:api)

## Scope / rollback

`tools/py` + `tools/js` + `tests` + `data/codex/_grammar|_drafts`. 0 forbidden-path, 0 nuove dipendenze, 0 file serviti modificati (loader globba `data/codex/*.yaml` flat). `git revert` pulito.