### PR TITLE
feat(sentience): populate interoception overrides via derive rule (OD-024 D4)

### DIFF
--- a/data/core/species/species_catalog.json
+++ b/data/core/species/species_catalog.json
@@ -114,7 +114,15 @@
       "genus": "Anguimagnus",
       "epithet": "litoralis",
       "source": "pack-v2-full-plus",
-      "merged_at": "2026-05-15"
+      "merged_at": "2026-05-15",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "chemnotela_toxica",
@@ -344,7 +352,16 @@
       "genus": "Elastovaranus",
       "epithet": "hydraulicus",
       "source": "pack-v2-full-plus",
-      "merged_at": "2026-05-15"
+      "merged_at": "2026-05-15",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "gulogluteus_scutiger",
@@ -1600,8 +1617,14 @@
         "interactions.symbiosis": "claude-polish-skiv-style-keystone",
         "visual_description": "claude-polish-per-clade-keystone",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_sonapteryx_resonans",
@@ -1765,8 +1788,14 @@
         "interactions.symbiosis": "claude-polish-skiv-style-keystone",
         "visual_description": "claude-polish-per-clade-keystone",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_ventornis_longiala",
@@ -1884,8 +1913,15 @@
         "interactions.symbiosis": "default-clade-nonkeystone",
         "visual_description": "claude-polish-per-clade-apex",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_pyrosaltus_celeris",
@@ -1940,8 +1976,14 @@
         "interactions.symbiosis": "default-clade-nonkeystone",
         "visual_description": "claude-polish-per-clade-threat",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_basaltocara_scutata",
@@ -1996,8 +2038,14 @@
         "interactions.symbiosis": "default-clade-nonkeystone",
         "visual_description": "claude-polish-per-clade-support",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_arenaceros_placidus",
@@ -2383,8 +2431,14 @@
         "interactions.symbiosis": "claude-polish-skiv-style-keystone",
         "visual_description": "claude-polish-per-clade-keystone",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_nebulocornis_mollis",
@@ -2551,8 +2605,14 @@
         "interactions.symbiosis": "claude-polish-skiv-style-bridge",
         "visual_description": "claude-polish-per-clade-bridge",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_tonitrudens_ferox",
@@ -2604,8 +2664,14 @@
         "interactions.symbiosis": "default-clade-nonkeystone",
         "visual_description": "claude-polish-per-clade-threat",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_rubrospina_velox",
@@ -2669,8 +2735,14 @@
         "interactions.symbiosis": "default-clade-nonkeystone",
         "visual_description": "needs-master-dd",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_paludogromus_magnus",
@@ -2776,8 +2848,14 @@
         "interactions.symbiosis": "default-clade-nonkeystone",
         "visual_description": "claude-polish-per-clade-threat",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_zephyrovum_fidelis",
@@ -2829,8 +2907,14 @@
         "interactions.symbiosis": "claude-polish-skiv-style-bridge",
         "visual_description": "claude-polish-per-clade-bridge",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_vitricyba_punctata",
@@ -2936,8 +3020,14 @@
         "interactions.symbiosis": "claude-polish-skiv-style-keystone",
         "visual_description": "claude-polish-per-clade-keystone",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_arboryxis_lenis",
@@ -3056,8 +3146,15 @@
         "interactions.symbiosis": "default-clade-nonkeystone",
         "visual_description": "claude-polish-per-clade-apex",
         "constraints": "heuristic-pattern-C-mechanical",
-        "biome_affinity": "d4-heuristic-suggest+master-dd-approve"
-      }
+        "biome_affinity": "d4-heuristic-suggest+master-dd-approve",
+        "interoception_traits": "d4-derived-rule"
+      },
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione"
+      ]
     },
     {
       "species_id": "sp_magnetocola_pastoris",
@@ -3452,7 +3549,15 @@
         "ecotypes"
       ],
       "genus": "Echopterus",
-      "epithet": "pollinifer"
+      "epithet": "pollinifer",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "ferrocolonia_magnetotattica",
@@ -3562,7 +3667,15 @@
         "trait_refs",
         "lifecycle_yaml"
       ],
-      "is_event": true
+      "is_event": true,
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "nano_rust_bloom",
@@ -3621,7 +3734,16 @@
         "ecotypes"
       ],
       "genus": "Oxidospora",
-      "epithet": "pestifera"
+      "epithet": "pestifera",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "rust_scavenger",
@@ -3681,7 +3803,15 @@
         "ecotypes"
       ],
       "genus": "Ferrivora",
-      "epithet": "saprophaga"
+      "epithet": "saprophaga",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "sand_burrower",
@@ -3742,7 +3872,15 @@
         "ecotypes"
       ],
       "genus": "Arenofossor",
-      "epithet": "saliphilus"
+      "epithet": "saliphilus",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "slag_veil_ambusher",
@@ -3792,7 +3930,15 @@
         "trait_refs",
         "lifecycle_yaml"
       ],
-      "is_event": true
+      "is_event": true,
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "aurora_bridge_runner",
@@ -3842,7 +3988,15 @@
         "trait_refs",
         "lifecycle_yaml"
       ],
-      "is_event": true
+      "is_event": true,
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "aurora_gull",
@@ -3902,7 +4056,15 @@
         "ecotypes"
       ],
       "genus": "Glacilarus",
-      "epithet": "borealis"
+      "epithet": "borealis",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "cryo_lynx",
@@ -3960,7 +4122,16 @@
         "ecotypes"
       ],
       "genus": "Cryofelis",
-      "epithet": "nivalis"
+      "epithet": "nivalis",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "steppe_bison_mini",
@@ -4020,7 +4191,15 @@
         "ecotypes"
       ],
       "genus": "Nanobison",
-      "epithet": "tundrae"
+      "epithet": "tundrae",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "thaw_rot",
@@ -4079,7 +4258,16 @@
         "ecotypes"
       ],
       "genus": "Geliputris",
