### PR TITLE
feat(codex): rich lore extractor -- catalog trait_refs + visual + lifecycle

### DIFF
--- a/data/codex/_grammar/aliena_lore.json
+++ b/data/codex/_grammar/aliena_lore.json
@@ -1,5 +1,5 @@
 {
-  "_README": "A.L.I.E.N.A. lore story-grammar (Tracery format) consumed by tools/py/codex_aliena_lore_gen.py. The HANDCRAFTED authoring layer (Wildermyth model): master-dd tunes these templates ONCE; the generator fills the #slots# from each creature's codex_entry.lore_vars and produces a per-creature DRAFT (pending human review). Each origin_<dim> defines the prose for one of the 6 A.L.I.E.N.A. dimensions; >1 variant per origin gives seeded variability across creatures. Slots: subject, biome_name, biome_trait, biome_tone, biome_hook, affixes, neighbors, lineage, archetype, morphotype, job, role, threat_tier, social, sentience, hook, eco_stance. biome_tone/biome_hook/affixes/neighbors come from the AUTHORED biome narrative (biomes.yaml narrative.tone/hooks + affixes + npc_archetypes). Keep variants ~150-420 chars (HA2 TV-readable band 100-500). NEVER reference a coherence/score slot (SPEC-H sez.8 secret invariant).",
+  "_README": "A.L.I.E.N.A. lore story-grammar (Tracery format) consumed by tools/py/codex_aliena_lore_gen.py. The HANDCRAFTED authoring layer (Wildermyth model): master-dd tunes these templates ONCE; the generator fills the #slots# from each creature's codex_entry.lore_vars and produces a per-creature DRAFT (pending human review). Each origin_<dim> defines the prose for one of the 6 A.L.I.E.N.A. dimensions; >1 variant per origin gives seeded variability across creatures. Slots: subject, biome_name, biome_trait, biome_tone, biome_hook, affixes, neighbors, lineage, archetype, morphotype, job, role, threat_tier, social, sentience, hook, eco_stance, traits, visual, lifecycle_arc, mutations. The *_rich origins (used when rich=True for catalog species) weave traits (trait_refs) + visual (visual_description) + lifecycle_arc (lifecycle phases) + mutations (mutation_morphology). biome_tone/biome_hook/affixes/neighbors come from the AUTHORED biome narrative (biomes.yaml narrative.tone/hooks + affixes + npc_archetypes). Keep variants ~150-420 chars (HA2 TV-readable band 100-500). NEVER reference a coherence/score slot (SPEC-H sez.8 secret invariant).",
   "origin_A_ambiente": [
     "Il territorio del #subject# e' #biome_name#: #biome_trait#. Un mondo da #biome_tone#, segnato da #affixes#. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.",
     "#biome_name# -- #biome_trait#, dal tono di #biome_tone# (#affixes#) -- non e' uno sfondo ma un avversario costante per il #subject#. Ogni movimento e' una risposta all'ambiente."
@@ -11,6 +11,14 @@
   "origin_I_impianto": [
     "Sul piano morfo-fisiologico il #subject# e' un #morphotype#, costruito attorno al ruolo di #job#. La struttura privilegia la prontezza sulla resistenza.",
     "Il corpo del #subject# -- #morphotype# -- e' ottimizzato per il ruolo di #job#: rapido, essenziale, fragile se isolato dal gruppo."
+  ],
+  "origin_L_linee_evolutive_rich": [
+    "La linea del #subject# porta i segni di #traits#: ogni tratto core e' la cicatrice di una pressione del bioma. Attraversa le fasi #lifecycle_arc#, conservando solo cio' che sopravvive.",
+    "Il #subject# evolve lungo le fasi #lifecycle_arc#. I suoi tratti -- #traits# -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo #archetype#."
+  ],
+  "origin_I_impianto_rich": [
+    "Morfologia: #visual# Ogni adattamento risponde a una pressione; le linee mutanti note (#mutations#) spingono il corpo oltre la forma base.",
+    "Il corpo del #subject#: #visual# Sotto pressione puo' sviluppare #mutations#, piegando la morfologia a cio' che il bioma esige."
   ],
   "origin_E_ecologia": [
     "Nell'ecologia di #biome_name# il #subject# occupa la nicchia di #role# (#threat_tier#), accanto a #neighbors#. #eco_stance#",

--- a/tests/test_codex_draft_scaffold.py
+++ b/tests/test_codex_draft_scaffold.py
@@ -127,3 +127,63 @@ def test_scaffold_draft_no_secret_score_fields():
     assert not (forbidden & set(ce.keys()))
     for dim in ce["aliena_dimensions"].values():
         assert not (forbidden & set(dim.keys()))
+
+
+def test_catalog_to_species_and_rich_slots():
+    entry = {
+        "species_id": "cryo_lynx",
+        "common_names": ["Lince Criogenica"],
+        "role_tags": ["predatore_terziario_apex"],
+        "biome_affinity": "savana",
+        "trait_refs": ["artigli_sette_vie", "criostasi_adattiva"],
+        "classification": {"macro_class": "Cursore quadrupede / predatore apex"},
+        "sentience_index": "T1",
+        "visual_description": "Felino compatto dal manto folto.",
+    }
+    sp = scaf.catalog_to_species(entry)
+    assert sp["id"] == "cryo_lynx"
+    assert sp["display_name"] == "Lince Criogenica"
+    assert sp["trait_refs"] == ["artigli_sette_vie", "criostasi_adattiva"]
+    assert sp["flags"]["sentient"] is False  # T1 -> not sentient
+    lifecycle = {
+        "phases": {"hatchling": {}, "mature": {}, "apex": {}},
+        "mutation_morphology": {"artigli_grip_to_glass": {}},
+    }
+    lv = scaf.extract_lore_vars(sp, BIOMES, lifecycle)
+    assert "artigli sette vie" in lv["traits"]
+    assert "Felino compatto" in lv["visual"]
+    assert "hatchling" in lv["lifecycle_arc"]
+    assert "artigli grip to glass" in lv["mutations"]
+
+
+def test_extract_lore_vars_rich_slots_fallback_for_stub():
+    # a stub species (no trait_refs / no lifecycle) gets safe fallbacks, never #leaks#.
+    lv = scaf.extract_lore_vars(SPECIES, BIOMES, None)
+    assert lv["traits"]  # non-empty fallback
+    assert lv["lifecycle_arc"]
+    assert lv["mutations"]
+    assert "#" not in lv["traits"] + lv["visual"] + lv["lifecycle_arc"] + lv["mutations"]
+
+
+def test_scaffold_rich_weaves_traits_into_content():
+    import json
+    from pathlib import Path as _P
+
+    grammar = json.load(
+        open(_P(__file__).resolve().parents[1] / "data/codex/_grammar/aliena_lore.json", encoding="utf-8")
+    )
+    entry = {
+        "species_id": "test_rich",
+        "common_names": ["Bestia Test"],
+        "role_tags": ["predatore"],
+        "biome_affinity": "savana",
+        "trait_refs": ["artigli_sette_vie"],
+        "classification": {"macro_class": "quadrupede"},
+        "sentience_index": "T1",
+        "visual_description": "Una bestia di prova distintiva.",
+    }
+    draft = scaf.scaffold_rich_draft(entry, {"phases": {"mature": {}}}, BIOMES, grammar)
+    dims = draft["codex_entry"]["aliena_dimensions"]
+    assert "artigli sette vie" in dims["L_linee_evolutive"]["content"]  # rich origin used
+    assert "bestia di prova" in dims["I_impianto"]["content"].lower()  # visual woven
+    assert "#" not in dims["L_linee_evolutive"]["content"]

--- a/tools/py/codex_aliena_lore_gen.py
+++ b/tools/py/codex_aliena_lore_gen.py
@@ -102,11 +102,19 @@ def generate_dimension(
     lore_vars: Dict[str, object],
     entry_id: str,
     dim_key: str,
+    rich: bool = False,
 ) -> str:
-    """Generate the prose for one A.L.I.E.N.A. dimension. Deterministic."""
+    """Generate the prose for one A.L.I.E.N.A. dimension. Deterministic.
+
+    rich=True prefers an `origin_<dim>_rich` symbol (which weaves trait/lifecycle
+    slots) when the grammar defines one; otherwise falls back to `origin_<dim>`.
+    """
     merged = _merge_vars(grammar, lore_vars)
     seed = f"{entry_id}:{dim_key}"
-    return _expand(merged, f"origin_{dim_key}", seed).strip()
+    symbol = f"origin_{dim_key}"
+    if rich and f"{symbol}_rich" in grammar:
+        symbol = f"{symbol}_rich"
+    return _expand(merged, symbol, seed).strip()
 
 
 def generate_all(
@@ -114,10 +122,11 @@ def generate_all(
     lore_vars: Dict[str, object],
     entry_id: str,
     dim_keys: Optional[Sequence[str]] = None,
+    rich: bool = False,
 ) -> Dict[str, str]:
     """Generate prose for all 6 dimensions -> {dim_key: content}."""
     keys = list(dim_keys) if dim_keys else ALIENA_DIMENSION_KEYS
-    return {k: generate_dimension(grammar, lore_vars, entry_id, k) for k in keys}
+    return {k: generate_dimension(grammar, lore_vars, entry_id, k, rich=rich) for k in keys}
 
 
 def extract_lore_vars(draft: Dict[str, object]) -> Dict[str, object]:

--- a/tools/py/codex_draft_scaffold.py
+++ b/tools/py/codex_draft_scaffold.py
@@ -122,7 +122,7 @@ def _biome_narrative(entry: Dict, biome_name: str, subject_id: str) -> Dict[str,
         "biome_tone": tone,
         "biome_hook": biome_hook,
         "affixes": ", ".join(affixes) or "pressioni ambientali",
-        "neighbors": ", ".join(neighbors) or "le altre creature del bioma",
+        "neighbors": ", ".join(neighbors) or "predatori e prede del posto",
     }
 
 
@@ -130,8 +130,14 @@ def _strip_token(text: str, token: str) -> str:
     return " ".join(t for t in text.split() if t.lower() != token)
 
 
-def extract_lore_vars(species: Dict, biomes_doc: Dict) -> Dict[str, str]:
-    """Derive the A.L.I.E.N.A. grammar slots from a species master record."""
+def extract_lore_vars(
+    species: Dict, biomes_doc: Dict, lifecycle_doc: Optional[Dict] = None
+) -> Dict[str, str]:
+    """Derive the A.L.I.E.N.A. grammar slots from a species master record.
+
+    For RICH (catalog) species, `species` carries trait_refs + visual_description
+    and `lifecycle_doc` carries phases + mutation_morphology; those feed the rich
+    slots (traits / visual / lifecycle_arc / mutations). For stubs they fall back."""
     index = build_biome_index(biomes_doc)
     biome_key, biome_entry = resolve_biome_entry(species.get("biomes") or [], biomes_doc, index)
     biome_name = (
@@ -169,6 +175,21 @@ def extract_lore_vars(species: Dict, biomes_doc: Dict) -> Dict[str, str]:
     subject = (species.get("display_name") or _humanize(species.get("id"))).lower()
     job = _humanize((species.get("jobs_bias") or [""])[0])
 
+    # rich slots: trait_refs (each trait = a pressure) + authored visual_description
+    # + lifecycle phases (evolutionary arc) + mutation_morphology. Fallbacks for stubs.
+    traits = ", ".join(_humanize(t) for t in (species.get("trait_refs") or [])) or (
+        "tratti adattivi non ancora documentati"
+    )
+    visual = str(species.get("visual_description") or "").strip()
+    visual = (visual + ("" if visual.endswith(".") else ".")) if visual else f"un {morphotype}."
+    lc = lifecycle_doc or {}
+    phases = lc.get("phases") or {}
+    phase_keys = list(phases.keys()) if isinstance(phases, dict) else [str(p) for p in phases]
+    lifecycle_arc = ", ".join(_humanize(p) for p in phase_keys) or "un ciclo di adattamento continuo"
+    muts = lc.get("mutation_morphology") or {}
+    mut_keys = list(muts.keys()) if isinstance(muts, dict) else [str(m) for m in muts]
+    mutations = ", ".join(_humanize(m) for m in mut_keys[:5]) or "nessuna mutazione documentata"
+
     return {
         "subject": subject,
         "biome_name": biome_name,
@@ -194,6 +215,11 @@ def extract_lore_vars(species: Dict, biomes_doc: Dict) -> Dict[str, str]:
         "biome_hook": narrative_vars["biome_hook"],
         "affixes": narrative_vars["affixes"],
         "neighbors": narrative_vars["neighbors"],
+        # rich (catalog + lifecycle); used by the *_rich grammar origins.
+        "traits": traits,
+        "visual": visual,
+        "lifecycle_arc": lifecycle_arc,
+        "mutations": mutations,
     }
 
 
@@ -223,8 +249,10 @@ def _facts(species: Dict, biome_key: str, biome_name: str) -> Dict[str, Dict]:
             "key_facts": [
                 f"resistance_archetype: {species.get('resistance_archetype')}",
                 f"role_trofico: {species.get('role_trofico')}; sentient: {(species.get('flags') or {}).get('sentient')}",
-            ],
-            "cross_ref": [f"species:{sid}"],
+            ]
+            + ([f"trait_refs: {', '.join(species['trait_refs'])}"] if species.get("trait_refs") else []),
+            "cross_ref": [f"species:{sid}"]
+            + [f"trait:{t}" for t in (species.get("trait_refs") or [])],
             "game_impact": f"Archetipo {species.get('resistance_archetype')}.",
         },
         "I_impianto": {
@@ -254,12 +282,21 @@ def _facts(species: Dict, biome_key: str, biome_name: str) -> Dict[str, Dict]:
     }
 
 
-def scaffold_draft(species: Dict, biomes_doc: Dict, grammar: Dict) -> Dict:
-    """Build a complete pending-review codex draft from a species record."""
+def scaffold_draft(
+    species: Dict,
+    biomes_doc: Dict,
+    grammar: Dict,
+    lifecycle_doc: Optional[Dict] = None,
+    rich: bool = False,
+) -> Dict:
+    """Build a complete pending-review codex draft from a species record.
+
+    rich=True (catalog species) weaves trait_refs/visual/lifecycle via the
+    *_rich grammar origins."""
     sid = species["id"]
     index = build_biome_index(biomes_doc)
     biome_key, biome_name, _ = resolve_biome(species.get("biomes") or [], biomes_doc, index)
-    lore_vars = extract_lore_vars(species, biomes_doc)
+    lore_vars = extract_lore_vars(species, biomes_doc, lifecycle_doc)
     enc = species.get("used_in_encounters") or []
     bal = species.get("balance") or {}
     display = species.get("display_name") or _humanize(sid)
@@ -281,7 +318,7 @@ def scaffold_draft(species: Dict, biomes_doc: Dict, grammar: Dict) -> Dict:
             "aliena_dimensions": _facts(species, biome_key, biome_name),
         }
     }
-    contents = gen.generate_all(grammar, lore_vars, sid)
+    contents = gen.generate_all(grammar, lore_vars, sid, rich=rich)
     gen.fill_draft(draft, contents)  # sets content + lore_review_status + scrubs score fields
     # Seed the A_ancoraggio narrative hook (HA2 SOFT expects story_hook_it there);
     # a starting point for the human review to refine.
@@ -294,23 +331,92 @@ def _load(path: str) -> Dict:
         return yaml.safe_load(fh)
 
 
+DEFAULT_CATALOG_PATH = "data/core/species/species_catalog.json"
+DEFAULT_LIFECYCLE_DIR = "data/core/species"
+
+
+def load_catalog(path: str = DEFAULT_CATALOG_PATH) -> Dict[str, Dict]:
+    """species_catalog.json -> {species_id: entry}."""
+    import json
+
+    with open(path, encoding="utf-8") as fh:
+        cat = json.load(fh).get("catalog") or []
+    return {s.get("species_id"): s for s in cat if isinstance(s, dict) and s.get("species_id")}
+
+
+def load_lifecycle(species_id: str, lifecycle_dir: str = DEFAULT_LIFECYCLE_DIR) -> Dict:
+    """Load data/core/species/<id>_lifecycle.yaml if present, else {}."""
+    p = Path(lifecycle_dir) / f"{species_id}_lifecycle.yaml"
+    if p.exists():
+        with open(p, encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    return {}
+
+
+def catalog_to_species(entry: Dict) -> Dict:
+    """Adapt a rich catalog entry to the species-dict shape extract_lore_vars
+    expects, carrying trait_refs + visual_description for the rich slots."""
+    role_tags = [str(t) for t in (entry.get("role_tags") or [])]
+    sent = str(entry.get("sentience_index") or "")
+    macro = (entry.get("classification") or {}).get("macro_class") or ""
+    morpho = macro.split("/")[0].strip()  # "Cursore quadrupede / predatore apex" -> first
+    is_apex = any("apex" in t for t in role_tags)
+    names = entry.get("common_names") or []
+    return {
+        "id": entry.get("species_id"),
+        "display_name": names[0] if names else _humanize(entry.get("species_id")),
+        "biomes": [entry["biome_affinity"]] if entry.get("biome_affinity") else [],
+        "role_trofico": role_tags[0] if role_tags else "",
+        "morphotype": morpho,
+        "resistance_archetype": "adattivo",
+        "jobs_bias": [],
+        "functional_tags": role_tags,
+        "flags": {"sentient": sent in ("T3", "T4", "T5")},
+        "balance": {"threat_tier": "T3" if is_apex else "T2"},
+        "used_in_encounters": [],
+        "trait_refs": entry.get("trait_refs") or [],
+        "visual_description": entry.get("visual_description") or "",
+    }
+
+
+def scaffold_rich_draft(catalog_entry: Dict, lifecycle_doc: Dict, biomes_doc: Dict, grammar: Dict) -> Dict:
+    """Scaffold a RICH draft from a catalog entry + its lifecycle (trait_refs +
+    visual_description + lifecycle phases/mutations via the *_rich origins)."""
+    species = catalog_to_species(catalog_entry)
+    return scaffold_draft(species, biomes_doc, grammar, lifecycle_doc=lifecycle_doc, rich=True)
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     p = argparse.ArgumentParser(description="Scaffold a codex A.L.I.E.N.A. draft from a species record")
-    p.add_argument("species", help="path to a species master YAML (packs/.../species/**/<id>.yaml)")
+    p.add_argument("species", nargs="?", help="path to a species master YAML (stub path)")
+    p.add_argument("--catalog", metavar="SPECIES_ID", help="RICH mode: scaffold from species_catalog.json + <id>_lifecycle.yaml")
     p.add_argument("--biomes", default="data/core/biomes.yaml")
     p.add_argument("--grammar", default=gen.DEFAULT_GRAMMAR_PATH)
     p.add_argument("--out-dir", default="data/codex/_drafts")
     p.add_argument("--print", action="store_true", help="print to stdout instead of writing")
     args = p.parse_args(argv)
 
-    species = _load(args.species)
-    sid = species.get("id")
-    if not sid:
-        print("ERROR: species record has no id", file=sys.stderr)
-        return 2
     biomes_doc = _load(args.biomes)
     grammar = gen.load_grammar(args.grammar)
-    draft = scaffold_draft(species, biomes_doc, grammar)
+
+    if args.catalog:
+        catalog = load_catalog()
+        entry = catalog.get(args.catalog)
+        if not entry:
+            print(f"ERROR: species_id '{args.catalog}' not in catalog", file=sys.stderr)
+            return 2
+        sid = args.catalog
+        draft = scaffold_rich_draft(entry, load_lifecycle(sid), biomes_doc, grammar)
+    else:
+        if not args.species:
+            print("ERROR: provide a species path or --catalog <species_id>", file=sys.stderr)
+            return 2
+        species = _load(args.species)
+        sid = species.get("id")
+        if not sid:
+            print("ERROR: species record has no id", file=sys.stderr)
+            return 2
+        draft = scaffold_draft(species, biomes_doc, grammar)
 
     served = Path("data/codex") / f"{sid}.yaml"
     if served.exists():


### PR DESCRIPTION
## Cosa (il salto di qualita' lore per specie RICCHE)

I dati ricchi che credevamo vault-only **sono nel checkout**: `species_catalog.json` (by `species_id`) ha **`trait_refs`** (ogni trait = una pressione evolutiva), **`visual_description`** (morfologia autorata), `biome_affinity`, `role_tags` + pointer `lifecycle_yaml`; `<id>_lifecycle.yaml` ha `phases` (arco evolutivo) + `mutation_morphology`.

- **`--catalog <species_id>`** mode: `load_catalog` + `load_lifecycle` + `catalog_to_species` + `scaffold_rich_draft`.
- Nuovi slot: `traits` / `visual` / `lifecycle_arc` / `mutations` (fallback-safe per gli stub).
- Grammar `*_rich` origins: L_linee intreccia i traits-come-pressioni + arco lifecycle; I_impianto usa la `visual_description` autorata + mutazioni. `rich=True` preferisce `origin_<dim>_rich`.

**31 specie ricche** disponibili (catalog ∩ lifecycle). Gli stub (le 6 promosse) non sono toccati.

## DEMO cryo_lynx (Lince Criogenica)

> **L_linee**: Il lince criogenica evolve lungo le fasi hatchling, juvenile, mature, apex, legacy. I suoi tratti -- artigli sette vie, carapace fase variabile, olfatto risonanza magnetica, criostasi adattiva, zampe a molla -- non sono ornamenti ma risposte: ognuno racconta una pressione superata.
>
> **I_impianto**: Morfologia: Felino compatto dal manto folto screziato di bianco-azzurro, zampe larghe da neve e occhi riflettenti adattati alla penombra polare. Ogni adattamento risponde a una pressione...

= traits REALI come pressioni + lifecycle arc + visual_description AUTORATA (vs gli stub templati).

## Nit / data-gap
- Alcuni biome_affinity ricchi (es. `cryosteppe`) NON sono autorati in biomes.yaml -> la narrativa-bioma fa fallback graceful (gap di copertura dati, non bug). Le specie ricche con bioma autorato avranno anche la narrativa.
- phase names in inglese (hatchling...) -- traducibili a piacimento (review).

## Gate / scope
TDD +3 (catalog adapter / rich slots / scaffold weaves traits). 16 py + 13 node green. ASCII/prettier clean. `tools/py` + `tests` + grammar. 0 forbidden-path, 0 dep, 0 draft committati (capability only). Le bozze ricche si generano on-demand col tool.