### PR TITLE
feat(codex): route + promote 2 rich codex entries (leviatano + perfusuas)

### DIFF
--- a/data/codex/leviatano_risonante.yaml
+++ b/data/codex/leviatano_risonante.yaml
@@ -36,9 +36,7 @@ codex_entry:
     affixes: luminescente, elettrico profondo, sinaptico, gravitazionale, pressione estrema
     neighbors: araldi fotofase, sciami memetici, leviatani risonanti
     traits: camere risonanza abyssal, emettitori voidsong, corazze ferro magnetico, bioantenne
-      gravitiche, emolinfa conducente, placche pressioniche, filamenti echo, spicole canalizzatrici,
-      lobi risonanti crepuscolo, pelle piezo satura, canto risonante, vortice nera flash,
-      ghiandole eco mappanti, cuore multicamera bassa pressione, emettitori voidsong
+      gravitiche, emolinfa conducente, placche pressioniche
     visual: un unknown.
     lifecycle_arc: hatchling, juvenile, mature, apex, legacy
     mutations: adattamenti ancora non catalogati
@@ -86,11 +84,8 @@ codex_entry:
       game_impact: Archetipo adattivo.
       content: 'Il leviatano risonante evolve lungo le fasi hatchling, juvenile, mature, apex,
         legacy. I suoi tratti -- camere risonanza abyssal, emettitori voidsong, corazze ferro
-        magnetico, bioantenne gravitiche, emolinfa conducente, placche pressioniche, filamenti
-        echo, spicole canalizzatrici, lobi risonanti crepuscolo, pelle piezo satura, canto
-        risonante, vortice nera flash, ghiandole eco mappanti, cuore multicamera bassa pressione,
-        emettitori voidsong -- non sono ornamenti ma risposte: ognuno racconta una pressione
-        superata, in archetipo adattivo.'
+        magnetico, bioantenne gravitiche, emolinfa conducente, placche pressioniche -- non
+        sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -135,4 +130,4 @@ codex_entry:
         i corridoi luminosi della Cresta Fotofase prima delle maree di spore. E'' qui che
         il Codex comincia: la prima forma di vita di cui annotare la verita''.'
       story_hook_it: un avversario unknown (T2) che affronti in Frattura Abissale Sinaptica
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/perfusuas_pedes.yaml
+++ b/data/codex/perfusuas_pedes.yaml
@@ -116,4 +116,4 @@ codex_entry:
         perche'' il zannapiedi apre il Codex. Intorno a lui le storie del bioma -- disinnescare
         camere di eco instabile prima del collasso -- danno peso al primo incontro.'
       story_hook_it: un avversario mammalo-artropode (T2) che affronti in Caverna Risonante
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/encounters/standard_01.yaml
+++ b/data/encounters/standard_01.yaml
@@ -25,6 +25,16 @@ groups:
     count: 1
     species_hint: echo_seer
     trait_ids: [spore_psichiche_silenziate]
+  - role: apex_neutral
+    power: 5
+    count: 1
+    species_hint: perfusuas_pedes
+    trait_ids: [artiglio_cinetico_a_urto, locomozione_miriapode_ibrida, sistemi_chimio_sonici]
+    notes: >-
+      Lo Zannapiedi (perfusuas_pedes) pattuglia le gallerie carsiche, neutrale
+      finche' la party non invade il suo territorio. Osservatore -- non interferisce
+      con la pattuglia, ma la sua presenza sblocca il Codex (encounter_completed).
+      Pattern apex_neutral (cfr. dune_stalker in enc_savana_pack_clash).
 
 party_vc:
   difficulty_multiplier: 1.0

--- a/tools/py/codex_draft_scaffold.py
+++ b/tools/py/codex_draft_scaffold.py
@@ -177,7 +177,10 @@ def extract_lore_vars(
 
     # rich slots: trait_refs (each trait = a pressure) + authored visual_description
     # + lifecycle phases (evolutionary arc) + mutation_morphology. Fallbacks for stubs.
-    traits = ", ".join(_humanize(t) for t in (species.get("trait_refs") or [])) or (
+    # cap to 6 core traits -- some species carry 15+ trait_refs which overflow the
+    # HA2 TV-readable band; the review can surface more if needed.
+    _trait_refs = list(dict.fromkeys(species.get("trait_refs") or []))  # dedup, keep order
+    traits = ", ".join(_humanize(t) for t in _trait_refs[:6]) or (
         "tratti adattivi non ancora documentati"
     )
     visual = str(species.get("visual_description") or "").strip()


### PR DESCRIPTION
## Cosa (routing corretto, fattibile su encounter esistenti)

Solo 2 rich draft combaciano con encounter esistenti:
- **leviatano_risonante**: gia' routato in `elite_01` (abisso_vulcanico boss) -> promosso.
- **perfusuas_pedes** (Zannapiedi, caverna ~ caverna_profonda): aggiunto come **apex_neutral** in `standard_01` (pattern balance-safe non-interferente, cfr. dune_stalker in enc_savana_pack_clash; trait_ids validati reali) -> unlock-reachable -> promosso.

Entrambe SERVITE (data/codex, human-reviewed). **HA2 9 entries errors=0 warnings=0, ZERO orphan.** encounter difficulty-guard errors=0.

+ extractor: **cap traits a 6 + dedup** (leviatano aveva 15 trait incl 1 duplicato -> L_linee over-band). leviatano rigenerato in-band.

## Restano 20 rich orphan
Biomi senza encounter (palude, caldera_glaciale, foresta_acida, atollo_obsidiana, frattura_abissale...) -> routing corretto = **creare encounter biome-appropriati** (content/balance = design master-dd). Non li forzo in encounter sbagliati.

## Scope
`data/encounters/standard_01.yaml` (+1 group apex_neutral, mirror del precedente dune_stalker) + extractor cap + 2 promozioni. 0 forbidden-path, 0 dep.