### PR TITLE
fix(traits): activate disorient on 2 assigned traits (secrezione, campo) [TKT-P6-B]

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -9835,12 +9835,12 @@ traits:
       action_type: melee_attack
     effect:
       kind: apply_status
-      stato: disoriented
+      stato: disorient
       duration: 1
       intensity: 1
       log_tag: secrezione_slowing_touch
     description_it: |
-      Secrezione rallentante palmi: apply_status disoriented su melee hit.
+      Secrezione rallentante palmi: apply_status disorient su melee hit.
       Mirror trait_mechanics (defense_mod 1 base + slowing_touch ability
       enemy-targeting). Status duration 1 + intensity 1 conservative.
 
@@ -10304,12 +10304,12 @@ traits:
       action_type: ranged_attack
     effect:
       kind: apply_status
-      stato: disoriented
+      stato: disorient
       duration: 2
       intensity: 1
       log_tag: sonaraptor_jamming_field
     description_it: |
-      Campo di interferenza acustica: apply_status disoriented 2t su
+      Campo di interferenza acustica: apply_status disorient 2t su
       ranged hit (jamming field). Coordination disruption Conquistatore
       semantica T4 acoustic intelligence.
 


### PR DESCRIPTION
## Cosa

Ultimi 2 dead-key `disoriented` (ora **0** in active_effects -- bug chiuso su tutti i 5). A differenza degli orfani (#2967), questi sono **assegnati a specie live** (catalog `trait_refs`) -> il fix **attiva** `disorient` (prima inerte) = balance change, **autorizzato master-dd** ("vanno fatti tutti"):

- `secrezione_rallentante_palmi`: `stato` disoriented -> disorient (melee, 1t)
- `campo_di_interferenza_acustica`: `stato` disoriented -> disorient (ranged, 2t)

Realizza l'intento gia' documentato (le `description_it` dicevano "apply_status disoriented").

## Verify

- `validate-datasets` -> 14/0.
- **combat-oracle CI** verifica band (sim=0 -> oracle neutral, ma cambio gameplay reale su specie live -> CI conferma no-regression).
- diff = solo `active_effects.yaml` (4 righe).

## Rollback

`git revert <SHA>` -- additive, reversibile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)