### PR TITLE
fix(linter): strip md headings/fences from prose summary (canon linter FP)

### DIFF
--- a/scripts/verify-swarm-claims.py
+++ b/scripts/verify-swarm-claims.py
@@ -1733,6 +1733,10 @@ def render_markdown(reports: list[dict]) -> str:
 
 _FRONTMATTER_RE = re.compile(r"\A---\r?\n.*?\r?\n---\r?\n", re.DOTALL)
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\[.*?\]|\{.*?\})\s*```", re.DOTALL)
+# Markdown structure that pollutes prose entity-extraction with spurious tokens.
+_MD_FENCE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_MD_HEADING_RE = re.compile(r"(?m)^[ \t]*#{1,6}[ \t].*$")
+_MD_SETEXT_RE = re.compile(r"(?m)^[ \t]*[=-]{2,}[ \t]*$")
 
 
 def _strip_frontmatter(text: str) -> str:
@@ -1740,17 +1744,39 @@ def _strip_frontmatter(text: str) -> str:
     return _FRONTMATTER_RE.sub("", text, count=1)
 
 
+def _markdown_to_prose(body: str) -> str:
+    """Pulisce la struttura markdown che genera token-entita' spuri.
+
+    - fenced code block (```...```): i loro canonical_refs sono raccolti a parte
+      (build_artifact_from_markdown li legge dal body completo); lasciare il
+      blocco aggiungerebbe solo rumore strutturale alla prosa.
+    - heading ATX/setext: sono label brevi, non claim; sotto whitespace-collapse
+      una parola di heading non terminata si fonde con l'articolo capitalizzato
+      della riga seguente nell'estrattore di frasi (es. '# Proposta' + 'La ...'
+      -> bigram 'proposta_la' = un falso HALLUCINATED). Rimuovi le righe heading.
+    """
+    text = _MD_FENCE_BLOCK_RE.sub(" ", body)
+    text = _MD_HEADING_RE.sub(" ", text)
+    text = _MD_SETEXT_RE.sub(" ", text)
+    return text
+
+
 def build_artifact_from_markdown(text: str, name: str = "doc") -> dict:
     """Adatta contenuto markdown (design doc / PR body) a un artifact dict.
 
-    Il body (post-frontmatter) diventa `summary`, cosi' la prose-extraction
-    (mentions + A.L.I.E.N.A. relational, assi A/N/I/L/E/A2) gira sul testo.
-    Qualunque fenced block ```json``` con una lista di {ref, claim} (o un dict
-    che contiene `canonical_refs`) viene promosso a `response.canonical_refs`
-    per il check esplicito Tier 4. Mirror del contratto artifact JSON.
+    Il body (post-frontmatter, ripulito da heading/code-fence via
+    _markdown_to_prose) diventa `summary`, cosi' la prose-extraction (mentions +
+    A.L.I.E.N.A. relational, assi A/N/I/L/E/A2) gira sul testo senza falsi
+    positivi da struttura markdown. Qualunque fenced block ```json``` con una
+    lista di {ref, claim} (o un dict con `canonical_refs`) viene letto dal body
+    COMPLETO e promosso a `response.canonical_refs` (Tier 4). Mirror artifact JSON.
     """
     body = _strip_frontmatter(text or "")
-    artifact: dict[str, Any] = {"agent": name, "cycle": 0, "summary": body}
+    artifact: dict[str, Any] = {
+        "agent": name,
+        "cycle": 0,
+        "summary": _markdown_to_prose(body),
+    }
     canonical_refs: list[dict] = []
     for m in _JSON_FENCE_RE.finditer(body):
         try:

--- a/tests/test_verify_swarm_claims.py
+++ b/tests/test_verify_swarm_claims.py
@@ -2017,6 +2017,32 @@ class MarkdownAdapterTest(unittest.TestCase):
         self.assertIn("abisso_vulcanico", mentions)
         self.assertIn("dune_stalker", mentions)
 
+    def test_heading_does_not_create_false_positive(self):
+        # Regression: '# Proposta' + 'La ...' previously merged (post
+        # whitespace-collapse) into the bigram 'proposta_la' -> false
+        # HALLUCINATED. Heading lines are now stripped from the prose summary.
+        text = "# Proposta\nLa specie dune_stalker abita il bioma savana.\n"
+        art = self.mod.build_artifact_from_markdown(text)
+        mentions = self.mod.extract_mentions(art)
+        self.assertNotIn("proposta_la", mentions)
+        # the real prose entities survive
+        self.assertIn("dune_stalker", mentions)
+
+    def test_code_fence_stripped_from_prose_but_refs_kept(self):
+        text = (
+            "Prosa con dune_stalker.\n\n"
+            "```json\n"
+            '[{"ref": "data/core/species.yaml#dune_stalker.biome_affinity", '
+            '"claim": "savana"}]\n'
+            "```\n"
+        )
+        art = self.mod.build_artifact_from_markdown(text)
+        # canonical_refs are still harvested from the full body
+        self.assertEqual(len(self.mod.extract_canonical_refs_from_artifact(art)), 1)
+        # but the fence's structural text is gone from the prose summary
+        self.assertNotIn("```", art["summary"])
+        self.assertNotIn("biome_affinity", art["summary"])
+
 
 class LoadArtifactTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Follow-up bugfix to #2915, found while live-testing the merged linter.

**Bug**: the markdown adapter put heading lines into the prose summary, and the phrase extractor (capitalized bigram) merged a heading word with the next line's capitalized article after whitespace-collapse -- `# Proposta` + `La specie ...` -> token `proposta_la` -> a **false HALLUCINATED** on an otherwise-correct citation.

**Fix**: `_markdown_to_prose()` strips ATX/setext headings + fenced code blocks from the summary before entity extraction. `canonical_refs` are still harvested from the full body first, so embedded ```json``` refs are unaffected.

**Verified live** (`--game-repo .`): heading doc + correct citation (`dune_stalker -> savana`) now strict **exit 0** (was exit 1); heading doc + wrong biome (`-> abisso_vulcanico`) still **exit 1** (CONTRADICTED). True-positive catch intact.

+2 regression tests; **169 pytest green** (run in CI `python-tests`). Reduces the markdown-tier false-positive surface (the tier ships advisory; this shrinks the noise before any flip-to-strict).

Coding-Agent: claude-opus-4-8