### PR TITLE
fix(traits): TKT-P6-B clean edits v1/v2/v4 (sussurro/mente_lucida/antenne_wideband)

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -1861,6 +1861,7 @@ traits:
     trigger:
       action_type: attack
       on_result: hit
+      min_mos: 3
     effect:
       kind: extra_damage
       amount: 1
@@ -2252,7 +2253,7 @@ traits:
     trigger:
       action_type: attack
       on_result: hit
-      min_mos: 3
+      min_mos: 5
     effect:
       kind: apply_status
       target_side: target
@@ -9528,12 +9529,12 @@ traits:
     effect:
       kind: apply_status
       target_side: target
-      stato: disoriented
+      stato: disorient
       turns: 1
       log_tag: sussurro_psichico_disoriented
     description_it: |
       Sussurro sonico disorientante. Ogni hit solido (MoS >= 5) applica
-      1 turno di disoriented: il target subisce -2 ai tiri d'attacco
+      1 turno di disorient: il target subisce -2 ai tiri d'attacco
       (confusione sensoriale profonda, ma breve).
 
   # DoT 2 PT/turno (piu' severo di bleeding 1 PT). Tick in tutti e 3 i


### PR DESCRIPTION
## Cosa

Phase 1 dell'execution plan TKT-P6-TRAIT-ORPHAN-DESIGN-B: i 3 edit **verificati puliti** (verdetti master-dd ratificati). Solo `data/core/traits/active_effects.yaml`, band-neutral (trait orphan, 0 ref in specie/sim).

| Verdetto | Edit |
|---|---|
| **v4** `sussurro_psichico` | **BUG-FIX**: stato `disoriented` -> `disorient`. Il runtime consuma solo `disorient` (session.js:576, roundOrchestrator.js:271) e l'enum schema = `["bleeding","fracture","disorient","rage","panic"]` (combat.schema.json:129) -> `disoriented` era **status inert + schema-invalid**. + prosa allineata. |
| **v2** `mente_lucida` | balance: trigger `min_mos` 3 -> 5 (panic 2t invariato). |
| **v1** `antenne_wideband` | trigger += `min_mos: 3` (differenzia da `antenne_dustsense` MoS5; gate R1=B). DB `data/traits/locomotorio/antenne_wideband.json` = metadata-only -> nessun sync. |

## Provenienza

Istruttoria [#2953](https://github.com/MasterDD-L34D/Game/pull/2953) (merged) + correzione re-ground + plan v5 ([#2956](https://github.com/MasterDD-L34D/Game/pull/2956)). Verdetti decisi una-domanda-alla-volta + 4 gate; questi 3 = gli unici classificati READY (gli altri BLOCKED/owner-gated, vedi #2956).

## Verify-before-done

- `python3 tools/py/game_cli.py validate-datasets` -> 14 controlli, 0 avvisi, tutti YAML validi.
- `scripts/trait_audit.py` -> clean (exit 0).
- diff = solo `active_effects.yaml` (4 ins / 3 del).
- **Band-neutral by construction**: i 3 trait sono orphan (0 ref in `species_catalog`/specie pack/sim party) -> nessun impatto su combat-oracle HC06/HC07. Snapshot non impattati (catturano solo il NOME del trait, non il trigger).

## Changelog / rollback

- Changelog: "fix trait sussurro_psichico status key (disoriented->disorient, schema-valid) + balance mente_lucida MoS5 + differentiate antenne_wideband MoS3".
- Rollback: `git revert <squash SHA>` -- additive, band-neutral, zero downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)