### PR TITLE
refactor(traits): rename magnetic cluster EN->IT (TKT-P6-B name-audit)

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -2753,7 +2753,7 @@ traits:
   # Esposizione canonica del trait + ladder T2 e' il deliverable P0;
   # l'evaluator extension (action_type=support, biome gating, requires-trait
   # gating) e' follow-up M-future (vedi card §"Concrete reuse paths" P1).
-  magnetic_rift_resonance:
+  risonanza_magnetica:
     tier: T2
     category: neurologico
     applies_to: actor
@@ -2779,15 +2779,15 @@ traits:
     biome_affinity:
       atollo_obsidiana: 0.9
     requires_traits:
-    - magnetic_sensitivity
-    - rift_attunement
+    - senso_magnetico
+    - sintonia_magnetica
 
-  # Stub T1 — prerequisito narrativo di magnetic_rift_resonance.
+  # Stub T1 — prerequisito narrativo di risonanza_magnetica.
   # No-op runtime: trigger su action_type=attack ma nessun effect concreto
   # (apply_status su 'sensed' che non e' consumato da policy.js). Serve come
   # "marcatore" data-only finche' M-future non aggiunge percezione magnetica
   # come stat-bonus (es. detection range +1 vs hidden enemies).
-  magnetic_sensitivity:
+  senso_magnetico:
     tier: T1
     category: sensoriale
     applies_to: actor
@@ -2803,10 +2803,10 @@ traits:
     description_it: |
       Sensibilita' magnetica passiva — l'unita' percepisce campi magnetici
       ambientali. Stub data-only (M-future: bonus detection in biomi
-      ferromagnetici). Prerequisito per magnetic_rift_resonance.
+      ferromagnetici). Prerequisito per risonanza_magnetica.
 
   # Stub T2 — biome-affinity locked. Stesso pattern no-op del precedente.
-  rift_attunement:
+  sintonia_magnetica:
     tier: T2
     category: sensoriale
     applies_to: actor
@@ -2819,12 +2819,12 @@ traits:
       target_side: actor
       stato: attuned
       turns: 2
-      log_tag: rift_attunement_passive
+      log_tag: sintonia_magnetica_passive
     description_it: |
       Sintonia con le fratture ossidiane — l'unita' canalizza l'energia
       magnetica del bioma. Stub data-only locked su atollo_obsidiana
       (M-future: enforcement biome gating). Prerequisito per
-      magnetic_rift_resonance.
+      risonanza_magnetica.
     biome_affinity:
       atollo_obsidiana: 0.8
 

--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -2915,15 +2915,15 @@
       "description_it": "Luminescenza Hydrotermica permette alle squadre di coordinare scambi di risorse e parametri di stabilizzazione di squadra all'interno di abisso vulcanico.",
       "description_en": "Luminescenza Hydrotermica allow squads to coordinate resource exchange and squad stabilisation parameters within abisso vulcanico."
     },
-    "magnetic_rift_resonance": {
-      "label_it": "Risonanza con Faglia Magnetica",
-      "label_en": "Magnetic Rift Resonance",
+    "risonanza_magnetica": {
+      "label_it": "Risonanza Magnetica",
+      "label_en": "Magnetic Resonance",
       "description_it": "Sintonizzazione neurologica con anomalie di campo magnetico — permette di leggere correnti di forza in biome di faglia.",
       "description_en": "Neurological attunement to magnetic field anomalies — reads force currents in rift biomes."
     },
-    "magnetic_sensitivity": {
-      "label_it": "Sensibilità Magnetica",
-      "label_en": "Magnetic Sensitivity",
+    "senso_magnetico": {
+      "label_it": "Senso Magnetico",
+      "label_en": "Magnetic Sense",
       "description_it": "Percezione passiva di campi magnetici locali — utile per orientamento in ambienti privi di luce diretta.",
       "description_en": "Passive perception of local magnetic fields — useful for orientation in lightless environments."
     },
@@ -3233,9 +3233,9 @@
       "description_it": "Microvascolatura dermica connessa a terminazioni radicali simbiotiche, rimuovendo calore e scambiando fluidi con substrati vegetali per regolare la temperatura basale.",
       "description_en": "Dermal microvasculature connected to symbiotic root terminals, shedding heat and exchanging fluids with plant substrates to regulate core temperature."
     },
-    "rift_attunement": {
-      "label_it": "Attunement con la Faglia",
-      "label_en": "Rift Attunement",
+    "sintonia_magnetica": {
+      "label_it": "Sintonia Magnetica",
+      "label_en": "Magnetic Attunement",
       "description_it": "Adattamento sensoriale a turbolenze elettromagnetiche di faglia — riduce penalità di percezione in tali biome.",
       "description_en": "Sensory adaptation to rift electromagnetic turbulence — reduces perception penalties in such biomes."
     },


### PR DESCRIPTION
## Cosa

Name-audit R2b -- rename del cluster magnetico (EN -> IT), nomi **ratificati master-dd** (AskUserQuestion). Cluster orphan (0 catalog/snapshot/DB) -> rename pulito su `active_effects.yaml` + `glossary.json`:

| vecchio | nuovo | EN label |
|---|---|---|
| `magnetic_rift_resonance` | `risonanza_magnetica` | Magnetic Resonance |
| `magnetic_sensitivity` | `senso_magnetico` | Magnetic Sense |
| `rift_attunement` | `sintonia_magnetica` | Magnetic Attunement |

`requires_traits` aggiornato. EN labels matchano l'IT (richiesta master-dd).

## Verify

- `validate-datasets` 14/0; `glossary.json` JSON valid; **0 old-name residui** in active_effects/glossary.
- `telepathicReveal.js` + test = solo commenti provenance (non-breaking, lasciati). docs storici = mention lasciate (non governance-validate).

## Rollback

`git revert <SHA>` -- additive, orphan traits (no gameplay impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)