### PR TITLE
feat(dataset-pack): derived-artifact reproducibility foundation (guard + deterministic pipeline + audit)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,16 @@ Segui queste regole quando lavori con snapshot o backup:
    smoke-test del preview server; assicurati che la tua PR non rompa questi
    step.
 
+## Artefatti derivati (NON hand-edit, regen con cautela)
+
+`data/core/species/species_catalog.json`, `data/traits/index.json` e
+`data/traits/species_affinity.json` sono DERIVED ma attualmente **stale** vs le
+sorgenti: un regen naive su un checkout dev produce un diff spurio enorme che
+corrompe il canon. Esegui `python tools/py/check_derived_reproducible.py` prima di
+rigenerare/committare e consulta
+[`docs/guide/derived-artifacts-reproducibility.md`](docs/guide/derived-artifacts-reproducibility.md)
+(root cause + ricette + remediation owner-gated).
+
 ## Contributi sui trait
 
 Per proposte e modifiche ai trait consulta la guida dedicata in

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12705,6 +12705,19 @@
       "source_of_truth": true,
       "language": "it-en",
       "review_cycle_days": 90
+    },
+    {
+      "path": "docs/guide/derived-artifacts-reproducibility.md",
+      "title": "Derived data artifacts -- reproducibility hazard + guard (trait bridge + species catalog)",
+      "doc_status": "draft",
+      "doc_owner": "claude-code",
+      "workstream": "dataset-pack",
+      "last_verified": "2026-06-22",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "authored"
     }
   ]
 }

