### PR TITLE
feat(pcg): marchio_predatorio in biome pools magnetar_badlands + crepuscolo (TKT-P6-B v7)

### DIFF
--- a/data/core/traits/biome_pools.json
+++ b/data/core/traits/biome_pools.json
@@ -167,7 +167,8 @@
           "ancestor_attacco_risposta_di_combattimento_co_01",
           "ancestor_attacco_contromanovra_co_02",
           "ancestor_sensi_percezione_se_01",
-          "ancestor_sensi_olfatto_so_01"
+          "ancestor_sensi_olfatto_so_01",
+          "marchio_predatorio"
         ]
       },
       "role_templates": [
@@ -740,7 +741,8 @@
           "ancestor_ardipithecus_ramidus_inibizione_cognitiva_cc_03",
           "ancestor_ardipithecus_ramidus_via_mesolimbica_dp_05",
           "ancestor_insediamento_costruzione_ne_01",
-          "ancestor_insediamento_efficienza_di_costruzione_ne_02"
+          "ancestor_insediamento_efficienza_di_costruzione_ne_02",
+          "marchio_predatorio"
         ]
       },
       "role_templates": [
@@ -754,7 +756,8 @@
           ],
           "preferred_traits": [
             "nebbia_mnesica",
-            "lobi_risonanti_crepuscolo"
+            "lobi_risonanti_crepuscolo",
+            "marchio_predatorio"
           ],
           "tier": 4
         },


### PR DESCRIPTION
## Cosa

Phase 2 dell'execution plan TKT-P6-TRAIT-ORPHAN-DESIGN-B: verdetto **v7** (`marchio_predatorio` -> PCG pool). Solo `data/core/traits/biome_pools.json`.

Aggiunto `marchio_predatorio` a:
- `magnetar_badlands` -> `traits.support` (coerenza tematica: `ferrimordax-rutilus`, che gia' porta marchio, e' badlands)
- `crepuscolo_synapse_bloom` -> `traits.support` + apex "Predatore Anamnestico" `preferred_traits` (fit tematico: mark/segnalazione-alla-squadra + memoria/recall)

## Gate risolti (decisi una-domanda-alla-volta)

- **D-1** (quale pool): "badlands + un imboscata-apex" -> `magnetar_badlands` + `crepuscolo_synapse_bloom` (l'unico imboscata-apex "Predatore Anamnestico", best thematic fit).
- **D-2** (band-neutralita'): **confermata** -- l'oracle badlands (`tests/ai/badlandsCalibScenarios.test.js`) costruisce parties da **roster fisso** (`c.ids`, ferrimordax = APEX fisso), NON PCG-dal-pool -> l'add al pool non tocca l'oracle.

## Verify-before-done

- `validate-datasets` -> 14 controlli, 0 avvisi.
- `validate-ecosystem-pack` -> exit 0.
- diff = solo `biome_pools.json` (3 add, dedup).
- `marchio_predatorio` gia' wired a runtime (status `marked` +1 dmg prossimo attaccante, session.js:726) + gia' su `ferrimordax-rutilus` -> band-neutral.

## Changelog / rollback

- Changelog: "add marchio_predatorio to PCG biome pools (magnetar_badlands + crepuscolo_synapse_bloom)".
- Rollback: `git revert <squash SHA>` -- additive, band-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)