### PR TITLE
feat(sentience): extend interoception grant to enemy units (OD-024 D3)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1811,6 +1811,29 @@ function createSessionRouter(options = {}) {
         units = scenarioUnits;
       }
 
+      // OD-024 D3 (master-dd #2941 ratification: grant extended player-only -> enemies):
+      // apply the sentience interoception grant to enemy/sistema units too (player chars
+      // get it at coopOrchestrator.submitCharacter). Flag-gated inside the helper
+      // (SENTIENCE_INTEROCEPTION_GRANT_ENABLED) -> band-neutral no-op when OFF. The enemy
+      // unit's `species` IS the catalog species_id slug (tier lookup key). Idempotent
+      // (no-dup) + never throws into /start.
+      try {
+        // eslint-disable-next-line global-require
+        const {
+          applySentienceInteroceptionGrant,
+        } = require('../services/sentience/sentienceInteroceptionGrant');
+        for (const u of units) {
+          if (!u || u.controlled_by !== 'sistema') continue;
+          const granted = applySentienceInteroceptionGrant({
+            species_id: u.species,
+            traits: u.traits,
+          });
+          if (Array.isArray(granted?.traits)) u.traits = granted.traits;
+        }
+      } catch {
+        /* sentience grant optional -- never block /start */
+      }
+
       // Q-001 T2.3 PR-3: applica difficulty profile scaling (opt-in, default normal)
       const requestedProfile =
         typeof req.body?.difficulty_profile === 'string'

--- a/tests/api/sentienceEnemyGrant.test.js
+++ b/tests/api/sentienceEnemyGrant.test.js
@@ -1,0 +1,75 @@
+// OD-024 D3 (master-dd #2941 ratification: grant extended player-only -> enemies).
+// Verifies the sentience interoception grant is applied to enemy/sistema units at
+// /start (player chars get it at submitCharacter), flag-gated -> band-neutral OFF.
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { createApp } = require('../../apps/backend/app');
+
+const FLAG = 'SENTIENCE_INTEROCEPTION_GRANT_ENABLED';
+// anguis_magnetica is T1 in species_catalog -> progressive subset = prop + vestibolare.
+const T1_SUBSET = ['propriocezione', 'equilibrio_vestibolare'];
+
+function units() {
+  return [
+    {
+      id: 'p1',
+      controlled_by: 'player',
+      species: 'guardiano_caverna',
+      hp: 10,
+      max_hp: 10,
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: 's1',
+      controlled_by: 'sistema',
+      species: 'anguis_magnetica',
+      traits: [],
+      hp: 5,
+      max_hp: 5,
+      position: { x: 5, y: 5 },
+    },
+  ];
+}
+
+async function startEnemy(app) {
+  const ss = await request(app).post('/api/session/start').send({ units: units() });
+  return (ss.body.state?.units || []).find((u) => u.id === 's1');
+}
+
+test('D3: sistema unit gains the interoception subset at /start (flag ON)', async (t) => {
+  const prev = process.env[FLAG];
+  process.env[FLAG] = 'true';
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const enemy = await startEnemy(app);
+  assert.ok(enemy, 'sistema unit present in state');
+  for (const id of T1_SUBSET) {
+    assert.ok(enemy.traits.includes(id), `enemy should be granted ${id} at T1`);
+  }
+});
+
+test('D3: flag OFF -> sistema unit traits unchanged (band-neutral)', async (t) => {
+  const prev = process.env[FLAG];
+  delete process.env[FLAG];
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (prev !== undefined) process.env[FLAG] = prev;
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const enemy = await startEnemy(app);
+  assert.ok(enemy, 'sistema unit present in state');
+  for (const id of T1_SUBSET) {
+    assert.ok(!enemy.traits.includes(id), `${id} must NOT be granted when flag OFF`);
+  }
+});


### PR DESCRIPTION
## OD-024 D3 — sentience interoception grant → enemy units

Per master-dd **#2941** ratification (D3 player-only → **player+enemies**). The generic `applySentienceInteroceptionGrant` helper now runs on `controlled_by==='sistema'` units at `/start` too (player chars already get it at `coopOrchestrator.submitCharacter`).

- **Single chokepoint** after unit assembly (session.js, covers both the character and legacy `/start` paths).
- Enemy `unit.species` IS the catalog `species_id` slug (tier lookup key).
- **Flag-gated** inside the helper (`SENTIENCE_INTEROCEPTION_GRANT_ENABLED`) → **band-neutral no-op when OFF**; idempotent (no-dup); never throws into `/start`.
- 2 integration tests: T1 sistema unit granted `propriocezione`+`equilibrio_vestibolare` when ON; unchanged when OFF (band-neutral). **Full `test:api` green, flag OFF default.**

**N=40** (band shifts bidirectionally when the flag flips ON) + the flip itself = **D7**, separate/gated. This PR is the wire only (band-neutral).

Not auto-merge-L3 (test file >50 LOC outside `apps/backend`) → master-dd manual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)