### PR TITLE
feat(sentience): interoception_traits ETL passthrough (OD-024 D4)

### DIFF
--- a/schemas/evo/species_catalog.schema.json
+++ b/schemas/evo/species_catalog.schema.json
@@ -116,6 +116,12 @@
             "type": "array",
             "items": { "type": "string" }
           },
+          "interoception_traits": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "description": "OD-024 D4 optional per-species interoception gateway override (propriocezione / equilibrio_vestibolare / nocicezione / termocezione). Propagated source->catalog by the ETL pipeline; consumed by apps/backend/services/sentience/sentienceInteroceptionGrant.js perSpeciesOverride. Omitted when unauthored."
+          },
           "lifecycle_yaml": {
             "type": ["string", "null"],
             "description": "Path to per-species lifecycle YAML (null for legacy-yaml-merge entries without lifecycle)"

--- a/tests/test_apply_interoception_traits.py
+++ b/tests/test_apply_interoception_traits.py
@@ -1,0 +1,126 @@
+"""OD-024 D4 -- operational populate path for interoception_traits.
+
+The ETL assemblers (merge_pack_v2 / promote) only carry the field on a full
+rebuild, which is obsolete (ADR-2026-05-15: merge_pack_v2 "becomes obsolete";
+catalog is the SoT, mutated in-place by tools/py/apply_*.py). This is the LIVE
+operational sync: read an authored `interoception_traits` field from
+data/core/species.yaml (+ species_expansion.yaml) and write it into the matching
+species_catalog.json entries IN PLACE -- mirror of tools/py/apply_biome_affinity.py.
+
+DRY-RUN by default; idempotent; whitelist-filtered; no-op on current data (no
+species authors the field yet -> catalog stays diff-clean).
+
+Run: PYTHONPATH=tools/py python -m pytest tests/test_apply_interoception_traits.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools" / "etl"))
+
+import apply_interoception_traits as apply_tool
+
+
+# ============================================================================
+# plan_interoception_changes (pure planner)
+# ============================================================================
+
+
+def test_plan_applies_source_value_to_matching_entry():
+    catalog = [{"species_id": "foo"}, {"species_id": "bar"}]
+    source = {"foo": ["propriocezione"]}
+    to_apply, skipped = apply_tool.plan_interoception_changes(catalog, source)
+    assert [(sp["species_id"], traits) for sp, traits in to_apply] == [
+        ("foo", ["propriocezione"])
+    ]
+
+
+def test_plan_skips_species_not_in_catalog():
+    catalog = [{"species_id": "foo"}]
+    source = {"ghost": ["nocicezione"]}
+    to_apply, skipped = apply_tool.plan_interoception_changes(catalog, source)
+    assert to_apply == []
+    assert any(sid == "ghost" and "not in catalog" in why for sid, why in skipped)
+
+
+def test_plan_is_idempotent_when_already_in_sync():
+    catalog = [{"species_id": "foo", "interoception_traits": ["propriocezione"]}]
+    source = {"foo": ["propriocezione"]}
+    to_apply, skipped = apply_tool.plan_interoception_changes(catalog, source)
+    assert to_apply == []
+    assert any(sid == "foo" for sid, why in skipped)
+
+
+def test_plan_empty_source_is_a_noop():
+    catalog = [{"species_id": "foo"}, {"species_id": "bar"}]
+    to_apply, skipped = apply_tool.plan_interoception_changes(catalog, {})
+    assert to_apply == []
+
+
+# ============================================================================
+# apply_changes (mutation + provenance)
+# ============================================================================
+
+
+def test_apply_changes_sets_field_and_provenance():
+    sp = {"species_id": "foo"}
+    apply_tool.apply_changes([(sp, ["propriocezione", "termocezione"])])
+    assert sp["interoception_traits"] == ["propriocezione", "termocezione"]
+    assert sp["_provenance"]["interoception_traits"] == apply_tool.PROV_TAG
+
+
+def test_apply_changes_preserves_other_keys():
+    sp = {"species_id": "foo", "trait_refs": ["x"], "sentience_index": "T2"}
+    apply_tool.apply_changes([(sp, ["nocicezione"])])
+    assert sp["trait_refs"] == ["x"]
+    assert sp["sentience_index"] == "T2"
+    assert sp["interoception_traits"] == ["nocicezione"]
+
+
+# ============================================================================
+# load_source_interoception (species.yaml + expansion parsing + whitelist filter)
+# ============================================================================
+
+
+def test_load_source_filters_whitelist_and_drops_empty(tmp_path):
+    species_yaml = tmp_path / "species.yaml"
+    species_yaml.write_text(
+        "species:\n"
+        "  - id: foo\n"
+        "    interoception_traits: [propriocezione, not_real]\n"
+        "  - id: bar\n"
+        "    interoception_traits: [only_bad]\n"
+        "  - id: baz\n",
+        encoding="utf-8",
+    )
+    source = apply_tool.load_source_interoception(species_yaml, None)
+    assert source == {"foo": ["propriocezione"]}  # bar dropped (all bad), baz absent
+
+
+def test_load_source_reads_expansion_examples(tmp_path):
+    species_yaml = tmp_path / "species.yaml"
+    species_yaml.write_text("species: []\n", encoding="utf-8")
+    expansion = tmp_path / "species_expansion.yaml"
+    expansion.write_text(
+        "species_examples:\n"
+        "  - id: qux\n"
+        "    interoception_traits: [termocezione]\n",
+        encoding="utf-8",
+    )
+    source = apply_tool.load_source_interoception(species_yaml, expansion)
+    assert source == {"qux": ["termocezione"]}
+
+
+# ============================================================================
+# current-data invariant: real sources author nothing -> no-op (diff-clean)
+# ============================================================================
+
+
+def test_real_sources_author_nothing_so_plan_is_empty():
+    species_yaml = REPO_ROOT / "data" / "core" / "species.yaml"
+    expansion = REPO_ROOT / "data" / "core" / "species_expansion.yaml"
+    source = apply_tool.load_source_interoception(species_yaml, expansion)
+    assert source == {}, f"expected no authored field on current data, got {source}"

--- a/tests/test_interoception_field_passthrough.py
+++ b/tests/test_interoception_field_passthrough.py
@@ -1,0 +1,141 @@
+"""OD-024 D4 -- interoception_traits source->catalog passthrough (ETL pipeline).
+
+The producer read-path (perSpeciesOverride in
+apps/backend/services/sentience/sentienceInteroceptionGrant.js) already ships and
+is tested by tests/api/sentience-interoception-grant.test.js. This covers the
+WRITE side: the generation pipeline must carry an optional
+`interoception_traits: [<gateway ids>]` field from a source species record
+through to the catalog entry, mirroring the trait_refs precedent but OMITTING the
+key when the source lacks it (so the catalog stays diff-clean on current data --
+no source authors the field yet).
+
+Gateway whitelist (= producer INTEROCEPTION_TRAIT_IDS): propriocezione,
+equilibrio_vestibolare, nocicezione, termocezione. A non-whitelist id is dropped
+at write time (defensive -- a typo can never reach the catalog).
+
+Run: PYTHONPATH=tools/py python -m pytest tests/test_interoception_field_passthrough.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ETL stages live in tools/etl; the shared field helper alongside them.
+sys.path.insert(0, str(REPO_ROOT / "tools" / "py"))
+sys.path.insert(0, str(REPO_ROOT / "tools" / "etl"))
+
+import merge_pack_v2_species as merge
+import promote_gameplay_to_canon as promote
+
+
+# ============================================================================
+# shared helper: filter_interoception (tools/etl/interoception_field.py)
+# ============================================================================
+
+
+def test_filter_keeps_only_whitelisted_ids_in_order():
+    from interoception_field import filter_interoception
+
+    assert filter_interoception(
+        ["termocezione", "not_a_real_trait", "propriocezione"]
+    ) == ["termocezione", "propriocezione"]
+
+
+def test_filter_dedups_preserving_first_occurrence():
+    from interoception_field import filter_interoception
+
+    assert filter_interoception(
+        ["propriocezione", "propriocezione", "nocicezione"]
+    ) == ["propriocezione", "nocicezione"]
+
+
+def test_filter_empty_inputs_return_empty_list():
+    from interoception_field import filter_interoception
+
+    assert filter_interoception(None) == []
+    assert filter_interoception([]) == []
+    assert filter_interoception("propriocezione") == []  # non-list
+    assert filter_interoception(["only_bad_ids"]) == []
+
+
+def test_helper_exposes_canonical_four_gateway_ids():
+    from interoception_field import INTEROCEPTION_TRAIT_IDS
+
+    assert sorted(INTEROCEPTION_TRAIT_IDS) == sorted(
+        ["propriocezione", "equilibrio_vestibolare", "nocicezione", "termocezione"]
+    )
+
+
+# ============================================================================
+# merge_pack_v2_species.build_entry (pack-v2 source path)
+# ============================================================================
+
+
+def test_build_entry_carries_filtered_interoception_from_pack():
+    pack = {
+        "scientific_name": "Foo bar",
+        "interoception_traits": ["propriocezione", "not_a_real_trait"],
+    }
+    entry = merge.build_entry("foo_bar", pack)
+    assert entry["interoception_traits"] == ["propriocezione"]
+
+
+def test_build_entry_omits_key_when_pack_lacks_field():
+    entry = merge.build_entry("foo_bar", {"scientific_name": "Foo bar"})
+    assert "interoception_traits" not in entry
+
+
+def test_build_entry_reads_field_from_legacy_overlay_when_pack_absent():
+    pack = {"scientific_name": "Foo bar"}
+    legacy = {"interoception_traits": ["nocicezione"]}
+    entry = merge.build_entry("foo_bar", pack, legacy=legacy)
+    assert entry["interoception_traits"] == ["nocicezione"]
+
+
+def test_build_entry_stub_branch_omits_key():
+    # pack is None -> stub branch (Frattura Abissale / dune_stalker). No source
+    # field -> the key must stay absent.
+    entry = merge.build_entry("dune_stalker", None)
+    assert "interoception_traits" not in entry
+
+
+# ============================================================================
+# merge_pack_v2_species.build_entry_from_legacy (legacy YAML residue path)
+# ============================================================================
+
+
+def test_build_entry_from_legacy_carries_filtered_interoception():
+    legacy = {
+        "genus": "Foo",
+        "epithet": "bar",
+        "interoception_traits": ["nocicezione", "termocezione", "bad_id"],
+    }
+    entry = merge.build_entry_from_legacy("foo_bar", legacy)
+    assert entry["interoception_traits"] == ["nocicezione", "termocezione"]
+
+
+def test_build_entry_from_legacy_omits_key_when_absent():
+    entry = merge.build_entry_from_legacy("foo_bar", {"genus": "Foo", "epithet": "bar"})
+    assert "interoception_traits" not in entry
+
+
+# ============================================================================
+# promote_gameplay_to_canon.derive_entry (gameplay YAML promote path)
+# ============================================================================
+
+
+def test_derive_entry_carries_filtered_interoception_from_gameplay_yaml():
+    pack = {
+        "role_trofico": "predator",
+        "interoception_traits": ["equilibrio_vestibolare", "junk"],
+    }
+    entry = promote.derive_entry(pack, "badlands", "test-creature")
+    assert entry["interoception_traits"] == ["equilibrio_vestibolare"]
+
+
+def test_derive_entry_omits_key_when_gameplay_yaml_lacks_field():
+    entry = promote.derive_entry({"role_trofico": "predator"}, "badlands", "test-creature")
+    assert "interoception_traits" not in entry

--- a/tools/etl/apply_interoception_traits.py
+++ b/tools/etl/apply_interoception_traits.py
@@ -1,0 +1,149 @@
+"""apply_interoception_traits.py -- OD-024 D4 operational populate path.
+
+Sync an authored `interoception_traits` field from the species sources
+(data/core/species.yaml + species_expansion.yaml) into the canonical
+species_catalog.json, IN PLACE -- the live mirror of tools/py/apply_biome_affinity.py.
+
+Why this exists (recon 2026-06-22): the ETL assemblers (merge_pack_v2_species /
+promote_gameplay_to_canon) only carry the field on a FULL rebuild, which is
+obsolete (ADR-2026-05-15: merge_pack_v2 "becomes obsolete"; the catalog is the SoT
+and is mutated in place by the tools/py/apply_*.py family). Without this tool the
+assembler passthrough is latent -- there is no operational way to populate the
+field. This is that path.
+
+Contract (mirror apply_biome_affinity.py):
+- Writes ONLY `interoception_traits` + `_provenance['interoception_traits']`.
+- DRY-RUN by default; `--apply` required to write the catalog.
+- Whitelist-filtered (tools/etl/interoception_field) -- a bad/typo id never lands.
+- Idempotent: a species already in sync with its source is skipped.
+- Conservative: never REMOVES the field (dropping a source authoring is a manual
+  decision); only adds/updates from a present, non-empty source value.
+- No-op on current data: no species authors the field yet -> the catalog stays
+  byte-identical (the tool returns before opening the file for write).
+- UTF-8 explicit, ensure_ascii=False, indent=2 + trailing newline (catalog format).
+
+Authoring: master-dd adds `interoception_traits: [<gateway ids>]` to a species in
+data/core/species.yaml (or species_expansion.yaml), then runs this with --apply.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+from interoception_field import filter_interoception
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CATALOG_PATH = REPO_ROOT / "data/core/species/species_catalog.json"
+SPECIES_YAML = REPO_ROOT / "data/core/species.yaml"
+EXPANSION_YAML = REPO_ROOT / "data/core/species_expansion.yaml"
+PROV_TAG = "d4-species-yaml-authored"
+
+
+def _collect(entries, source, seen):
+    """Add filtered, non-empty interoception_traits from a list of source entries
+    into `source` (keyed by id), respecting first-seen precedence via `seen`."""
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        sid = entry.get("id")
+        if not sid or sid in seen:
+            continue
+        seen.add(sid)
+        filtered = filter_interoception(entry.get("interoception_traits"))
+        if filtered:
+            source[sid] = filtered
+
+
+def load_source_interoception(species_yaml_path=SPECIES_YAML, expansion_yaml_path=EXPANSION_YAML):
+    """Return {species_id: [filtered gateway ids]} for every source species that
+    authors a non-empty interoception_traits. species.yaml wins over the expansion
+    examples (mirrors merge_pack_v2 legacy precedence)."""
+    source: dict = {}
+    seen: set = set()
+    sp_path = Path(species_yaml_path) if species_yaml_path else None
+    if sp_path and sp_path.exists():
+        data = yaml.safe_load(sp_path.read_text(encoding="utf-8")) or {}
+        _collect(data.get("species", []), source, seen)
+    exp_path = Path(expansion_yaml_path) if expansion_yaml_path else None
+    if exp_path and exp_path.exists():
+        data = yaml.safe_load(exp_path.read_text(encoding="utf-8")) or {}
+        _collect(data.get("species_examples", []), source, seen)
+    return source
+
+
+def plan_interoception_changes(catalog, source_map):
+    """Match authored values to catalog species. Skip species not present and
+    species already in sync (idempotent). Return (to_apply, skipped).
+    to_apply = [(species_obj, [ids])]."""
+    by_id = {}
+    for sp in catalog:
+        key = sp.get("species_id") or sp.get("legacy_slug")
+        if key:
+            by_id.setdefault(key, sp)
+    to_apply, skipped = [], []
+    for sid, traits in source_map.items():
+        sp = by_id.get(sid)
+        if sp is None:
+            skipped.append((sid, "not in catalog"))
+            continue
+        if sp.get("interoception_traits") == traits:
+            skipped.append((sid, "already in sync"))
+            continue
+        to_apply.append((sp, traits))
+    return to_apply, skipped
+
+
+def apply_changes(to_apply):
+    for sp, traits in to_apply:
+        sp["interoception_traits"] = traits
+        prov = sp.setdefault("_provenance", {})
+        if not isinstance(prov, dict):
+            prov = {}
+            sp["_provenance"] = prov
+        prov["interoception_traits"] = PROV_TAG
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Sync authored interoception_traits from species sources into the canonical catalog"
+    )
+    ap.add_argument("--species-yaml", default=str(SPECIES_YAML))
+    ap.add_argument("--expansion-yaml", default=str(EXPANSION_YAML))
+    ap.add_argument("--catalog", default=str(CATALOG_PATH))
+    ap.add_argument("--apply", action="store_true", help="write the catalog (default: dry-run)")
+    args = ap.parse_args(argv)
+
+    source = load_source_interoception(args.species_yaml, args.expansion_yaml)
+
+    with open(args.catalog, encoding="utf-8") as f:
+        data = json.load(f)
+    catalog = data["catalog"]
+    to_apply, skipped = plan_interoception_changes(catalog, source)
+
+    print(f"[source] {len(source)} species author interoception_traits")
+    print(f"[plan] {len(to_apply)} to apply, {len(skipped)} skipped")
+    for sid, why in skipped:
+        print(f"  skip {sid}: {why}")
+    for sp, traits in to_apply:
+        print(f"  + {sp.get('species_id')}: interoception_traits={traits}")
+
+    if not args.apply:
+        print("[DRY-RUN] no write. Re-run with --apply to write the catalog.")
+        return 0
+    if not to_apply:
+        print("[apply] nothing to apply (catalog unchanged).")
+        return 0
+
+    apply_changes(to_apply)
+    with open(args.catalog, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    print(f"[APPLIED] wrote {len(to_apply)} interoception_traits into {args.catalog}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/etl/interoception_field.py
+++ b/tools/etl/interoception_field.py
@@ -1,0 +1,45 @@
+"""OD-024 D4 -- shared interoception_traits field helper for the species ETL.
+
+Single Python SoT for the interoception gateway whitelist + the source->catalog
+filter, imported by the catalog assemblers (merge_pack_v2_species.py +
+promote_gameplay_to_canon.py). Mirrors the producer whitelist in
+apps/backend/services/sentience/sentienceInteroceptionGrant.js
+(INTEROCEPTION_TRAIT_IDS) -- keep the two in sync.
+
+The filter normalizes a raw source value into a clean, whitelist-only,
+order-preserving, de-duplicated list. Callers add the field to a catalog entry
+ONLY when the result is non-empty, so a source without the field leaves the entry
+(and therefore the regenerated catalog) byte-identical. D4 is infra-only:
+ZERO species author the field in this work -> the passthrough is a no-op on
+current data (band-neutral).
+"""
+
+from __future__ import annotations
+
+# RFC sentience v0.1 interoception gateway trait ids (OD-024, RFC sez.5 MVP).
+# Canonical 4 -- must match producer INTEROCEPTION_TRAIT_IDS (JS).
+INTEROCEPTION_TRAIT_IDS = (
+    "propriocezione",
+    "equilibrio_vestibolare",
+    "nocicezione",
+    "termocezione",
+)
+
+
+def filter_interoception(value):
+    """Normalize a raw source `interoception_traits` value for the catalog.
+
+    Returns a list containing only canonical gateway ids, in first-seen order,
+    de-duplicated. Any non-list input (None, str, ...) or all-unknown input
+    yields []. Callers omit the catalog key when the result is empty so the
+    field stays absent until a species actually authors it.
+    """
+    if not isinstance(value, list):
+        return []
+    out = []
+    seen = set()
+    for raw in value:
+        if raw in INTEROCEPTION_TRAIT_IDS and raw not in seen:
+            out.append(raw)
+            seen.add(raw)
+    return out

--- a/tools/etl/merge_pack_v2_species.py
+++ b/tools/etl/merge_pack_v2_species.py
@@ -53,6 +53,8 @@ import sys
 from datetime import date
 from pathlib import Path
 
+from interoception_field import filter_interoception
+
 # Sentience tier defaults for non-Pack-v2 species (RFC v0.1 heuristic mapping).
 # Animal types → T1 (Proto-Sentiente, reattivo).
 # Skiv/Custode pre-canonical → T3 (Emergente).
@@ -158,7 +160,7 @@ def build_entry(species_id: str, pack: dict | None, legacy: dict | None = None) 
                         pack_trait_refs.extend(t for t in section if isinstance(t, str))
             elif isinstance(tp, list):
                 pack_trait_refs = [t for t in tp if isinstance(t, str)]
-        return {
+        entry = {
             'species_id': species_id,
             'scientific_name': pack.get('scientific_name', species_id.replace('_', ' ').title()),
             'common_names': pack.get('common_names', []),
@@ -186,6 +188,17 @@ def build_entry(species_id: str, pack: dict | None, legacy: dict | None = None) 
             'source': source,
             'merged_at': today,
         }
+        # D4 (OD-024) -- carry an authored interoception_traits set source->catalog
+        # (pack first, legacy overlay fallback). Omitted when absent so the catalog
+        # stays diff-clean until a species authors it. Mirrors trait_refs, filtered
+        # to the gateway whitelist (a bad id never reaches the catalog).
+        intero = filter_interoception(
+            pack.get('interoception_traits')
+            or (legacy.get('interoception_traits') if legacy else None)
+        )
+        if intero:
+            entry['interoception_traits'] = intero
+        return entry
     # Stub for species missing from Pack v2 (Frattura Abissale + dune_stalker).
     return {
         'species_id': species_id,
@@ -292,6 +305,11 @@ def build_entry_from_legacy(species_id: str, legacy: dict) -> dict:
 
     role_tags = legacy.get('role_tags', [])
 
+    # D4 (OD-024) -- carry an authored interoception_traits set source->catalog,
+    # filtered to the gateway whitelist. Omitted below when empty so the catalog
+    # stays diff-clean until a species authors the field.
+    intero = filter_interoception(legacy.get('interoception_traits'))
+
     # ecotypes: legacy role_tags (apex/predator/keystone...) are roles, NOT
     # ecotype_cluster enum values. Leave empty; canonical ecotype clusters live
     # in data/external/evo/species/<id>_ecotypes.json, authored per-species
@@ -300,7 +318,7 @@ def build_entry_from_legacy(species_id: str, legacy: dict) -> dict:
 
     sentience = legacy.get('sentience_index') or legacy.get('sentience_tier') or 'T1'
 
-    return {
+    entry = {
         'species_id': species_id,
         'scientific_name': scientific,
         'common_names': common_names,
@@ -337,6 +355,9 @@ def build_entry_from_legacy(species_id: str, legacy: dict) -> dict:
         'source': 'legacy-yaml-merge',
         'merged_at': today,
     }
+    if intero:
+        entry['interoception_traits'] = intero
+    return entry
 
 
 def main():

--- a/tools/etl/promote_gameplay_to_canon.py
+++ b/tools/etl/promote_gameplay_to_canon.py
@@ -39,6 +39,8 @@ from datetime import date
 
 import yaml
 
+from interoception_field import filter_interoception
+
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 CATALOG_PATH = os.path.join(REPO_ROOT, "data", "core", "species", "species_catalog.json")
 SPECIES_DIR = os.path.join(REPO_ROOT, "packs", "evo_tactics_pack", "data", "species")
@@ -89,7 +91,7 @@ def derive_entry(pack, biome, fid):
     danger = TIER_DANGER.get(tier, 1)
     sentience = "T3" if sentient else "T1"  # RFC heuristic: sentient->T3, animal->T1
 
-    return {
+    entry = {
         "species_id": norm(fid),
         # --- STUB design fields (presence required by integrity test) ---
         "scientific_name": "",              # TODO author Latin binomial
@@ -122,6 +124,13 @@ def derive_entry(pack, biome, fid):
         "_promote_stub": True,
         "_todo_fields": list(TODO_FIELDS),
     }
+    # D4 (OD-024) -- carry an authored interoception_traits set from the gameplay
+    # YAML source->catalog (mirrors role_tags read-from-source). Omitted when
+    # absent so the catalog stays diff-clean until a species authors the field.
+    intero = filter_interoception(pack.get("interoception_traits"))
+    if intero:
+        entry["interoception_traits"] = intero
+    return entry
 
 
 def main():


### PR DESCRIPTION
## Sommario

OD-024 **D4 = pipeline-only** (master-dd verdict 2026-06-22): propaga un campo
OPZIONALE `interoception_traits: [<gateway ids>]` da un record specie *source*
attraverso l'ETL fino a `data/core/species/species_catalog.json`, così l'override
del producer gia' shippato (`sentienceInteroceptionGrant.perSpeciesOverride`)
diventa usabile. **ZERO specie autorano il campo in questo lavoro** -> band-neutral,
solo-infra, catalog diff-clean.

## Cosa cambia

- **`tools/etl/interoception_field.py`** (nuovo): SoT Python della whitelist gateway
  (mirror del producer `INTEROCEPTION_TRAIT_IDS`) + filtro (solo-whitelist,
  order-preserving, de-dup).
- **passthrough** nei 3 assembler del catalog, mirror del precedente `trait_refs`:
  `merge_pack_v2_species.build_entry` (+ overlay legacy) e `build_entry_from_legacy`;
  `promote_gameplay_to_canon.derive_entry`. La chiave e' **OMESSA quando la source
  non la porta** -> il catalog rigenerato resta byte-identico (no empty-array
  injection).
- **schema** `schemas/evo/species_catalog.schema.json`: proprieta' opzionale
  `interoception_traits` (mirror `trait_refs`; additive, non invalida le entry
  esistenti).

## Recon (Phase 0, ETL flow era l'ignoto)

- **Nessun full-regen idempotente in-repo**: `merge_pack_v2` e' one-time (richiede il
  vault esterno `--pack-v2`, hardcoda version + `merged_at`, droppa le specie
  appese da `promote`); non e' invocato da nessun npm/Make/CI. Il catalog viene
  mutato incrementalmente da tool dedicati + PR di calibrazione.
- => non si puo' "lanciare il regen e mostrare diff vuoto"; il no-op e' provato
  **per costruzione** (omit-when-absent + nessuna source autora il campo) +
  unit-test, non ri-eseguendo l'assembler. (= escape hatch R4 del piano.)
- L'assembler NON e' in `services/generation/` (forbidden-path). `enrich_species_heuristic`
  muta in-place -> preserva chiavi sconosciute (nessun edit).

## Test plan / evidenze

- [x] 12 nuovi unit-test passthrough (`tests/test_interoception_field_passthrough.py`) — RED provato prima dell'impl.
- [x] `species_catalog.json` **non toccato** + valida contro lo schema aggiornato (0 entry portano il campo).
- [x] producer read-path verde (`tests/api/sentience-interoception-grant.test.js` 26/0, blocco D4 override gia' esistente).
- [x] `node scripts/run-test-api.cjs` = **4566 pass / 0 fail** (un re-run ha colpito il noto flake rotating-file `reports/status.json` su Windows parallelo, NON un test-failure).
- [x] prettier-check verde (schema); Python ASCII-clean.
- [x] review adversariale compensativa (Codex rate-limited) — nessun finding reale (la claim "test su mock" e' refutata: i test chiamano gli assembler reali e fallivano in RED quando il passthrough era assente).

## Flag / rollback

- `SENTIENCE_INTEROCEPTION_GRANT_ENABLED` resta **OFF**. Band-neutral (nessun cambio di comportamento, catalog diff-clean). Rollback = revert del commit.

## Guardrail

- Tocca `schemas/evo/` (gated) + >50 LOC fuori `apps/backend` -> **master-dd manual merge** (NON auto-merge-L3). ADR-0011 trailer presente.

## Dopo D4 (residui, owner/master-dd-gated)

- **D7** flip incrementale (N=40 per pezzo, poi flag ON in keys.env).
- **D6** engine #3 encumbrance (PARKED: serve sistema inventario/peso assente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)