-      "epithet": "liquefaciens"
+      "epithet": "liquefaciens",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "zephyr_spore_courier",
@@ -4129,7 +4317,15 @@
         "trait_refs",
         "lifecycle_yaml"
       ],
-      "is_event": true
+      "is_event": true,
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "cactus_weaver",
@@ -4188,7 +4384,15 @@
         "ecotypes"
       ],
       "genus": "Cactotextor",
-      "epithet": "hydrophorus"
+      "epithet": "hydrophorus",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "noctule_termico",
@@ -4249,7 +4453,15 @@
         "ecotypes"
       ],
       "genus": "Thermonoctus",
-      "epithet": "vagans"
+      "epithet": "vagans",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "silica_bloom",
@@ -4310,7 +4522,16 @@
         "ecotypes"
       ],
       "genus": "Siliciflora",
-      "epithet": "pestifera"
+      "epithet": "pestifera",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "thermo_raptor",
@@ -4369,7 +4590,16 @@
         "ecotypes"
       ],
       "genus": "Thermoraptor",
-      "epithet": "aridus"
+      "epithet": "aridus",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "blight_micotico",
@@ -4429,7 +4659,15 @@
         "ecotypes"
       ],
       "genus": "Mycotabes",
-      "epithet": "corruptor"
+      "epithet": "corruptor",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "glowcap_weaver",
@@ -4536,7 +4774,15 @@
         "ecotypes"
       ],
       "genus": "Silvalupus",
-      "epithet": "temperatus"
+      "epithet": "temperatus",
+      "interoception_traits": [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione"
+      ],
+      "_provenance": {
+        "interoception_traits": "d4-derived-rule"
+      }
     },
     {
       "species_id": "myco_spire_warden",

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12624,6 +12624,19 @@
       "review_cycle_days": 30,
       "primary": false,
       "track": "migrated"
+    },
+    {
+      "path": "docs/superpowers/specs/2026-06-22-od024-d4-interoception-overrides-rule-design.md",
+      "title": "OD-024 D4 -- principled interoception_traits override rule (full pass)",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "backend",
+      "last_verified": "2026-06-22",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "migrated"
     }
   ]
 }

