### PR TITLE
feat(sim): symmetric interoception N=40 co-op measure (OD-024 D7)

### DIFF
--- a/docs/ops/2026-06-22-od024-d7-interoception-flip-runbook.md
+++ b/docs/ops/2026-06-22-od024-d7-interoception-flip-runbook.md
@@ -49,47 +49,55 @@ Run (on a worktree off origin/main, catalog with the #2955 overrides):
 # baseline (flag OFF)
 node tools/sim/full-loop-batch.js --runs 40 --seed-base 7000 \
   --out reports/sim/intero-n40-off
-# flag ON
+# flag ON, enemy-side only (single-player full-loop = grant fires on sistema via /start)
 SENTIENCE_INTEROCEPTION_GRANT_ENABLED=true node tools/sim/full-loop-batch.js \
   --runs 40 --seed-base 7000 --out reports/sim/intero-n40-on
+# flag ON, SYMMETRIC (real co-op = party + enemy both granted)
+SENTIENCE_INTEROCEPTION_GRANT_ENABLED=true SIM_GRANT_PARTY_INTEROCEPTION=1 \
+  node tools/sim/full-loop-batch.js --runs 40 --seed-base 7000 \
+  --out reports/sim/intero-n40-symmetric
 ```
 
-Compare `summary.json` between arms (completion_rate + the meta bands +
-`od024_firing_pct` should be 0 in the OFF arm and >0 in the ON arm).
+Compare `summary.json` between arms (completion_rate + the 7 meta bands). Note:
+`full-loop-batch` does not emit the `od024_firing_pct` pillar metric, so the signal
+is the band deltas below; the metrics differing between arms (paired same-seed) is
+itself proof the grant fired.
 
 <!-- EVIDENCE -->
 
-**Run 2026-06-22** (commit `7ddbe3d3`, N=40, `--seed-base 7000`, branch cave_path,
-policy greedy; in-process). All 7 meta-metrics IN-BAND in BOTH arms:
+**Run 2026-06-22** (N=40, `--seed-base 7000`, branch cave_path, policy greedy;
+in-process). THREE arms, paired same-seed. **All 7 meta-metrics IN-BAND in every
+arm.** Key metrics (completion band 0.4-0.7, attrition 0-1, bp_drift 0.5-2):
 
-| metric                            | band            | OFF   | ON    | in-band   |
-| --------------------------------- | --------------- | ----- | ----- | --------- |
-| completion_rate                   | 0.4-0.7         | 0.625 | 0.600 | yes / yes |
-| roster_attrition                  | 0-1             | 0.533 | 0.470 | yes / yes |
-| economy build_power_drift         | 0.5-2           | 1.135 | 1.08  | yes / yes |
-| relationship recruit_rate         | (no hard range) | 5.175 | 5.575 | yes / yes |
-| offspring_avg                     | >=1             | 4.375 | 4.70  | yes / yes |
-| lineage_diversity                 | >=3             | 5     | 5     | yes / yes |
-| roster_composition distinct_roles | >=3             | 5     | 5     | yes / yes |
+| arm                        | grant scope               | completion | attrition | bp_drift | all in-band |
+| -------------------------- | ------------------------- | ---------- | --------- | -------- | ----------- |
+| OFF (baseline)             | none                      | 0.625      | 0.533     | 1.135    | yes         |
+| enemy-only                 | sistema via `/start` (D3) | 0.600      | 0.470     | 1.080    | yes         |
+| **symmetric (real co-op)** | party + enemy             | **0.525**  | 0.583     | 1.105    | yes         |
 
-Delta is small and directionally sensible: flag ON makes encounters marginally
-harder (completion -0.025, attrition -0.063 = a few more real losses), consistent
-with enemies gaining pain/proprioception awareness. No band breaks. Reports:
-`reports/sim/intero-n40-{off,on}/` (summary.json + report.md).
+The enemy-only arm uses `full-loop-batch` as-is (single-player: grant fires on
+`sistema` units via `session.js /start`, NOT the party). The symmetric arm adds
+the opt-in `applyPartyInteroceptionGrant` (`SIM_GRANT_PARTY_INTEROCEPTION=1`) so
+the party ALSO gets the real producer grant -- the true co-op condition (party via
+`coopOrchestrator.submitCharacter` + enemy via `/start`).
 
-**Scope caveat (honest):** the metrics DIFFER between arms (paired same-seed) only
-because the grant FIRED -- proof the flag had a real effect. BUT `full-loop-batch`
-is a SINGLE-PLAYER AI sim: it exercises the grant on `sistema`/enemy units via
-`session.js` `/start` (D3 enemy-wire), NOT the co-op party-submit path
-(`coopOrchestrator.submitCharacter`, which only runs in real co-op). So this N=40
-validates the ENEMY-side of the flip is band-safe. The party-side (co-op) gives
-both sides the grant symmetrically, so the net win-rate shift should be no larger;
-a co-op-path measure can confirm before/with the flip if master-dd wants it.
+**Finding (a prior hypothesis was REFUTED by the measure -- why "measure first"
+mattered):** the symmetric case does NOT cancel out. Both sides gaining +1 attack
+(propriocezione) makes combats bloodier -> symmetric is the HARDEST arm: completion
+0.525 (the largest shift, -0.10 vs the OFF baseline) and the highest attrition
+(0.583). It is STILL well inside the 0.4-0.7 band, but the flip makes the game
+**meaningfully harder**, not neutral. Reports:
+`reports/sim/intero-n40-{off,on,symmetric}/`.
 
 <!-- /EVIDENCE -->
 
 **Verdict:** PENDING master-dd. The batch REPORTS the band placement (L-069); it never
-ratifies the flip. master-dd reads the table + decides ON vs re-tune.
+ratifies the flip. **Decision input:** all three arms are in-band, so the flip is
+band-SAFE; but the real co-op condition (symmetric) drops completion 0.625 -> 0.525
+(a real, noticeable difficulty increase, not a wash). master-dd choices: (a) flip ON
+and accept the harder combats as the intended cost of the sentience layer; (b) flip ON
+AND soften enemy scaling a notch to re-center completion ~0.6; (c) hold. Re-tune is a
+separate calibration knob, not a blocker for band-safety.
 
 ## Flip steps (OWNER hands -- production)
 

--- a/reports/sim/intero-n40-symmetric/report.md
+++ b/reports/sim/intero-n40-symmetric/report.md
@@ -7,31 +7,31 @@ Runs: **40** | Completed: **21/40** | Policy: `greedy` | Branch: `cave_path`
 | Metric | Value | Band | In band |
 |---|---|---|:---:|
 | completion_rate | 0.525 | 0.4 - 0.7 | ✅ |
-| roster_attrition | 0.583 | 0 - 1 | ✅ |
-| economy_flow | drift 1.105 (pe 40.6, bp 149.1) | 0.5 - 2 | ✅ |
-| relationship_progress | recruit 4.55, aff 1, mate 3.85 | composite | ✅ |
-| offspring_viability | offspring 3.85 | >= 1 | ✅ |
+| roster_attrition | 0.494 | 0 - 1 | ✅ |
+| economy_flow | drift 1.035 (pe 45.6, bp 166.2) | 0.5 - 2 | ✅ |
+| relationship_progress | recruit 5.175, aff 1, mate 4.35 | composite | ✅ |
+| offspring_viability | offspring 4.35 | >= 1 | ✅ |
 | lineage_diversity | 5 crosses, dominant dune-stalker x nano-rust-bloom | >= 3 | ✅ |
 | roster_composition | dominant APEX/HAZARD, 5 roles | >= 3 | ✅ |
 
-> Note (economy_flow): PE earned + build-power drift; PI sink exercised (385 attempts)
+> Note (economy_flow): PE earned + build-power drift; PI sink exercised (437 attempts)
 
 ## Personality axes (Opt 3 OUTPUT) -- N-sample evidence
 
-2055 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
+2252 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
 
 | axis | n | mean | sd | min | max | neutral_rate |
 | --- | --- | --- | --- | --- | --- | --- |
-| symbiosis_predation | 2055 | 0.991 | 0.042 | 0.688 | 1.000 | 0.000 |
-| explore_caution | 2055 | 0.631 | 0.208 | 0.500 | 1.000 | 0.709 |
-| solitary_swarm | 2055 | 0.575 | 0.204 | 0.250 | 1.000 | 0.773 |
-| memory_instinct | 2055 | 0.505 | 0.048 | 0.448 | 0.875 | 0.886 |
-| agile_robust | 2055 | 0.479 | 0.075 | 0.140 | 0.735 | 0.672 |
+| symbiosis_predation | 2252 | 0.990 | 0.047 | 0.688 | 1.000 | 0.000 |
+| explore_caution | 2252 | 0.628 | 0.206 | 0.500 | 1.000 | 0.715 |
+| solitary_swarm | 2252 | 0.581 | 0.205 | 0.250 | 1.000 | 0.772 |
+| memory_instinct | 2252 | 0.506 | 0.052 | 0.435 | 0.875 | 0.884 |
+| agile_robust | 2252 | 0.479 | 0.076 | 0.140 | 0.735 | 0.664 |
 
 Degenerate (all-5 neutral) rate: 0.000.
-Dominant-axis histogram: symbiosis_predation 1867, solitary_swarm 188.
-Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.89.
-Faction player (675): symbiosis_predation 1.00, explore_caution 0.64, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
-Faction sistema (1380): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.55, memory_instinct 0.51, agile_robust 0.50.
+Dominant-axis histogram: symbiosis_predation 2042, solitary_swarm 210.
+Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.90.
+Faction player (757): symbiosis_predation 1.00, explore_caution 0.63, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
+Faction sistema (1495): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
 
 Per-run records: `runs.jsonl`. Aggregate: `summary.json`.

--- a/reports/sim/intero-n40-symmetric/report.md
+++ b/reports/sim/intero-n40-symmetric/report.md
@@ -1,0 +1,37 @@
+# Full-loop meta band-metrics
+
+Runs: **40** | Completed: **21/40** | Policy: `greedy` | Branch: `cave_path`
+
+> **RATIFIED (master-dd, L-069)** -- RATIFIED 2026-06-03 by master-dd (L-069): the working bands. Reversible (two-way door) -- revise when evidence warrants. Keep the design space healthy (Quality-Diversity); do not optimize to a single best run. GRAPH-MODE RE-RATIFIED 2026-06-04 by master-dd (#2603): with the real draft rosters + the cm3/hp2/dcAdd1 overlay, graph-mode completion lands ~0.66 (N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60), inside this 0.4-0.7 band -- the fallback-era wider 0.4-0.85 is superseded; completion_rate [0.4, 0.7] holds for both static and graph mode.
+
+| Metric | Value | Band | In band |
+|---|---|---|:---:|
+| completion_rate | 0.525 | 0.4 - 0.7 | ✅ |
+| roster_attrition | 0.583 | 0 - 1 | ✅ |
+| economy_flow | drift 1.105 (pe 40.6, bp 149.1) | 0.5 - 2 | ✅ |
+| relationship_progress | recruit 4.55, aff 1, mate 3.85 | composite | ✅ |
+| offspring_viability | offspring 3.85 | >= 1 | ✅ |
+| lineage_diversity | 5 crosses, dominant dune-stalker x nano-rust-bloom | >= 3 | ✅ |
+| roster_composition | dominant APEX/HAZARD, 5 roles | >= 3 | ✅ |
+
+> Note (economy_flow): PE earned + build-power drift; PI sink exercised (385 attempts)
+
+## Personality axes (Opt 3 OUTPUT) -- N-sample evidence
+
+2055 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
+
+| axis | n | mean | sd | min | max | neutral_rate |
+| --- | --- | --- | --- | --- | --- | --- |
+| symbiosis_predation | 2055 | 0.991 | 0.042 | 0.688 | 1.000 | 0.000 |
+| explore_caution | 2055 | 0.631 | 0.208 | 0.500 | 1.000 | 0.709 |
+| solitary_swarm | 2055 | 0.575 | 0.204 | 0.250 | 1.000 | 0.773 |
+| memory_instinct | 2055 | 0.505 | 0.048 | 0.448 | 0.875 | 0.886 |
+| agile_robust | 2055 | 0.479 | 0.075 | 0.140 | 0.735 | 0.672 |
+
+Degenerate (all-5 neutral) rate: 0.000.
+Dominant-axis histogram: symbiosis_predation 1867, solitary_swarm 188.
+Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.89.
+Faction player (675): symbiosis_predation 1.00, explore_caution 0.64, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
+Faction sistema (1380): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.55, memory_instinct 0.51, agile_robust 0.50.
+
+Per-run records: `runs.jsonl`. Aggregate: `summary.json`.

--- a/reports/sim/intero-n40-symmetric/summary.json
+++ b/reports/sim/intero-n40-symmetric/summary.json
@@ -3,12 +3,14 @@
     "runs": 40,
     "branch": "cave_path",
     "policy": "greedy",
-    "commit": "eda2bf30780653c4b36d18865b109ec1f76f89d0",
+    "commit": "b7b8ff7d1cfc2cd1f28a607ea0705751f845027c",
     "flags": {
       "META_NETWORK_ROUTING": "false",
       "IDEA_ENGINE_STUB_ORCHESTRATOR": "1",
       "IDEA_ENGINE_DISABLE_STATUS_REFRESH": "1",
-      "A13_WOUND_READ_DISABLED": "0"
+      "A13_WOUND_READ_DISABLED": "0",
+      "SENTIENCE_INTEROCEPTION_GRANT_ENABLED": "true",
+      "SIM_GRANT_PARTY_INTEROCEPTION": "1"
     },
     "enemyScaling": {
       "countMult": 5,
@@ -35,7 +37,7 @@
       "note": "completed campaigns / N"
     },
     "roster_attrition": {
-      "value": 0.583,
+      "value": 0.494,
       "range": [
         0,
         1
@@ -44,31 +46,31 @@
       "note": "survivors / units-that-fought (exclusive: real losses, no wipe)"
     },
     "economy_flow": {
-      "pe_earned_avg": 40.6,
-      "build_power_avg": 149.1,
-      "build_power_drift": 1.105,
+      "pe_earned_avg": 45.6,
+      "build_power_avg": 166.2,
+      "build_power_drift": 1.035,
       "pi_sink_exercised": true,
-      "pi_pick_attempts": 385,
-      "pi_insufficient": 336,
+      "pi_pick_attempts": 437,
+      "pi_insufficient": 383,
       "has_signal": true,
       "range": [
         0.5,
         2
       ],
       "in_band": true,
-      "note": "PE earned + build-power drift; PI sink exercised (385 attempts)"
+      "note": "PE earned + build-power drift; PI sink exercised (437 attempts)"
     },
     "relationship_progress": {
-      "recruit_rate": 4.55,
+      "recruit_rate": 5.175,
       "affinity_proven_rate": 1,
-      "reached_step": 28,
-      "mating_rate": 3.85,
+      "reached_step": 33,
+      "mating_rate": 4.35,
       "range": null,
       "in_band": true,
       "note": "recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire"
     },
     "offspring_viability": {
-      "offspring_avg": 3.85,
+      "offspring_avg": 4.35,
       "viable_rate": 1,
       "range": [
         1,
@@ -80,10 +82,10 @@
     "lineage_diversity": {
       "value": 5,
       "lineage_profile": {
-        "dune-stalker x nano-rust-bloom": 49,
-        "ferrocolonia-magnetotattica x nano-rust-bloom": 28,
-        "ferrocolonia-magnetotattica x sand-burrower": 28,
-        "rust-scavenger x sand-burrower": 28,
+        "dune-stalker x nano-rust-bloom": 54,
+        "ferrocolonia-magnetotattica x nano-rust-bloom": 33,
+        "ferrocolonia-magnetotattica x sand-burrower": 33,
+        "rust-scavenger x sand-burrower": 33,
         "dune-stalker x rust-scavenger": 21
       },
       "dominant_lineages": [
@@ -99,11 +101,11 @@
     },
     "roster_composition": {
       "role_profile": {
-        "APEX": 49,
-        "HAZARD": 49,
-        "PREDATOR": 28,
-        "PREY": 28,
-        "SUPPORT": 28
+        "APEX": 54,
+        "HAZARD": 54,
+        "PREDATOR": 33,
+        "PREY": 33,
+        "SUPPORT": 33
       },
       "distinct_roles": 5,
       "dominant_roles": [
@@ -124,53 +126,53 @@
     "total": 40
   },
   "personality": {
-    "n_samples": 2055,
+    "n_samples": 2252,
     "per_axis": {
       "symbiosis_predation": {
-        "n": 2055,
-        "mean": 0.9910975252154224,
-        "sd": 0.04152018542353667,
+        "n": 2252,
+        "mean": 0.9897569807674955,
+        "sd": 0.04653227269195095,
         "min": 0.6875,
         "max": 1,
         "neutral_rate": 0
       },
       "explore_caution": {
-        "n": 2055,
-        "mean": 0.6314777609593528,
-        "sd": 0.20804802374100861,
+        "n": 2252,
+        "mean": 0.6281532396631069,
+        "sd": 0.20577073412250133,
         "min": 0.5,
         "max": 1,
-        "neutral_rate": 0.7094890510948905
+        "neutral_rate": 0.7149200710479574
       },
       "solitary_swarm": {
-        "n": 2055,
-        "mean": 0.5753041362530413,
-        "sd": 0.20386673873025077,
+        "n": 2252,
+        "mean": 0.5808170515097691,
+        "sd": 0.2054338395800278,
         "min": 0.25,
         "max": 1,
-        "neutral_rate": 0.7727493917274939
+        "neutral_rate": 0.7717584369449378
       },
       "memory_instinct": {
-        "n": 2055,
-        "mean": 0.5048081015224165,
-        "sd": 0.048363678923144235,
-        "min": 0.4479166666666667,
+        "n": 2252,
+        "mean": 0.5058839353032293,
+        "sd": 0.05162423171875342,
+        "min": 0.43452380952380953,
         "max": 0.875,
-        "neutral_rate": 0.8861313868613139
+        "neutral_rate": 0.8836589698046181
       },
       "agile_robust": {
-        "n": 2055,
-        "mean": 0.47883326177186597,
-        "sd": 0.07476056509761894,
+        "n": 2252,
+        "mean": 0.4785806080869339,
+        "sd": 0.07617438993154894,
         "min": 0.13999999999999996,
         "max": 0.7352941176470588,
-        "neutral_rate": 0.6715328467153284
+        "neutral_rate": 0.6638543516873889
       }
     },
     "degenerate_rate": 0,
     "dominant_hist": {
-      "solitary_swarm": 188,
-      "symbiosis_predation": 1867
+      "solitary_swarm": 210,
+      "symbiosis_predation": 2042
     },
     "correlations": [
       {
@@ -178,112 +180,112 @@
           "symbiosis_predation",
           "explore_caution"
         ],
-        "r": -0.24722453815105397
+        "r": -0.24811105693022267
       },
       {
         "pair": [
           "symbiosis_predation",
           "solitary_swarm"
         ],
-        "r": -0.44666623469873046
+        "r": -0.4491644217285558
       },
       {
         "pair": [
           "symbiosis_predation",
           "memory_instinct"
         ],
-        "r": -0.8893025748698108
+        "r": -0.8981064943071118
       },
       {
         "pair": [
           "symbiosis_predation",
           "agile_robust"
         ],
-        "r": -0.03842051323250485
+        "r": -0.04323999691161958
       },
       {
         "pair": [
           "explore_caution",
           "solitary_swarm"
         ],
-        "r": 0.2647943179511311
+        "r": 0.2902046579476232
       },
       {
         "pair": [
           "explore_caution",
           "memory_instinct"
         ],
-        "r": 0.12131910320384584
+        "r": 0.13262035386401405
       },
       {
         "pair": [
           "explore_caution",
           "agile_robust"
         ],
-        "r": 0.014691808953227276
+        "r": 0.02136955207548624
       },
       {
         "pair": [
           "solitary_swarm",
           "memory_instinct"
         ],
-        "r": 0.20710279287322345
+        "r": 0.232565833401832
       },
       {
         "pair": [
           "solitary_swarm",
           "agile_robust"
         ],
-        "r": -0.053038871283999894
+        "r": -0.05307707873020039
       },
       {
         "pair": [
           "memory_instinct",
           "agile_robust"
         ],
-        "r": 0.04478848927812474
+        "r": 0.04643304398041087
       }
     ],
     "by_faction": {
       "player": {
-        "n_samples": 675,
+        "n_samples": 757,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 675,
-            "mean": 0.9964899436099839,
-            "sd": 0.01069628085141437,
-            "min": 0.9467084639498432,
+            "n": 757,
+            "mean": 0.996721056454446,
+            "sd": 0.010239830959772841,
+            "min": 0.9547368421052631,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 675,
-            "mean": 0.6378495769218446,
-            "sd": 0.21321385487243294,
+            "n": 757,
+            "mean": 0.6264858143959856,
+            "sd": 0.20756846100868123,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7022222222222222
+            "neutral_rate": 0.726552179656539
           },
           "solitary_swarm": {
-            "n": 675,
-            "mean": 0.6177777777777778,
-            "sd": 0.26143950979901776,
+            "n": 757,
+            "mean": 0.6235138705416117,
+            "sd": 0.25751954974295543,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.5777777777777777
+            "neutral_rate": 0.5944517833553501
           },
           "memory_instinct": {
-            "n": 675,
-            "mean": 0.4969469431404189,
-            "sd": 0.012823858242240463,
-            "min": 0.4490254872563718,
+            "n": 757,
+            "mean": 0.4971954098961982,
+            "sd": 0.012007548765524612,
+            "min": 0.45942982456140347,
             "max": 0.5267857142857143,
-            "neutral_rate": 0.8681481481481481
+            "neutral_rate": 0.8758256274768824
           },
           "agile_robust": {
-            "n": 675,
-            "mean": 0.4355590413943335,
-            "sd": 0.11927782841912025,
+            "n": 757,
+            "mean": 0.4362794311912324,
+            "sd": 0.12069183759092876,
             "min": 0.13999999999999996,
             "max": 0.7352941176470588,
             "neutral_rate": 0
@@ -291,42 +293,42 @@
         }
       },
       "sistema": {
-        "n_samples": 1380,
+        "n_samples": 1495,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 1380,
-            "mean": 0.9884599292615607,
-            "sd": 0.04989998816337462,
+            "n": 1495,
+            "mean": 0.9862306896002558,
+            "sd": 0.05631653644865088,
             "min": 0.6875,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 1380,
-            "mean": 0.6283611118472644,
-            "sd": 0.20540199146992238,
+            "n": 1495,
+            "mean": 0.6289975479756224,
+            "sd": 0.20484925432112763,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7130434782608696
+            "neutral_rate": 0.7090301003344481
           },
           "solitary_swarm": {
-            "n": 1380,
-            "mean": 0.5545289855072464,
-            "sd": 0.16475540465410768,
+            "n": 1495,
+            "mean": 0.5591973244147157,
+            "sd": 0.16912332835392616,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.8681159420289855
+            "neutral_rate": 0.8615384615384616
           },
           "memory_instinct": {
-            "n": 1380,
-            "mean": 0.5086532333396983,
-            "sd": 0.057945606969618126,
-            "min": 0.4479166666666667,
+            "n": 1495,
+            "mean": 0.5102834093722081,
+            "sd": 0.06232126437424397,
+            "min": 0.43452380952380953,
             "max": 0.875,
-            "neutral_rate": 0.894927536231884
+            "neutral_rate": 0.8876254180602007
           },
           "agile_robust": {
-            "n": 1380,
+            "n": 1495,
             "mean": 0.5,
             "sd": 0,
             "min": 0.5,

--- a/reports/sim/intero-n40-symmetric/summary.json
+++ b/reports/sim/intero-n40-symmetric/summary.json
@@ -1,0 +1,340 @@
+{
+  "config": {
+    "runs": 40,
+    "branch": "cave_path",
+    "policy": "greedy",
+    "commit": "eda2bf30780653c4b36d18865b109ec1f76f89d0",
+    "flags": {
+      "META_NETWORK_ROUTING": "false",
+      "IDEA_ENGINE_STUB_ORCHESTRATOR": "1",
+      "IDEA_ENGINE_DISABLE_STATUS_REFRESH": "1",
+      "A13_WOUND_READ_DISABLED": "0"
+    },
+    "enemyScaling": {
+      "countMult": 5,
+      "countAdd": 0,
+      "hpMult": 1,
+      "hpAdd": 3,
+      "modAdd": 1,
+      "dcAdd": 1
+    },
+    "peEarned": 8,
+    "a13": false,
+    "a13MaxRetries": 1
+  },
+  "n": 40,
+  "provisional": false,
+  "metrics": {
+    "completion_rate": {
+      "value": 0.525,
+      "range": [
+        0.4,
+        0.7
+      ],
+      "in_band": true,
+      "note": "completed campaigns / N"
+    },
+    "roster_attrition": {
+      "value": 0.583,
+      "range": [
+        0,
+        1
+      ],
+      "in_band": true,
+      "note": "survivors / units-that-fought (exclusive: real losses, no wipe)"
+    },
+    "economy_flow": {
+      "pe_earned_avg": 40.6,
+      "build_power_avg": 149.1,
+      "build_power_drift": 1.105,
+      "pi_sink_exercised": true,
+      "pi_pick_attempts": 385,
+      "pi_insufficient": 336,
+      "has_signal": true,
+      "range": [
+        0.5,
+        2
+      ],
+      "in_band": true,
+      "note": "PE earned + build-power drift; PI sink exercised (385 attempts)"
+    },
+    "relationship_progress": {
+      "recruit_rate": 4.55,
+      "affinity_proven_rate": 1,
+      "reached_step": 28,
+      "mating_rate": 3.85,
+      "range": null,
+      "in_band": true,
+      "note": "recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire"
+    },
+    "offspring_viability": {
+      "offspring_avg": 3.85,
+      "viable_rate": 1,
+      "range": [
+        1,
+        null
+      ],
+      "in_band": true,
+      "note": "mean offspring per run >= threshold (breeding exercised); lineage spread = the separate lineage_diversity metric"
+    },
+    "lineage_diversity": {
+      "value": 5,
+      "lineage_profile": {
+        "dune-stalker x nano-rust-bloom": 49,
+        "ferrocolonia-magnetotattica x nano-rust-bloom": 28,
+        "ferrocolonia-magnetotattica x sand-burrower": 28,
+        "rust-scavenger x sand-burrower": 28,
+        "dune-stalker x rust-scavenger": 21
+      },
+      "dominant_lineages": [
+        "dune-stalker x nano-rust-bloom"
+      ],
+      "unknown_lineage_count": 0,
+      "range": [
+        3,
+        null
+      ],
+      "in_band": true,
+      "note": "distinct parent-species crosses across the batch (>= 3 = healthy spread, no collapse); dominant cross is POLICY-SENSITIVE -> P4 in breeding; UNKNOWN/missing parents excluded, tracked as unknown_lineage_count"
+    },
+    "roster_composition": {
+      "role_profile": {
+        "APEX": 49,
+        "HAZARD": 49,
+        "PREDATOR": 28,
+        "PREY": 28,
+        "SUPPORT": 28
+      },
+      "distinct_roles": 5,
+      "dominant_roles": [
+        "APEX",
+        "HAZARD"
+      ],
+      "unknown_count": 0,
+      "range": [
+        3,
+        null
+      ],
+      "in_band": true,
+      "note": "role_class profile of the recruited roster (UNKNOWN excluded, tracked as unknown_count); dominant_roles diverge by policy -> P4 measurable (composition, not quantity)"
+    }
+  },
+  "completion": {
+    "completed": 21,
+    "total": 40
+  },
+  "personality": {
+    "n_samples": 2055,
+    "per_axis": {
+      "symbiosis_predation": {
+        "n": 2055,
+        "mean": 0.9910975252154224,
+        "sd": 0.04152018542353667,
+        "min": 0.6875,
+        "max": 1,
+        "neutral_rate": 0
+      },
+      "explore_caution": {
+        "n": 2055,
+        "mean": 0.6314777609593528,
+        "sd": 0.20804802374100861,
+        "min": 0.5,
+        "max": 1,
+        "neutral_rate": 0.7094890510948905
+      },
+      "solitary_swarm": {
+        "n": 2055,
+        "mean": 0.5753041362530413,
+        "sd": 0.20386673873025077,
+        "min": 0.25,
+        "max": 1,
+        "neutral_rate": 0.7727493917274939
+      },
+      "memory_instinct": {
+        "n": 2055,
+        "mean": 0.5048081015224165,
+        "sd": 0.048363678923144235,
+        "min": 0.4479166666666667,
+        "max": 0.875,
+        "neutral_rate": 0.8861313868613139
+      },
+      "agile_robust": {
+        "n": 2055,
+        "mean": 0.47883326177186597,
+        "sd": 0.07476056509761894,
+        "min": 0.13999999999999996,
+        "max": 0.7352941176470588,
+        "neutral_rate": 0.6715328467153284
+      }
+    },
+    "degenerate_rate": 0,
+    "dominant_hist": {
+      "solitary_swarm": 188,
+      "symbiosis_predation": 1867
+    },
+    "correlations": [
+      {
+        "pair": [
+          "symbiosis_predation",
+          "explore_caution"
+        ],
+        "r": -0.24722453815105397
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "solitary_swarm"
+        ],
+        "r": -0.44666623469873046
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "memory_instinct"
+        ],
+        "r": -0.8893025748698108
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "agile_robust"
+        ],
+        "r": -0.03842051323250485
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "solitary_swarm"
+        ],
+        "r": 0.2647943179511311
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "memory_instinct"
+        ],
+        "r": 0.12131910320384584
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "agile_robust"
+        ],
+        "r": 0.014691808953227276
+      },
+      {
+        "pair": [
+          "solitary_swarm",
+          "memory_instinct"
+        ],
+        "r": 0.20710279287322345
+      },
+      {
+        "pair": [
+          "solitary_swarm",
+          "agile_robust"
+        ],
+        "r": -0.053038871283999894
+      },
+      {
+        "pair": [
+          "memory_instinct",
+          "agile_robust"
+        ],
+        "r": 0.04478848927812474
+      }
+    ],
+    "by_faction": {
+      "player": {
+        "n_samples": 675,
+        "per_axis": {
+          "symbiosis_predation": {
+            "n": 675,
+            "mean": 0.9964899436099839,
+            "sd": 0.01069628085141437,
+            "min": 0.9467084639498432,
+            "max": 1,
+            "neutral_rate": 0
+          },
+          "explore_caution": {
+            "n": 675,
+            "mean": 0.6378495769218446,
+            "sd": 0.21321385487243294,
+            "min": 0.5,
+            "max": 1,
+            "neutral_rate": 0.7022222222222222
+          },
+          "solitary_swarm": {
+            "n": 675,
+            "mean": 0.6177777777777778,
+            "sd": 0.26143950979901776,
+            "min": 0.25,
+            "max": 1,
+            "neutral_rate": 0.5777777777777777
+          },
+          "memory_instinct": {
+            "n": 675,
+            "mean": 0.4969469431404189,
+            "sd": 0.012823858242240463,
+            "min": 0.4490254872563718,
+            "max": 0.5267857142857143,
+            "neutral_rate": 0.8681481481481481
+          },
+          "agile_robust": {
+            "n": 675,
+            "mean": 0.4355590413943335,
+            "sd": 0.11927782841912025,
+            "min": 0.13999999999999996,
+            "max": 0.7352941176470588,
+            "neutral_rate": 0
+          }
+        }
+      },
+      "sistema": {
+        "n_samples": 1380,
+        "per_axis": {
+          "symbiosis_predation": {
+            "n": 1380,
+            "mean": 0.9884599292615607,
+            "sd": 0.04989998816337462,
+            "min": 0.6875,
+            "max": 1,
+            "neutral_rate": 0
+          },
+          "explore_caution": {
+            "n": 1380,
+            "mean": 0.6283611118472644,
+            "sd": 0.20540199146992238,
+            "min": 0.5,
+            "max": 1,
+            "neutral_rate": 0.7130434782608696
+          },
+          "solitary_swarm": {
+            "n": 1380,
+            "mean": 0.5545289855072464,
+            "sd": 0.16475540465410768,
+            "min": 0.25,
+            "max": 1,
+            "neutral_rate": 0.8681159420289855
+          },
+          "memory_instinct": {
+            "n": 1380,
+            "mean": 0.5086532333396983,
+            "sd": 0.057945606969618126,
+            "min": 0.4479166666666667,
+            "max": 0.875,
+            "neutral_rate": 0.894927536231884
+          },
+          "agile_robust": {
+            "n": 1380,
+            "mean": 0.5,
+            "sd": 0,
+            "min": 0.5,
+            "max": 0.5,
+            "neutral_rate": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/sim/fullLoopPartyInteroception.test.js
+++ b/tests/sim/fullLoopPartyInteroception.test.js
@@ -1,0 +1,47 @@
+// OD-024 D7 co-op-path measure -- the full loop is single-player, so the party
+// never goes through coopOrchestrator.submitCharacter (only the enemies get the
+// interoception grant via session /start, D3). applyPartyInteroceptionGrant is an
+// OPT-IN sim helper that applies the REAL producer to the party combat units too, so
+// an N=40 batch can measure the SYMMETRIC (party + enemy) flip condition. Default off
+// = byte-identical.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { applyPartyInteroceptionGrant } = require('../../tools/sim/full-loop-runner');
+
+describe('OD-024 D7 -- applyPartyInteroceptionGrant (opt-in symmetric measure)', () => {
+  test('disabled -> roster returned unchanged (same reference, byte-identical default)', () => {
+    const roster = [{ id: 'u1', species_id: 'anguis_magnetica', traits: [] }];
+    const out = applyPartyInteroceptionGrant(roster, { enabled: false });
+    assert.equal(out, roster);
+  });
+
+  test('enabled -> qualifying party unit gains its interoception set (real catalog)', () => {
+    // anguis_magnetica = T1 + atollo_obsidiana + danger 2 -> D4 override [prop, vest, noci].
+    const roster = [{ id: 'u1', species_id: 'anguis_magnetica', traits: [] }];
+    const out = applyPartyInteroceptionGrant(roster, { enabled: true });
+    assert.deepEqual([...out[0].traits].sort(), [
+      'equilibrio_vestibolare',
+      'nocicezione',
+      'propriocezione',
+    ]);
+  });
+
+  test('enabled -> unknown species (not in catalog) left unchanged (fail-closed)', () => {
+    const roster = [{ id: 'u1', species_id: 'does_not_exist', traits: ['coda_balanciere'] }];
+    const out = applyPartyInteroceptionGrant(roster, { enabled: true });
+    assert.deepEqual(out[0].traits, ['coda_balanciere']);
+  });
+
+  test('enabled -> preserves pre-existing traits, no duplicates', () => {
+    const roster = [
+      { id: 'u1', species_id: 'anguis_magnetica', traits: ['propriocezione', 'coda_balanciere'] },
+    ];
+    const out = applyPartyInteroceptionGrant(roster, { enabled: true });
+    assert.ok(out[0].traits.includes('coda_balanciere'));
+    assert.equal(out[0].traits.filter((t) => t === 'propriocezione').length, 1);
+  });
+});

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -237,6 +237,10 @@ async function runBatch(opts = {}) {
       enemyScaling,
       peEarned,
       ...(a13 ? { a13: true, a13MaxRetries } : {}),
+      // OD-024 D7 (opt-in): SIM_GRANT_PARTY_INTEROCEPTION=1 also grants the party the
+      // interoception set (the co-op submitCharacter path the single-player loop skips),
+      // so a paired batch can measure the SYMMETRIC party+enemy flip. Default off.
+      grantPartyInteroception: process.env.SIM_GRANT_PARTY_INTEROCEPTION === '1',
     };
     const res = await runOne(runOpts);
     const scenarioChain = (res.chapters || []).map((c) => c.encounter);

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -408,6 +408,9 @@ async function runChildOnce(args) {
     enemyScaling: calibrationScaling(),
     peEarned: peEarnedConfig(),
     ...(args.a13 ? { a13: true, a13MaxRetries: args.a13MaxRetries } : {}),
+    // OD-024 D7 (opt-in): child inherits process.env but runOpts must thread the flag
+    // explicitly (mirror the in-process path), else --isolate silently skips the party grant.
+    grantPartyInteroception: process.env.SIM_GRANT_PARTY_INTEROCEPTION === '1',
   });
   const out = args.out || path.join(os.tmpdir(), `fl-child-${args.childSeed}.json`);
   fs.writeFileSync(out, JSON.stringify(res));
@@ -424,6 +427,11 @@ function currentFlags() {
     // A13 N=40 control arm: '1' = read-side amplifier neutralized (wound still persists).
     // Provenance MUST carry it -- it is the A/B discriminator between the two batches.
     A13_WOUND_READ_DISABLED: process.env.A13_WOUND_READ_DISABLED || '0',
+    // OD-024 D7 interoception flip arms: the enemy-side grant (producer flag) + the
+    // opt-in party-side grant. Both are A/B discriminators -- provenance must carry them.
+    SENTIENCE_INTEROCEPTION_GRANT_ENABLED:
+      process.env.SENTIENCE_INTEROCEPTION_GRANT_ENABLED || 'false',
+    SIM_GRANT_PARTY_INTEROCEPTION: process.env.SIM_GRANT_PARTY_INTEROCEPTION || '0',
   };
 }
 

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -71,6 +71,23 @@ function freshRoster(roster, aliveIds) {
     .map((u) => ({ ...u, hp: u.max_hp ?? u.hp, status: {} }));
 }
 
+// OD-024 D7 co-op-path measure (opt-in). The full loop is single-player, so the party
+// never goes through coopOrchestrator.submitCharacter -- only the enemies get the
+// interoception grant (session /start, D3 enemy-wire). With { enabled: true } the REAL
+// producer is applied to the party combat units too, so an N=40 batch can measure the
+// SYMMETRIC (party + enemy) flip condition instead of enemy-only. Default off -> returns
+// the roster unchanged (byte-identical). The producer self-loads the catalog + registry
+// and gates on tier internally, so a forced-on env only matters per qualifying species.
+function applyPartyInteroceptionGrant(roster, { enabled } = {}) {
+  if (!enabled) return roster;
+  // eslint-disable-next-line global-require
+  const {
+    applySentienceInteroceptionGrant,
+  } = require('../../apps/backend/services/sentience/sentienceInteroceptionGrant');
+  const env = { SENTIENCE_INTEROCEPTION_GRANT_ENABLED: 'true' };
+  return roster.map((u) => applySentienceInteroceptionGrant(u, { env }));
+}
+
 // Weak deterministic enemy for a chapter (MVP). fase-2 swaps in scaled scenario
 // enemies (encounter YAML) for real attrition/completion bands.
 function enemiesForChapter(step) {
@@ -181,6 +198,9 @@ async function runFullLoop(http, opts = {}) {
     // The retry is what makes wound->re-fight-the-wounded-biome observable in-run.
     a13 = false,
     a13MaxRetries = 1,
+    // OD-024 D7 (opt-in): also grant the party the interoception set (mirrors the co-op
+    // submitCharacter path the single-player loop skips) -> measures the symmetric flip.
+    grantPartyInteroception = false,
   } = opts;
   // Roster GROWS as the Nido recruits: it starts as the authored party and gains a
   // faithful combat unit per cleared chapter. knownIds is the matching id universe so a
@@ -279,7 +299,9 @@ async function runFullLoop(http, opts = {}) {
       const sum = await driver.summary(http, id);
       enc = sum.body?.current_encounter?.encounter_id || `chapter_${step}`;
     }
-    const aliveRoster = freshRoster(roster, aliveIds);
+    const aliveRoster = applyPartyInteroceptionGrant(freshRoster(roster, aliveIds), {
+      enabled: grantPartyInteroception,
+    });
     if (aliveRoster.length === 0) {
       violations.push({ step, v: ['roster wiped before chapter'] });
       break;
@@ -478,4 +500,4 @@ async function runFullLoop(http, opts = {}) {
   };
 }
 
-module.exports = { runFullLoop, enemiesForChapter, sumGrants };
+module.exports = { runFullLoop, enemiesForChapter, sumGrants, applyPartyInteroceptionGrant };


### PR DESCRIPTION
## Sommario

"Misura prima" (master-dd): la N=40 di #2960 esercitava il grant **solo sui nemici**
(full-loop single-player -> `session /start`, D3); il path co-op party-submit era
non misurato. Questo aggiunge un party-grant **opt-in** per misurare la condizione
**simmetrica** (party + nemici, = vero co-op). Flag resta OFF.

## Cosa cambia (sim-infra, opt-in default-off)

- `tools/sim/full-loop-runner.js`: `applyPartyInteroceptionGrant` (opt-in -> default
  byte-identical) applica il **producer reale** alle unita' party in combat; threaded
  via `runFullLoop opts.grantPartyInteroception`.
- `tools/sim/full-loop-batch.js`: `SIM_GRANT_PARTY_INTEROCEPTION=1` lo abilita.
- `tests/sim/fullLoopPartyInteroception.test.js`: 4 unit-test (grant su specie reale,
  fail-closed unknown, no-dup, disabled=no-op).
- runbook `docs/ops/...d7-...md` aggiornato (tabella 3-arm + decision input + comando).

## Risultato N=40 (3 bracci, seed-base 7000 appaiato, TUTTI in-banda)

| arm | grant | completion (0.4-0.7) | attrition | bp_drift |
| --- | --- | --- | --- | --- |
| OFF | nessuno | 0.625 | 0.533 | 1.135 |
| enemy-only | nemici (/start) | 0.600 | 0.470 | 1.080 |
| **simmetrico (co-op)** | party + nemici | **0.525** | 0.583 | 1.105 |

## Finding (refuta l'ipotesi "should cancel" di #2960)

Il caso simmetrico **NON si annulla**: entrambi i lati +1 attacco (propriocezione) =
combattimenti piu' sanguinosi -> simmetrico = **arm piu' difficile** (-0.10 completion
vs baseline, attrition piu' alta), MA **ancora in-banda**. Quindi il flip e' band-SAFE
ma rende il gioco **sensibilmente piu' duro**, non neutro. Ecco perche' "misurare
prima" contava -- il ragionamento a priori era sbagliato.

## Verdetto = tuo

Tutti in-banda -> flip band-safe. Scelte: (a) flip ON e accetti i combat piu' duri come
costo del layer sentience; (b) flip ON + ammorbidisci enemy-scaling per ri-centrare
completion ~0.6; (c) hold. Re-tune = knob separato, non blocca la band-safety.

## Guardrail

sim-infra opt-in (default off -> byte-identical, 208 sim test verdi) + docs + evidenza.
Nessun forbidden-path, nessun flip, flag OFF. ADR-0011 trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)