### PR TITLE
feat(imprint): C2-imprint backend MVP -- additive L'Impronta beat + affinity + cosmetic hint

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -366,8 +366,13 @@ function createCoopRouter({
     if (!room) return res.status(403).json({ error: 'host_auth_failed' });
     const orch = coopStore.get(code);
     if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    const connected = connectedQuorumPids(room, orch);
+    // Reject opening a beat with no connected device players -> the assignment would be
+    // empty and the beat could never complete (no axis owners). The host opens AFTER
+    // players connect, post-onboarding.
+    if (connected.length === 0) return res.status(400).json({ error: 'no_connected_players' });
     try {
-      const tally = orch.openImprint({ connectedPlayerIds: connectedQuorumPids(room, orch) });
+      const tally = orch.openImprint({ connectedPlayerIds: connected });
       broadcastCoopState(room, orch);
       return res.json({ tally });
     } catch (err) {
@@ -393,6 +398,7 @@ function createCoopRouter({
 
   router.post('/coop/imprint/cancel', (req, res) => {
     const { code, host_token: hostToken } = req.body || {};
+    if (!isImprintEnabled()) return res.status(409).json({ error: 'imprint_disabled' });
     const room = authHost(code, hostToken);
     if (!room) return res.status(403).json({ error: 'host_auth_failed' });
     const orch = coopStore.get(code);
@@ -403,6 +409,26 @@ function createCoopRouter({
       return res.json({ tally });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'imprint_cancel_failed' });
+    }
+  });
+
+  // Host anti-deadlock: force-complete the open beat by filling any unmarked axes with the
+  // onboarding defaults, then stamp the cosmetic hint. The host EXPLICITLY chooses this
+  // over cancel (a silent auto-defaulting timer stays a master-dd design call, build-spec
+  // open-risk). No-op when the beat is closed.
+  router.post('/coop/imprint/force', (req, res) => {
+    const { code, host_token: hostToken } = req.body || {};
+    if (!isImprintEnabled()) return res.status(409).json({ error: 'imprint_disabled' });
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const tally = orch.forceCompleteImprint();
+      broadcastCoopState(room, orch);
+      return res.json({ tally });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'imprint_force_failed' });
     }
   });
 

--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -18,6 +18,7 @@ const { buildPhaseChangePayload } = require('../services/coop/phaseChangePayload
 // drain WS (#2707/#2708): l'host conta SOLO se e' il submitter corrente o
 // possiede gia' un PG (host-plays); la TV-mirror (mai input) resta esclusa.
 const { lifecycleQuorumPids } = require('../services/network/wsSession');
+const { isImprintEnabled } = require('../services/imprint/imprintBiomeWeights');
 // OD-058 D3 (#2531) -- server-side vcSnapshot replay dal ledger della sessione
 // combat linkata (coopStore.linkSession): il debrief coop non e' piu'
 // trust-the-host.
@@ -127,6 +128,13 @@ function createCoopRouter({
         type: 'route_tally',
         payload: orch.routeTally(quorumPids(room, orch, null), connectedQuorumPids(room, orch)),
       });
+    }
+    // C2-imprint -- re-surface the imprint beat (phase-agnostic: gated on an open beat OR
+    // a stamped hint, not a PHASES value; mirror route_choice). Keeps phones in sync on
+    // any coop-state rebroadcast. Band-neutral: with the flag OFF the beat never opens and
+    // no hint exists, so this never fires.
+    if (orch.imprintOpen || orch.brancoBiomeHint) {
+      room.broadcast({ type: 'imprint_tally', payload: orch.imprintTally() });
     }
     // M19 — debrief ready list if in debrief.
     if (orch.phase === 'debrief') {
@@ -343,6 +351,58 @@ function createCoopRouter({
       return res.json({ phase: orch.phase, advance: result.advance });
     } catch (err) {
       return res.status(400).json({ error: err.message || 'mission_start_failed' });
+    }
+  });
+
+  // C2-imprint (ratified L'Impronta affinity 6.1-A + additive beat 6.2-A). Device-authority
+  // NON-gating cosmetic beat: host OPENS, each connected player MARKS its round-robin
+  // assigned axis; on all 4 axes the cosmetic biome-affinity hint is stamped. Flag-gated at
+  // the open path (IMPRINT_BEAT_ENABLED) -> with the flag OFF the beat never opens
+  // (band-neutral). The host may only open/cancel; the completion is the device marks.
+  router.post('/coop/imprint/open', (req, res) => {
+    const { code, host_token: hostToken } = req.body || {};
+    if (!isImprintEnabled()) return res.status(409).json({ error: 'imprint_disabled' });
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const tally = orch.openImprint({ connectedPlayerIds: connectedQuorumPids(room, orch) });
+      broadcastCoopState(room, orch);
+      return res.json({ tally });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'imprint_open_failed' });
+    }
+  });
+
+  router.post('/coop/imprint/mark', (req, res) => {
+    const { code, player_id: playerId, player_token: playerToken, axis, value } = req.body || {};
+    const auth = authPlayer(code, playerId, playerToken);
+    if (!auth) return res.status(403).json({ error: 'player_auth_failed' });
+    const { room } = auth;
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const tally = orch.submitImprintMark(playerId, { axis, value });
+      broadcastCoopState(room, orch);
+      return res.json({ tally });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'imprint_mark_failed' });
+    }
+  });
+
+  router.post('/coop/imprint/cancel', (req, res) => {
+    const { code, host_token: hostToken } = req.body || {};
+    const room = authHost(code, hostToken);
+    if (!room) return res.status(403).json({ error: 'host_auth_failed' });
+    const orch = coopStore.get(code);
+    if (!orch) return res.status(409).json({ error: 'run_not_started' });
+    try {
+      const tally = orch.cancelImprint();
+      broadcastCoopState(room, orch);
+      return res.json({ tally });
+    } catch (err) {
+      return res.status(400).json({ error: err.message || 'imprint_cancel_failed' });
     }
   });
 

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -13,6 +13,13 @@ const { emergeBrancoTraitFromPulses } = require('../identity/brancoTraitEmergenc
 const { emergeIdentity, emitCreatureNamed } = require('../identity/identityService');
 const { aggregateFormPulses } = require('../formPulseVc');
 const consentSM = require('./lethalConsent');
+const {
+  computeImprintBiomeWeights,
+  topBiome,
+  IMPRINT_AXES,
+  IMPRINT_AXIS_DEFAULTS,
+  isValidAxisValue,
+} = require('../imprint/imprintBiomeWeights');
 
 // CAMP-1/CAMP-2 - run.id is the SistemaState persistence key (server writes
 // SistemaState under run.id; Godot client keys CampaignState.campaign_id on
@@ -168,6 +175,16 @@ class CoopOrchestrator {
     this.creatureIdentities = new Map();
     this.chronicleBaseDir = chronicleBaseDir || null;
     this.namePool = Array.isArray(namePool) ? namePool : null;
+    // C2-imprint (ratified L'Impronta affinity 6.1-A + additive beat 6.2-A) -- NON-gating
+    // transient side-collection (mirror formPulses; no PHASES enum change). Host opens the
+    // beat; the 4 body-part axes are round-robin assigned to the N connected players and
+    // marked per-device; on all-4-axes-marked the cosmetic biome-affinity hint is stamped.
+    // Flag-gated at the open path (IMPRINT_BEAT_ENABLED): with the beat never opened these
+    // stay empty/null -> band-neutral. NEVER binds a biome (route-canon) or feeds combat.
+    this.imprintMarks = new Map(); // axis -> { value, by, ts }
+    this.imprintAssignment = null; // { player_id: [axis,...] } | null (set on open)
+    this.imprintOpen = false;
+    this.brancoBiomeHint = null; // { leans_toward, weights } | null (stamped on quorum)
     this.log = [];
     this._listeners = new Set();
     // W5-bb (cross-repo Godot v2 mirror) — world enricher service injection.
@@ -303,6 +320,7 @@ class CoopOrchestrator {
     this.creatureIdentities.clear();
     this.onboardingChoice = null;
     this.onboardingChoices.clear();
+    this._resetImprint();
     this._clearLethalConsentTimer(); // SPEC-J: drop any armed auto-timeout
     this.lethalConsent = null; // SPEC-J: never carry a consent round across runs
     this._setPhase('character_creation');
@@ -350,6 +368,7 @@ class CoopOrchestrator {
     this.creatureIdentities.clear();
     this.onboardingChoice = null;
     this.onboardingChoices.clear();
+    this._resetImprint();
     this._clearLethalConsentTimer(); // SPEC-J: drop any armed auto-timeout
     this.lethalConsent = null; // SPEC-J: never carry a consent round across runs
     this._setPhase('onboarding');
@@ -1402,6 +1421,131 @@ class CoopOrchestrator {
       tally.all_connected_ready = connectedTotal > 0 && connectedReady === connectedTotal;
     }
     return tally;
+  }
+
+  // ---- C2-imprint beat (NON-gating side-collection; mirror formPulses + missionReadyTally) ----
+
+  // Reset all imprint beat state. Called on run (re)start; the cosmetic hint is
+  // run-scoped (persists across scenario advances within a run, re-imprinted only on a
+  // fresh run -- so it is NOT cleared in advanceScenarioOrEnd).
+  _resetImprint() {
+    this.imprintMarks.clear();
+    this.imprintAssignment = null;
+    this.imprintOpen = false;
+    this.brancoBiomeHint = null;
+  }
+
+  // Round-robin the 4 fixed axes over the connected players so every axis is owned by
+  // exactly one player and ownership scales to N=2-4 (4p -> 1 axis each; 3p -> one player
+  // owns 2; 2p -> 2 each). Pure; never throws.
+  assignImprintAxes(connectedPlayerIds = []) {
+    const players = (Array.isArray(connectedPlayerIds) ? connectedPlayerIds : []).filter(Boolean);
+    const out = {};
+    for (const pid of players) out[pid] = [];
+    if (players.length === 0) return out;
+    IMPRINT_AXES.forEach((axis, i) => {
+      out[players[i % players.length]].push(axis);
+    });
+    return out;
+  }
+
+  // Host opens the beat (route enforces host). Assigns axes to the connected players,
+  // clears any prior marks/hint, marks the beat open. Non-gating: does NOT change phase.
+  openImprint({ connectedPlayerIds = [] } = {}) {
+    this.imprintMarks.clear();
+    this.brancoBiomeHint = null;
+    this.imprintAssignment = this.assignImprintAxes(connectedPlayerIds);
+    this.imprintOpen = true;
+    this._emit('imprint_opened', { assignment: this.imprintAssignment });
+    return this.imprintTally();
+  }
+
+  // A player marks ITS assigned axis (device-authority: only the owner may mark an axis).
+  // Typed errors the route maps to 4xx; never silently mutates on a closed/unknown beat.
+  // On all-4-axes-marked, stamps the cosmetic hint.
+  submitImprintMark(playerId, { axis, value } = {}) {
+    if (!this.imprintOpen) throw new Error('imprint_not_open');
+    if (!playerId) throw new Error('player_id_required');
+    if (!IMPRINT_AXES.includes(axis)) throw new Error('invalid_axis');
+    if (!isValidAxisValue(axis, value)) throw new Error('invalid_value');
+    const owned =
+      this.imprintAssignment && Array.isArray(this.imprintAssignment[playerId])
+        ? this.imprintAssignment[playerId]
+        : null;
+    if (!owned) throw new Error('player_not_assigned');
+    if (!owned.includes(axis)) throw new Error('axis_not_assigned');
+    this.imprintMarks.set(axis, {
+      value: String(value).toUpperCase(),
+      by: playerId,
+      ts: this.now(),
+    });
+    this._emit('imprint_marked', { axis, by: playerId });
+    if (IMPRINT_AXES.every((a) => this.imprintMarks.has(a))) this._computeImprintHint();
+    return this.imprintTally();
+  }
+
+  // Axis-based readiness tally (the 4 fixed axes, NOT per-player -- a 2-3p team completes
+  // when all 4 axes have a value). `all_axes_marked` is the cosmetic-hint trigger.
+  imprintTally() {
+    const perAxis = {};
+    for (const axis of IMPRINT_AXES) {
+      const m = this.imprintMarks.get(axis);
+      perAxis[axis] = m ? { value: m.value, by: m.by } : null;
+    }
+    const pending = IMPRINT_AXES.filter((a) => !this.imprintMarks.has(a));
+    return {
+      open: this.imprintOpen,
+      assignment: this.imprintAssignment,
+      axes_total: IMPRINT_AXES.length,
+      axes_marked: IMPRINT_AXES.length - pending.length,
+      axes_pending: pending,
+      all_axes_marked: pending.length === 0,
+      per_axis: perAxis,
+      branco_biome_hint: this.brancoBiomeHint,
+    };
+  }
+
+  // Build the team 4-tuple from the marks and stamp the COSMETIC biome-affinity hint.
+  // NEVER assigns/binds a biome (route-canon); display-only. Closes the beat.
+  _computeImprintHint() {
+    const tuple = {};
+    for (const axis of IMPRINT_AXES) {
+      const m = this.imprintMarks.get(axis);
+      if (m) tuple[axis] = m.value;
+    }
+    const weights = computeImprintBiomeWeights([tuple]);
+    const leans = topBiome(weights);
+    this.brancoBiomeHint = leans ? { leans_toward: leans, weights } : null;
+    this.imprintOpen = false;
+    this._emit('imprint_hint', this.brancoBiomeHint);
+    return this.brancoBiomeHint;
+  }
+
+  // Anti-deadlock: fill pending axes with the onboarding defaults, then stamp the hint.
+  // Used by the open beat's timeout (wiring) and host force.
+  forceCompleteImprint() {
+    if (!this.imprintOpen) return this.imprintTally();
+    for (const axis of IMPRINT_AXES) {
+      if (!this.imprintMarks.has(axis)) {
+        this.imprintMarks.set(axis, {
+          value: IMPRINT_AXIS_DEFAULTS[axis],
+          by: null,
+          ts: this.now(),
+        });
+      }
+    }
+    this._computeImprintHint();
+    return this.imprintTally();
+  }
+
+  // Host cancel (anti-deadlock soft escape). Abandons the beat without a hint.
+  cancelImprint() {
+    this.imprintOpen = false;
+    this.imprintMarks.clear();
+    this.imprintAssignment = null;
+    this.brancoBiomeHint = null;
+    this._emit('imprint_cancelled', {});
+    return this.imprintTally();
   }
 
   /**

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -1723,6 +1723,9 @@ class CoopOrchestrator {
       run: this.run,
       characters: Array.from(this.characters.values()),
       log: this.log.slice(-50),
+      // C2-imprint -- additive, guarded: present only when the beat is open or a hint was
+      // stamped, so the snapshot stays byte-identical when the flag is OFF (band-neutral).
+      ...(this.imprintOpen || this.brancoBiomeHint ? { imprint: this.imprintTally() } : {}),
     };
   }
 }

--- a/apps/backend/services/imprint/imprintBiomeWeights.js
+++ b/apps/backend/services/imprint/imprintBiomeWeights.js
@@ -1,0 +1,146 @@
+'use strict';
+
+// Imprint biome-AFFINITY weights (C2-imprint, ratified L'Impronta affinity 6.1-A).
+//
+// PURE, READ-ONLY, NON-BINDING. Maps the team's 4-axis imprint choices to a
+// normalized { biome: weight } cosmetic-display distribution. It NEVER assigns or
+// binds a biome (biome stays route-canon via world_setup/confirmWorld) and its output
+// MUST NEVER be fed into damage / score / affinity / route math -- it only drives the
+// cosmetic "il tuo branco tende verso X" hint.
+//
+// DISTINCT from apps/backend/services/species/biomeAffinity.js (species<->biome COMBAT
+// affinity, getBiomeAffinityModifier, wired at session.js). Different name + export on
+// purpose -- do not merge the two.
+//
+// Non-throwing by contract: invalid/missing axes are skipped; empty/all-invalid input
+// returns {}; a missing/broken config returns {}. Mirrors the band-neutral, never-crash
+// posture of the surrounding coop helpers.
+//
+// Plan: docs/planning/2026-06-22-aa01-c2-imprint-build-spec.md (STEP 2).
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const VALID = {
+  locomotion: new Set(['VELOCE', 'SILENZIOSA']),
+  offense: new Set(['PROFONDA', 'RAPIDA']),
+  defense: new Set(['DURA', 'FLESSIBILE']),
+  senses: new Set(['LONTANO', 'ACUTO']),
+};
+
+let cachedConfig = null;
+
+function defaultConfigPath() {
+  return path.resolve(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    'data',
+    'core',
+    'imprint',
+    'biome_resolution.yaml',
+  );
+}
+
+function loadConfig(configPath) {
+  if (cachedConfig && !configPath) return cachedConfig;
+  const resolved = configPath || defaultConfigPath();
+  const config = yaml.load(fs.readFileSync(resolved, 'utf8'));
+  if (!configPath) cachedConfig = config;
+  return config;
+}
+
+function resetCache() {
+  cachedConfig = null;
+}
+
+// Build the "L_O_D_S" lookup key from one 4-tuple. Returns null (NOT throw) if any
+// axis is missing or invalid -- the caller skips that tuple.
+function tupleKey(tuple) {
+  if (!tuple || typeof tuple !== 'object') return null;
+  const l = String(tuple.locomotion || '').toUpperCase();
+  const o = String(tuple.offense || '').toUpperCase();
+  const d = String(tuple.defense || '').toUpperCase();
+  const s = String(tuple.senses || '').toUpperCase();
+  if (
+    !VALID.locomotion.has(l) ||
+    !VALID.offense.has(o) ||
+    !VALID.defense.has(d) ||
+    !VALID.senses.has(s)
+  ) {
+    return null;
+  }
+  return `${l[0]}_${o[0]}_${d[0]}_${s[0]}`;
+}
+
+/**
+ * Compute normalized cosmetic biome-affinity weights from the team's imprint tuples.
+ *
+ * Shared-branco model passes a single team tuple ([{...}]) -> a one-biome distribution
+ * ({ biome: 1 }); a future per-creature model can pass N tuples -> a spread distribution.
+ *
+ * @param {Array<{locomotion,offense,defense,senses}>|object} teamTuples
+ * @param {{ config_path?: string }} [opts]
+ * @returns {{ [biome: string]: number }} normalized weights (sum = 1), or {} when there
+ *   is no valid tuple. NEVER throws. NEVER returns a biome_id assignment.
+ */
+function computeImprintBiomeWeights(teamTuples, opts = {}) {
+  const tuples = Array.isArray(teamTuples) ? teamTuples : teamTuples ? [teamTuples] : [];
+  let config;
+  try {
+    config = loadConfig(opts.config_path);
+  } catch {
+    return {};
+  }
+  const lookup = (config && config.base_lookup) || {};
+  const fallback = config && config.fallback_biome;
+
+  const counts = {};
+  let total = 0;
+  for (const tuple of tuples) {
+    const key = tupleKey(tuple);
+    if (!key) continue;
+    const biome = lookup[key] || fallback;
+    if (!biome) continue;
+    counts[biome] = (counts[biome] || 0) + 1;
+    total += 1;
+  }
+  if (total === 0) return {};
+
+  const weights = {};
+  for (const biome of Object.keys(counts)) {
+    weights[biome] = counts[biome] / total;
+  }
+  return weights;
+}
+
+/**
+ * The biome with the highest weight (stable on ties), or null for empty weights.
+ * Drives the cosmetic hint "leans_toward".
+ *
+ * @param {{ [biome: string]: number }} weights
+ * @returns {string|null}
+ */
+function topBiome(weights) {
+  if (!weights || typeof weights !== 'object') return null;
+  let best = null;
+  let bestWeight = -Infinity;
+  for (const biome of Object.keys(weights)) {
+    const w = weights[biome];
+    if (typeof w === 'number' && w > bestWeight) {
+      best = biome;
+      bestWeight = w;
+    }
+  }
+  return best;
+}
+
+module.exports = {
+  computeImprintBiomeWeights,
+  topBiome,
+  tupleKey,
+  resetCache,
+};

--- a/apps/backend/services/imprint/imprintBiomeWeights.js
+++ b/apps/backend/services/imprint/imprintBiomeWeights.js
@@ -29,6 +29,33 @@ const VALID = {
   senses: new Set(['LONTANO', 'ACUTO']),
 };
 
+// The 4 imprint body-part axes (fixed; players are round-robin assigned to them).
+const IMPRINT_AXES = ['locomotion', 'offense', 'defense', 'senses'];
+
+// Anti-deadlock defaults (onboarding_v2 deliberation default_choices p1..p4). A pending
+// axis at the open beat's timeout falls back to these so the team 4-tuple is always
+// complete. NOT a balance value -- cosmetic only.
+const IMPRINT_AXIS_DEFAULTS = Object.freeze({
+  locomotion: 'VELOCE',
+  offense: 'PROFONDA',
+  defense: 'DURA',
+  senses: 'LONTANO',
+});
+
+const IMPRINT_BEAT_FLAG = 'IMPRINT_BEAT_ENABLED';
+
+// Flag gate (mirror staminaFatigue.isFatigueEnabled): OFF by default so the beat never
+// opens and nothing is stamped -> band-neutral. Used by the WS/REST open path.
+function isImprintEnabled(env = process.env) {
+  return Boolean(env) && env[IMPRINT_BEAT_FLAG] === 'true';
+}
+
+// True iff `value` is a legal choice for `axis`. Case-insensitive; never throws.
+function isValidAxisValue(axis, value) {
+  const set = VALID[axis];
+  return Boolean(set) && set.has(String(value == null ? '' : value).toUpperCase());
+}
+
 let cachedConfig = null;
 
 function defaultConfigPath() {
@@ -143,4 +170,8 @@ module.exports = {
   topBiome,
   tupleKey,
   resetCache,
+  IMPRINT_AXES,
+  IMPRINT_AXIS_DEFAULTS,
+  isImprintEnabled,
+  isValidAxisValue,
 };

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1025,6 +1025,11 @@ function sendCoopSnapshotToPlayer(room, orch, playerId) {
     send({ type: 'route_choice', payload: { candidates: orch.routeCandidates } });
     send({ type: 'route_tally', payload: orch.routeTally(allIds, connectedIds) });
   }
+  // C2-imprint -- reconnect parity: re-surface the beat to a reconnecting/joining player
+  // (guarded: only when open or a hint exists -> band-neutral when the flag is OFF).
+  if (orch.imprintOpen || orch.brancoBiomeHint) {
+    send({ type: 'imprint_tally', payload: orch.imprintTally() });
+  }
   if (orch.phase === 'debrief' && typeof orch.debriefReadyList === 'function') {
     send({
       type: 'debrief_ready_list',
@@ -1093,6 +1098,11 @@ function rebroadcastCoopState(room, orch) {
   ) {
     room.broadcast({ type: 'route_choice', payload: { candidates: orch.routeCandidates } });
     room.broadcast({ type: 'route_tally', payload: orch.routeTally(allIds, connectedIds) });
+  }
+  // C2-imprint -- host-transfer parity: re-surface the beat to the whole room (guarded:
+  // only when open or a hint exists -> band-neutral when the flag is OFF).
+  if (orch.imprintOpen || orch.brancoBiomeHint) {
+    room.broadcast({ type: 'imprint_tally', payload: orch.imprintTally() });
   }
   if (orch.phase === 'debrief' && typeof orch.debriefReadyList === 'function') {
     room.broadcast({
@@ -2336,6 +2346,13 @@ function createWsServer({
               type: 'route_tally',
               payload: orch.routeTally(allPids, connectedPids),
             });
+          }
+          // C2-imprint -- a disconnect changes who can mark; the beat is NON-gating (no
+          // phase to advance), but re-surface imprint_tally so remaining phones see the
+          // current state (an axis owned by the departed player stays pending -> the host
+          // can cancel/force). Guarded -> band-neutral when the flag is OFF.
+          if (orch && (orch.imprintOpen || orch.brancoBiomeHint)) {
+            room.broadcast({ type: 'imprint_tally', payload: orch.imprintTally() });
           }
           // SPEC-K K-05: a disconnect can COMPLETE the Nido readiness quorum (the
           // departed peer was the last not-ready connected player). Re-broadcast the

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -1435,6 +1435,34 @@ function createWsServer({
           // Resolves choice from campaign onboarding YAML, calls
           // orch.submitOnboardingChoice (auto-advances onboarding →
           // character_creation), broadcasts onboarding_chosen.
+          // C2-imprint -- drain the device-authority imprint mark server-side (mirror
+          // onboarding_choice). Submitter identity is SOCKET-BOUND (playerId from the
+          // authenticated connection, NOT from the payload) so a player cannot mark on
+          // another's behalf. On completion the orchestrator stamps the cosmetic hint.
+          if (action === 'imprint_mark' && coopStore) {
+            try {
+              const orch = coopStore.get(room.code);
+              if (!orch) {
+                socket.send(
+                  JSON.stringify({ type: 'error', payload: { code: 'run_not_started' } }),
+                );
+                return;
+              }
+              const axis = typeof msg.payload?.axis === 'string' ? msg.payload.axis : '';
+              const value = msg.payload?.value;
+              const tally = orch.submitImprintMark(playerId, { axis, value });
+              room.broadcast({ type: 'imprint_tally', payload: tally });
+              socket.send(JSON.stringify({ type: 'imprint_mark_accepted', payload: { tally } }));
+            } catch (err) {
+              socket.send(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { code: err.message || 'imprint_mark_failed' },
+                }),
+              );
+            }
+            return;
+          }
           if (action === 'onboarding_choice' && coopStore) {
             try {
               const orch = coopStore.get(room.code);

--- a/data/core/imprint/biome_resolution.yaml
+++ b/data/core/imprint/biome_resolution.yaml
@@ -1,0 +1,92 @@
+# Biome resolution -- 4-tuple imprint choices -> biome mapping data.
+#
+# Source: aa01 CAP-11 (audit Impronta CAP-10). Ported for C2-imprint as the data
+# behind the imprint biome-AFFINITY producer (services/imprint/imprintBiomeWeights.js).
+# The affinity is COSMETIC + NON-BINDING: biome stays route-canon. base_lookup is the
+# only part the weights producer reads; `modulation` is preserved design data (it was
+# the cap-11 binding-resolve variant system, NOT used by the cosmetic weights).
+#
+# 4 body-part axes (Jackbox L'Impronta):
+#   locomotion: VELOCE | SILENZIOSA
+#   offense:    PROFONDA | RAPIDA
+#   defense:    DURA | FLESSIBILE
+#   senses:     LONTANO | ACUTO
+# 16 combos (2^4) -> 7 core biomes. Key "L_O_D_S" = first letter of each choice.
+
+schema_version: '1.0'
+
+base_lookup:
+  # open-ground (veloce/lontano dominant)
+  V_P_D_L: savana # veloce profonda dura lontano
+  V_P_F_L: savana # veloce profonda flessibile lontano
+  V_R_D_L: badlands # veloce rapida dura lontano
+  V_R_F_L: badlands # veloce rapida flessibile lontano
+
+  # cavern/underground (silenzioso/acuto dominant)
+  S_P_D_A: caverna_risonante # silenziosa profonda dura acuto
+  S_P_F_A: caverna_risonante # silenziosa profonda flessibile acuto
+  S_R_D_A: rovine_planari # silenziosa rapida dura acuto
+  S_R_F_A: rovine_planari # silenziosa rapida flessibile acuto
+
+  # hybrids
+  V_P_D_A: rovine_planari # veloce profondo duro acuto
+  V_R_D_A: badlands # veloce rapido duro acuto
+  S_P_D_L: palude_tossica # silenziosa profonda dura lontano
+  S_R_D_L: palude_tossica # silenziosa rapida dura lontano
+
+  # extremes
+  V_P_F_A: canopia_ionica # veloce profondo flessibile acuto
+  V_R_F_A: canopia_ionica # veloce rapido flessibile acuto
+  S_P_F_L: reef_luminescente # silenziosa profonda flessibile lontano
+  S_R_F_L: reef_luminescente # silenziosa rapida flessibile lontano
+
+# Final distribution (sanity): savana 2, badlands 3, caverna_risonante 2,
+# rovine_planari 3, palude_tossica 2, canopia_ionica 2, reef_luminescente 2
+# -> max canalization 3/16 = 18.7% (target <20%).
+
+# Team-composition modulation -- PRESERVED design data from cap-11 (binding-resolve
+# variant affixes). NOT read by the cosmetic weights producer; kept for a future
+# route-vote-weighting / variant layer decision.
+modulation:
+  - rule_id: cryo_dominance
+    condition:
+      trait: defense
+      value: DURA
+      min_player_count: 3
+    affix: hardened
+    biome_variants:
+      savana: savana_arida_dura
+      badlands: badlands_pietrosi
+      palude_tossica: palude_indurita
+
+  - rule_id: silent_majority
+    condition:
+      trait: locomotion
+      value: SILENZIOSA
+      min_player_count: 3
+    affix: stealth_advantage
+    biome_variants:
+      caverna_risonante: caverna_silenziosa
+      rovine_planari: rovine_sussurranti
+
+  - rule_id: long_range_focus
+    condition:
+      trait: senses
+      value: LONTANO
+      min_player_count: 3
+    affix: open_ground
+    biome_variants:
+      savana: savana_aperta_orizzonte
+      badlands: badlands_orizzonte
+
+  - rule_id: deep_strike
+    condition:
+      trait: offense
+      value: PROFONDA
+      min_player_count: 3
+    affix: punishing_terrain
+    biome_variants:
+      caverna_risonante: caverna_profonda_eco
+
+# Fallback (should never fire if base_lookup is complete).
+fallback_biome: savana

--- a/tests/api/coopImprintBeat.test.js
+++ b/tests/api/coopImprintBeat.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+// C2-imprint STEP 1 -- coopOrchestrator imprint beat (non-gating, device-authority).
+// Plan: docs/planning/2026-06-22-aa01-c2-imprint-build-spec.md
+// Mirrors the missionReadyTally / formPulses device-authority pattern.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+
+function mk(hostId = 'p_h') {
+  return new CoopOrchestrator({ roomCode: 'IMPR', hostId, now: () => 1000 });
+}
+
+// Mark all 4 axes to the canonical savana tuple (V_P_D_L), respecting assignment.
+function markSavana(co, assignment) {
+  const VALUES = { locomotion: 'VELOCE', offense: 'PROFONDA', defense: 'DURA', senses: 'LONTANO' };
+  for (const [pid, axes] of Object.entries(assignment)) {
+    for (const axis of axes) co.submitImprintMark(pid, { axis, value: VALUES[axis] });
+  }
+}
+
+test('assignImprintAxes: round-robin scales to N players (4/3/2/0)', () => {
+  const co = mk();
+  assert.deepEqual(co.assignImprintAxes(['a', 'b', 'c', 'd']), {
+    a: ['locomotion'],
+    b: ['offense'],
+    c: ['defense'],
+    d: ['senses'],
+  });
+  assert.deepEqual(co.assignImprintAxes(['a', 'b', 'c']), {
+    a: ['locomotion', 'senses'],
+    b: ['offense'],
+    c: ['defense'],
+  });
+  assert.deepEqual(co.assignImprintAxes(['a', 'b']), {
+    a: ['locomotion', 'defense'],
+    b: ['offense', 'senses'],
+  });
+  assert.deepEqual(co.assignImprintAxes([]), {});
+});
+
+test('openImprint: opens beat + assigns, tally has 4 pending axes + no hint', () => {
+  const co = mk();
+  const tally = co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'] });
+  assert.equal(tally.open, true);
+  assert.equal(tally.axes_total, 4);
+  assert.equal(tally.axes_marked, 0);
+  assert.equal(tally.axes_pending.length, 4);
+  assert.equal(tally.all_axes_marked, false);
+  assert.equal(tally.branco_biome_hint, null);
+});
+
+test('submitImprintMark on a closed beat throws imprint_not_open', () => {
+  const co = mk();
+  assert.throws(
+    () => co.submitImprintMark('a', { axis: 'locomotion', value: 'VELOCE' }),
+    /imprint_not_open/,
+  );
+});
+
+test('device-authority: only the assigned owner may mark an axis', () => {
+  const co = mk();
+  co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'] }); // a=locomotion
+  // a owns locomotion -> ok
+  const t = co.submitImprintMark('a', { axis: 'locomotion', value: 'VELOCE' });
+  assert.equal(t.per_axis.locomotion.value, 'VELOCE');
+  assert.equal(t.per_axis.locomotion.by, 'a');
+  // a does NOT own offense -> axis_not_assigned
+  assert.throws(
+    () => co.submitImprintMark('a', { axis: 'offense', value: 'PROFONDA' }),
+    /axis_not_assigned/,
+  );
+  // ghost player not in assignment -> player_not_assigned
+  assert.throws(
+    () => co.submitImprintMark('zz', { axis: 'defense', value: 'DURA' }),
+    /player_not_assigned/,
+  );
+});
+
+test('mark validates axis + value (no silent accept)', () => {
+  const co = mk();
+  co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'] });
+  assert.throws(
+    () => co.submitImprintMark('a', { axis: 'bogus', value: 'VELOCE' }),
+    /invalid_axis/,
+  );
+  assert.throws(
+    () => co.submitImprintMark('a', { axis: 'locomotion', value: 'BOGUS' }),
+    /invalid_value/,
+  );
+  assert.throws(
+    () => co.submitImprintMark('', { axis: 'locomotion', value: 'VELOCE' }),
+    /player_id_required/,
+  );
+});
+
+test('all 4 axes marked (4 players) -> cosmetic hint stamped, beat closes', () => {
+  const co = mk();
+  const assignment = co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'] }).assignment;
+  markSavana(co, assignment);
+  const t = co.imprintTally();
+  assert.equal(t.all_axes_marked, true);
+  assert.equal(t.open, false, 'beat auto-closes on completion');
+  assert.deepEqual(t.branco_biome_hint, { leans_toward: 'savana', weights: { savana: 1 } });
+});
+
+test('N=2 scaling: each player owns 2 axes, all 4 -> hint', () => {
+  const co = mk();
+  const assignment = co.openImprint({ connectedPlayerIds: ['a', 'b'] }).assignment;
+  // a: locomotion+defense, b: offense+senses
+  assert.deepEqual(assignment, { a: ['locomotion', 'defense'], b: ['offense', 'senses'] });
+  markSavana(co, assignment);
+  const t = co.imprintTally();
+  assert.equal(t.all_axes_marked, true);
+  assert.equal(t.branco_biome_hint.leans_toward, 'savana');
+});
+
+test('forceCompleteImprint: fills pending axes with defaults + stamps hint', () => {
+  const co = mk();
+  co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'] });
+  co.submitImprintMark('a', { axis: 'locomotion', value: 'VELOCE' });
+  const t = co.forceCompleteImprint();
+  assert.equal(t.all_axes_marked, true);
+  assert.equal(t.open, false);
+  // defaults: offense PROFONDA, defense DURA, senses LONTANO + locomotion VELOCE -> savana
+  assert.equal(t.branco_biome_hint.leans_toward, 'savana');
+  assert.equal(t.per_axis.offense.by, null, 'defaulted axis has no submitter');
+});
+
+test('cancelImprint: abandons the beat, no hint, marks cleared', () => {
+  const co = mk();
+  const assignment = co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'] }).assignment;
+  co.submitImprintMark('a', { axis: 'locomotion', value: 'VELOCE' });
+  const t = co.cancelImprint();
+  assert.equal(t.open, false);
+  assert.equal(t.axes_marked, 0);
+  assert.equal(t.branco_biome_hint, null);
+  assert.equal(t.assignment, null);
+});
+
+test('run (re)start resets the imprint beat (hint is run-scoped)', () => {
+  const co = mk();
+  const assignment = co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'] }).assignment;
+  markSavana(co, assignment);
+  assert.ok(co.imprintTally().branco_biome_hint, 'hint set pre-reset');
+  co.startRun({ scenarioStack: ['enc_tutorial_01'] }); // phase lobby -> character_creation
+  const t = co.imprintTally();
+  assert.equal(t.open, false);
+  assert.equal(t.branco_biome_hint, null);
+  assert.equal(t.axes_marked, 0);
+});
+
+test('hint is NEVER a biome assignment: weights only, no biome_id field', () => {
+  const co = mk();
+  const assignment = co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'] }).assignment;
+  markSavana(co, assignment);
+  const hint = co.imprintTally().branco_biome_hint;
+  assert.ok(!('biome_id' in hint), 'must not bind a biome');
+  assert.ok(hint.weights && typeof hint.weights === 'object');
+  const sum = Object.values(hint.weights).reduce((a, b) => a + b, 0);
+  assert.ok(Math.abs(sum - 1) < 1e-9);
+});

--- a/tests/api/coopImprintRest.test.js
+++ b/tests/api/coopImprintRest.test.js
@@ -21,7 +21,7 @@ function buildApp() {
   app.use(express.json());
   app.use('/api', createLobbyRouter({ lobby }));
   app.use('/api', createCoopRouter({ lobby, coopStore }));
-  return { app };
+  return { app, coopStore };
 }
 
 async function createAndJoin(app) {
@@ -187,5 +187,24 @@ test('POST /coop/imprint/force -> 403 bad host token (flag ON)', async () => {
       .post('/api/coop/imprint/force')
       .send({ code: h.code, host_token: 'bad' });
     assert.equal(res.status, 403);
+  });
+});
+
+test('POST /coop/imprint/force -> 200 + hint when flag ON + beat open', async () => {
+  // Route plumbing happy-path: open the beat via the orchestrator (the route's
+  // connectedQuorumPids needs WS-attached players), then host force-completes via REST ->
+  // defaults fill the unmarked axes and the cosmetic hint is stamped.
+  await withFlag('true', async () => {
+    const { app, coopStore } = buildApp();
+    const { h, j } = await createAndJoin(app);
+    await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+    coopStore.get(h.code).openImprint({ connectedPlayerIds: [j.player_id] });
+    const res = await request(app)
+      .post('/api/coop/imprint/force')
+      .send({ code: h.code, host_token: h.host_token });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.tally.all_axes_marked, true);
+    assert.equal(res.body.tally.open, false);
+    assert.ok(res.body.tally.branco_biome_hint.leans_toward, 'hint stamped from defaults');
   });
 });

--- a/tests/api/coopImprintRest.test.js
+++ b/tests/api/coopImprintRest.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+// C2-imprint STEP 1 -- REST transport for the imprint beat (route plumbing + flag-gate).
+// The full device-authority mark->hint flow is covered by tests/api/coopImprintBeat.test.js
+// (happy-path quorum needs WS-connected players; here we exercise auth + gating + shape).
+// Plan: docs/planning/2026-06-22-aa01-c2-imprint-build-spec.md
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const request = require('supertest');
+const { createLobbyRouter } = require('../../apps/backend/routes/lobby');
+const { createCoopRouter } = require('../../apps/backend/routes/coop');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+const { LobbyService } = require('../../apps/backend/services/network/wsSession');
+
+function buildApp() {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createLobbyRouter({ lobby }));
+  app.use('/api', createCoopRouter({ lobby, coopStore }));
+  return { app };
+}
+
+async function createAndJoin(app) {
+  const { body: h } = await request(app).post('/api/lobby/create').send({ host_name: 'H' });
+  const { body: j } = await request(app)
+    .post('/api/lobby/join')
+    .send({ code: h.code, player_name: 'Alice' });
+  return { h, j };
+}
+
+// Run an async fn with IMPRINT_BEAT_ENABLED forced to a value, restoring it after.
+async function withFlag(value, fn) {
+  const prev = process.env.IMPRINT_BEAT_ENABLED;
+  if (value === undefined) delete process.env.IMPRINT_BEAT_ENABLED;
+  else process.env.IMPRINT_BEAT_ENABLED = value;
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.IMPRINT_BEAT_ENABLED;
+    else process.env.IMPRINT_BEAT_ENABLED = prev;
+  }
+}
+
+test('POST /coop/imprint/open -> 409 imprint_disabled when flag OFF (band-neutral)', async () => {
+  await withFlag(undefined, async () => {
+    const { app } = buildApp();
+    const { h } = await createAndJoin(app);
+    await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+    const res = await request(app)
+      .post('/api/coop/imprint/open')
+      .send({ code: h.code, host_token: h.host_token });
+    assert.equal(res.status, 409);
+    assert.equal(res.body.error, 'imprint_disabled');
+  });
+});
+
+test('POST /coop/imprint/open -> 403 bad host token (flag ON)', async () => {
+  await withFlag('true', async () => {
+    const { app } = buildApp();
+    const { h } = await createAndJoin(app);
+    await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+    const res = await request(app)
+      .post('/api/coop/imprint/open')
+      .send({ code: h.code, host_token: 'bad' });
+    assert.equal(res.status, 403);
+  });
+});
+
+test('POST /coop/imprint/open -> 409 run not started (flag ON)', async () => {
+  await withFlag('true', async () => {
+    const { app } = buildApp();
+    const { h } = await createAndJoin(app);
+    const res = await request(app)
+      .post('/api/coop/imprint/open')
+      .send({ code: h.code, host_token: h.host_token });
+    assert.equal(res.status, 409);
+    assert.equal(res.body.error, 'run_not_started');
+  });
+});
+
+test('POST /coop/imprint/open -> 200 + open tally when flag ON + run started', async () => {
+  await withFlag('true', async () => {
+    const { app } = buildApp();
+    const { h } = await createAndJoin(app);
+    await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+    const res = await request(app)
+      .post('/api/coop/imprint/open')
+      .send({ code: h.code, host_token: h.host_token });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.tally.open, true);
+    assert.equal(res.body.tally.axes_total, 4);
+    assert.equal(res.body.tally.branco_biome_hint, null);
+  });
+});
+
+test('POST /coop/imprint/mark -> 403 bad player token', async () => {
+  const { app } = buildApp();
+  const { h, j } = await createAndJoin(app);
+  await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+  const res = await request(app).post('/api/coop/imprint/mark').send({
+    code: h.code,
+    player_id: j.player_id,
+    player_token: 'bad',
+    axis: 'locomotion',
+    value: 'VELOCE',
+  });
+  assert.equal(res.status, 403);
+});
+
+test('POST /coop/imprint/mark -> 409 run not started', async () => {
+  const { app } = buildApp();
+  const { h, j } = await createAndJoin(app);
+  const res = await request(app).post('/api/coop/imprint/mark').send({
+    code: h.code,
+    player_id: j.player_id,
+    player_token: j.player_token,
+    axis: 'locomotion',
+    value: 'VELOCE',
+  });
+  assert.equal(res.status, 409);
+});
+
+test('POST /coop/imprint/mark -> 400 when beat not open (typed error)', async () => {
+  const { app } = buildApp();
+  const { h, j } = await createAndJoin(app);
+  await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+  const res = await request(app).post('/api/coop/imprint/mark').send({
+    code: h.code,
+    player_id: j.player_id,
+    player_token: j.player_token,
+    axis: 'locomotion',
+    value: 'VELOCE',
+  });
+  assert.equal(res.status, 400);
+  assert.equal(res.body.error, 'imprint_not_open');
+});
+
+test('POST /coop/imprint/cancel -> 403 bad host token', async () => {
+  const { app } = buildApp();
+  const { h } = await createAndJoin(app);
+  await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+  const res = await request(app)
+    .post('/api/coop/imprint/cancel')
+    .send({ code: h.code, host_token: 'bad' });
+  assert.equal(res.status, 403);
+});

--- a/tests/api/coopImprintRest.test.js
+++ b/tests/api/coopImprintRest.test.js
@@ -82,7 +82,10 @@ test('POST /coop/imprint/open -> 409 run not started (flag ON)', async () => {
   });
 });
 
-test('POST /coop/imprint/open -> 200 + open tally when flag ON + run started', async () => {
+test('POST /coop/imprint/open -> 400 no_connected_players (no WS-connected device)', async () => {
+  // The host must open AFTER players connect; a joined-but-not-WS-connected roster yields
+  // an empty connected quorum -> reject (else the beat opens with no axis owners and can
+  // never complete). The connected-open happy path is exercised e2e by the WS test.
   await withFlag('true', async () => {
     const { app } = buildApp();
     const { h } = await createAndJoin(app);
@@ -90,10 +93,8 @@ test('POST /coop/imprint/open -> 200 + open tally when flag ON + run started', a
     const res = await request(app)
       .post('/api/coop/imprint/open')
       .send({ code: h.code, host_token: h.host_token });
-    assert.equal(res.status, 200);
-    assert.equal(res.body.tally.open, true);
-    assert.equal(res.body.tally.axes_total, 4);
-    assert.equal(res.body.tally.branco_biome_hint, null);
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error, 'no_connected_players');
   });
 });
 
@@ -139,12 +140,52 @@ test('POST /coop/imprint/mark -> 400 when beat not open (typed error)', async ()
   assert.equal(res.body.error, 'imprint_not_open');
 });
 
-test('POST /coop/imprint/cancel -> 403 bad host token', async () => {
-  const { app } = buildApp();
-  const { h } = await createAndJoin(app);
-  await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
-  const res = await request(app)
-    .post('/api/coop/imprint/cancel')
-    .send({ code: h.code, host_token: 'bad' });
-  assert.equal(res.status, 403);
+test('POST /coop/imprint/cancel -> 409 imprint_disabled when flag OFF', async () => {
+  await withFlag(undefined, async () => {
+    const { app } = buildApp();
+    const { h } = await createAndJoin(app);
+    await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+    const res = await request(app)
+      .post('/api/coop/imprint/cancel')
+      .send({ code: h.code, host_token: h.host_token });
+    assert.equal(res.status, 409);
+    assert.equal(res.body.error, 'imprint_disabled');
+  });
+});
+
+test('POST /coop/imprint/cancel -> 403 bad host token (flag ON)', async () => {
+  await withFlag('true', async () => {
+    const { app } = buildApp();
+    const { h } = await createAndJoin(app);
+    await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+    const res = await request(app)
+      .post('/api/coop/imprint/cancel')
+      .send({ code: h.code, host_token: 'bad' });
+    assert.equal(res.status, 403);
+  });
+});
+
+test('POST /coop/imprint/force -> 409 imprint_disabled when flag OFF', async () => {
+  await withFlag(undefined, async () => {
+    const { app } = buildApp();
+    const { h } = await createAndJoin(app);
+    await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+    const res = await request(app)
+      .post('/api/coop/imprint/force')
+      .send({ code: h.code, host_token: h.host_token });
+    assert.equal(res.status, 409);
+    assert.equal(res.body.error, 'imprint_disabled');
+  });
+});
+
+test('POST /coop/imprint/force -> 403 bad host token (flag ON)', async () => {
+  await withFlag('true', async () => {
+    const { app } = buildApp();
+    const { h } = await createAndJoin(app);
+    await request(app).post('/api/coop/run/start').send({ code: h.code, host_token: h.host_token });
+    const res = await request(app)
+      .post('/api/coop/imprint/force')
+      .send({ code: h.code, host_token: 'bad' });
+    assert.equal(res.status, 403);
+  });
 });

--- a/tests/api/coopImprintWs.test.js
+++ b/tests/api/coopImprintWs.test.js
@@ -1,0 +1,153 @@
+// C2-imprint STEP 1 -- WS transport for the imprint beat. Proves the mark drains
+// server-side, broadcasts imprint_tally, and that submitter identity is SOCKET-BOUND
+// (a player cannot mark an axis it does not own, even by sending it in the payload).
+// Plan: docs/planning/2026-06-22-aa01-c2-imprint-build-spec.md
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const WebSocket = require('ws');
+const { LobbyService, createWsServer } = require('../../apps/backend/services/network/wsSession');
+const { createCoopStore } = require('../../apps/backend/services/coop/coopStore');
+
+function attachBuffer(ws) {
+  ws.__buf = [];
+  ws.__waiters = [];
+  ws.on('message', (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
+    ws.__buf.push(msg);
+    for (const w of ws.__waiters.slice()) {
+      if (w.predicate(msg)) {
+        ws.__waiters = ws.__waiters.filter((x) => x !== w);
+        w.resolve(msg);
+      }
+    }
+  });
+  return ws;
+}
+
+function waitForMessage(ws, predicate, timeoutMs = 3000) {
+  for (const msg of ws.__buf) {
+    if (predicate(msg)) return Promise.resolve(msg);
+  }
+  return new Promise((resolve, reject) => {
+    const waiter = { predicate, resolve, reject };
+    const timer = setTimeout(() => {
+      ws.__waiters = ws.__waiters.filter((x) => x !== waiter);
+      reject(new Error('timeout waiting for ws message'));
+    }, timeoutMs);
+    waiter.resolve = (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    ws.__waiters.push(waiter);
+  });
+}
+
+function openWs(port, { code, player_id, token }) {
+  const url = `ws://127.0.0.1:${port}/ws?code=${encodeURIComponent(code)}&player_id=${encodeURIComponent(player_id)}&token=${encodeURIComponent(token)}`;
+  return attachBuffer(new WebSocket(url));
+}
+
+function waitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+function markIntent(axis, value) {
+  return JSON.stringify({ type: 'intent', payload: { action: 'imprint_mark', axis, value } });
+}
+
+test('WS imprint_mark: device marks drain server-side -> hint on all 4 axes', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Cat' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    // Host opens the beat (route does this via connectedQuorumPids; here the 2 players
+    // are the connected device set -> a=[locomotion,defense], b=[offense,senses]).
+    orch.openImprint({ connectedPlayerIds: [p1.player_id, p2.player_id] });
+
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    const p2Ws = openWs(port, { code: room.code, player_id: p2.player_id, token: p2.player_token });
+    await Promise.all([waitOpen(p1Ws), waitOpen(p2Ws)]);
+    await Promise.all([
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+      waitForMessage(p2Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // p1 owns locomotion + defense; p2 owns offense + senses. Mark the savana tuple.
+    p1Ws.send(markIntent('locomotion', 'VELOCE'));
+    p1Ws.send(markIntent('defense', 'DURA'));
+    p2Ws.send(markIntent('offense', 'PROFONDA'));
+    p2Ws.send(markIntent('senses', 'LONTANO'));
+
+    const done = await waitForMessage(
+      p2Ws,
+      (m) => m.type === 'imprint_tally' && m.payload?.all_axes_marked === true,
+      2500,
+    );
+    assert.equal(done.payload.branco_biome_hint.leans_toward, 'savana');
+    assert.equal(done.payload.open, false, 'beat auto-closes on completion');
+
+    p1Ws.close();
+    p2Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS imprint_mark: identity is socket-bound -> cannot mark an unowned axis', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Cat' });
+
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    orch.openImprint({ connectedPlayerIds: [p1.player_id, p2.player_id] });
+
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    await waitOpen(p1Ws);
+    await waitForMessage(p1Ws, (m) => m.type === 'hello');
+
+    // p1 owns [locomotion, defense]; offense belongs to p2. p1 tries to mark offense.
+    p1Ws.send(markIntent('offense', 'PROFONDA'));
+    const err = await waitForMessage(p1Ws, (m) => m.type === 'error', 2000);
+    assert.equal(err.payload.code, 'axis_not_assigned');
+    // offense stays unmarked on the orchestrator (not spoofed by the payload).
+    assert.equal(orch.imprintTally().per_axis.offense, null);
+
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});

--- a/tests/api/coopImprintWs.test.js
+++ b/tests/api/coopImprintWs.test.js
@@ -151,3 +151,72 @@ test('WS imprint_mark: identity is socket-bound -> cannot mark an unowned axis',
     await wsHandle.close();
   }
 });
+
+test('WS reconnect parity: a player connecting after open gets imprint_tally in its snapshot', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Cat' });
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    orch.openImprint({ connectedPlayerIds: [p1.player_id, p2.player_id] });
+
+    // p1 connects AFTER the beat opened -> its connect snapshot must carry imprint_tally.
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    await waitOpen(p1Ws);
+    const tally = await waitForMessage(p1Ws, (m) => m.type === 'imprint_tally', 2500);
+    assert.equal(tally.payload.open, true);
+    assert.equal(tally.payload.axes_total, 4);
+
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});
+
+test('WS disconnect parity: a peer leaving re-broadcasts imprint_tally to the rest', async () => {
+  const lobby = new LobbyService();
+  const coopStore = createCoopStore({ lobby });
+  const wsHandle = createWsServer({ lobby, coopStore, port: 0 });
+  await new Promise((resolve) => {
+    if (wsHandle.wss.address()) return resolve();
+    wsHandle.wss.on('listening', () => resolve());
+  });
+  const port = wsHandle.wss.address().port;
+
+  try {
+    const room = lobby.createRoom({ hostName: 'TV' });
+    const p1 = lobby.joinRoom({ code: room.code, playerName: 'Bob' });
+    const p2 = lobby.joinRoom({ code: room.code, playerName: 'Cat' });
+    const orch = coopStore.getOrCreate(room.code);
+    orch.startRun({ scenarioStack: ['enc_tutorial_01'] });
+    orch.openImprint({ connectedPlayerIds: [p1.player_id, p2.player_id] });
+
+    const p1Ws = openWs(port, { code: room.code, player_id: p1.player_id, token: p1.player_token });
+    const p2Ws = openWs(port, { code: room.code, player_id: p2.player_id, token: p2.player_token });
+    await Promise.all([waitOpen(p1Ws), waitOpen(p2Ws)]);
+    await Promise.all([
+      waitForMessage(p1Ws, (m) => m.type === 'hello'),
+      waitForMessage(p2Ws, (m) => m.type === 'hello'),
+    ]);
+
+    // Drop prior frames so we only observe the post-disconnect re-broadcast.
+    p1Ws.__buf.length = 0;
+    p2Ws.close();
+    const after = await waitForMessage(p1Ws, (m) => m.type === 'imprint_tally', 2500);
+    assert.equal(after.payload.open, true, 'remaining player re-surfaced the beat state');
+
+    p1Ws.close();
+  } finally {
+    await wsHandle.close();
+  }
+});

--- a/tests/services/imprintBiomeWeights.test.js
+++ b/tests/services/imprintBiomeWeights.test.js
@@ -130,3 +130,37 @@ test('does NOT collide with species biomeAffinity export surface', () => {
     'must not re-export the species combat-affinity name',
   );
 });
+
+const {
+  IMPRINT_AXES,
+  IMPRINT_AXIS_DEFAULTS,
+  isImprintEnabled,
+  isValidAxisValue,
+} = require('../../apps/backend/services/imprint/imprintBiomeWeights');
+
+test('IMPRINT_AXES = the 4 body-part axes', () => {
+  assert.deepEqual(IMPRINT_AXES, ['locomotion', 'offense', 'defense', 'senses']);
+});
+
+test('IMPRINT_AXIS_DEFAULTS covers all 4 axes with valid values', () => {
+  for (const axis of IMPRINT_AXES) {
+    assert.ok(isValidAxisValue(axis, IMPRINT_AXIS_DEFAULTS[axis]), `${axis} default valid`);
+  }
+});
+
+test('isValidAxisValue: case-insensitive, rejects bad axis/value, never throws', () => {
+  assert.equal(isValidAxisValue('locomotion', 'VELOCE'), true);
+  assert.equal(isValidAxisValue('locomotion', 'veloce'), true);
+  assert.equal(isValidAxisValue('locomotion', 'BOGUS'), false);
+  assert.equal(isValidAxisValue('bogus_axis', 'VELOCE'), false);
+  assert.equal(isValidAxisValue('senses', null), false);
+  assert.equal(isValidAxisValue('senses', undefined), false);
+});
+
+test('isImprintEnabled: OFF by default, ON only when env flag === "true"', () => {
+  assert.equal(isImprintEnabled({}), false);
+  assert.equal(isImprintEnabled({ IMPRINT_BEAT_ENABLED: 'false' }), false);
+  assert.equal(isImprintEnabled({ IMPRINT_BEAT_ENABLED: '1' }), false);
+  assert.equal(isImprintEnabled({ IMPRINT_BEAT_ENABLED: 'true' }), true);
+  assert.equal(isImprintEnabled(null), false);
+});

--- a/tests/services/imprintBiomeWeights.test.js
+++ b/tests/services/imprintBiomeWeights.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+// C2-imprint STEP 2 -- imprintBiomeWeights producer (pure, read-only, non-binding).
+// Plan: docs/planning/2026-06-22-aa01-c2-imprint-build-spec.md
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  computeImprintBiomeWeights,
+  topBiome,
+  tupleKey,
+} = require('../../apps/backend/services/imprint/imprintBiomeWeights');
+
+// All 16 combos -> expected base biome (from data/core/imprint/biome_resolution.yaml).
+const EXPECTED = {
+  V_P_D_L: 'savana',
+  V_P_F_L: 'savana',
+  V_R_D_L: 'badlands',
+  V_R_F_L: 'badlands',
+  S_P_D_A: 'caverna_risonante',
+  S_P_F_A: 'caverna_risonante',
+  S_R_D_A: 'rovine_planari',
+  S_R_F_A: 'rovine_planari',
+  V_P_D_A: 'rovine_planari',
+  V_R_D_A: 'badlands',
+  S_P_D_L: 'palude_tossica',
+  S_R_D_L: 'palude_tossica',
+  V_P_F_A: 'canopia_ionica',
+  V_R_F_A: 'canopia_ionica',
+  S_P_F_L: 'reef_luminescente',
+  S_R_F_L: 'reef_luminescente',
+};
+
+const LOCO = { V: 'VELOCE', S: 'SILENZIOSA' };
+const OFF = { P: 'PROFONDA', R: 'RAPIDA' };
+const DEF = { D: 'DURA', F: 'FLESSIBILE' };
+const SEN = { L: 'LONTANO', A: 'ACUTO' };
+
+function tupleFromKey(key) {
+  const [l, o, d, s] = key.split('_');
+  return { locomotion: LOCO[l], offense: OFF[o], defense: DEF[d], senses: SEN[s] };
+}
+
+test('all 16 combos: single tuple -> { expectedBiome: 1 }', () => {
+  for (const [key, biome] of Object.entries(EXPECTED)) {
+    const w = computeImprintBiomeWeights([tupleFromKey(key)]);
+    assert.deepEqual(w, { [biome]: 1 }, `combo ${key}`);
+    assert.equal(topBiome(w), biome, `topBiome ${key}`);
+  }
+});
+
+test('tupleKey encodes first letters; invalid axis -> null (no throw)', () => {
+  assert.equal(
+    tupleKey({ locomotion: 'VELOCE', offense: 'PROFONDA', defense: 'DURA', senses: 'LONTANO' }),
+    'V_P_D_L',
+  );
+  assert.equal(
+    tupleKey({ locomotion: 'veloce', offense: 'profonda', defense: 'dura', senses: 'lontano' }),
+    'V_P_D_L',
+  ); // case-insensitive
+  assert.equal(
+    tupleKey({ locomotion: 'BOGUS', offense: 'PROFONDA', defense: 'DURA', senses: 'LONTANO' }),
+    null,
+  );
+  assert.equal(tupleKey({ locomotion: 'VELOCE', offense: 'PROFONDA', defense: 'DURA' }), null); // missing senses
+  assert.equal(tupleKey(null), null);
+  assert.equal(tupleKey('nope'), null);
+});
+
+test('multi-tuple aggregation normalizes to sum = 1', () => {
+  // 2x savana + 1x badlands + 1x canopia_ionica -> 0.5 / 0.25 / 0.25
+  const tuples = [
+    tupleFromKey('V_P_D_L'), // savana
+    tupleFromKey('V_P_F_L'), // savana
+    tupleFromKey('V_R_D_L'), // badlands
+    tupleFromKey('V_P_F_A'), // canopia_ionica
+  ];
+  const w = computeImprintBiomeWeights(tuples);
+  assert.equal(w.savana, 0.5);
+  assert.equal(w.badlands, 0.25);
+  assert.equal(w.canopia_ionica, 0.25);
+  const sum = Object.values(w).reduce((a, b) => a + b, 0);
+  assert.ok(Math.abs(sum - 1) < 1e-9, `sum=${sum}`);
+  assert.equal(topBiome(w), 'savana');
+});
+
+test('empty / all-invalid input -> {} (never throws)', () => {
+  assert.deepEqual(computeImprintBiomeWeights([]), {});
+  assert.deepEqual(computeImprintBiomeWeights(null), {});
+  assert.deepEqual(computeImprintBiomeWeights(undefined), {});
+  assert.deepEqual(computeImprintBiomeWeights([{ locomotion: 'X' }, null, 42]), {});
+});
+
+test('partial-valid input: invalid tuples skipped, valid ones counted', () => {
+  const w = computeImprintBiomeWeights([
+    tupleFromKey('V_P_D_L'), // savana (valid)
+    { locomotion: 'VELOCE' }, // invalid -> skipped
+    null, // skipped
+  ]);
+  assert.deepEqual(w, { savana: 1 });
+});
+
+test('accepts a single tuple object (not wrapped in array)', () => {
+  const w = computeImprintBiomeWeights(tupleFromKey('S_R_F_L'));
+  assert.deepEqual(w, { reef_luminescente: 1 });
+});
+
+test('output is weights-only: no biome_id key, values in [0,1], no input mutation', () => {
+  const tuple = tupleFromKey('V_P_D_L');
+  const snapshot = JSON.stringify(tuple);
+  const w = computeImprintBiomeWeights([tuple]);
+  assert.ok(!('biome_id' in w), 'must not expose a biome_id assignment');
+  for (const v of Object.values(w)) {
+    assert.ok(v > 0 && v <= 1, `weight ${v} out of (0,1]`);
+  }
+  assert.equal(JSON.stringify(tuple), snapshot, 'input tuple must not be mutated');
+});
+
+test('topBiome: null/empty -> null', () => {
+  assert.equal(topBiome({}), null);
+  assert.equal(topBiome(null), null);
+  assert.equal(topBiome('nope'), null);
+});
+
+test('does NOT collide with species biomeAffinity export surface', () => {
+  const mod = require('../../apps/backend/services/imprint/imprintBiomeWeights');
+  assert.equal(typeof mod.computeImprintBiomeWeights, 'function');
+  assert.ok(
+    !('getBiomeAffinityModifier' in mod),
+    'must not re-export the species combat-affinity name',
+  );
+});


### PR DESCRIPTION
## C2-imprint backend MVP (additive L'Impronta beat + affinity + cosmetic hint)

Builds the ratified L'Impronta reconciliation (C1 + the C2-imprint build-spec in the docs PR #2959): an **additive, device-authority, NON-gating** imprint beat. Flag-gated **default-OFF** (`IMPRINT_BEAT_ENABLED`) + band-neutral. Part of the aa01 reconciliation (master-dd SUPERSEDE override); source branches preserved.

### Design (master-dd ratified)
- biomeResolver -> **AFFINITY** (6.1-A): cosmetic weight, biome stays route-canon; affinity NEVER binds a biome or feeds combat/score/route math.
- onboarding -> **ADDITIVE separate-phase** beat (6.2-A): no PHASES enum change, no char_creation/world_setup collapse, no host-token start.
- N-player scaling: creatures = N connected players (2-4); the 4 fixed axes round-robin-assigned (4p->1 each, 3p->one owns 2, 2p->2 each); tally completes when all 4 axes are marked.

### What landed (STEP 0-3 backend)
- **STEP 0** flag `IMPRINT_BEAT_ENABLED` + axis schema/defaults (`services/imprint/imprintBiomeWeights.js`).
- **STEP 1** orchestrator beat (`coopOrchestrator.js`, mirrors `formPulses`/`missionReadyTally`): `openImprint`/`assignImprintAxes`/`submitImprintMark` (device-authority: owner-only per axis, typed 4xx)/`imprintTally`/`_computeImprintHint`/`forceCompleteImprint`/`cancelImprint` + run-reset clears (hint run-scoped, persists across scenarios). WS intent `imprint_mark` (socket-bound identity) + REST `POST /coop/imprint/{open,mark,cancel,force}` + `imprint_tally` re-surfaced in `broadcastCoopState`/`rebroadcastCoopState`/`sendCoopSnapshotToPlayer`/disconnect (host-transfer + reconnect + disconnect parity).
- **STEP 2** pure producer `computeImprintBiomeWeights(teamTuples) -> {biome:weight}` + `topBiome` + data port `data/core/imprint/biome_resolution.yaml` (distinct from the existing `services/species/biomeAffinity.js`; never returns a biome_id; never throws).
- **STEP 3** cosmetic hint surface via coop-state (`branco_biome_hint`) + guarded `snapshot()`.

### Band-neutrality (flag OFF)
Beat never opens -> `imprintOpen=false`/`brancoBiomeHint=null` -> every broadcast/snapshot branch is guarded and never fires; `publicSessionView`/coop-state byte-identical. coop 235/235 + AI 554/554 unchanged.

### Review
`coop-phase-validator` adversarial pass: **2 P1 + 3 P2 + 1 P3 + 1 follow-up, all resolved + re-verified** (force route reachability, reconnect/host-transfer/disconnect `imprint_tally` parity, empty-connected reject, flag-gate consistency, guarded snapshot). Band-neutrality / state-hygiene / no-spoof refuted-clean. ~45 imprint tests (producer + orchestrator + REST + WS e2e incl socket-bound device-authority).

### Scope / guardrails
- Files: `apps/backend/**` (allowed) + `data/core/imprint/biome_resolution.yaml` (new, 92 LOC port from aa01 cap-11) + tests. **No forbidden paths** (.github/workflows, migrations, packages/contracts, services/generation). **No new deps** (`js-yaml` already used). The 92-LOC data file is the only >50-LOC non-test outside `apps/backend/` -- a ratified-C2 data port (flagging per guardrail).

### Deferred (documented, not in this MVP)
- `publicSessionView` in-match field (coop-state carries the hint; co-op clients read coop state) -- thin follow-up.
- Silent auto-timer defaulting (host `force` is explicit; auto-defaulting is a master-dd design call).
- Route-vote affinity weighting (behind the `META_NETWORK_ROUTING` flip) + axis->trait grant (non-band-neutral, separate spec).

### Next + rollback
Godot surface chip (cross-repo Game-Godot-v2, per build-spec) -> then flip `IMPRINT_BEAT_ENABLED` after the surface lands + playtest (master-dd). Rollback: flag stays OFF (inert) or revert; no schema/contract/data-canon change.