--- a/docs/superpowers/plans/2026-06-22-od024-d4-derive-interoception-overrides.md
+++ b/docs/superpowers/plans/2026-06-22-od024-d4-derive-interoception-overrides.md
@@ -1,0 +1,207 @@
+# OD-024 D4 derive interoception overrides -- Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]` checkboxes.
+
+**Goal:** Populate per-species `interoception_traits` overrides into `data/core/species/species_catalog.json` from a ratified rule (tier-floor + ecological boosts), via a new rule-based ETL tool.
+
+**Architecture:** New `tools/etl/derive_interoception_overrides.py` mirrors `apply_biome_affinity.py` / `apply_interoception_traits.py`: pure rule core (compute override from a catalog entry) + DRY-RUN/`--apply` IO wrapper that writes the field in place. Reuses `tools/etl/interoception_field.py` (whitelist + filter). Flag `SENTIENCE_INTEROCEPTION_GRANT_ENABLED` stays OFF -> band-neutral despite the catalog diff.
+
+**Tech Stack:** Python 3.12 (`C:/Users/edusc/AppData/Local/Programs/Python/Python312/python.exe`), pytest, node (`run-test-api.cjs` regression).
+
+Spec: `docs/superpowers/specs/2026-06-22-od024-d4-interoception-overrides-rule-design.md`.
+
+---
+
+## Ratified constants
+
+- `NOCICEPTION_DANGER_THRESHOLD = 2`
+- `THERMAL_BIOMES = {deserto_caldo, abisso_vulcanico, dorsale_termale_tropicale, pianura_salina_iperarida, cryosteppe, caldera_glaciale, mezzanotte_orbitale, stratosfera_tempestosa, badlands}`
+- `TIER_INTEROCEPTION_MAP = {T1: [propriocezione, equilibrio_vestibolare], T2: [nocicezione], T3: [termocezione]}` (cumulative; mirror of producer).
+- Expected impact: 33 overrides (30 T1, 3 T2); 41 stay on tier default; T0 skipped.
+
+---
+
+### Task 1: pure rule core (TDD)
+
+**Files:**
+
+- Create: `tools/etl/derive_interoception_overrides.py`
+- Test: `tests/test_derive_interoception_overrides.py`
+
+- [ ] **Step 1: failing tests** (`tests/test_derive_interoception_overrides.py`)
+
+```python
+import sys
+from pathlib import Path
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools" / "etl"))
+import derive_interoception_overrides as d
+
+def test_tier_default_cumulative():
+    assert d.tier_default("T1") == ["propriocezione", "equilibrio_vestibolare"]
+    assert d.tier_default("T2") == ["propriocezione", "equilibrio_vestibolare", "nocicezione"]
+    assert d.tier_default("T3") == ["propriocezione", "equilibrio_vestibolare", "nocicezione", "termocezione"]
+    assert d.tier_default("T0") == []
+    assert d.tier_default("garbage") == []
+
+def test_derive_adds_nocicezione_for_danger_T1():
+    e = {"sentience_index": "T1", "risk_profile": {"danger_level": 2}, "biome_affinity": "savana"}
+    assert d.derive_override(e) == ["propriocezione", "equilibrio_vestibolare", "nocicezione"]
+
+def test_derive_adds_termocezione_for_thermal_biome_T1():
+    e = {"sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": "badlands"}
+    assert d.derive_override(e) == ["propriocezione", "equilibrio_vestibolare", "termocezione"]
+
+def test_derive_both_additions_T2():
+    e = {"sentience_index": "T2", "risk_profile": {"danger_level": 3}, "biome_affinity": "deserto_caldo"}
+    assert d.derive_override(e) == ["propriocezione", "equilibrio_vestibolare", "nocicezione", "termocezione"]
+
+def test_derive_none_when_equals_tier_default():
+    # T1, low danger, non-thermal -> no addition -> None (no override row)
+    e = {"sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": "foresta_temperata"}
+    assert d.derive_override(e) is None
+
+def test_derive_none_for_T3_plus():
+    # T3 already has all 4 by tier -> additions cannot exceed -> None
+    e = {"sentience_index": "T3", "risk_profile": {"danger_level": 3}, "biome_affinity": "abisso_vulcanico"}
+    assert d.derive_override(e) is None
+
+def test_derive_none_for_T0():
+    e = {"sentience_index": "T0", "risk_profile": {"danger_level": 3}, "biome_affinity": "badlands"}
+    assert d.derive_override(e) is None
+
+def test_plan_overrides_counts(tmp_catalog=None):
+    catalog = [
+        {"species_id": "a", "sentience_index": "T1", "risk_profile": {"danger_level": 2}, "biome_affinity": "savana"},
+        {"species_id": "b", "sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": "foresta_temperata"},
+    ]
+    to_apply, skipped = d.plan_overrides(catalog)
+    assert [sp["species_id"] for sp, _ in to_apply] == ["a"]
+
+def test_plan_idempotent_when_in_sync():
+    catalog = [{"species_id": "a", "sentience_index": "T1", "risk_profile": {"danger_level": 2},
+                "biome_affinity": "savana", "interoception_traits": ["propriocezione", "equilibrio_vestibolare", "nocicezione"]}]
+    to_apply, skipped = d.plan_overrides(catalog)
+    assert to_apply == []
+```
+
+- [ ] **Step 2: run -> FAIL** `PYTHONPATH=tools/py <py> -m pytest tests/test_derive_interoception_overrides.py -q` (ModuleNotFound).
+
+- [ ] **Step 3: implement core** (`tools/etl/derive_interoception_overrides.py`)
+
+```python
+from interoception_field import INTEROCEPTION_TRAIT_IDS, filter_interoception
+
+NOCICEPTION_DANGER_THRESHOLD = 2
+THERMAL_BIOMES = frozenset({
+    "deserto_caldo", "abisso_vulcanico", "dorsale_termale_tropicale",
+    "pianura_salina_iperarida", "cryosteppe", "caldera_glaciale",
+    "mezzanotte_orbitale", "stratosfera_tempestosa", "badlands",
+})
+TIER_INTEROCEPTION_MAP = {  # cumulative; mirror producer interoceptionForTier (D2)
+    "T1": ["propriocezione", "equilibrio_vestibolare"],
+    "T2": ["nocicezione"],
+    "T3": ["termocezione"],
+}
+
+def _rank(t):
+    return int(t[1]) if isinstance(t, str) and len(t) == 2 and t[0] == "T" and t[1].isdigit() else None
+
+def tier_default(tier):
+    r = _rank(tier)
+    if r is None:
+        return []
+    out = []
+    for k, ids in TIER_INTEROCEPTION_MAP.items():
+        if _rank(k) <= r:
+            out += ids
+    return filter_interoception(out)
+
+def derive_override(entry):
+    r = _rank(entry.get("sentience_index"))
+    if r is None or r < 1:   # T0/unknown -> producer gates out -> no override
+        return None
+    base = tier_default(entry.get("sentience_index"))
+    additions = set()
+    if (entry.get("risk_profile") or {}).get("danger_level", 1) >= NOCICEPTION_DANGER_THRESHOLD:
+        additions.add("nocicezione")
+    if entry.get("biome_affinity") in THERMAL_BIOMES:
+        additions.add("termocezione")
+    full = filter_interoception(list(base) + [a for a in INTEROCEPTION_TRAIT_IDS if a in additions])
+    return full if full != base else None
+
+def plan_overrides(catalog):
+    to_apply, skipped = [], []
+    for sp in catalog:
+        override = derive_override(sp)
+        if override is None:
+            skipped.append((sp.get("species_id"), "tier-default or below-gateway"))
+        elif sp.get("interoception_traits") == override:
+            skipped.append((sp.get("species_id"), "already in sync"))
+        else:
+            to_apply.append((sp, override))
+    return to_apply, skipped
+```
+
+- [ ] **Step 4: run -> PASS.**
+- [ ] **Step 5: commit** (`git add` tool+test; ADR-0011 trailer).
+
+### Task 2: IO wrapper + CLI (TDD)
+
+**Files:** Modify `tools/etl/derive_interoception_overrides.py`; extend test file.
+
+- [ ] **Step 1: failing tests** -- `apply_changes` sets field+`_provenance`(`PROV_TAG`), preserves other keys; `main(["--apply","--catalog",tmp])` writes 1 entry on a 2-entry temp catalog then is idempotent on re-run; dry-run default writes nothing.
+
+```python
+def test_apply_changes_sets_field_and_provenance():
+    sp = {"species_id": "a"}
+    d.apply_changes([(sp, ["propriocezione", "nocicezione"])])
+    assert sp["interoception_traits"] == ["propriocezione", "nocicezione"]
+    assert sp["_provenance"]["interoception_traits"] == d.PROV_TAG
+
+def test_main_apply_then_idempotent(tmp_path):
+    import json
+    cat = {"catalog": [
+        {"species_id": "a", "sentience_index": "T1", "risk_profile": {"danger_level": 2}, "biome_affinity": "savana"},
+        {"species_id": "b", "sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": "palude"},
+    ]}
+    p = tmp_path / "c.json"; p.write_text(json.dumps(cat), encoding="utf-8")
+    assert d.main(["--apply", "--catalog", str(p)]) == 0
+    after = json.loads(p.read_text(encoding="utf-8"))["catalog"]
+    assert after[0]["interoception_traits"] == ["propriocezione", "equilibrio_vestibolare", "nocicezione"]
+    assert "interoception_traits" not in after[1]
+    mtime = p.stat().st_mtime_ns
+    assert d.main(["--apply", "--catalog", str(p)]) == 0  # idempotent: nothing to apply
+```
+
+- [ ] **Step 2: run -> FAIL.**
+- [ ] **Step 3: implement** `PROV_TAG="d4-derived-rule"`, `CATALOG_PATH`, `apply_changes` (mirror `apply_interoception_traits.apply_changes`), `main(argv)` (mirror: dry-run default, `--apply` gate, `if not to_apply: return 0` before write, `json.dump(..., ensure_ascii=False, indent=2); f.write("\n")`).
+- [ ] **Step 4: run -> PASS.** Also run the full combined ETL pytest.
+- [ ] **Step 5: commit.**
+
+### Task 3: regenerate the real catalog
+
+**Files:** Modify `data/core/species/species_catalog.json` (generated, via tool -- NOT hand-edit).
+
+- [ ] **Step 1:** dry-run `<py> tools/etl/derive_interoception_overrides.py` -> expect "33 to apply".
+- [ ] **Step 2:** `<py> tools/etl/derive_interoception_overrides.py --apply`.
+- [ ] **Step 3:** verify diff scoped -- `git diff data/core/species/species_catalog.json` shows ONLY added `interoception_traits` + `_provenance` lines (no other field churn); count `+ "interoception_traits"` == 33.
+- [ ] **Step 4:** schema validates (jsonschema check from D4 PR); `derive ... --apply` re-run = "nothing to apply" (idempotent).
+- [ ] **Step 5: commit** the regenerated catalog.
+
+### Task 4: full regression + band-neutral
+
+- [ ] **Step 1:** `PYTHONPATH=tools/py <py> -m pytest tests/ tools/py -q` -> green (catch any catalog-reading test reacting; re-baseline only if a snapshot legitimately reacts -- document it).
+- [ ] **Step 2:** `node scripts/run-test-api.cjs` -> green (synergyCombo flake known; re-run once if it alone fails). Producer band-neutral: `sentience-interoception-grant` + `coopSentienceGrant` still green with flag OFF.
+- [ ] **Step 3:** `npx prettier --check` touched JSON (catalog + any). Python ASCII-clean.
+
+### Task 5: review + PR
+
+- [ ] **Step 1:** compensating adversarial review (cavecrew-reviewer) of the tool+catalog diff (Codex rate-limited).
+- [ ] **Step 2:** PR off origin/main. Note: catalog CHANGES (33 overrides) but band-neutral (flag OFF); touches `data/core` (regenerate-or-die honored: tool-generated) + the spec/plan/registry. master-dd manual merge (>50 LOC outside apps/backend). N=40 gates the D7 flip (owner).
+
+## Self-review
+
+- Spec coverage: rule (Task 1), write path (Task 2), populate (Task 3), regression/band-neutral (Task 4), review/PR (Task 5). All covered.
+- No placeholders: all code shown.
+- Type consistency: `tier_default`/`derive_override`/`plan_overrides`/`apply_changes`/`main` + `PROV_TAG` consistent across tasks; mirror `interoception_field` API (`INTEROCEPTION_TRAIT_IDS`, `filter_interoception`).