--- a/docs/guide/derived-artifacts-reproducibility.md
+++ b/docs/guide/derived-artifacts-reproducibility.md
@@ -1,0 +1,188 @@
+---
+title: 'Derived data artifacts -- reproducibility hazard + guard (trait bridge + species catalog)'
+date: 2026-06-22
+doc_status: draft
+doc_owner: claude-code
+workstream: dataset-pack
+last_verified: '2026-06-22'
+source_of_truth: false
+review_cycle_days: 90
+tags: [derived, reproducibility, drift, trait, species, catalog, etl, guard, ci]
+---
+
+# Derived data artifacts -- reproducibility hazard
+
+## TL;DR (verdict)
+
+Two families of committed DERIVED artifacts are **stale (drift), NOT a build-host
+split**. Every real source IS in-repo -- the `/tmp` paths in the catalog
+provenance are misleading leftover stamps from the original one-off build host,
+not a required external input. A naive "just regenerate it" on a plain dev
+checkout therefore produces a massive spurious diff that corrupts the canon and
+blocks otherwise-simple trait/species data work (this is what stalled
+TKT-P6-TRAIT-ORPHAN-DESIGN-B v3/v5/v6 + the v8 trait rename).
+
+| Family             | Artifact(s)                                                   | Generator                                | Committed                        | No-op regen on dev       | Diff                                            |
+| ------------------ | ------------------------------------------------------------- | ---------------------------------------- | -------------------------------- | ------------------------ | ----------------------------------------------- |
+| 1. Trait bridge    | `data/traits/index.json`, `data/traits/species_affinity.json` | `tools/py/build_species_trait_bridge.py` | 287 affinity entries             | 54                       | 18101 lines on index.json; 3746 del on affinity |
+| 2. Species catalog | `data/core/species/species_catalog.json`                      | `tools/etl/` 5-stage ETL                 | 75 species (stub:5 / promote:22) | 74 (stub:21 / promote:5) | ~2990 lines                                     |
+
+All numbers above were **reproduced on a clean worktree off origin/main** (see
+[Evidence](#evidence)). The guard `tools/py/check_derived_reproducible.py`
+detects this drift without writing any corrupt artifact.
+
+> The repo's "regenerate-or-die, never hand-edit derived species files" rule
+> (canon-enforcement Phase A/B/D, `docs/pipelines/PIPELINE_SPECIES_BIOMES_STANDARD.md`)
+> is currently **unsafe**: regenerate != committed. Until the
+> [remediation](#owner-gated-remediation) lands, treat these artifacts as
+> append-only and run the guard before any regen+commit.
+
+## Family 1 -- trait bridge (DRIFT)
+
+Root cause = stale output + generator non-determinism + a source-layer mismatch:
+
+1. **Stale since 2025-12-03.** The affinity content was last genuinely generated
+   by commit `7944d5d8` ("Complete trait species affinity coverage", 2025-12-03)
+   from the THEN-richer pack species set. Across 2026 the pack species were pruned
+   (canon-reconcile, orphan drops `#2813`, `#2271` deprecation, schema canonization
+   `#2427`) down to **54** distinct trait references, but the bridge was never
+   re-run. Result: **80 of the 84 species** referenced by the committed affinity
+   no longer exist in the catalog (mostly deleted species + `*-trait-keeper`
+   carriers).
+2. **Source-layer mismatch (why renaming a per-trait file did nothing).**
+   `build_species_affinity()` reads trait ids from the **species YAML**
+   (`genetic_traits` + `derived_from_environment` in `packs/evo_tactics_pack/data/species`),
+   NOT from the per-trait DB files `data/traits/<cat>/<trait>.json`. The per-trait
+   files are only read by `--validate-only`. So a v8-style rename of
+   `data/traits/<cat>/<trait>.json` cannot change the regen -- the affinity id
+   comes from the species YAML. (The trait DEFINITIONS in `index.json` are built
+   by a SEPARATE tool, `scripts/build_trait_index.js`, from the per-trait files;
+   the Python bridge only overlays the `species_affinity` sub-field onto existing
+   entries.)
+3. **Post-hoc manual edit.** `#2885` (2026-06-20) hand-added a top-level
+   `schema_version: "2.0"` wrapper key to `species_affinity.json` that the bridge
+   does NOT emit -> a regen silently drops it.
+4. **Windows newline non-determinism.** The bridge uses `Path.write_text(...)`
+   (text mode) -> on Windows it emits CRLF, but the committed file is LF
+   (`.gitattributes`). Even a content-identical regen diffs on every line on
+   Windows.
+
+## Family 2 -- species catalog ETL (DRIFT)
+
+The chain `merge_pack_v2_species -> enrich_species_heuristic ->
+promote_gameplay_to_canon -> derive_interoception_overrides ->
+apply_interoception_traits` runs fine from in-repo sources, but the committed
+catalog is **not reproducible even with the documented recipe**. Three concrete
+mechanisms (each predicted by the guard):
+
+1. **Downgrade-on-rerun (pipeline order bug).** `merge` emits a bare
+   `game-canonical-stub` for every `data/core/species/*_lifecycle.yaml`; `promote`
+   then SKIPS any species already in the catalog. **16** species that were
+   `gameplay-promote` (rich: morphotype / threat_tier / pack_path) when the catalog
+   was built have since gained a lifecycle YAML, so a re-run stubs them at merge
+   and promote skips them -> they DOWNGRADE to bare stubs. Adding a lifecycle YAML
+   makes the catalog worse on the next regen.
+2. **Lingering events (additive promote never prunes).** **6** entries
+   (`aurora_bridge_runner`, `glowcap_weaver`, `magneto_ridge_hunter`,
+   `myco_spire_warden`, `slag_veil_ambusher`, `zephyr_spore_courier`) are
+   ecological events (`role_trofico=evento_ecologico`). They were promoted before
+   the `is_event` filter (v0.4.3) landed; promote only ADDS, so they were never
+   removed. A fresh run excludes them.
+3. **Missing newer species.** A fresh run promotes 5 gameplay species
+   (`arboryxis_lenis`, `ferrimordax_rutilus`, `ferriscroba_detrita`,
+   `nebulocornis_mollis`, `rubrospina_velox`) absent from the committed catalog.
+
+Plus the footguns that make a faithful regen hard to even attempt:
+
+- `source_provenance` points at `/tmp/species_catalog_v0.2.0_backup.json` +
+  `/tmp/species_*_etl_source.yaml` (ephemeral build-host leftovers). The real
+  in-repo inputs are `data/external/evo/species/species_catalog.json` (pack-v2)
+  and the archived legacy YAMLs at
+  `docs/archive/historical-snapshots/2026-05-15_species-deprecation/`.
+- The default `--species-yaml` / `--expansion-yaml` of `merge_pack_v2_species.py`
+  point at `data/core/species.yaml` / `species_expansion.yaml`, which were
+  **deleted** in `#2271`. With the defaults, legacy absorb silently = 0 species
+  (-38).
+- `promote_gameplay_to_canon.py` has no `--out` / `--catalog` flag -- it writes
+  the real catalog IN-PLACE, so you cannot dry-test it to a temp.
+
+## Guard
+
+`tools/py/check_derived_reproducible.py` makes the drift visible and CI-gateable.
+It NEVER writes a tracked file: the trait-bridge check regenerates the affinity
+map in-process to memory; the catalog check is a non-destructive prediction of
+exactly which entries a full ETL re-run would add / drop / downgrade.
+
+```bash
+python tools/py/check_derived_reproducible.py                 # both, exit 1 on drift
+python tools/py/check_derived_reproducible.py --only trait-bridge
+python tools/py/check_derived_reproducible.py --warn-only     # advisory (exit 0)
+```
+
+Run it **before** regenerating + committing any of these artifacts. A clean exit
+means a no-op regen reproduces the committed file from current sources.
+
+## Faithful regen recipes (use only after the guard is clean / per owner)
+
+Trait bridge (2 steps -- definitions then affinity overlay):
+
+```bash
+node scripts/build_trait_index.js          # index.json trait definitions (per-trait JSON -> index)
+python tools/py/build_species_trait_bridge.py   # species_affinity.json + index species_affinity overlay
+```
+
+Species catalog (5 stages, non-default source args required):
+
+```bash
+AR=docs/archive/historical-snapshots/2026-05-15_species-deprecation
+python tools/etl/merge_pack_v2_species.py \
+  --pack-v2 data/external/evo/species/species_catalog.json \
+  --species-yaml "$AR/species.yaml" --expansion-yaml "$AR/species_expansion.yaml" \
+  --lifecycle-dir data/core/species --out data/core/species/species_catalog.json
+python tools/etl/enrich_species_heuristic.py --catalog data/core/species/species_catalog.json --in-place
+python tools/etl/promote_gameplay_to_canon.py --all-gameplay
+python tools/etl/derive_interoception_overrides.py --apply
+python tools/etl/apply_interoception_traits.py --apply
+```
+
+> WARNING: as of 2026-06-22 this recipe does NOT reproduce the committed catalog
+> byte-for-byte (74 vs 75 species; stub/promote partition flips). See
+> [remediation](#owner-gated-remediation) -- it needs the pipeline fix first,
+> otherwise it REGRESSES the catalog.
+
+## Owner-gated remediation (proposed, NOT done here)
+
+Making a no-op regen reproduce the committed artifacts requires generator/pipeline
+fixes plus a one-time re-baseline. These touch consumed data + (for CI wiring)
+forbidden paths, so they are owner / master-dd gated:
+
+1. **Generator determinism (tools, low risk):**
+   - `build_species_trait_bridge.py`: write LF explicitly (`open(..., newline="")`
+     or normalize) and preserve/emit the `schema_version` wrapper.
+   - add `--out` to `promote_gameplay_to_canon.py` (and friends) so the chain is
+     dry-testable to a temp.
+2. **Pipeline idempotency (tools, design call):** make `promote` not lose to a
+   bare lifecycle stub (e.g. merge should not stub a species that has a gameplay
+   YAML, or promote should upgrade an existing stub in place), and prune entries
+   whose source no longer qualifies (lingering `evento_ecologico`).
+3. **Re-baseline (data change, master-dd):** after 1+2, run the recipes once and
+   commit the fresh artifacts. For Family 1 this drops the 80 dead-species
+   references (desired); confirm consumers (`apps/backend/services/traitRepository.js`,
+   `apps/backend/services/catalog.js`, mission-console, trait-editor,
+   `scripts/qa/frattura_abissale_validations.py`) tolerate the leaner affinity.
+4. **CI wiring (forbidden path `.github/workflows/`, owner):** add
+   `python tools/py/check_derived_reproducible.py` as a gate (or `--warn-only`
+   advisory first) so future drift fails loudly.
+
+## Source / derived map (reference)
+
+- DERIVED (regenerate, never hand-edit): `data/core/species/species_catalog.json`,
+  `data/traits/index.json`, `data/traits/species_affinity.json`, the pack catalog
+  mirror, generation snapshots.
+- SOURCE: `data/core/traits/active_effects.yaml`, `data/core/traits/glossary.json`,
+  per-trait `data/traits/<cat>/<trait>.json`, `data/external/evo/species/species_catalog.json`,
+  pack species YAML under `packs/evo_tactics_pack/data/species`, and the archived
+  legacy YAMLs under `docs/archive/historical-snapshots/2026-05-15_species-deprecation/`.
+
+Related: [`2026-06-22-tkt-p6-b-resolution-status.md`](../planning/2026-06-22-tkt-p6-b-resolution-status.md),
+[`2026-06-22-tkt-p6-b-reground-correction.md`](../planning/2026-06-22-tkt-p6-b-reground-correction.md).

--- a/docs/reports/2026-06-22-gap1-trait-triage.md
+++ b/docs/reports/2026-06-22-gap1-trait-triage.md
@@ -1,0 +1,93 @@
+---
+title: 'GAP1 trait triage -- 53 resolver-only traits (Phase 1)'
+date: 2026-06-22
+doc_status: draft
+doc_owner: claude-code
+workstream: dataset-pack
+last_verified: '2026-06-22'
+source_of_truth: false
+review_cycle_days: 90
+tags: [trait, triage, gap, salvage]
+---
+
+# GAP1 trait triage -- 53 resolver-only traits
+
+Triage of the 53 traits in `active_effects` with no per-trait DB file ([audit](2026-06-22-trait-gate-audit.md)). Master-dd review before authoring.
+
+## DROP -- not traits (16)
+
+All `starter_bioma_<mbti>` = MBTI starter-biome assignments that live in active_effects but are NOT creature traits. Leave in active_effects as starter mappings; do NOT author per-trait DB files.
+
+- `starter_bioma_enfj`
+- `starter_bioma_enfp`
+- `starter_bioma_entj`
+- `starter_bioma_entp`
+- `starter_bioma_esfj`
+- `starter_bioma_esfp`
+- `starter_bioma_estj`
+- `starter_bioma_estp`
+- `starter_bioma_infj`
+- `starter_bioma_infp`
+- `starter_bioma_intj`
+- `starter_bioma_intp`
+- `starter_bioma_isfj`
+- `starter_bioma_isfp`
+- `starter_bioma_istj`
+- `starter_bioma_istp`
+
+## AUTHOR + needs glossary entry (4)
+
+Real (OD-024 interoception, ratified) but missing from the glossary too -> author per-trait DB file AND add a glossary entry.
+
+| id | category |
+| --- | --- |
+| `equilibrio_vestibolare` | sensoriale |
+| `nocicezione` | sensoriale |
+| `propriocezione` | sensoriale |
+| `termocezione` | sensoriale |
+
+## AUTHOR -- real, full registry data (33)
+
+Have an active_effects mechanic + a glossary label + category -> mechanical per-trait DB file authoring (id + category + label + mechanic ref).
+
+| id | category | label |
+| --- | --- | --- |
+| `aculei_velenosi` | fisiologico | Aculei Velenosi |
+| `arco_voltaico` | traumatico | Arco Voltaico |
+| `aura_glaciale` | fisiologico | Aura Glaciale |
+| `canto_di_richiamo` | comportamentale | Canto di Richiamo |
+| `cervello_predittivo` | mentale | Cervello Predittivo |
+| `cuore_in_furia` | fisiologico | Cuore in Furia |
+| `denti_seghettati` | fisiologico | Denti Seghettati |
+| `ferocia` | comportamentale | Ferocia |
+| `intimidatore` | comportamentale | Aura Intimidatoria |
+| `legame_di_branco` | comportamentale | Legame di Branco |
+| `marchio_predatorio` | comportamentale | Marchio Predatorio |
+| `martello_osseo` | traumatico | Martello Osseo |
+| `mente_lucida` | mentale | Mente Lucida |
+| `midollo_iperattivo` | comportamentale | Midollo Iperattivo |
+| `pelle_elastomera` | fisiologico | Pelle Elastomera |
+| `pelli_anti_ustione` | fisiologico | Pelli Anti-Ustione |
+| `pelli_cave` | difensivo | pelli_cave |
+| `pelli_fitte` | fisiologico | Pelli Fitte |
+| `pungiglione_paralizzante` | traumatico | Pungiglione Paralizzante |
+| `risonanza_magnetica` | neurologico | Risonanza Magnetica |
+| `scarica_ionica` | traumatico | Scarica Ionica |
+| `senso_magnetico` | sensoriale | Senso Magnetico |
+| `sensori_sismici` | fisiologico | Sensori Sismici |
+| `sintonia_magnetica` | sensoriale | Sintonia Magnetica |
+| `spirito_combattivo` | comportamentale | Spirito Combattivo |
+| `spore_paniche` | comportamentale | Spore Paniche |
+| `stordimento` | traumatico | Colpo Stordente |
+| `sussurro_psichico` | comportamentale | Sussurro Psichico |
+| `tela_appiccicosa` | fisiologico | Tela Appiccicosa |
+| `tentacoli_uncinati` | fisiologico | Tentacoli Uncinati |
+| `voce_imperiosa` | comportamentale | Voce Imperiosa |
+| `wounded_perma` | persistente | Ferita Permanente |
+| `zampe_radianti` | fisiologico | Zampe Radianti |
+
+## Plan
+
+- DROP 16 starter_bioma_* (confirm: not traits).
+- AUTHOR 37 per-trait DB files (33 from full registry data + 4 interoception also needing a glossary entry).
+- Then `node scripts/build_trait_index.js` + bridge + guard.

--- a/docs/reports/2026-06-22-trait-gate-audit.md
+++ b/docs/reports/2026-06-22-trait-gate-audit.md
@@ -1,0 +1,200 @@
+---
+title: 'Trait gate audit -- multi-registry coverage (Phase 1)'
+date: 2026-06-22
+doc_status: draft
+doc_owner: claude-code
+workstream: dataset-pack
+last_verified: '2026-06-22'
+source_of_truth: false
+review_cycle_days: 90
+tags: [trait, audit, gate, registry, coverage, salvage]
+---
+
+# Trait gate audit -- multi-registry coverage (Phase 1)
+
+Phase 1 of [`derived-canon-salvage-roadmap`](../superpowers/plans/2026-06-22-derived-canon-salvage-roadmap.md). Audits every trait against three registries: per-trait DB files (`data/traits/<cat>/<trait>.json`), the resolver (`data/core/traits/active_effects.yaml`), and the glossary (`data/core/traits/glossary.json`). `ancestor_*` identity-only traits are excluded (Tier-Ancestor policy: no per-trait file expected).
+
+## Summary
+
+| Check | Result |
+| --- | --- |
+| Per-trait files vs schema gate (ADR-2026-05-29) | **263/263 PASS** (0 failures) |
+| Per-trait DB files | 263 |
+| Resolver (active_effects) ids, non-ancestor | 213 |
+| Glossary ids | 604 |
+| GAP 1: in resolver, NO per-trait file | **53** |
+| GAP 2: per-trait file, NOT in resolver | **103** |
+
+No per-trait file fails the schema gate -- the work is coverage, not conformance.
+
+## GAP 1 -- in active_effects (resolver) but NO per-trait DB file (53)
+
+Resolve mechanically but lack a canonical DB definition. Many are clearly real + recent (interoception `nocicezione`/`propriocezione`/`equilibrio_vestibolare`; TKT-P6-B `cervello_predittivo`/`mente_lucida`/`marchio_predatorio`; bond `legame_di_branco`). They need a per-trait file to fully pass the iter (mostly mechanical authoring from the active_effects entry; a few `starter_bioma_*` may be non-traits to drop). Includes the 6 traits missing from the stale affinity: `legame_di_branco`, `marchio_predatorio`, `ferocia`, `aculei_velenosi`, `martello_osseo`, `pelle_elastomera`.
+
+- `aculei_velenosi`
+- `arco_voltaico`
+- `aura_glaciale`
+- `canto_di_richiamo`
+- `cervello_predittivo`
+- `cuore_in_furia`
+- `denti_seghettati`
+- `equilibrio_vestibolare`
+- `ferocia`
+- `intimidatore`
+- `legame_di_branco`
+- `marchio_predatorio`
+- `martello_osseo`
+- `mente_lucida`
+- `midollo_iperattivo`
+- `nocicezione`
+- `pelle_elastomera`
+- `pelli_anti_ustione`
+- `pelli_cave`
+- `pelli_fitte`
+- `propriocezione`
+- `pungiglione_paralizzante`
+- `risonanza_magnetica`
+- `scarica_ionica`
+- `senso_magnetico`
+- `sensori_sismici`
+- `sintonia_magnetica`
+- `spirito_combattivo`
+- `spore_paniche`
+- `starter_bioma_enfj`
+- `starter_bioma_enfp`
+- `starter_bioma_entj`
+- `starter_bioma_entp`
+- `starter_bioma_esfj`
+- `starter_bioma_esfp`
+- `starter_bioma_estj`
+- `starter_bioma_estp`
+- `starter_bioma_infj`
+- `starter_bioma_infp`
+- `starter_bioma_intj`
+- `starter_bioma_intp`
+- `starter_bioma_isfj`
+- `starter_bioma_isfp`
+- `starter_bioma_istj`
+- `starter_bioma_istp`
+- `stordimento`
+- `sussurro_psichico`
+- `tela_appiccicosa`
+- `tentacoli_uncinati`
+- `termocezione`
+- `voce_imperiosa`
+- `wounded_perma`
+- `zampe_radianti`
+
+## GAP 2 -- per-trait DB file but NOT in active_effects (103)
+
+Defined as DB files but not wired to the resolver -> likely inert (no mechanical effect). Each needs either an active_effects entry (design-call: WHAT effect) or a decision that it is descriptive-only. Note the `*_2` dup-suffix entries (e.g. `artigli_sette_vie_2`) = probable duplicates to reconcile first.
+
+- `antenne_waveguide`
+- `appendici_thermotattiche`
+- `articolazioni_multiassiali`
+- `artigli_sette_vie_2`
+- `bioantenne_gravitiche`
+- `branchie_solfatiche`
+- `branchie_turbina`
+- `camere_anticorrosione`
+- `camere_nutrienti_vent`
+- `canto_risonante`
+- `capsule_paracadute`
+- `cartilagine_flessotermica_venti`
+- `cartilagini_desertiche`
+- `cavita_risonanti_tundra`
+- `cervelletto_equilibrio_statico`
+- `chemiorecettori_bromuro`
+- `chioma_parassita_canopica`
+- `cinghia_iper_ciliare`
+- `circolazione_bifasica_palude`
+- `circolazione_cooling_loop`
+- `ciste_riduttive`
+- `ciste_salmastre`
+- `cisti_di_ibernazione_minerale`
+- `cisti_iperbariche`
+- `coda_frusta_cinetica_2`
+- `coda_stabilizzatrice_geiser`
+- `colonne_vibromagnetiche`
+- `coralli_partner`
+- `coralli_sinaptici_fotofase`
+- `coscienza_dalveare_diffusa`
+- `criostasi_adattiva_2`
+- `cromofori_alert_acido`
+- `cuscinetti_elettrostatici`
+- `echi_risonanti`
+- `ectotermia_dinamica`
+- `emettitori_voidsong`
+- `emolinfa_conducente`
+- `enzimi_metanoossidanti`
+- `epitelio_fosforescente`
+- `estroflessione_gastrica_acida`
+- `filtri_planctonici`
+- `flagelli_ancoranti`
+- `focus_frazionato_2`
+- `foliage_fotocatodico`
+- `foliaggio_spugna`
+- `ghiaccio_piezoelettrico`
+- `ghiandola_caustica`
+- `ghiandole_fango_coesivo`
+- `ghiandole_mnemoniche`
+- `ghiandole_ventosa`
+- `giunti_antitorsione`
+- `gusci_magnesio`
+- `impulsi_bioluminescenti`
+- `integumento_bipolare`
+- `lamelle_sincroniche`
+- `lamine_scudo_silice`
+- `linfa_tampone`
+- `lobi_risonanti_crepuscolo`
+- `locomozione_miriapode_ibrida`
+- `luminescenza_hydrotermica`
+- `mantelli_geotermici`
+- `membrane_captura_rugiada`
+- `membrane_planata_vectored`
+- `motore_biologico_silenzioso`
+- `mucillagine_simbionte_mangrovie`
+- `mucose_aderenza_sonica`
+- `mucose_barofile`
+- `nebbia_mnesica`
+- `nodi_micorrizici_oracolari`
+- `nodi_sinaptici_superficiali`
+- `organi_metacronici`
+- `organi_sismici_cutanei`
+- `pathfinder`
+- `pianificatore`
+- `piume_solari_fotovoltaiche`
+- `placca_diffusione_foschia`
+- `placche_pressioniche`
+- `polmoni_cristallini_alta_quota`
+- `random`
+- `rete_filtro_polmonare`
+- `risonanza_di_branco_2`
+- `riverbero_memetico`
+- `rostro_linguale_prensile`
+- `sacche_galleggianti_ascensoriali_2`
+- `sacche_spore_stratosferiche`
+- `scheletro_idro_regolante_2`
+- `scintilla_sinaptica`
+- `scudo_gluteale_cheratinizzato`
+- `secrezioni_antistatiche`
+- `siero_anti_gelo_naturale`
+- `sinapsi_coraline_polifoniche`
+- `spicole_canalizzatrici`
+- `squame_diffusori_ionici`
+- `squame_rifrangenti_deserto`
+- `struttura_elastica_amorfa_2`
+- `tattiche_di_branco`
+- `tattiche_di_branco_2`
+- `traits_aggregate`
+- `unghie_a_micro_adesione`
+- `vello_condensatore_nebbie`
+- `vello_di_assorbimento_totale`
+- `vortice_nera_flash`
+- `zanne_idracida`
+
+## Closure approach (proposed)
+
+- **GAP 1 (mine, mostly mechanical):** author a per-trait DB file per resolver entry (id + category + label from glossary + mechanic ref). Flag ambiguous `starter_bioma_*` for you.
+- **GAP 2 (design-gated):** the mechanical effect for each inert trait is a design call -- I propose, you ratify (same model as the creatures). Reconcile `*_2` dupes first.
+- After closure: `node scripts/build_trait_index.js` + bridge + `check_derived_reproducible.py`.

--- a/docs/superpowers/plans/2026-06-22-derived-canon-salvage-roadmap.md
+++ b/docs/superpowers/plans/2026-06-22-derived-canon-salvage-roadmap.md
@@ -1,0 +1,157 @@
+---
+title: 'Derived-canon salvage roadmap -- everything through the gates (traits + 14 retired creatures)'
+date: 2026-06-22
+doc_status: draft
+doc_owner: claude-code
+workstream: dataset-pack
+last_verified: '2026-06-22'
+source_of_truth: false
+review_cycle_days: 90
+tags: [roadmap, derived, trait, species, salvage, canon, reproducibility, etl]
+---
+
+# Derived-canon salvage roadmap
+
+> Program plan. Phase 0 is detailed + executable; later phases are scoped with
+> their gates and will get their own bite-sized plans when reached.
+
+**Goal:** No silent drops. Every trait + feature earns canon status by passing
+the established gates; the 14 retired creatures are adapted, renamed (IP-safe),
+and run through species canonization -- on a pipeline that is first made
+reproducible.
+
+**Master-dd decisions (2026-06-22):**
+
+1. **Re-baseline at END** -- do the pipeline CODE fixes now; the single data
+   re-baseline (commit fresh catalog + affinity) happens once at the end, after
+   traits + creatures are in. No double re-baseline.
+2. **14 creatures: I draft, you ratify** -- per creature I propose an IP-safe
+   canon name + lore (lore-gen DRAFT) + biome/stats heuristic from its salvaged
+   trait-kit; you approve/correct per creature; then I canonize.
+3. **Trait scope = re-sync + audit gate + rename-style batch v8.**
+
+**Sequencing:** Phase 0 (foundation, no design) -> Phase 1 (audit) -> Phase 2
+(rename-style, your name-ratify) -> Phase 3 (creatures, your per-creature
+ratify) -> Phase 4 (single re-baseline). Each phase = its own PR(s).
+
+**Prereq context:** [`docs/guide/derived-artifacts-reproducibility.md`](../../guide/derived-artifacts-reproducibility.md)
+(root cause) + guard `tools/py/check_derived_reproducible.py`. Foundation PR: #2971.
+
+---
+
+## Phase 0 -- Pipeline reproducibility (CODE only, no re-baseline) [MINE]
+
+Make a no-op regen reproduce committed output (modulo provenance), so later
+phases canonize onto a trustworthy base. TDD; tools only (no forbidden paths;
+no data commit).
+
+### Task 0.1 -- Bridge determinism (`tools/py/build_species_trait_bridge.py`)
+
+- LF newlines (Windows `write_text` emits CRLF; committed is LF) -> write with
+  `newline="\n"` / `open(..., newline="")`.
+- `schema_version` aware: preserve/emit the top-level wrapper key that `#2885`
+  added to `species_affinity.json` (read existing value, default if absent).
+- Match the committed top-level key ordering of `index.json` + `species_affinity.json`
+  (inspect first; the current `sort_keys=True` may reorder vs committed).
+- Guard `--only trait-bridge` newline/schema_version findings clear; content
+  delta (287->54 stale) stays flagged (resolved at Phase 4 re-baseline).
+
+### Task 0.2 -- ETL dry-testability (`tools/etl/`)
+
+- Add `--catalog` + `--out` to `promote_gameplay_to_canon.py` (currently
+  hardcoded `CATALOG_PATH`, no dry-test). Verify `apply_interoception_traits.py`
+  accepts `--catalog`. Default behaviour unchanged when flags omitted.
+
+### Task 0.3 -- Idempotency: kill the lifecycle-stub downgrade (`promote` + integrity test)
+
+- Today: `merge` stubs every `*_lifecycle.yaml` species; `promote` SKIPS
+  existing ids -> a species that gained a lifecycle YAML downgrades from rich
+  `gameplay-promote` to bare `game-canonical-stub` (16 species).
+- Fix: `promote` UPGRADES an existing bare stub in place when a gameplay YAML
+  exists for it (preserve `lifecycle_yaml` link; set source `gameplay-promote`),
+  instead of skipping. Real species already richer than a stub are left alone.
+- Update `tests/api/envelope-b-data-integrity.test.js` source-count expectations
+  to the post-fix partition (TDD: write the new expectation first, watch it
+  fail, then fix `promote`).
+
+### Task 0.4 -- Refresh the guard
+
+- After 0.1-0.3, the guard should no longer report the newline/schema_version or
+  downgrade items as drift; the remaining stale-content delta is the Phase-4
+  re-baseline target. Update guard messages/assertions accordingly.
+
+Exit criteria: `check_derived_reproducible.py` reports ONLY the expected
+re-baseline content delta; existing suites green (`node --test tests/api/...`,
+governance `--strict`).
+
+---
+
+## Phase 1 -- Trait audit (gate-conformance) [MINE audit; fixes may need your call]
+
+- Audit EVERY trait in `data/traits/<cat>/*.json` + `data/core/traits/active_effects.yaml`
+  - `data/core/traits/glossary.json` against the ADR-2026-05-29 schema gate
+    (`tools/lint/trait_schema_gate.py`) and the multi-registry orphan check.
+- Output: `docs/reports/2026-06-22-trait-gate-audit.md` -- per-trait PASS/FAIL +
+  the 6 traits missing from affinity (`legame_di_branco`, `marchio_predatorio`,
+  `ferocia`, `aculei_velenosi`, `martello_osseo`, `pelle_elastomera`).
+- Mechanical fixes I apply; semantic/design fixes are flagged for you.
+
+## Phase 2 -- Trait rename-style batch v8 [GATE: you ratify the name list]
+
+- Run `tools/py/normalize_trait_style.py` + `tools/py/styleguide_compliance_report.py`
+  -> propose renames (anglicisms/eponyms -> IT canon): `antenne_tesla`,
+  `antenne_dustsense`, `antenne_wideband`, `biochip_memoria -> corteccia_predatoria`,
+  `magnetic_*`/`rift_*` (all-EN), etc.
+- You ratify the final names. Then ONE batch PR: rename in per-trait
+  `data/traits/<cat>/<trait>.json` + `active_effects.yaml` + `glossary.json` +
+  locale, then regenerate (bridge + `sync_trait_lists.js` + snapshots).
+
+## Phase 3 -- 14 retired creatures: adapt + rename + canonize [GATE: per-creature ratify]
+
+Salvaged trait-kits (distinctive traits beyond the universal ciclo_vitale/
+metabolismo/respirazione) recovered from the stale affinity. D&D-name placeholders
+-> need IP-safe rename + new identity. Per creature I produce a DRAFT (name +
+lore via lore-gen + biome/stats heuristic); you ratify; I canonize via the Phase-0
+pipeline + HITL gate (`lore_review_status: human_reviewed`).
+
+| Retired id             | Distinctive salvaged kit                                                             | Concept seed                               |
+| ---------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------ |
+| archon-solare          | aura_scudo_radianza, ali_solari_fotoni, visione_spettrale                            | radiant solar flyer                        |
+| balor-fission          | frusta_fiammeggiante, mantello_meteoritico, artigli_sette_vie                        | fire/meteor bruiser (D&D name)             |
+| banshee-risonante      | ali_fono_risonanti, voce_spettrale, lamenti_diradanti, intangibilita_parziale        | sonic wraith flyer                         |
+| bulette-fase           | armatura_pietra_planare, carapace_fase_variabile, sensori_geomagnetici               | phasing burrower (D&D name)                |
+| couatl-aurora          | ali_solari_fotoni, ghiandole_nettare_memetico, sensori_geomagnetici                  | auroral winged serpent (myth/D&D)          |
+| golem-runico           | armatura_pietra_planare, matrice_antimagia, nuclei_di_controllo, origine_artificiale | artificial anti-magic construct            |
+| magnet-fathom-surveyor | olfatto_risonanza_magnetica, struttura_elastica_amorfa, filamenti_digestivi          | magnetic amorphous surveyor                |
+| marilith-vault         | frusta_fiammeggiante, nucleo_ovomotore_rotante, artigli_sette_vie                    | multi-limb rotary striker (D&D name)       |
+| orbital-ascendant      | sacche_galleggianti_ascensoriali, occhi_cristallo_modulare, criostasi_adattiva       | high-altitude floater                      |
+| otyugh-sentinella      | proboscide_polifaga, filtri_bioattivi, membrane_osmotiche, sensori_chimici           | filth-filter sentinel (D&D name)           |
+| psionic-canopy-scout   | mimetismo_cromatico_passivo, sacche_galleggianti, spore_psichiche_silenziate         | psionic canopy glider                      |
+| rakshasa-corte         | artigli_psionici, maschera_illusoria, tessuti_adattivi                               | illusionist courtier (myth/D&D name)       |
+| resonant-claw-hunter   | artigli_sette_vie (thin -- 1 trait)                                                  | resonant clawed hunter (candidate: museum) |
+| treant-portale         | corteccia_memetica, radici_ancora_planare, reti_capillari_radici, pigmenti_aurorali  | rooted planar anchor (D&D-adjacent name)   |
+
+Note: `random` / `pathfinder` appear in some kits = parse artifacts, not real
+traits -- drop on adaptation.
+
+## Phase 4 -- Single re-baseline [GATE: your OK -- given for end-of-program]
+
+- Run the Phase-0-fixed pipeline once (bridge 2-step + ETL 5-stage with the
+  faithful in-repo source args), commit fresh `species_catalog.json`,
+  `index.json`, `species_affinity.json`. Provenance flips `/tmp` -> in-repo.
+- Guard goes GREEN (no-op regen reproduces committed).
+- Verify backend consumers (`traitRepository.js`, `catalog.js`, mission-console,
+  trait-editor, QA scripts) tolerate the refreshed data.
+
+---
+
+## Gate table (who decides)
+
+| Item                                          | Owner                                |
+| --------------------------------------------- | ------------------------------------ |
+| Pipeline determinism/idempotency code         | me                                   |
+| Trait audit + mechanical fixes                | me                                   |
+| Trait rename names (v8)                       | master-dd                            |
+| 14 creatures identity (name/lore/biome/stats) | master-dd (I draft)                  |
+| Final re-baseline (data commit)               | master-dd (OK given, end-of-program) |
+| CI wiring of the guard (`.github/workflows/`) | master-dd (forbidden path)           |

--- a/docs/superpowers/plans/2026-06-22-derived-canon-salvage-roadmap.md
+++ b/docs/superpowers/plans/2026-06-22-derived-canon-salvage-roadmap.md
@@ -37,6 +37,32 @@ ratify) -> Phase 4 (single re-baseline). Each phase = its own PR(s).
 **Prereq context:** [`docs/guide/derived-artifacts-reproducibility.md`](../../guide/derived-artifacts-reproducibility.md)
 (root cause) + guard `tools/py/check_derived_reproducible.py`. Foundation PR: #2971.
 
+## Status + corrected sequencing (2026-06-22)
+
+DONE in PR #2971 (foundation, green, awaiting master-dd merge): Phase 0 pipeline
+fixes + guard + doc + Phase 1 audit + GAP1 triage.
+
+**Corrected sequencing (verify-first).** Authoring a new trait/creature is
+CI-coupled to derived-sync: the coverage validator requires the per-trait id in
+`index.json.traits` (the aggregate of all per-trait files) AND the evo-pack mirror
+must be re-synced (`sync:evo-pack`). A naive source-add (GAP1 batch 1) failed CI on
+both and was reverted. There is no single `add-trait` tool today -- that gap is the
+trait-side reproducibility hazard.
+
+So the order is NOT "author, then re-baseline at the end". It is:
+
+1. Phase 0 -- pipeline reproducibility (DONE, #2971).
+2. **Phase 1.5 -- `add_trait` sync helper (NEW, the unblock).** One deterministic
+   tool that, given a trait id, writes the per-trait DB file + the
+   `index.json.traits` entry + updates `traits_aggregate` + runs `sync:evo-pack`,
+   so a trait cleanly "passes the iter" in one atomic, CI-green step. Build TDD.
+3. GAP1 authoring (37: 33 + 4 interoception-also-need-glossary) THROUGH the helper,
+   batch per category. Decisions taken: triage-first (16 drop / 37 author); batch
+   per category.
+4. Phase 3 creatures THROUGH the helper + species canonization (Phase 0.3 promote).
+5. Affinity/catalog re-baseline (species_affinity 287->54 + catalog refresh) =
+   separate end-step, still owner-gated.
+
 ---
 
 ## Phase 0 -- Pipeline reproducibility (CODE only, no re-baseline) [MINE]

--- a/tests/test_build_species_trait_bridge.py
+++ b/tests/test_build_species_trait_bridge.py
@@ -1,0 +1,75 @@
+"""Task 0.1 -- build_species_trait_bridge deterministic + schema_version-aware.
+
+Reproducibility fix (docs/guide/derived-artifacts-reproducibility.md): the bridge
+must emit LF (not CRLF on Windows), preserve top-level key order (no global
+re-sort of an EDITED index.json), and carry the schema_version wrapper on
+species_affinity.json (the #2885 contract). A no-op regen must be byte-stable.
+
+Run: PYTHONPATH=tools/py python -m pytest tests/test_build_species_trait_bridge.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools" / "py"))
+
+import build_species_trait_bridge as b  # noqa: E402
+
+PACK = REPO_ROOT / "packs" / "evo_tactics_pack" / "data" / "species"
+
+
+def _run(tmp_path, schema_version="2.0"):
+    out_aff = tmp_path / "species_affinity.json"
+    if schema_version is not None:
+        out_aff.write_text(
+            json.dumps({"schema_version": schema_version}) + "\n", encoding="utf-8"
+        )
+    out_index = tmp_path / "index.json"
+    # traits in deliberately NON-alphabetical order to detect a global re-sort.
+    out_index.write_text(
+        json.dumps(
+            {
+                "schema_version": "2.0",
+                "traits": {"zzz_trait": {"id": "zzz_trait"}, "aaa_trait": {"id": "aaa_trait"}},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rc = b.main(
+        ["--species-root", str(PACK), "--trait-index", str(out_index), "--out-json", str(out_aff)]
+    )
+    assert rc == 0
+    return out_aff, out_index
+
+
+def test_affinity_lf_and_schema_version_first_then_sorted(tmp_path):
+    out_aff, _ = _run(tmp_path)
+    raw = out_aff.read_bytes()
+    assert b"\r\n" not in raw, "must be LF, not CRLF"
+    keys = list(json.loads(raw).keys())
+    assert keys[0] == "schema_version", "schema_version must be the first key"
+    traits = [k for k in keys if k != "schema_version"]
+    assert traits == sorted(traits), "trait keys must be sorted"
+
+
+def test_affinity_preserves_existing_schema_version(tmp_path):
+    out_aff, _ = _run(tmp_path, schema_version="9.9")
+    assert json.loads(out_aff.read_text(encoding="utf-8")).get("schema_version") == "9.9"
+
+
+def test_affinity_default_schema_version_when_absent(tmp_path):
+    out_aff, _ = _run(tmp_path, schema_version=None)
+    assert json.loads(out_aff.read_text(encoding="utf-8")).get("schema_version") == "2.0"
+
+
+def test_index_traits_order_preserved_not_resorted(tmp_path):
+    _, out_index = _run(tmp_path)
+    data = json.loads(out_index.read_text(encoding="utf-8"))
+    assert b"\r\n" not in out_index.read_bytes(), "index must be LF"
+    assert list(data["traits"].keys())[0] == "zzz_trait", "must NOT globally re-sort index traits"

--- a/tests/test_promote_gameplay_to_canon.py
+++ b/tests/test_promote_gameplay_to_canon.py
@@ -1,0 +1,84 @@
+"""Phase 0.2/0.3 -- promote_gameplay_to_canon: --catalog/--out + stub-upgrade.
+
+Fix the downgrade-on-rerun bug (docs/guide/derived-artifacts-reproducibility.md):
+a species that gained a *_lifecycle.yaml gets a bare game-canonical-stub at the
+merge stage; promote must UPGRADE that stub with its gameplay data (preserving
+the lifecycle_yaml link) instead of skipping it. Richer entries are left
+untouched. --catalog/--out make the (previously in-place-only) writer dry-testable.
+
+Run: PYTHONPATH=tools/etl python -m pytest tests/test_promote_gameplay_to_canon.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools" / "etl"))
+
+import promote_gameplay_to_canon as p  # noqa: E402
+
+# echo_wing has BOTH packs/.../badlands/echo-wing.yaml and a lifecycle YAML, so a
+# fresh merge stubs it and (pre-fix) promote skips it -> the downgrade case.
+STUB = {
+    "species_id": "echo_wing",
+    "source": "game-canonical-stub",
+    "lifecycle_yaml": "data/core/species/echo_wing_lifecycle.yaml",
+    "sentience_index": "T1",
+}
+
+
+def _write_cat(tmp_path, entries):
+    cp = tmp_path / "species_catalog.json"
+    cp.write_text(
+        json.dumps({"catalog": entries, "stats": {}}, ensure_ascii=False), encoding="utf-8"
+    )
+    return cp
+
+
+def _entry(cat_path, sid):
+    out = json.loads(cat_path.read_text(encoding="utf-8"))
+    return next(e for e in out["catalog"] if e["species_id"] == sid)
+
+
+def test_catalog_flag_writes_to_given_path(tmp_path):
+    cp = _write_cat(tmp_path, [])
+    assert p.main(["--biome", "badlands", "--catalog", str(cp)]) == 0
+    out = json.loads(cp.read_text(encoding="utf-8"))
+    assert any(e["species_id"] == "echo_wing" for e in out["catalog"]), "new species still added"
+
+
+def test_promote_upgrades_bare_lifecycle_stub(tmp_path):
+    cp = _write_cat(tmp_path, [dict(STUB)])
+    p.main(["--biome", "badlands", "--catalog", str(cp)])
+    ew = _entry(cp, "echo_wing")
+    assert ew["source"] == "gameplay-promote", "bare stub must be upgraded, not skipped"
+    assert ew.get("_promote_stub") is True
+    assert ew["lifecycle_yaml"] == "data/core/species/echo_wing_lifecycle.yaml", "link preserved"
+    out = json.loads(cp.read_text(encoding="utf-8"))
+    assert sum(1 for e in out["catalog"] if e["species_id"] == "echo_wing") == 1, "no duplicate"
+
+
+def test_promote_leaves_rich_entry_untouched(tmp_path):
+    rich = {
+        "species_id": "echo_wing",
+        "source": "pack-v2-full-plus",
+        "sentience_index": "T2",
+        "scientific_name": "Echo wing",
+        "lifecycle_yaml": "data/core/species/echo_wing_lifecycle.yaml",
+    }
+    cp = _write_cat(tmp_path, [rich])
+    p.main(["--biome", "badlands", "--catalog", str(cp)])
+    ew = _entry(cp, "echo_wing")
+    assert ew["source"] == "pack-v2-full-plus", "richer non-stub entry untouched"
+    assert ew["scientific_name"] == "Echo wing"
+
+
+def test_out_flag_does_not_touch_input(tmp_path):
+    cp = _write_cat(tmp_path, [])
+    outp = tmp_path / "out.json"
+    p.main(["--biome", "badlands", "--catalog", str(cp), "--out", str(outp)])
+    assert outp.exists()
+    assert json.loads(cp.read_text(encoding="utf-8"))["catalog"] == [], "input left untouched"

--- a/tools/etl/apply_interoception_traits.py
+++ b/tools/etl/apply_interoception_traits.py
@@ -1,5 +1,9 @@
 """apply_interoception_traits.py -- OD-024 D4 operational populate path.
 
+NOTE (reproducibility): mutates the DERIVED species_catalog.json (stale vs current
+sources). Run tools/py/check_derived_reproducible.py first and read
+docs/guide/derived-artifacts-reproducibility.md before regenerating + committing.
+
 Sync an authored `interoception_traits` field from the species sources
 (data/core/species.yaml + species_expansion.yaml) into the canonical
 species_catalog.json, IN PLACE -- the live mirror of tools/py/apply_biome_affinity.py.

--- a/tools/etl/derive_interoception_overrides.py
+++ b/tools/etl/derive_interoception_overrides.py
@@ -1,5 +1,9 @@
 """derive_interoception_overrides.py -- OD-024 D4 principled override populate.
 
+NOTE (reproducibility): mutates the DERIVED species_catalog.json (stale vs current
+sources). Run tools/py/check_derived_reproducible.py first and read
+docs/guide/derived-artifacts-reproducibility.md before regenerating + committing.
+
 Derive a per-species `interoception_traits` override from a RATIFIED rule and
 write it into the canonical species_catalog.json IN PLACE. Rule-based mirror of
 tools/py/apply_biome_affinity.py + tools/etl/apply_interoception_traits.py.

--- a/tools/etl/enrich_species_heuristic.py
+++ b/tools/etl/enrich_species_heuristic.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Phase 3 Path Quick — heuristic enrichment per legacy-yaml-merge species.
 
+NOTE (reproducibility): operates on the DERIVED species_catalog.json, which is
+stale vs current sources. Run tools/py/check_derived_reproducible.py first and
+read docs/guide/derived-artifacts-reproducibility.md before regenerating +
+committing.
+
 ADR-2026-05-15 Q1 Option A Phase 3 (autonomous Path Quick):
 Fill 4 heuristic fields per 38 legacy-yaml-merge entries in species_catalog.json:
 

--- a/tools/etl/merge_pack_v2_species.py
+++ b/tools/etl/merge_pack_v2_species.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 """ETL: merge Pack v2-full-plus species catalog into Game/ canonical.
 
+NOTE (reproducibility): the committed species_catalog.json is a DERIVED artifact
+that is STALE vs current sources -- a naive full re-run does not reproduce it and
+can regress it (the default --species-yaml/--expansion-yaml point at files deleted
+in #2271). Run tools/py/check_derived_reproducible.py first and read
+docs/guide/derived-artifacts-reproducibility.md before regenerating + committing.
+
+
 OD-031 (pack drift merge) + OD-027 (full Species type) + OD-024 (sentience full
 45/45 — wave A: 10 Pack v2 species with sentience_index already assigned).
 

--- a/tools/etl/promote_gameplay_to_canon.py
+++ b/tools/etl/promote_gameplay_to_canon.py
@@ -138,13 +138,18 @@ def derive_entry(pack, biome, fid):
     return entry
 
 
-def main():
+def main(argv=None):
     ap = argparse.ArgumentParser()
     ap.add_argument("--biome", action="append", default=[], help="biome dir to promote (repeatable)")
     ap.add_argument("--all-gameplay", action="store_true",
                     help="promote the 6 gameplay-touched biomes (excludes rovine_planari = D6)")
+    ap.add_argument("--catalog", default=CATALOG_PATH,
+                    help="catalog JSON to read (and write unless --out); default = canonical")
+    ap.add_argument("--out", help="write result here instead of in place (dry-test to a temp)")
     ap.add_argument("--dry-run", action="store_true")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
+    catalog_path = args.catalog
+    out_path = args.out or args.catalog
 
     # Multi-species gameplay biomes. EXCLUDES:
     #  - rovine_planari (D6 LOCKED = new content, separate decision)
@@ -156,17 +161,22 @@ def main():
         print("ERROR: pass --biome <name> or --all-gameplay", file=sys.stderr)
         return 2
 
-    catalog = json.load(open(CATALOG_PATH, encoding="utf-8"))
-    existing = {e["species_id"] for e in catalog["catalog"]}
+    catalog = json.load(open(catalog_path, encoding="utf-8"))
+    existing_by_id = {e["species_id"]: e for e in catalog["catalog"]}
 
-    added, skipped, excluded_events = [], [], []
+    added, upgraded, skipped, excluded_events = [], [], [], []
     for biome in biomes:
         for p in sorted(glob.glob(os.path.join(SPECIES_DIR, biome, "*.yaml"))):
             fid = os.path.splitext(os.path.basename(p))[0]
             if not is_creature(fid):
                 continue
             sid = norm(fid)
-            if sid in existing:
+            existing_entry = existing_by_id.get(sid)
+            # Skip only when a richer entry already exists. A bare game-canonical-stub
+            # (a lifecycle species the merge stage stubbed) is UPGRADED with its
+            # gameplay data instead of being skipped -- otherwise gaining a lifecycle
+            # YAML would silently downgrade the species to a bare stub on every re-run.
+            if existing_entry is not None and existing_entry.get("source") != "game-canonical-stub":
                 skipped.append(sid)
                 continue
             pack = load_yaml(p)
@@ -174,9 +184,17 @@ def main():
                 excluded_events.append(sid)  # ecological event, not a species
                 continue
             entry = derive_entry(pack, biome, fid)
-            catalog["catalog"].append(entry)
-            existing.add(sid)
-            added.append(sid)
+            if existing_entry is not None:
+                # Upgrade in place, preserving the lifecycle_yaml link from the stub.
+                if existing_entry.get("lifecycle_yaml"):
+                    entry["lifecycle_yaml"] = existing_entry["lifecycle_yaml"]
+                catalog["catalog"][catalog["catalog"].index(existing_entry)] = entry
+                existing_by_id[sid] = entry
+                upgraded.append(sid)
+            else:
+                catalog["catalog"].append(entry)
+                existing_by_id[sid] = entry
+                added.append(sid)
 
     # Recompute stats.
     cat = catalog["catalog"]
@@ -193,6 +211,7 @@ def main():
         catalog["source_provenance"]["gameplay_promote"] = "packs/evo_tactics_pack/data/species"
 
     print(f"added {len(added)}: {added}")
+    print(f"upgraded stubs {len(upgraded)}: {upgraded}")
     print(f"skipped (already canon) {len(skipped)}: {skipped}")
     print(f"excluded events (role={EVENT_ROLE}) {len(excluded_events)}: {excluded_events}")
     print(f"catalog now {len(cat)} species; by_source={by_source}")
@@ -200,10 +219,10 @@ def main():
     if args.dry_run:
         print("[dry-run] not written")
         return 0
-    with open(CATALOG_PATH, "w", encoding="utf-8") as f:
+    with open(out_path, "w", encoding="utf-8") as f:
         json.dump(catalog, f, ensure_ascii=False, indent=2)
         f.write("\n")
-    print(f"written {CATALOG_PATH}")
+    print(f"written {out_path}")
     return 0
 
 

--- a/tools/etl/promote_gameplay_to_canon.py
+++ b/tools/etl/promote_gameplay_to_canon.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Promote gameplay pack-species YAML into the canonical species_catalog.json.
 
+NOTE (reproducibility): additive-only (never prunes) + writes the catalog IN-PLACE
+with no --out, and is skipped by lifecycle stubs -> a re-run does not reproduce the
+committed catalog. Run tools/py/check_derived_reproducible.py first and read
+docs/guide/derived-artifacts-reproducibility.md before regenerating + committing.
+
 Wave 3 / CANON-RECONCILE (Option 1 "unify"): the canon SoT
 (data/core/species/species_catalog.json, 53 species) and the gameplay creatures
 (packs/evo_tactics_pack/data/species/<biome>/<id>.yaml) were near-disjoint naming

--- a/tools/py/build_species_trait_bridge.py
+++ b/tools/py/build_species_trait_bridge.py
@@ -26,6 +26,11 @@ except ModuleNotFoundError:  # pragma: no cover - fallback con messaggio chiaro
 
 ROLE_WEIGHTS: Mapping[str, int] = {"core": 3, "synergy": 2, "optional": 1}
 
+# species_affinity.json carries a top-level schema_version wrapper key (added by
+# #2885). The bridge preserves the existing value and defaults to this when the
+# output file is absent, so a re-baseline keeps the schema-version contract.
+SCHEMA_VERSION_DEFAULT = "2.0"
+
 
 @dataclass
 class SpeciesTraitRoles:
@@ -74,9 +79,14 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def _write_json(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    # LF explicitly (Windows text mode would emit CRLF; committed files are LF) +
+    # NO sort_keys: callers pass payloads in their intended order, so an EDITED
+    # index.json keeps its existing top-level key order instead of being globally
+    # re-sorted (a major source of the historical spurious diff).
     path.write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
+        newline="\n",
     )
 
 
@@ -317,6 +327,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def build_affinity_output(
+    affinity: Mapping[str, list[dict[str, Any]]], out_path: Path
+) -> dict[str, Any]:
+    """Wrap the affinity map as the serialized species_affinity.json payload:
+    schema_version first, then trait ids sorted. The schema_version is preserved
+    from the existing output file when present, else SCHEMA_VERSION_DEFAULT."""
+    schema_version = SCHEMA_VERSION_DEFAULT
+    if out_path.exists():
+        try:
+            existing = _load_json(out_path)
+            if isinstance(existing, Mapping) and isinstance(existing.get("schema_version"), str):
+                schema_version = existing["schema_version"]
+        except (json.JSONDecodeError, OSError):
+            pass
+    ordered: dict[str, Any] = {"schema_version": schema_version}
+    for trait_id in sorted(affinity):
+        ordered[trait_id] = affinity[trait_id]
+    return ordered
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
@@ -339,7 +369,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Rilevati {len(affinity)} trait con associazioni specie")
         return 0
 
-    _write_json(args.out_json, affinity)
+    _write_json(args.out_json, build_affinity_output(affinity, args.out_json))
 
     index_payload = merge_into_trait_index(args.trait_index, affinity)
     _write_json(args.trait_index, index_payload)

--- a/tools/py/build_species_trait_bridge.py
+++ b/tools/py/build_species_trait_bridge.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Genera la tabella ponte trait↔specie con pesi normalizzati."""
+"""Genera la tabella ponte trait<->specie con pesi normalizzati.
+
+NOTE (reproducibility): committed output (data/traits/index.json +
+species_affinity.json) is STALE on a plain dev checkout -- a naive regen yields a
+huge spurious diff. It reads trait ids from the species YAML, NOT from the
+per-trait data/traits/<cat>/<trait>.json files. Run
+tools/py/check_derived_reproducible.py first and read
+docs/guide/derived-artifacts-reproducibility.md before regenerating + committing.
+"""
 from __future__ import annotations
 
 import argparse

--- a/tools/py/check_derived_reproducible.py
+++ b/tools/py/check_derived_reproducible.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Guard: detect drift between committed DERIVED data artifacts and what their
+generators would produce from the CURRENT in-repo sources.
+
+Context + root-cause writeup: docs/guide/derived-artifacts-reproducibility.md
+
+Why this exists (TKT-P6-TRAIT-ORPHAN-DESIGN-B, 2026-06-22): two families of
+committed derived artifacts are STALE vs their current in-repo sources, so a
+naive "just regenerate it" on a plain dev checkout produces a huge spurious diff
+that corrupts the canon and blocks otherwise-simple trait/species data work:
+
+  1. Trait bridge   -- data/traits/index.json + data/traits/species_affinity.json
+                       (tools/py/build_species_trait_bridge.py). Committed affinity
+                       references ~80 species that no longer exist in the catalog;
+                       a default regen collapses it (~287 -> ~54 trait entries).
+  2. Species catalog -- data/core/species/species_catalog.json (the merge -> enrich
+                       -> promote -> derive -> apply ETL chain in tools/etl/).
+                       Committed catalog is stale vs the current sources (lingering
+                       evento_ecologico entries, gameplay-promote entries that a
+                       re-run would downgrade to bare stubs, missing newer species).
+
+This is DRIFT, not a build-host split: every real source IS in-repo. The /tmp
+paths in the catalog's source_provenance are misleading leftover stamps from the
+original one-off build host, not a required external input.
+
+This script makes the drift VISIBLE (and CI-gateable) WITHOUT writing any
+corrupt artifact. It never touches a tracked file:
+  - trait-bridge:    regenerates the affinity map in-process to memory and
+                     semantic-diffs it vs the committed file (ignores newline /
+                     schema_version wrapper / ordering noise).
+  - species-catalog: NON-destructive fingerprint scan that predicts exactly which
+                     committed entries a full ETL re-run would add/drop/downgrade,
+                     plus a provenance + input-existence check. (The promote/derive/
+                     apply stages write the real catalog in-place with no --out, so
+                     re-running them here would dirty the tree -- we predict instead.)
+
+Exit code: non-zero when drift is found (so CI can gate). --warn-only forces 0.
+
+Usage:
+  python tools/py/check_derived_reproducible.py                 # both checks
+  python tools/py/check_derived_reproducible.py --only trait-bridge
+  python tools/py/check_derived_reproducible.py --warn-only     # advisory (exit 0)
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRAITS_DIR = REPO_ROOT / "data" / "traits"
+AFFINITY_PATH = TRAITS_DIR / "species_affinity.json"
+PACK_SPECIES_ROOT = REPO_ROOT / "packs" / "evo_tactics_pack" / "data" / "species"
+CATALOG_PATH = REPO_ROOT / "data" / "core" / "species" / "species_catalog.json"
+BRIDGE_PATH = REPO_ROOT / "tools" / "py" / "build_species_trait_bridge.py"
+
+RUNBOOK = "docs/guide/derived-artifacts-reproducibility.md"
+
+
+def _load_json(path: Path):
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _import_bridge():
+    """Import build_species_trait_bridge as a module so we can call its pure
+    build_species_affinity() without spawning a subprocess or writing files."""
+    name = "_build_species_trait_bridge"
+    spec = importlib.util.spec_from_file_location(name, BRIDGE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the module's @dataclass can resolve cls.__module__.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def check_trait_bridge() -> list[str]:
+    """Return a list of drift findings (empty == reproducible)."""
+    findings: list[str] = []
+    if not AFFINITY_PATH.exists():
+        return [f"{AFFINITY_PATH.relative_to(REPO_ROOT)} missing"]
+
+    committed = _load_json(AFFINITY_PATH)
+    # The committed file carries a top-level schema_version wrapper key (added by a
+    # consumer migration) that the bridge does NOT emit -- record it as drift.
+    has_schema_wrapper = "schema_version" in committed
+    committed_traits = {k: v for k, v in committed.items() if isinstance(v, list)}
+
+    bridge = _import_bridge()
+    regen = bridge.build_species_affinity(PACK_SPECIES_ROOT)
+
+    c_ids = set(committed_traits)
+    r_ids = set(regen)
+    only_committed = c_ids - r_ids
+    only_regen = r_ids - c_ids
+
+    # Dead species: referenced by committed affinity but absent from the live catalog.
+    dead = set()
+    if CATALOG_PATH.exists():
+        live = {e["species_id"] for e in _load_json(CATALOG_PATH).get("catalog", [])}
+        for entries in committed_traits.values():
+            for e in entries:
+                if isinstance(e, dict) and e.get("species_id") not in live:
+                    dead.add(e.get("species_id"))
+
+    print(f"  [trait-bridge] committed trait entries: {len(c_ids)}; "
+          f"regen from {PACK_SPECIES_ROOT.relative_to(REPO_ROOT)}: {len(r_ids)}")
+    if only_committed or only_regen:
+        findings.append(
+            f"trait-id set differs: {len(only_committed)} only-committed (stale), "
+            f"{len(only_regen)} only-regen (new). A no-op regen would rewrite "
+            f"species_affinity.json (and index.json) wholesale."
+        )
+    if dead:
+        findings.append(
+            f"{len(dead)} species referenced by committed affinity are NOT in the "
+            f"current catalog (e.g. {sorted(dead)[:5]}). Output is stale."
+        )
+    if has_schema_wrapper:
+        findings.append(
+            "committed species_affinity.json has a top-level schema_version key "
+            "that build_species_trait_bridge.py does not emit -> regen drops it."
+        )
+    return findings
+
+
+def _resolve_pack_path(rel: str) -> Path | None:
+    if not rel:
+        return None
+    p = (REPO_ROOT / rel)
+    return p if p.exists() else None
+
+
+def check_species_catalog() -> list[str]:
+    """Non-destructive prediction of what a full ETL re-run would change."""
+    findings: list[str] = []
+    if not CATALOG_PATH.exists():
+        return [f"{CATALOG_PATH.relative_to(REPO_ROOT)} missing"]
+
+    data = _load_json(CATALOG_PATH)
+    catalog = data.get("catalog", [])
+
+    # 1. Provenance points at out-of-repo /tmp build-host leftovers.
+    prov = data.get("source_provenance") or {}
+    tmp_prov = sorted(k for k, v in prov.items() if isinstance(v, str) and ("/tmp" in v or v.startswith("\\tmp")))
+    if tmp_prov:
+        findings.append(
+            f"source_provenance points at ephemeral build-host paths for {tmp_prov}; "
+            f"the real in-repo inputs are data/external/evo/species/species_catalog.json "
+            f"+ docs/archive/historical-snapshots/2026-05-15_species-deprecation/."
+        )
+
+    # 2. gameplay-promote entries that now have a lifecycle YAML -> a re-run stubs
+    #    them at the merge stage and promote then SKIPS them (downgrade-on-regen).
+    downgrade = []
+    lingering_events = []
+    for e in catalog:
+        if e.get("source") != "gameplay-promote":
+            continue
+        sid = e.get("species_id")
+        if (CATALOG_PATH.parent / f"{sid}_lifecycle.yaml").exists():
+            downgrade.append(sid)
+        # 3. gameplay-promote entries whose pack source is an ecological event
+        #    (role_trofico=evento_ecologico) -> a re-run excludes them (additive
+        #    promote never pruned them after the is_event filter landed).
+        pack_path = _resolve_pack_path(e.get("pack_path", ""))
+        if pack_path is not None:
+            try:
+                import yaml  # local import: only needed for this check
+                pack = yaml.safe_load(pack_path.read_text(encoding="utf-8")) or {}
+                if str(pack.get("role_trofico", "")).strip() == "evento_ecologico":
+                    lingering_events.append(sid)
+            except Exception:  # pragma: no cover - parse hiccup is itself a signal
+                findings.append(f"gameplay-promote '{sid}': pack source unreadable ({e.get('pack_path')})")
+
+    if downgrade:
+        findings.append(
+            f"{len(downgrade)} gameplay-promote species now have a lifecycle YAML "
+            f"(e.g. {sorted(downgrade)[:5]}); a re-run downgrades them to bare "
+            f"game-canonical-stub entries (loses morphotype/threat/pack_path)."
+        )
+    if lingering_events:
+        findings.append(
+            f"{len(lingering_events)} catalog entries are ecological events "
+            f"(role_trofico=evento_ecologico) that a current re-run excludes: "
+            f"{sorted(lingering_events)}."
+        )
+
+    print(f"  [species-catalog] entries: {len(catalog)}; version: {data.get('version')}; "
+          f"by_source: {data.get('stats', {}).get('by_source')}")
+    return findings
+
+
+CHECKS = {
+    "trait-bridge": check_trait_bridge,
+    "species-catalog": check_species_catalog,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--only", choices=sorted(CHECKS), help="run a single check")
+    ap.add_argument("--warn-only", action="store_true", help="report drift but exit 0")
+    args = ap.parse_args(argv)
+
+    selected = [args.only] if args.only else list(CHECKS)
+    total = 0
+    for name in selected:
+        print(f"== {name} ==")
+        findings = CHECKS[name]()
+        if findings:
+            for f in findings:
+                print(f"  DRIFT: {f}")
+            total += len(findings)
+        else:
+            print("  OK: reproducible from current in-repo sources.")
+
+    print()
+    if total:
+        print(f"FOUND {total} drift finding(s). Committed derived artifacts are NOT a "
+              f"no-op regen on this checkout.")
+        print(f"Do NOT commit a naive regenerate. See {RUNBOOK} for the owner-gated "
+              f"remediation (re-baseline + generator/pipeline fixes).")
+        return 0 if args.warn_only else 1
+    print("All checked derived artifacts reproduce from current in-repo sources.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/py/check_derived_reproducible.py
+++ b/tools/py/check_derived_reproducible.py
@@ -156,19 +156,17 @@ def check_species_catalog() -> list[str]:
             f"+ docs/archive/historical-snapshots/2026-05-15_species-deprecation/."
         )
 
-    # 2. gameplay-promote entries that now have a lifecycle YAML -> a re-run stubs
-    #    them at the merge stage and promote then SKIPS them (downgrade-on-regen).
-    downgrade = []
+    # 2. gameplay-promote entries whose pack source is an ecological event
+    #    (role_trofico=evento_ecologico) -> a fresh re-run excludes them (additive
+    #    promote never pruned them after the is_event filter landed). They linger in
+    #    the committed catalog until the re-baseline.
+    #    (The earlier lifecycle-stub "downgrade" finding is retired: promote now
+    #    UPGRADES a bare stub in place instead of skipping it -- Phase 0.3.)
     lingering_events = []
     for e in catalog:
         if e.get("source") != "gameplay-promote":
             continue
         sid = e.get("species_id")
-        if (CATALOG_PATH.parent / f"{sid}_lifecycle.yaml").exists():
-            downgrade.append(sid)
-        # 3. gameplay-promote entries whose pack source is an ecological event
-        #    (role_trofico=evento_ecologico) -> a re-run excludes them (additive
-        #    promote never pruned them after the is_event filter landed).
         pack_path = _resolve_pack_path(e.get("pack_path", ""))
         if pack_path is not None:
             try:
@@ -179,12 +177,6 @@ def check_species_catalog() -> list[str]:
             except Exception:  # pragma: no cover - parse hiccup is itself a signal
                 findings.append(f"gameplay-promote '{sid}': pack source unreadable ({e.get('pack_path')})")
 
-    if downgrade:
-        findings.append(
-            f"{len(downgrade)} gameplay-promote species now have a lifecycle YAML "
-            f"(e.g. {sorted(downgrade)[:5]}); a re-run downgrades them to bare "
-            f"game-canonical-stub entries (loses morphotype/threat/pack_path)."
-        )
     if lingering_events:
         findings.append(
             f"{len(lingering_events)} catalog entries are ecological events "

--- a/tools/py/check_derived_reproducible.py
+++ b/tools/py/check_derived_reproducible.py
@@ -84,16 +84,19 @@ def check_trait_bridge() -> list[str]:
         return [f"{AFFINITY_PATH.relative_to(REPO_ROOT)} missing"]
 
     committed = _load_json(AFFINITY_PATH)
-    # The committed file carries a top-level schema_version wrapper key (added by a
-    # consumer migration) that the bridge does NOT emit -- record it as drift.
-    has_schema_wrapper = "schema_version" in committed
     committed_traits = {k: v for k, v in committed.items() if isinstance(v, list)}
 
     bridge = _import_bridge()
-    regen = bridge.build_species_affinity(PACK_SPECIES_ROOT)
+    # Compare against the bridge's ACTUAL serialized output (schema_version wrapper
+    # + sorted traits), so the schema_version key is no longer flagged as drift now
+    # that the bridge emits it.
+    regen = bridge.build_affinity_output(
+        bridge.build_species_affinity(PACK_SPECIES_ROOT), AFFINITY_PATH
+    )
+    schema_parity = ("schema_version" not in committed) or ("schema_version" in regen)
 
     c_ids = set(committed_traits)
-    r_ids = set(regen)
+    r_ids = {k for k, v in regen.items() if isinstance(v, list)}
     only_committed = c_ids - r_ids
     only_regen = r_ids - c_ids
 
@@ -119,10 +122,10 @@ def check_trait_bridge() -> list[str]:
             f"{len(dead)} species referenced by committed affinity are NOT in the "
             f"current catalog (e.g. {sorted(dead)[:5]}). Output is stale."
         )
-    if has_schema_wrapper:
+    if not schema_parity:
         findings.append(
-            "committed species_affinity.json has a top-level schema_version key "
-            "that build_species_trait_bridge.py does not emit -> regen drops it."
+            "bridge output is missing the schema_version wrapper that committed "
+            "species_affinity.json carries (the #2885 contract)."
         )
     return findings
 


### PR DESCRIPTION
## What + why

Resolves the TKT-P6-TRAIT-ORPHAN-DESIGN-B blocker: committed DERIVED data
artifacts are not faithfully regenerable from in-repo sources, so data work that
touches them produces huge spurious diffs.

**Verdict (reproduced on a clean worktree off origin/main): DRIFT, not a
build-host split.** Every real source IS in-repo; the `/tmp` paths in
`species_catalog.json` provenance are misleading leftover stamps.

This PR is the **reproducibility foundation** (no data re-baseline -- that is a
separate, owner-gated step):

### Diagnosis + guard
- `tools/py/check_derived_reproducible.py` -- non-destructive drift guard;
  predicts what a regen would change without writing any artifact (exit 1 on
  drift, `--warn-only`).
- `docs/guide/derived-artifacts-reproducibility.md` -- root cause + recipes +
  owner-gated remediation (+ docs_registry entry).
- Reproducibility NOTE in the 6 generator docstrings + a CONTRIBUTING pointer.

### Phase-0 pipeline fixes (deterministic, no data change)
- `build_species_trait_bridge.py`: LF output (was CRLF on Windows), no global
  re-sort of an edited index.json, schema_version wrapper preserved/emitted.
- `promote_gameplay_to_canon.py`: `--catalog`/`--out` (dry-testable) + UPGRADE a
  bare lifecycle stub in place instead of skipping it (kills the
  downgrade-on-rerun bug).
- TDD: `tests/test_build_species_trait_bridge.py` (4) + `tests/test_promote_gameplay_to_canon.py` (4).

### Trait audit (Phase 1)
- All 263 per-trait files PASS the ADR-2026-05-29 schema gate (coverage, not
  conformance). Reports: `docs/reports/2026-06-22-trait-gate-audit.md`
  (GAP1 53 resolver-only / GAP2 103 inert) + `2026-06-22-gap1-trait-triage.md`
  (16 drop / 37 author).

## Follow-up (next PRs, NOT here)
Authoring new traits/creatures is CI-coupled to derived-sync (index.json
aggregate + evo-pack mirror) and there is no single `add-trait` tool yet ->
next: build an `add_trait` sync helper, then run GAP1 + the 14 retired-creature
salvage through it; then the affinity/catalog re-baseline. Plan:
`docs/superpowers/plans/2026-06-22-derived-canon-salvage-roadmap.md`.

## Guardrails
- No forbidden paths (no `.github/workflows`, `migrations`, `packages/contracts`,
  `services/generation`). `docs_registry.json` updated atomically.
- >50 new lines outside `apps/backend/` = the requested deliverable.
- ADR-0011 trailers on every commit; no self-merge -- master-dd review requested.

## Verification
`check_derived_reproducible.py` (4 genuine re-baseline targets) · bridge 4/4 ·
promote 4/4 · envelope-b 29/29 · schema gate 263/263 · governance errors=0 ·
python-tests + ci-gate green.

## Rollback (03A)
Additive tools/docs only (no data/runtime touched) -> `git revert` the range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
