### PR TITLE
fix(tooling): repoint biome-check to species catalog + unzip -o

### DIFF
--- a/docs/pipelines/BIOME_FEATURE_CHECKS.md
+++ b/docs/pipelines/BIOME_FEATURE_CHECKS.md
@@ -16,7 +16,7 @@ Standard di check & dry-run per nuove feature Bioma + Specie + Trait
 Questo documento definisce:
 
 - la procedura standard di **check** e **dry-run** per l'integrazione di un nuovo bioma complesso e delle sue specie/trait;
-- come usare lo script `tools/traits/check_biome_feature.py` (con i suoi limiti attuali, vedi §3.5);
+- come usare lo script `tools/traits/check_biome_feature.py` (stage specie repointed al catalog, vedi §3.5);
 - come integrare questi check con i validator canonici e nei merge reali.
 
 ---
@@ -94,7 +94,7 @@ Lo script effettua (in lettura):
 - `data/core/traits/glossary.json`
 - `data/traits/index.json`
 - `data/traits/species_affinity.json`
-- `data/core/species.yaml` (**percorso STALE -- vedi §3.5**)
+- `data/core/species/species_catalog.json` (catalog: `species_id` + `biome_affinity` + `trait_refs`)
 
 ### 3.4 Sequenza raccomandata per una nuova feature
 
@@ -110,15 +110,15 @@ python tools/traits/check_biome_feature.py --biome <slug> --dry-run --verbose
 - Eseguire lint/test del progetto (`npm run schema:lint`, `pytest`, `node --test ...`).
 - Se tutto e' OK -> procedere con PR/merge.
 
-### 3.5 LIMITE NOTO (stage specie rotto)
+### 3.5 Stage specie (repointed al catalog -- RISOLTO)
 
