### PR TITLE
docs(ops): resolve Postgres auto-start (cmd PG-ensure) (OD-024 D7 follow-up)

### DIFF
--- a/docs/ops/2026-06-20-prod-backend-task-resilience.md
+++ b/docs/ops/2026-06-20-prod-backend-task-resilience.md
@@ -5,7 +5,7 @@ type: runbook
 doc_status: active
 doc_owner: master-dd
 workstream: ops-qa
-last_verified: '2026-06-20'
+last_verified: '2026-06-22'
 source_of_truth: false
 language: en
 review_cycle_days: 30
@@ -89,6 +89,27 @@ Register-ScheduledTask -Xml (Get-Content C:\Users\edusc\evo-backend-task-backup-
   rewrite (detach instead of block) + an idempotent health-check guard. Deferred as
   a bigger change; the RestartCount-999 + AtStartup fix covers the observed failure
   modes with no rewrite.
-- **Postgres auto-start** (separate prod dependency) -- the portable PG is started
-  by hand (`pg_ctl -D C:/dev/tools/pgdata-game`); a parallel ops residue, not in
-  this runbook.
+- ~~**Postgres auto-start**~~ -- **RESOLVED 2026-06-22** (see below).
+
+## Postgres auto-start (RESOLVED 2026-06-22)
+
+The backend's `DATABASE_URL` points at a portable Postgres
+(`postgresql://...@localhost:5432/game`, data dir `C:/dev/tools/pgdata-game`, binaries
+`C:/dev/tools/pgsql/bin`). It had **no auto-start**, so after a reboot the startup
+lobby hydrate failed with `Can't reach database server at localhost:5432`
+(`lobbyPersistence`, caught/non-fatal -> co-op rooms not restored). Found during the
+OD-024 D7 interoception flip (prod had been running PG-down).
+
+**Fix (applied, non-elevated):** `start-evo-backend.cmd` now **ensures PG before the
+backend** -- idempotent `pg_ctl ... start` (no-op if already running) + a bounded
+(<=30s) `pg_isready` wait, then `source keys.env` + `npm run start:api`. So PG comes
+up on every backend (re)start (logon / crash-restart). Verified: a controlled restart
+hydrated cleanly (`[lobby-ws] Prisma hydrate: 3 room(s) restored`, `/api/health` 200).
+Backup of the pre-edit cmd: `C:\Users\edusc\start-evo-backend.cmd.bak-20260622`.
+
+**Pure-boot survival** still rides on the backend task gaining an **AtStartup** trigger
+(the elevated owner fix above) -- once applied, the cmd brings PG up on boot too. PG
+recovers its own data dir automatically (WAL redo) after an unclean stop. The portable
+PG is NOT registered as a Windows service (would be the only way to start it fully
+independent of the backend task; deferred -- the cmd coupling covers the observed
+failure mode).


### PR DESCRIPTION
## Sommario

Chiude il follow-up "Postgres auto-start" del runbook prod-resilience (2026-06-20).

Durante il flip D7 prod risultava **PG-down**: il `DATABASE_URL` punta a un Postgres
portable (`localhost:5432/game`, data `C:/dev/tools/pgdata-game`) senza auto-start ->
dopo un reboot l'hydrate lobby falliva (`can't reach database server`, caught/non-fatale).

## Fix (applicato sull'host, non-elevato)

`start-evo-backend.cmd` ora **garantisce PG prima del backend**: `pg_ctl start`
idempotente (no-op se gia' su) + attesa `pg_isready` (<=30s), poi `source keys.env` +
`npm run start:api`. PG sale ad ogni (re)start del backend (logon / crash-restart).
Backup pre-edit: `start-evo-backend.cmd.bak-20260622`.

## Verifica

- PG avviato (pg_ctl, auto-recovery dal stop sporco 06-17), `pg_isready` OK, `game` DB
  + tabelle intatte (`lobby_sessions`=5, `lobby_players`=13), migrate status "up to date".
- restart controllato con cmd editato: **`/api/health` 200**, **`[lobby-ws] Prisma hydrate: 3 room(s) restored`**, nessun errore DB-reach.

## Residuo (owner, elevato)

Pure-boot survival = trigger **AtStartup** sul task EvoTacticsBackend (fix elevato gia'
documentato nel runbook + `fix-evo-backend-task-resilience.ps1`); una volta applicato, la
cmd porta su PG anche al boot. PG NON e' registrato come servizio Windows (deferred).

Doc-only (host cmd change documentata; non e' in repo). ADR-0011 trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)