### PR TITLE
refactor(combat): CAP-06 elevation inline -> elevationDamageMultiplier helper

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -22,6 +22,7 @@ const {
 const { DEFAULT_ATTACK_RANGE } = require('../services/ai/policy');
 const { buildAtlasLive } = require('../services/atlasLive');
 const { applicableSynergies } = require('../services/combat/synergyDetector');
+const { elevationDamageMultiplier } = require('../services/grid/hexGrid');
 
 function rollD20(rng) {
   return Math.floor(rng() * 20) + 1;
@@ -743,9 +744,18 @@ function computePositionalDamage({
   const tElev = Number.isFinite(Number(target?.elevation)) ? Number(target.elevation) : 0;
   const delta = aElev - tElev;
 
-  let elevMul = 1;
-  if (delta >= 1) elevMul = 1 + elevationBonus;
-  else if (delta <= -1) elevMul = 1 + elevationPenalty;
+  // CAP-06 (M14-A) refactor: single-source-of-truth via il helper canonico
+  // `elevationDamageMultiplier` (apps/backend/services/grid/hexGrid.js). Pre-refactor
+  // questa funzione duplicava inline la stessa logica delta>=1 / delta<=-1. Per i
+  // parametri usati dai caller (default 0.3 / -0.15; nessun caller passa
+  // penalty < -0.9) il helper e' EXACTLY equivalente all'inline: il floor interno
+  // Math.max(mult, 0.1) non morde mai nel range reale (vedi positionalDamage.test.js).
+  const elevMul = elevationDamageMultiplier({
+    attackerElevation: aElev,
+    targetElevation: tElev,
+    bonus: elevationBonus,
+    penalty: elevationPenalty,
+  });
   let flankMul = 1;
   if (quadrant === 'flank') flankMul = 1 + flankBonus;
   let rearMul = 1;

--- a/tests/services/positionalDamage.test.js
+++ b/tests/services/positionalDamage.test.js
@@ -125,3 +125,70 @@ test('positional: explicit rearMultiplier honored', () => {
   });
   assert.equal(res.damage, 15);
 });
+
+// --- CAP-06 (M14-A) refactor regression: inline elevMul -> elevationDamageMultiplier helper ---
+// Asserts the refactor is behavior-identical to the pre-refactor inline formula
+// (delta>=1 -> 1+bonus; delta<=-1 -> 1+penalty; else 1) across the realistic param
+// range used by every caller (default 0.3/-0.15; tests pass bonus up to 1.5; no
+// caller passes penalty < -0.9). See plan docs/planning/2026-06-22-aa01-impronta-reconciliation-plan.md (F2).
+const { elevationDamageMultiplier } = require('../../apps/backend/services/grid/hexGrid');
+
+function frontElevPair(aElev, tElev) {
+  // front quadrant isolates elevation (flank/rear multipliers = 1.0)
+  const target = mkUnit({ x: 3, y: 3, facing: 'S', elevation: tElev });
+  const actor = mkUnit({ x: 3, y: 4, elevation: aElev });
+  return { actor, target };
+}
+
+test('CAP-06 regression: parts.elevation == inline formula across realistic params', () => {
+  const cases = [
+    { aElev: 2, tElev: 0, bonus: 0.3, penalty: -0.15 }, // delta +2
+    { aElev: 1, tElev: 0, bonus: 0.3, penalty: -0.15 }, // delta +1
+    { aElev: 0, tElev: 0, bonus: 0.3, penalty: -0.15 }, // delta 0
+    { aElev: 0, tElev: 1, bonus: 0.3, penalty: -0.15 }, // delta -1
+    { aElev: 0, tElev: 3, bonus: 0.3, penalty: -0.15 }, // delta -3
+    { aElev: 2, tElev: 0, bonus: 1.5, penalty: -0.15 }, // custom large bonus (cf. cap test L98)
+    { aElev: 0, tElev: 2, bonus: 0.3, penalty: -0.5 }, // custom penalty within range (> -0.9)
+  ];
+  for (const c of cases) {
+    const { actor, target } = frontElevPair(c.aElev, c.tElev);
+    const res = computePositionalDamage({
+      actor,
+      target,
+      baseDamage: 10,
+      elevationBonus: c.bonus,
+      elevationPenalty: c.penalty,
+    });
+    const delta = c.aElev - c.tElev;
+    let inline = 1;
+    if (delta >= 1) inline = 1 + c.bonus;
+    else if (delta <= -1) inline = 1 + c.penalty;
+    const expected = Math.round(inline * 100) / 100;
+    assert.equal(res.quadrant, 'front', 'front isolates elevation');
+    assert.equal(
+      res.parts.elevation,
+      expected,
+      `delta=${delta} bonus=${c.bonus} penalty=${c.penalty}`,
+    );
+    // helper is the single source of truth
+    const helperMul = elevationDamageMultiplier({
+      attackerElevation: c.aElev,
+      targetElevation: c.tElev,
+      bonus: c.bonus,
+      penalty: c.penalty,
+    });
+    assert.equal(res.parts.elevation, Math.round(helperMul * 100) / 100);
+  }
+});
+
+test('CAP-06 boundary: helper 0.1-floor on elevMul only bites for penalty < -0.9 (out of caller range)', () => {
+  // The single intentional divergence vs the old inline (which floored only the TOTAL
+  // product). No production/test caller passes such an extreme penalty; pinned here.
+  const m = elevationDamageMultiplier({
+    attackerElevation: 0,
+    targetElevation: 1,
+    bonus: 0.3,
+    penalty: -0.95,
+  });
+  assert.equal(m, 0.1); // 1 + (-0.95) = 0.05 -> Math.max(0.05, 0.1) = 0.1
+});


### PR DESCRIPTION
## CAP-06 elevation refactor (aa01 reconciliation, Track A)

Re-apply of the `aa01/cap-06` refactor onto current main: `computePositionalDamage`
(`apps/backend/routes/sessionHelpers.js`) now calls the canonical
`elevationDamageMultiplier` helper (`apps/backend/services/grid/hexGrid.js`) instead of
duplicating the inline `delta>=1 / delta<=-1` logic. Single source of truth.

### Why it is a true refactor (no balance change)
Caller audit (finding F2 of the plan): the 3 callers (`session.js:767`,
`abilityExecutor.js:2130`, internal) all use the defaults (bonus 0.3 / penalty -0.15);
**no caller passes a custom `elevationPenalty`**. The helper's internal `Math.max(mult, 0.1)`
floor only diverges from the old inline for `penalty < -0.9` (out of caller range) ->
behavior-identical in practice. F2c (master-dd flag) did NOT trigger.

### Tests
- New regression test (`parts.elevation` == inline formula across delta {>=1, 0, <=-1}
  + custom bonus/penalty in range) + boundary test pinning the floor edge.
- 32 elevation tests + 41 `abilityExecutor` caller tests + **554/554 AI baseline** green; prettier clean.

### Plan / context
Part of the aa01 Sprint-Impronta reconciliation (master-dd SUPERSEDE override). Plan:
`docs/planning/2026-06-22-aa01-impronta-reconciliation-plan.md` (sibling docs PR).

### Rollback
Single-commit revert; no schema/contract/data/flag change.