--- a/docs/superpowers/specs/2026-06-22-od024-d4-interoception-overrides-rule-design.md
+++ b/docs/superpowers/specs/2026-06-22-od024-d4-interoception-overrides-rule-design.md
@@ -1,0 +1,132 @@
+---
+title: 'OD-024 D4 -- principled interoception_traits override rule (full pass)'
+doc_status: draft
+doc_owner: master-dd
+workstream: backend
+last_verified: '2026-06-22'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+---
+
+# OD-024 D4 -- principled interoception_traits override rule
+
+## Goal
+
+D4 shipped the pipeline (PR #2950): the producer reads a per-species
+`interoception_traits` override (`perSpeciesOverride`), the schema allows it, the
+ETL assemblers carry it, and `tools/etl/apply_interoception_traits.py` syncs an
+authored value from `species.yaml` into the catalog. ZERO species author the
+field yet.
+
+This is the principled **full pass** (master-dd verdict 2026-06-22, Approach A):
+derive a per-species override for every catalog species from a ratified rule
+combining sentience tier (D2 baseline) + ecology, and write it into
+`data/core/species/species_catalog.json`. The override REPLACES the D2 tier
+subset, so the rule computes `tier_default UNION ecological_additions` and writes
+it only where it differs from the tier default (no redundant rows).
+
+**Band-neutral:** the grant flag `SENTIENCE_INTEROCEPTION_GRANT_ENABLED` stays
+OFF, so the producer never grants -> no runtime behavior change despite the
+catalog diff. N=40 calibration gates the eventual flip (D7, owner).
+
+## Key simplification (data-grounded)
+
+`propriocezione` + `equilibrio_vestibolare` are the T1 floor, so every T1+ species
+already carries both via the tier default. The only ecological ADDITIONS the rule
+can make are therefore:
+
+- **nocicezione** to a sub-T2 species (T2+ already have it by tier)
+- **termocezione** to a sub-T3 species (T3+ already have it by tier)
+
+No aerial/aquatic detection is needed (vestibular is universal). The sparse
+`morphotype` (13/75) and `ecology` (12/75) fields are NOT used as drivers; the
+rule uses only fields present on 100% of species: `sentience_index`,
+`biome_affinity`, `risk_profile.danger_level`.
+
+## The rule
+
+```
+base       = tier_default(sentience_index)        # D2 cumulative map
+additions  = {}
+  + nocicezione   if risk_profile.danger_level >= 2     (RATIFIED 2026-06-22)
+  + termocezione  if biome_affinity in THERMAL_BIOMES   (RATIFIED 2026-06-22)
+override   = canonical_order(filter_whitelist(base UNION additions))
+write override to the catalog entry IFF override != base
+skip species whose tier rank < 1 (T0 / unknown) -- the producer gates them out
+  before reading the override, so an override there is dead.
+```
+
+`tier_default` mirrors the producer `interoceptionForTier` (D2 map): `T1 =
+[propriocezione, equilibrio_vestibolare]`, `T2 += nocicezione`, `T3+ +=
+termocezione`. `filter_whitelist` + canonical order come from the shared
+`tools/etl/interoception_field.py` (`INTEROCEPTION_TRAIT_IDS`).
+
+### THERMAL_BIOMES (RATIFIED 2026-06-22)
+
+Hot: `deserto_caldo`, `abisso_vulcanico`, `dorsale_termale_tropicale`,
+`pianura_salina_iperarida`. Cold: `cryosteppe`, `caldera_glaciale`,
+`mezzanotte_orbitale`, `stratosfera_tempestosa`. Arid-extreme: `badlands`
+(master-dd call; `atollo_obsidiana` + `canyons_risonanti` ruled NON-thermal).
+
+Non-thermal (no termocezione boost): `foresta_temperata`, `palude`, `savana`,
+`canopia_ionica`, `foresta_acida`, `steppe_algoritmiche`, `reef_luminescente`,
+`caverna`, `frattura_abissale_sinaptica`, `atollo_obsidiana`,
+`canyons_risonanti`.
+
+## Impact (computed on current catalog, 75 species)
+
+33 species get an override (30 T1, 3 T2); 41 stay on the tier default (no row);
+1 T0 skipped. Examples: thermal-biome T1 species -> `[prop, vest, termo]`; T1
+danger>=2 -> `[prop, vest, noci]`; T2 thermal+danger -> all 4.
+
+## Implementation
+
+New `tools/etl/derive_interoception_overrides.py` (rule-based mirror of
+`tools/py/apply_biome_affinity.py` + `apply_interoception_traits.py`):
+
+- Module-level constants documented as RATIFIED: `THERMAL_BIOMES`,
+  `NOCICEPTION_DANGER_THRESHOLD = 2`, `TIER_INTEROCEPTION_MAP` (mirror of the
+  producer D2 map). Reuse `interoception_field.filter_interoception` +
+  `INTEROCEPTION_TRAIT_IDS`.
+- Pure core: `tier_default(tier)`, `derive_override(entry)` (returns the override
+  list or `None` when it equals the tier default / tier < T1),
+  `plan_overrides(catalog)` -> `(to_apply, skipped)`.
+- IO wrapper: DRY-RUN by default, `--apply` to write; idempotent (entry already
+  in sync -> skip); writes `interoception_traits` + `_provenance` (tag
+  `d4-derived-rule`); `json.dump(ensure_ascii=False, indent=2)` + trailing
+  newline (catalog format).
+- Distinct from `apply_interoception_traits.py` (which reads an authored
+  `species.yaml` field): this DERIVES from the rule. Both target the same catalog
+  field; the rule-derived pass is the canonical D4 populate, manual authoring
+  stays available for later exceptions.
+
+## Test plan
+
+- TDD pure functions: `tier_default` per tier; `derive_override` for each
+  add-path (thermal T1, danger T1, both T2, T3+ -> None, T0 -> None, in-sync ->
+  None); `plan_overrides` count/idempotency.
+- Regenerate the catalog via `--apply`; assert the 33-entry diff is exactly
+  `interoception_traits` + `_provenance` additions (no other field churn).
+- Schema still validates (`interoception_traits` already an allowed property).
+- Re-baseline any catalog snapshot/hash test that reacts to the new field
+  (e.g. `tests/server/generationSnapshot.spec.js`) -- expected, documented.
+- Full `node scripts/run-test-api.cjs` green; `PYTHONPATH=tools/py pytest`
+  green. Producer band-neutral with flag OFF (no grant) -- assert no win-rate
+  oracle shift.
+
+## Non-goals
+
+- Flipping `SENTIENCE_INTEROCEPTION_GRANT_ENABLED` (D7, owner, post N=40).
+- Down-deviations / removing a baseline trait (Approach A is additive-only).
+- Using morphotype/ecology as drivers (too sparse; revisit if authored later).
+
+## Risks
+
+- When the flag eventually flips, granting nocicezione/termocezione to ~33 more
+  species shifts win-rates -> N=40 per the D7 gate (owner). Catalog change here is
+  inert until then.
+- Catalog snapshot tests will need a one-time re-baseline (the field is new).
+- The rule is SDMG (designed here); the THERMAL set + danger threshold are
+  RATIFIED by master-dd 2026-06-22, but the win-rate consequence is only known
+  post N=40.

--- a/tests/api/coopSentienceGrant.test.js
+++ b/tests/api/coopSentienceGrant.test.js
@@ -23,9 +23,12 @@ function buildOrch() {
   return co;
 }
 
-// anguis_magnetica is T1 in data/core/species/species_catalog.json (qualifies).
+// glowcap_weaver is T1 + foresta_temperata + danger 1 in species_catalog.json:
+// no D4 derived override -> stays on the pure tier default, so the progressive
+// gating (T1 subset granted, higher-tier ids withheld) is still observable on
+// real data after the D4 populate. (anguis_magnetica now carries an override.)
 function t1Spec() {
-  return { name: 'Anguis', form_id: 'INTJ', species_id: 'anguis_magnetica', traits: [] };
+  return { name: 'Glowcap', form_id: 'INTJ', species_id: 'glowcap_weaver', traits: [] };
 }
 
 function withFlag(value, fn) {

--- a/tests/api/sentience-interoception-grant.test.js
+++ b/tests/api/sentience-interoception-grant.test.js
@@ -260,10 +260,17 @@ describe('OD-024 producer -- no-dup + immutability + id validation', () => {
 });
 
 describe('OD-024 producer -- real species_catalog (default loaders)', () => {
-  test('anguis_magnetica (T1, real catalog) grants the T1 subset with flag ON', () => {
-    // No catalog/registry injected -> exercises the real disk loaders.
+  test('anguis_magnetica (T1, real catalog) grants its D4 override with flag ON', () => {
+    // No catalog/registry injected -> exercises the real disk loaders. anguis_magnetica
+    // = T1 + atollo_obsidiana + danger 2, so the D4 derive rule (PR populating
+    // interoception_traits) adds nocicezione to the tier floor. Proves a populated
+    // per-species override flows from the real catalog through perSpeciesOverride e2e.
     const out = grant.applySentienceInteroceptionGrant(spec('anguis_magnetica'), { env: FLAG_ON });
-    assert.deepEqual([...out.traits].sort(), [...T1_SET].sort());
+    assert.deepEqual([...out.traits].sort(), [
+      'equilibrio_vestibolare',
+      'nocicezione',
+      'propriocezione',
+    ]);
   });
 
   test('proteus_plasma (T0, real catalog) grants nothing with flag ON', () => {

--- a/tests/test_derive_interoception_overrides.py
+++ b/tests/test_derive_interoception_overrides.py
@@ -1,0 +1,159 @@
+"""OD-024 D4 -- principled interoception_traits override DERIVE rule.
+
+Rule-based populate (Approach A, master-dd ratified 2026-06-22): per-species
+override = tier_default (D2) UNION ecological additions, written only where it
+differs from the tier default. Additions: nocicezione if danger>=2; termocezione
+if biome in THERMAL_BIOMES. prop+vest are the universal T1 floor (no gate). T0 /
+below-gateway skipped (producer gates them out before reading the override).
+
+Spec: docs/superpowers/specs/2026-06-22-od024-d4-interoception-overrides-rule-design.md
+Run: PYTHONPATH=tools/py python -m pytest tests/test_derive_interoception_overrides.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools" / "etl"))
+
+import derive_interoception_overrides as d
+
+
+# ============================================================================
+# tier_default (mirror of producer interoceptionForTier / D2 map)
+# ============================================================================
+
+
+def test_tier_default_cumulative():
+    assert d.tier_default("T1") == ["propriocezione", "equilibrio_vestibolare"]
+    assert d.tier_default("T2") == ["propriocezione", "equilibrio_vestibolare", "nocicezione"]
+    assert d.tier_default("T3") == [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione",
+    ]
+    assert d.tier_default("T0") == []
+    assert d.tier_default("garbage") == []
+
+
+# ============================================================================
+# derive_override (the rule)
+# ============================================================================
+
+
+def test_derive_adds_nocicezione_for_danger_T1():
+    e = {"sentience_index": "T1", "risk_profile": {"danger_level": 2}, "biome_affinity": "savana"}
+    assert d.derive_override(e) == ["propriocezione", "equilibrio_vestibolare", "nocicezione"]
+
+
+def test_derive_adds_termocezione_for_thermal_biome_T1():
+    e = {"sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": "badlands"}
+    assert d.derive_override(e) == ["propriocezione", "equilibrio_vestibolare", "termocezione"]
+
+
+def test_derive_both_additions_T2_canonical_order():
+    e = {"sentience_index": "T2", "risk_profile": {"danger_level": 3}, "biome_affinity": "deserto_caldo"}
+    assert d.derive_override(e) == [
+        "propriocezione",
+        "equilibrio_vestibolare",
+        "nocicezione",
+        "termocezione",
+    ]
+
+
+def test_derive_none_when_equals_tier_default():
+    e = {"sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": "foresta_temperata"}
+    assert d.derive_override(e) is None
+
+
+def test_derive_none_for_T3_plus():
+    # T3 already carries all 4 by tier -> additions can't exceed -> None.
+    e = {"sentience_index": "T3", "risk_profile": {"danger_level": 3}, "biome_affinity": "abisso_vulcanico"}
+    assert d.derive_override(e) is None
+
+
+def test_derive_none_for_T0_below_gateway():
+    e = {"sentience_index": "T0", "risk_profile": {"danger_level": 3}, "biome_affinity": "badlands"}
+    assert d.derive_override(e) is None
+
+
+def test_derive_non_thermal_ambiguous_biomes_no_termocezione():
+    # atollo_obsidiana + canyons_risonanti ruled NON-thermal (master-dd 2026-06-22).
+    for biome in ("atollo_obsidiana", "canyons_risonanti"):
+        e = {"sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": biome}
+        assert d.derive_override(e) is None
+
+
+# ============================================================================
+# plan_overrides
+# ============================================================================
+
+
+def test_plan_overrides_selects_only_deviating():
+    catalog = [
+        {"species_id": "a", "sentience_index": "T1", "risk_profile": {"danger_level": 2}, "biome_affinity": "savana"},
+        {"species_id": "b", "sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": "foresta_temperata"},
+    ]
+    to_apply, skipped = d.plan_overrides(catalog)
+    assert [sp["species_id"] for sp, _ in to_apply] == ["a"]
+    assert any(sid == "b" for sid, _ in skipped)
+
+
+def test_plan_idempotent_when_in_sync():
+    catalog = [
+        {
+            "species_id": "a",
+            "sentience_index": "T1",
+            "risk_profile": {"danger_level": 2},
+            "biome_affinity": "savana",
+            "interoception_traits": ["propriocezione", "equilibrio_vestibolare", "nocicezione"],
+        }
+    ]
+    to_apply, skipped = d.plan_overrides(catalog)
+    assert to_apply == []
+    assert any(sid == "a" and "in sync" in why for sid, why in skipped)
+
+
+# ============================================================================
+# apply_changes + main (IO)
+# ============================================================================
+
+
+def test_apply_changes_sets_field_and_provenance():
+    sp = {"species_id": "a", "trait_refs": ["x"]}
+    d.apply_changes([(sp, ["propriocezione", "nocicezione"])])
+    assert sp["interoception_traits"] == ["propriocezione", "nocicezione"]
+    assert sp["_provenance"]["interoception_traits"] == d.PROV_TAG
+    assert sp["trait_refs"] == ["x"]  # other keys preserved
+
+
+def test_main_apply_then_idempotent(tmp_path):
+    cat = {
+        "catalog": [
+            {"species_id": "a", "sentience_index": "T1", "risk_profile": {"danger_level": 2}, "biome_affinity": "savana"},
+            {"species_id": "b", "sentience_index": "T1", "risk_profile": {"danger_level": 1}, "biome_affinity": "palude"},
+        ]
+    }
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps(cat), encoding="utf-8")
+    assert d.main(["--apply", "--catalog", str(p)]) == 0
+    after = json.loads(p.read_text(encoding="utf-8"))["catalog"]
+    assert after[0]["interoception_traits"] == ["propriocezione", "equilibrio_vestibolare", "nocicezione"]
+    assert "interoception_traits" not in after[1]
+    # idempotent: second --apply finds nothing to apply, leaves file untouched.
+    before = p.read_text(encoding="utf-8")
+    assert d.main(["--apply", "--catalog", str(p)]) == 0
+    assert p.read_text(encoding="utf-8") == before
+
+
+def test_main_dry_run_does_not_write(tmp_path):
+    cat = {"catalog": [{"species_id": "a", "sentience_index": "T1", "risk_profile": {"danger_level": 2}, "biome_affinity": "savana"}]}
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps(cat), encoding="utf-8")
+    before = p.read_text(encoding="utf-8")
+    assert d.main(["--catalog", str(p)]) == 0  # dry-run default
+    assert p.read_text(encoding="utf-8") == before

--- a/tools/etl/derive_interoception_overrides.py
+++ b/tools/etl/derive_interoception_overrides.py
@@ -1,0 +1,158 @@
+"""derive_interoception_overrides.py -- OD-024 D4 principled override populate.
+
+Derive a per-species `interoception_traits` override from a RATIFIED rule and
+write it into the canonical species_catalog.json IN PLACE. Rule-based mirror of
+tools/py/apply_biome_affinity.py + tools/etl/apply_interoception_traits.py.
+
+Rule (master-dd ratified 2026-06-22, Approach A = tier-floor + ecological boosts):
+  override = tier_default(sentience_index)  UNION  ecological additions
+    + nocicezione   if risk_profile.danger_level >= NOCICEPTION_DANGER_THRESHOLD
+    + termocezione  if biome_affinity in THERMAL_BIOMES
+  write the override ONLY where it differs from the tier default (no redundant
+  rows); skip tier < T1 (producer gates them out before reading the override).
+
+propriocezione + equilibrio_vestibolare are the universal T1 floor, so the only
+ecological additions the rule can make are nocicezione (to sub-T2) and
+termocezione (to sub-T3). Spec:
+docs/superpowers/specs/2026-06-22-od024-d4-interoception-overrides-rule-design.md
+
+Contract: DRY-RUN by default; `--apply` required to write. Idempotent (a species
+already in sync is skipped). Whitelist-filtered + canonical order via
+interoception_field. Band-neutral: the grant flag SENTIENCE_INTEROCEPTION_GRANT_
+ENABLED stays OFF, so the producer never grants -- the catalog diff is inert
+until the D7 flip (owner, post N=40). UTF-8, ensure_ascii=False, indent=2 +
+trailing newline (catalog format).
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from interoception_field import INTEROCEPTION_TRAIT_IDS, filter_interoception
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CATALOG_PATH = REPO_ROOT / "data/core/species/species_catalog.json"
+PROV_TAG = "d4-derived-rule"
+
+# RATIFIED 2026-06-22 (master-dd).
+NOCICEPTION_DANGER_THRESHOLD = 2
+THERMAL_BIOMES = frozenset(
+    {
+        "deserto_caldo",
+        "abisso_vulcanico",
+        "dorsale_termale_tropicale",
+        "pianura_salina_iperarida",
+        "cryosteppe",
+        "caldera_glaciale",
+        "mezzanotte_orbitale",
+        "stratosfera_tempestosa",
+        "badlands",
+    }
+)
+# Cumulative; mirror of producer interoceptionForTier (sentienceInteroceptionGrant.js D2 map).
+TIER_INTEROCEPTION_MAP = {
+    "T1": ["propriocezione", "equilibrio_vestibolare"],
+    "T2": ["nocicezione"],
+    "T3": ["termocezione"],
+}
+
+
+def _rank(tier):
+    return (
+        int(tier[1])
+        if isinstance(tier, str) and len(tier) == 2 and tier[0] == "T" and tier[1].isdigit()
+        else None
+    )
+
+
+def tier_default(tier):
+    """The D2 cumulative interoception subset for a tier (whitelist-ordered)."""
+    r = _rank(tier)
+    if r is None:
+        return []
+    out = []
+    for k, ids in TIER_INTEROCEPTION_MAP.items():
+        if _rank(k) <= r:
+            out += ids
+    return filter_interoception(out)
+
+
+def derive_override(entry):
+    """Return the rule-derived override list for a catalog entry, or None when it
+    equals the tier default (no row needed) or the tier is below the gateway (T0/
+    unknown -- the producer gates it out before reading the override)."""
+    r = _rank(entry.get("sentience_index"))
+    if r is None or r < 1:
+        return None
+    base = tier_default(entry.get("sentience_index"))
+    additions = set()
+    if (entry.get("risk_profile") or {}).get("danger_level", 1) >= NOCICEPTION_DANGER_THRESHOLD:
+        additions.add("nocicezione")
+    if entry.get("biome_affinity") in THERMAL_BIOMES:
+        additions.add("termocezione")
+    full = filter_interoception(
+        list(base) + [a for a in INTEROCEPTION_TRAIT_IDS if a in additions]
+    )
+    return full if full != base else None
+
+
+def plan_overrides(catalog):
+    """Return (to_apply, skipped). to_apply = [(species_obj, override_list)] for
+    species whose rule-derived override differs from what they already carry."""
+    to_apply, skipped = [], []
+    for sp in catalog:
+        override = derive_override(sp)
+        if override is None:
+            skipped.append((sp.get("species_id"), "tier-default or below-gateway"))
+        elif sp.get("interoception_traits") == override:
+            skipped.append((sp.get("species_id"), "already in sync"))
+        else:
+            to_apply.append((sp, override))
+    return to_apply, skipped
+
+
+def apply_changes(to_apply):
+    for sp, override in to_apply:
+        sp["interoception_traits"] = override
+        prov = sp.setdefault("_provenance", {})
+        if not isinstance(prov, dict):
+            prov = {}
+            sp["_provenance"] = prov
+        prov["interoception_traits"] = PROV_TAG
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Derive per-species interoception_traits overrides (ratified rule) into the catalog"
+    )
+    ap.add_argument("--catalog", default=str(CATALOG_PATH))
+    ap.add_argument("--apply", action="store_true", help="write the catalog (default: dry-run)")
+    args = ap.parse_args(argv)
+
+    with open(args.catalog, encoding="utf-8") as f:
+        data = json.load(f)
+    catalog = data["catalog"]
+    to_apply, skipped = plan_overrides(catalog)
+
+    print(f"[plan] {len(to_apply)} to apply, {len(skipped)} skipped (of {len(catalog)})")
+    for sp, override in to_apply:
+        print(f"  + {sp.get('species_id')} ({sp.get('sentience_index')}): {override}")
+
+    if not args.apply:
+        print("[DRY-RUN] no write. Re-run with --apply to write the catalog.")
+        return 0
+    if not to_apply:
+        print("[apply] nothing to apply (catalog unchanged).")
+        return 0
+
+    apply_changes(to_apply)
+    with open(args.catalog, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    print(f"[APPLIED] wrote {len(to_apply)} interoception_traits overrides into {args.catalog}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Sommario

D4 **populate principled** (master-dd Approccio A ratificato 2026-06-22): deriva un
override `interoception_traits` per-specie da una regola e lo scrive in
`data/core/species/species_catalog.json` via nuovo tool ETL. Sblocca davvero
l'override del producer (`perSpeciesOverride`, gia' shippato in #2950).

Brainstorm -> spec -> plan -> TDD (superpowers). Spec:
`docs/superpowers/specs/2026-06-22-od024-d4-interoception-overrides-rule-design.md`.

## La regola (Approccio A: tier-floor + boost ecologici)

```
override = tier_default(sentience_index, D2)  UNION  aggiunte ecologiche
  + nocicezione   se risk_profile.danger_level >= 2      (RATIFICATO)
  + termocezione  se biome_affinity in THERMAL_BIOMES    (RATIFICATO)
scrivi override SOLO se != tier_default ; salta tier < T1 (il producer li gate-a)
```

`propriocezione` + `equilibrio_vestibolare` = floor universale T1 -> le uniche
aggiunte sono nocicezione (a sub-T2) e termocezione (a sub-T3). `THERMAL_BIOMES` =
deserto_caldo, abisso_vulcanico, dorsale_termale_tropicale, pianura_salina_iperarida,
cryosteppe, caldera_glaciale, mezzanotte_orbitale, stratosfera_tempestosa, **badlands**
(atollo_obsidiana + canyons_risonanti = NON-termici, call master-dd).

## Impatto

**33/75 specie** ricevono un override (30 T1, 3 T2) + `_provenance: d4-derived-rule`;
41 restano sul tier-default (nessuna riga), 1 T0 saltato. Diff strutturale verificato
entry-by-entry vs HEAD = **esattamente** `interoception_traits` + `_provenance` su quelle
33, nient'altro.

## Band-neutral

Flag `SENTIENCE_INTEROCEPTION_GRANT_ENABLED` resta **OFF** -> il producer non concede
mai -> nessun cambio runtime nonostante il catalog diff. Il flip (D7) e' owner-gated
post N=40; la regola SDMG e' ratificata ma la conseguenza sulle win-rate si conosce
solo a N=40.

## Implementazione

- `tools/etl/derive_interoception_overrides.py` (rule-based, mirror di apply_biome_affinity
  / apply_interoception_traits): DRY-RUN default + `--apply`, idempotente,
  whitelist-filtrato, riusa `interoception_field`. `TIER_INTEROCEPTION_MAP` = mirror
  del producer D2.
- Catalog **rigenerato dal tool** (NON hand-edit: regenerate-or-die rispettato).

## Test plan / evidenze

- [x] 13 unit-test TDD (tier_default / derive_override / plan_overrides / apply / main dry-run+idempotent) -- RED provato prima dell'impl.
- [x] catalog: diff scoped (33 entry, solo i 2 campi), idempotente (re-run = nothing to apply), schema valida, prettier-clean.
- [x] **2 test real-catalog aggiornati** (conseguenza attesa: l'override cambia il grant flag-ON): coopSentienceGrant repuntato a `glowcap_weaver` (T1 no-override, mantiene la prova di progressive-gating); sentience-interoception-grant ora asserisce l'override reale di `anguis_magnetica` [prop, vest, noci] = prova e2e catalog->perSpeciesOverride.
- [x] `node scripts/run-test-api.cjs` = **4566 pass / 0 fail**; full pytest **1216 passed / 5 xfailed**; band-neutral (test flag-OFF verde).
- [x] review adversariale compensativa (Codex rate-limited) = 7/7 invarianti, 0 finding (mirror-mappa producer, additive-only, idempotenza, whitelist verificati).

## Guardrail

- Modifica `data/core/species/species_catalog.json` (rigenerato, non hand-edit) + >50 LOC fuori `apps/backend` -> **master-dd manual merge** (non auto-merge-L3). ADR-0011 trailer. Tocca anche docs/superpowers (spec+plan) + docs_registry.json (atomico).
- Dopo: **D7** flip incrementale (owner, keys.env + N=40); **D6 #3** encumbrance PARCHEGGIATO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)