### PR TITLE
feat(codex): promote 6 tutorial A.L.I.E.N.A. codex entries (human-reviewed)

### DIFF
--- a/data/codex/apex_predatore.yaml
+++ b/data/codex/apex_predatore.yaml
@@ -100,4 +100,4 @@ codex_entry:
         perche'' il predatore apex apre il Codex. Intorno a lui le storie del bioma -- recuperare
         convogli cristallizzati e nodi di risonanza sepolti -- danno peso al primo incontro.'
       story_hook_it: un avversario predatore apex boss (T3) che affronti in Savana Ionizzata
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/cacciatore_corazzato.yaml
+++ b/data/codex/cacciatore_corazzato.yaml
@@ -101,4 +101,4 @@ codex_entry:
         il cacciatore corazzato apre il Codex. Intorno a lui le storie del bioma -- recuperare
         convogli cristallizzati e nodi di risonanza sepolti -- danno peso al primo incontro.'
       story_hook_it: un avversario predatore tank (T2) che affronti in Savana Ionizzata
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/guardiano_caverna.yaml
+++ b/data/codex/guardiano_caverna.yaml
@@ -102,4 +102,4 @@ codex_entry:
         camere di eco instabile prima del collasso. E'' qui che il Codex comincia: la prima
         forma di vita di cui annotare la verita''.'
       story_hook_it: un avversario difensore territoriale (T1) che affronti in Caverna Risonante
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/guardiano_pozza.yaml
+++ b/data/codex/guardiano_pozza.yaml
@@ -101,4 +101,4 @@ codex_entry:
         bioma -- recuperare reagenti bio-luminescenti per le squadre mediche -- danno peso
         al primo incontro.'
       story_hook_it: un avversario predatore acquatico agile (T2) che affronti in Palude Tossica
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/predone_agile.yaml
+++ b/data/codex/predone_agile.yaml
@@ -100,4 +100,4 @@ codex_entry:
         convogli cristallizzati e nodi di risonanza sepolti. E'' qui che il Codex comincia:
         la prima forma di vita di cui annotare la verita''.'
       story_hook_it: un avversario predatore secondario (T1) che affronti in Savana Ionizzata
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/predoni_nomadi.yaml
+++ b/data/codex/predoni_nomadi.yaml
@@ -83,7 +83,7 @@ codex_entry:
   # edit the 6 content: blocks below, then set lore_review_status: human_reviewed
   # (or remove this field) and run promote_codex_draft.js. The gate refuses to
   # promote while this flag is present.
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed
 
   aliena_dimensions:
     A_ambiente:


### PR DESCRIPTION
## Cosa

master-dd ha revisionato in sessione le 6 bozze enriched (predoni + 5 tutorial) e ha approvato la promozione. `lore_review_status: human_reviewed` + move `data/codex/_drafts/<id>.yaml` -> `data/codex/<id>.yaml`.

**= primi codex unlock reali in-flow**: il loader flat ora le serve + il trigger `encounter_completed` le sblocca (le 6 specie hanno `used_in_encounters`).

Entries: predoni_nomadi, apex_predatore, cacciatore_corazzato, guardiano_caverna, guardiano_pozza, predone_agile.

## Gate
- **HA2 canonical: 7/7 entries 6/6 dims, errors=0 warnings=0, ZERO orphan** (tutte roster-recognized/unlock-reachable).
- Secret invariant intatto (no score fields). node codex 11/11.
- Pipeline: research->architettura->generalizza->biome-narrative->review-master-dd->promote.

## Scope
Doc/data-only (6 rename _drafts->data/codex). 0 forbidden-path, 0 dep.