### PR TITLE
fix(traits): dead disorient key on 2 orphan traits (arco_voltaico, zoccoli_risonanti_steppe)

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -525,7 +525,7 @@ traits:
     effect:
       kind: apply_status
       target_side: target
-      stato: disoriented
+      stato: disorient
       turns: 1
       log_tag: voltaic_arc_disorient
     resistances:
@@ -9900,7 +9900,7 @@ traits:
       action_type: melee_attack
     effect:
       kind: apply_status
-      stato: disoriented
+      stato: disorient
       duration: 1
       intensity: 1
       log_tag: zoccoli_resonant_stomp


### PR DESCRIPTION
## Cosa

Follow-up del bug v4 (sussurro_psichico, #2963): lo stato `disoriented` non e' nell'enum canonico (`["bleeding","fracture","disorient","rage","panic"]`) -> status inert + schema-invalid. 5 trait avevano la dead-key; #2963 ha fixato sussurro. Qui i 2 **orphan** restanti (band-neutral, 0 ref specie/sim):

- `arco_voltaico` (528): `stato: disoriented` -> `disorient` (log_tag + prosa gia' su "disorient").
- `zoccoli_risonanti_steppe` (9903): `stato: disoriented` -> `disorient`.

## NON toccati (flag master-dd)

`secrezione_rallentante_palmi` + `campo_di_interferenza_acustica` = stesso bug MA **assegnati a specie live** (catalog `trait_refs`). Il fix li **attiva** (disorient prima inerte) = stealth balance buff -> serve ratifica master-dd, NON silent. Decisione: fixarli (attivazione voluta) o lasciarli inerti?

## Verify

- `validate-datasets` -> 14 controlli, 0 avvisi.
- diff = solo `active_effects.yaml` (2 `stato`).
- Band-neutral (entrambi orphan: 0 ref `species_catalog`/pack/sim).

## Rollback

`git revert <SHA>` -- additive, band-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)