### PR TITLE
feat(combat): nocicezione ferito action-timing slow (OD-024 engine #1)

### DIFF
--- a/apps/backend/services/combat/statusModifiers.js
+++ b/apps/backend/services/combat/statusModifiers.js
@@ -103,9 +103,21 @@ function computeWoundedPermaAttackPenalty(unit) {
   return { penalty, severity, active: true };
 }
 
+// True when the unit carries the `ferito` status, in EITHER shape: object-map
+// (`status.ferito` = turns-remaining N or boolean true) or the back-compat array
+// (`status = ['ferito', ...]`). Mirrors traitEffects.hasActorStatus without the
+// cross-module require (statusModifiers stays leaf).
+function _isFerito(unit) {
+  const st = unit && unit.status;
+  if (!st) return false;
+  if (Array.isArray(st)) return st.includes('ferito');
+  return isPositive(st.ferito);
+}
+
 /**
  * Action 5b — slow_down trigger when ANY of: panic > 0, confused > 0,
- * bleeding ≥ medium severity, fracture ≥ medium severity. Returns
+ * bleeding ≥ medium severity, fracture ≥ medium severity, OR the unit carries
+ * the `nocicezione` interoception trait while Ferito (OD-024 engine #1). Returns
  * action_speed reduction amount (1 = "1 tier slower", 0 = no penalty).
  *
  * Reads unit.status object-map shape (panic/confused/bleeding/fracture =
@@ -131,6 +143,17 @@ function computeSlowDownPenalty(unit) {
     if (BLEEDING_FRACTURE_SLOW_DOWN_THRESHOLD[sev]) {
       triggers.push(`fracture:${sev}`);
     }
+  }
+  // OD-024 engine #1 (action-timing): the `nocicezione` interoception trait makes a
+  // unit act 1 tier slower WHILE Ferito ("ritardi quando Ferito" -- master-dd ratified
+  // 2026-06-21: passive -1 initiative). Joins the existing slow triggers under the SAME
+  // canonical "1 tier slower" cap (return below) -- NO new magnitude in the resolver,
+  // and it does NOT cumulate with bleeding/fracture. The sentience grant flag
+  // (SENTIENCE_INTEROCEPTION_GRANT_ENABLED) gates WHO carries nocicezione, so this is
+  // band-neutral until that flag flips (no unit carries the trait today).
+  const traits = Array.isArray(unit && unit.traits) ? unit.traits : [];
+  if (traits.includes('nocicezione') && _isFerito(unit)) {
+    triggers.push('nocicezione:ferito');
   }
   return { amount: triggers.length > 0 ? 1 : 0, triggers };
 }

--- a/tests/services/roundOrchestrator.test.js
+++ b/tests/services/roundOrchestrator.test.js
@@ -285,6 +285,24 @@ test('computeResolvePriority applies panic -2 and disorient -1 penalties', () =>
   assert.equal(computeResolvePriority(disUnit, attack), 8);
 });
 
+test('OD-024 engine #1: nocicezione + ferito → -1 initiative (1 tier slower)', () => {
+  const attack = { type: 'attack' };
+  // nocicezione + ferito -> slow_down 1 (via computeSlowDownPenalty): 10 + 0 - 1 = 9.
+  const nociFerito = {
+    id: 'nf',
+    initiative: 10,
+    traits: ['nocicezione'],
+    status: { ferito: true },
+  };
+  assert.equal(computeResolvePriority(nociFerito, attack), 9);
+  // same trait, NOT ferito -> no slow: 10.
+  const nociClean = { id: 'nc', initiative: 10, traits: ['nocicezione'], status: {} };
+  assert.equal(computeResolvePriority(nociClean, attack), 10);
+  // ferito but no nocicezione -> no slow: 10 (band-neutral for non-carriers).
+  const feritoNoTrait = { id: 'ft', initiative: 10, traits: [], status: { ferito: true } };
+  assert.equal(computeResolvePriority(feritoNoTrait, attack), 10);
+});
+
 // ─────────────────────────────────────────────────────────────────
 // 4. Resolve round integration (4 test, con mock resolveAction)
 // ─────────────────────────────────────────────────────────────────

--- a/tests/services/statusModifiers.test.js
+++ b/tests/services/statusModifiers.test.js
@@ -315,6 +315,56 @@ test('Action 5b: clean unit → no trigger', () => {
   assert.equal(r.amount, 0);
 });
 
+// ──────────────────────────────────────────────────────────────────────
+// OD-024 engine #1 — nocicezione "ritardi quando Ferito" (action-timing slow)
+// ──────────────────────────────────────────────────────────────────────
+
+test('OD-024: nocicezione + ferito (object-map bool) → slow_down 1 tier', () => {
+  const unit = { id: 'a', traits: ['nocicezione'], status: { ferito: true } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.includes('nocicezione:ferito'));
+});
+
+test('OD-024: nocicezione + ferito (turns-remaining N) → slow_down', () => {
+  const unit = { id: 'a', traits: ['nocicezione'], status: { ferito: 2 } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.includes('nocicezione:ferito'));
+});
+
+test('OD-024: nocicezione + ferito (array-shape status) → slow_down', () => {
+  const unit = { id: 'a', traits: ['nocicezione'], status: ['ferito', 'stordito'] };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1);
+  assert.ok(r.triggers.includes('nocicezione:ferito'));
+});
+
+test('OD-024: nocicezione WITHOUT ferito → no trigger', () => {
+  const unit = { id: 'a', traits: ['nocicezione'], status: {} };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 0);
+  assert.ok(!r.triggers.includes('nocicezione:ferito'));
+});
+
+test('OD-024: ferito WITHOUT nocicezione → no slow (ferito alone never slows)', () => {
+  const unit = { id: 'a', traits: ['altro_tratto'], status: { ferito: true } };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 0);
+});
+
+test('OD-024: nocicezione+ferito + bleeding-medium → capped 1 tier (no cumulate)', () => {
+  const unit = {
+    id: 'a',
+    traits: ['nocicezione'],
+    status: { ferito: true, bleeding: 2, bleeding_severity: 'medium' },
+  };
+  const r = computeSlowDownPenalty(unit);
+  assert.equal(r.amount, 1); // canonical cap, NOT 2
+  assert.ok(r.triggers.includes('nocicezione:ferito'));
+  assert.ok(r.triggers.some((t) => t.startsWith('bleeding:medium')));
+});
+
 test('Action 5b: computeStatusModifiers exports actorSlowDown flag + log entry', () => {
   const actor = { id: 'a', status: { panic: 1 } };
   const target = { id: 'b', status: {} };


### PR DESCRIPTION
## OD-024 engine #1 — nocicezione "ritardi quando Ferito" (action-timing)

First of the 3 D6 hook engines (master-dd ratified 2026-06-21: **ADD −1 initiative, passive while Ferito**). Independent of the producer PR #2932 — composes with it (the grant assigns `nocicezione`; this makes the trait cause a slow) but does not code-depend, so it branches off `main`.

### Verify-first re-scoping
D6 assumed the action-timing engine "doesn't exist". It does: `computeResolvePriority` (`initiative + speed − penalty`) + `computeSlowDownPenalty` (panic/bleeding/fracture → "1 tier slower", capped). So this is a **small extension, not a new engine**.

### Change
- `computeSlowDownPenalty` gains a `nocicezione + ferito` trigger, joining the existing slow triggers under the **same canonical "1 tier slower" cap** — **no new magnitude** in the resolver, and it does **not** cumulate with bleeding/fracture.
- `_isFerito` handles both status shapes (object-map `status.ferito` + back-compat array `status = ['ferito']`).
- **`active_effects.yaml` untouched** (it's strict-schema-gated; the slow is the resolver's existing cap, not a per-trait value).

### Band-neutrality
The sentience grant flag (`SENTIENCE_INTEROCEPTION_GRANT_ENABLED`, OFF) gates **who** carries `nocicezione` — no unit carries it today → zero band impact. Live once the grant flips (gated on N=40).

### Tests
`statusModifiers` +6 (object-map/turns/array shapes, no-trait, no-ferito, cap-with-bleeding), `roundOrchestrator` +1 (`computeResolvePriority` −1 lands, non-carriers unaffected). **75 combat unit-tests + 34 ripple green.**

### Guardrail
Touches combat-core (`statusModifiers`/round-resolve) but all in `apps/backend`; test files >50 LOC outside `apps/backend` → **not auto-merge-L3** → master-dd manual merge. No forbidden paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