-Lo script carica ancora il monolite rimosso `data/core/species.yaml` (riga `species_path`).
-Dopo la rimozione del monolite (#2271 -> per-specie `data/core/species/*.yaml` + `species_catalog.json`),
-il caricamento fallisce con `File YAML mancante: .../data/core/species.yaml` e lo script termina con
-exit code 1 PRIMA di eseguire i check bioma/pool. **Finche' lo script non punta a `species_catalog.json`,
-lo stage di coverage specie e' non operativo.** Per la coerenza specie<->bioma affidati ai validator
-canonici di §4 (che leggono il layout corrente). La fix dello script e' tracciata come follow-up
-(fuori scope di questo doc; lo script NON e' un file di doc).
+Lo script ora carica `data/core/species/species_catalog.json` (lista sotto
+`catalog`; il monolite `data/core/species.yaml` era stato rimosso in #2271). Lo
+stage di coverage specie<->bioma e' di nuovo OPERATIVO: filtra le entry per
+`biome_affinity == <slug>`, raccoglie gli `species_id` e verifica i `trait_refs`
+contro glossary/index. Verificato live (es. `--biome savana` -> 4 specie,
+`--biome atollo_obsidiana` -> 3, exit 0). I validator canonici di §4 restano la
+coerenza autoritativa specie<->bioma sul layout corrente.
 
 ---
 

--- a/scripts/report_incoming.sh
+++ b/scripts/report_incoming.sh
@@ -11,7 +11,7 @@ TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/incoming_validation.XXXXXX")"
 trap 'rm -rf "${TEMP_ROOT}"' EXIT
 
 if ! command -v unzip >/dev/null 2>&1; then
-    echo "Errore: il comando 'unzip' non è disponibile nel PATH." >&2
+    echo "Errore: il comando 'unzip' non e' disponibile nel PATH." >&2
     exit 1
 fi
 
@@ -43,7 +43,7 @@ process_zip() {
     mkdir -p "${log_dir}"
     summary_file="${log_dir}/summary.txt"
 
-    if ! unzip -q "${zip_file}" -d "${extraction_dir}"; then
+    if ! unzip -qo "${zip_file}" -d "${extraction_dir}"; then
         {
             echo "zip_file: ${base}"
             echo "timestamp: ${TIMESTAMP}"

--- a/tools/traits/check_biome_feature.py
+++ b/tools/traits/check_biome_feature.py
@@ -66,7 +66,10 @@ def check_biome_feature(biome_slug: str, verbose: bool = False):
     glossary_path = ROOT / "data/core/traits/glossary.json"
     index_path = ROOT / "data/traits/index.json"
     species_affinity_path = ROOT / "data/traits/species_affinity.json"
-    species_path = ROOT / "data/core/species.yaml"
+    # data/core/species.yaml removed in #2271 (split). Canonical SoT is the
+    # JSON catalog data/core/species/species_catalog.json: list under "catalog",
+    # each entry has species_id + biome_affinity + trait_refs (flat slug list).
+    species_path = ROOT / "data/core/species/species_catalog.json"
 
     # Caricamenti
     biomes, err = load_yaml(biomes_path)
@@ -93,7 +96,7 @@ def check_biome_feature(biome_slug: str, verbose: bool = False):
     if err:
         warnings.append(err)  # alcune repo potrebbero non usarlo
 
-    species, err = load_yaml(species_path)
+    species, err = load_json(species_path)
     if err:
         issues.append(err)
 
@@ -132,15 +135,13 @@ def check_biome_feature(biome_slug: str, verbose: bool = False):
                         if trait_id not in trait_ids_known:
                             missing_traits.add(trait_id)
 
-    # dalle species
-    if isinstance(species, dict) and "species" in species:
-        for spc in species["species"]:
+    # dalle species (catalog: trait_refs flat slug list, ex-trait_plan)
+    if isinstance(species, dict) and "catalog" in species:
+        for spc in species["catalog"]:
             if spc.get("biome_affinity") == biome_slug:
-                trait_plan = spc.get("trait_plan", {})
-                for section in ("core", "optional", "temp"):
-                    for trait_id in trait_plan.get(section, []):
-                        if trait_id not in trait_ids_known:
-                            missing_traits.add(trait_id)
+                for trait_id in spc.get("trait_refs", []):
+                    if trait_id not in trait_ids_known:
+                        missing_traits.add(trait_id)
 
     if missing_traits:
         issues.append(
@@ -149,10 +150,10 @@ def check_biome_feature(biome_slug: str, verbose: bool = False):
 
     # 4) Species ↔ biome_affinity
     species_for_biome = []
-    if isinstance(species, dict) and "species" in species:
-        for spc in species["species"]:
+    if isinstance(species, dict) and "catalog" in species:
+        for spc in species["catalog"]:
             if spc.get("biome_affinity") == biome_slug:
-                species_for_biome.append(spc.get("id"))
+                species_for_biome.append(spc.get("species_id"))
     if not species_for_biome:
         warnings.append(f"Nessuna species con biome_affinity='{biome_slug}' trovata.")
     elif verbose:


### PR DESCRIPTION
Two follow-ups from the #2914 campaign closeout.

**1. `tools/traits/check_biome_feature.py`** loaded the removed `data/core/species.yaml` (#2271). The validators exit 0 on missing file, so the species-coverage stage was a silent no-op (false security). Repoint to `data/core/species/species_catalog.json` (`catalog` list): `id`->`species_id`, `biome_affinity` (same), `trait_plan`->`trait_refs` (flat slug list). **Verified live**: `--biome savana` -> 4 species, `--biome atollo_obsidiana` -> 3, exit 0 (was crash/no-op). Note: tools/traits/ is not in the CI `python` paths-filter, so this is verified by direct run, not CI.

**2. `scripts/report_incoming.sh`**: `unzip -q` -> `unzip -qo` (no interactive prompt on re-extract). TKT-SALVAGE-A1 (ex `tooling_maintenance_log`). +ASCII-fixed one legacy non-ASCII char (script encoding policy).

**`docs/pipelines/BIOME_FEATURE_CHECKS.md`**: known-limit §3.5 -> RISOLTO, species path corrected.

Verification: `bash -n` + `ast.parse` OK; live runs shown above; governance errors=0; prettier clean. Rollback: `git revert`. Refs: #2914.