### PR TITLE
fix(ci): repoint dead species validation + guard lighthouse config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,9 +230,15 @@ jobs:
         working-directory: tools/ts
         run: npm test
 
-      - name: Validate Species (TS)
-        working-directory: tools/ts
-        run: node dist/validate_species.js ../../data/core/species.yaml
+      # Species validation moved off the legacy data/core/species.yaml (removed
+      # in #2271, Phase 4c.6 ADR-2026-05-15) to the JSON catalog
+      # data/core/species/species_catalog.json. validate_species.ts is a
+      # YAML-`catalog.slots`-schema validator that cannot parse the catalog, so
+      # it only no-ops here. Canonical species/catalog validation now runs in
+      # cli-checks + python-tests (`game_cli.py validate-datasets`) and
+      # dataset-checks (speciesIndexIntegrity / speciesTraitReferences). No
+      # Node-side catalog validator exists, so this TS-only job no longer
+      # validates species (data changes trigger the `data` paths-filter jobs).
 
   # dashboard-quality job rimosso — apps/dashboard cancellato in #1343
   # (SPRINT_001 fase 2). Il workspace non esiste piu' nel repo.
@@ -355,10 +361,14 @@ jobs:
       - name: Run pytest
         run: pytest
 
-      - name: Validate Species (Python)
+      # Species now live in data/core/species/species_catalog.json (legacy
+      # data/core/species.yaml removed in #2271 / Phase 4c.6 ADR-2026-05-15).
+      # validate-datasets runs validate_species_catalog_schema +
+      # validate_species_ecology against the catalog; mirrors the cli-checks
+      # "Validate base datasets (CLI)" step.
+      - name: Validate base datasets (CLI)
         working-directory: tools/py
-        run: |
-          python3 validate_species.py ../../data/core/species.yaml
+        run: python3 game_cli.py validate-datasets
 
       - name: Run Python validation script
         working-directory: tools/py
@@ -721,6 +731,16 @@ jobs:
         run: |
           if [ -z "$SITE_BASE_URL" ]; then
             echo "SITE_BASE_URL not configured; skipping Lighthouse audit." >&2
+            exit 0
+          fi
+          # docs/ Pages site is in maintenance-mode (master-dd 2026-06-21) and no
+          # root lighthouserc.json is committed (only a stray copy under
+          # incoming/lavoro_da_classificare/). Guard so the job stays a true
+          # no-op instead of failing on a missing --config when SITE_BASE_URL is
+          # set. Master-dd call: restore a root lighthouserc.json to re-enable
+          # auditing, or drop this job.
+          if [ ! -f ./lighthouserc.json ]; then
+            echo "lighthouserc.json not found at repo root; skipping Lighthouse audit (site in maintenance-mode)." >&2
             exit 0
           fi
           lhci autorun --config=./lighthouserc.json


### PR DESCRIPTION
## Cosa

Due bug latenti in `.github/workflows/ci.yml` (trovati riscrivendo `docs/pipelines/ci-pipeline.md`, [#2931](https://github.com/MasterDD-L34D/Game/pull/2931)). **Forbidden path** (`.github/workflows/`) -> **PR-only, merge manuale master-dd, NO auto-merge, NO `--admin`.**

## Bug 1 - riferimento a dataset specie rimosso

`ci.yml` aveva due step "Validate Species" che puntavano a `data/core/species.yaml`, **rimosso in #2271** (split in `data/core/species/*.yaml` + `species_catalog.json`).

**Ground-truth correction (verify-first):** la premessa "falliscono su file mancante" e' STALE. I validator (`validate_species.ts`/`.py`) erano gia' patchati (ADR-2026-05-15 Phase 4c.6) per **`exit 0` se il path manca** -> gli step **no-op silenziosi, validavano NULLA** (falsa sicurezza). Entrambi i tool sono YAML-`catalog.slots`-schema-specific e **non leggono** il catalogo JSON -> repuntarli e' impossibile senza refactor.

Fix:
- **`python-tests`**: step sostituito con `python3 game_cli.py validate-datasets` (working-dir `tools/py`). Esegue `validate_species_catalog_schema` + `validate_species_ecology` sul nuovo `species_catalog.json`; **mirror esatto** dello step `cli-checks` "Validate base datasets (CLI)" (`validate-datasets` == `validate_datasets.main()`, lo stesso di `dataset-checks`).
- **`typescript-tests`**: step **rimosso** (con commento). Job Node-only, nessun validator catalogo lato Node, e il validator TS e' morto. Le modifiche ai dati specie attivano il filtro `data` -> validazione coperta da `cli-checks` + `python-tests` + `dataset-checks` (speciesIndexIntegrity / speciesTraitReferences).

**Comando di replacement provato in locale (exit 0):**
```
$ cd tools/py && py game_cli.py validate-datasets
packs/evo_tactics_pack: 14 controlli eseguiti, 0 avvisi.
Tutti i dataset YAML sono validi.
EXIT=0
```
(vecchio step, per confronto: `py validate_species.py ../../data/core/species.yaml` -> `[validate_species] DEPRECATED ... Skipping validation. EXIT=0` = no-op)

## Bug 2 - `lighthouse-ci` punta a config assente (DECISIONE master-dd)

Il job si aspetta un `lighthouserc.json` a root che **non esiste** (solo copia stray in `incoming/lavoro_da_classificare/`). Con `SITE_BASE_URL` impostato, `lhci autorun --config=./lighthouserc.json` **fallisce** su config mancante.

Fix conservativo (NO rimozione job = owner-gated): **guard sull'esistenza del config** -> lo step resta un vero no-op finche' `lighthouserc.json` manca, invece di fallire. Rimuove il fallimento latente senza decidere unilateralmente sulla struttura del workflow.

**Call master-dd (3 opzioni):**
1. **Lasciare il guard (raccomandato)** - sito docs/ Pages in maintenance-mode (master-dd 2026-06-21); job inerte, zero manutenzione.
2. **Ripristinare `lighthouserc.json` a root** - se si vuole riabilitare l'audit Lighthouse.
3. **Rimuovere il job `lighthouse-ci`** - se l'audit non serve piu'.

## Doc

`docs/pipelines/ci-pipeline.md` su origin/main e' **gia' corretto** dalla riscrittura #2931 (documenta `validate-datasets`, l'architettura paths-filter, la nota maintenance-mode di `lighthouse-ci`, e una nota esplicita sul drift `species.yaml`). Le mie edit locali a quel doc erano basate su una copia STALE pre-#2931 -> **droppate in rebase**. Questo PR ora tocca **solo `ci.yml`**.

## Verifiche
- `py -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` -> **OK** (YAML valido, anche post-rebase)
- `game_cli.py validate-datasets` -> **exit 0** (output sopra)
- `prettier --check .github/workflows/ci.yml` -> **clean**
- Linee aggiunte = **pure ASCII** (encoding policy)
- Nessun `run:` step referenzia piu' il file rimosso (restano solo commenti esplicativi)
- Rebasato su origin/main -> **MERGEABLE**, 1 commit

## Rollback
`git revert` del commit. Cambi isolati a 2 step CI + 1 guard; nessun impatto runtime/dati.

## Note merge
Forbidden path -> **NON auto-mergiare, NON `--admin`**. Richiede review + approvazione manuale master-dd.