### PR TITLE
fix(codex): aliena grammar job-article concordance

### DIFF
--- a/data/codex/_grammar/aliena_lore.json
+++ b/data/codex/_grammar/aliena_lore.json
@@ -10,7 +10,7 @@
   ],
   "origin_I_impianto": [
     "Sul piano morfo-fisiologico il #subject# e' un #morphotype#, costruito attorno al ruolo di #job#. La struttura privilegia la prontezza sulla resistenza.",
-    "Il corpo del #subject# -- #morphotype# -- e' ottimizzato per il #job#: rapido, essenziale, fragile se isolato dal gruppo."
+    "Il corpo del #subject# -- #morphotype# -- e' ottimizzato per il ruolo di #job#: rapido, essenziale, fragile se isolato dal gruppo."
   ],
   "origin_E_ecologia": [
     "Nell'ecologia di #biome_name# il #subject# occupa la nicchia di #role# (#threat_tier#). Esercita pressione sulle prede senza contendere l'apice.",


### PR DESCRIPTION
## Cosa

`origin_I_impianto` variante 2 generava "ottimizzato per il #job#" -> "per il skirmisher" (articolo sbagliato per nomi s+consonante / vocale). Riformulo "per il **ruolo di** #job#": l'articolo concorda con "ruolo", corretto per QUALSIASI valore-slot (no logica lo/il/l' per-valore). Fix strutturale 1-riga.

Regen predoni verificato: "ottimizzato per il ruolo di skirmisher". pytest 7/7.

Follow-up del PoC #2907 (master-dd ha chiesto il fix del nit). #2907 mostra ancora il testo pre-fix -- rigenerabile dopo merge se vuoi (o lo editi in review).

## Scope / rollback

Data-only (1 riga JSON grammar). 0 forbidden-path, 0 dep. `git revert` pulito.