### PR TITLE
feat(coop): imprint warning-only deadline timer (warn, never auto-default)

### DIFF
--- a/apps/backend/routes/coop.js
+++ b/apps/backend/routes/coop.js
@@ -34,6 +34,14 @@ const { isDeepStrictEqual } = require('node:util');
 // so tests + ops can toggle without re-instantiating the router.
 const worldConfirmQuorumEnabled = () => process.env.WORLD_CONFIRM_QUORUM_ENABLED === 'true';
 
+// C2-imprint WARNING-ONLY deadline (master-dd 2026-06-23): after this many ms with the beat
+// still open, the orchestrator flags `timeout_warning` so the host TV can prompt force/wait.
+// It NEVER auto-defaults / auto-completes. Read at call time + env-overridable; 0 disables.
+const imprintWarningTimeoutMs = () => {
+  const raw = Number(process.env.IMPRINT_WARNING_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 45000;
+};
+
 function createCoopRouter({
   lobby,
   coopStore,
@@ -372,7 +380,11 @@ function createCoopRouter({
     // players connect, post-onboarding.
     if (connected.length === 0) return res.status(400).json({ error: 'no_connected_players' });
     try {
-      const tally = orch.openImprint({ connectedPlayerIds: connected });
+      const tally = orch.openImprint({
+        connectedPlayerIds: connected,
+        timeoutMs: imprintWarningTimeoutMs(),
+        onTimeout: () => broadcastCoopState(room, orch),
+      });
       broadcastCoopState(room, orch);
       return res.json({ tally });
     } catch (err) {

--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -185,6 +185,11 @@ class CoopOrchestrator {
     this.imprintAssignment = null; // { player_id: [axis,...] } | null (set on open)
     this.imprintOpen = false;
     this.brancoBiomeHint = null; // { leans_toward, weights } | null (stamped on quorum)
+    // C2-imprint deadline (master-dd 2026-06-23): WARNING-ONLY timer. On fire the beat
+    // STAYS open + flags `timeout_warning` so the host TV can prompt force/wait -- it does
+    // NOT silently auto-default (the rejected option). Cleared on every resolve/reset.
+    this.imprintTimeoutWarning = false;
+    this._imprintTimer = null;
     this.log = [];
     this._listeners = new Set();
     // W5-bb (cross-repo Godot v2 mirror) — world enricher service injection.
@@ -1429,10 +1434,20 @@ class CoopOrchestrator {
   // run-scoped (persists across scenario advances within a run, re-imprinted only on a
   // fresh run -- so it is NOT cleared in advanceScenarioOrEnd).
   _resetImprint() {
+    this._clearImprintTimer();
+    this.imprintTimeoutWarning = false;
     this.imprintMarks.clear();
     this.imprintAssignment = null;
     this.imprintOpen = false;
     this.brancoBiomeHint = null;
+  }
+
+  // Cancel the pending imprint deadline timer, if any (mirror _clearLethalConsentTimer).
+  _clearImprintTimer() {
+    if (this._imprintTimer) {
+      this._clearTimeoutFn(this._imprintTimer);
+      this._imprintTimer = null;
+    }
   }
 
   // Round-robin the 4 fixed axes over the connected players so every axis is owned by
@@ -1451,13 +1466,38 @@ class CoopOrchestrator {
 
   // Host opens the beat (route enforces host). Assigns axes to the connected players,
   // clears any prior marks/hint, marks the beat open. Non-gating: does NOT change phase.
-  openImprint({ connectedPlayerIds = [] } = {}) {
+  openImprint({ connectedPlayerIds = [], timeoutMs, onTimeout } = {}) {
+    this._clearImprintTimer();
+    this.imprintTimeoutWarning = false;
     this.imprintMarks.clear();
     this.brancoBiomeHint = null;
     this.imprintAssignment = this.assignImprintAxes(connectedPlayerIds);
     this.imprintOpen = true;
     this._emit('imprint_opened', { assignment: this.imprintAssignment });
+    this._armImprintTimer(timeoutMs, onTimeout);
     return this.imprintTally();
+  }
+
+  // Arm the WARNING-ONLY deadline (mirror openLethalConsent: DI _setTimeoutFn + unref so it
+  // never keeps the process alive). On fire: flag `timeout_warning` (the beat STAYS open) +
+  // invoke onTimeout so the transport re-broadcasts. NO auto-default / auto-complete --
+  // host force/cancel or the device marks remain the only resolutions.
+  _armImprintTimer(timeoutMs, onTimeout) {
+    if (typeof timeoutMs !== 'number' || timeoutMs <= 0) return;
+    const handle = this._setTimeoutFn(() => {
+      if (!this.imprintOpen) return;
+      this.imprintTimeoutWarning = true;
+      this._emit('imprint_timeout_warning', {});
+      if (typeof onTimeout === 'function') {
+        try {
+          onTimeout(this.imprintTally());
+        } catch (_e) {
+          /* never crash the timer callback (unhandled throw in setTimeout = process exit) */
+        }
+      }
+    }, timeoutMs);
+    if (handle && typeof handle.unref === 'function') handle.unref();
+    this._imprintTimer = handle;
   }
 
   // A player marks ITS assigned axis (device-authority: only the owner may mark an axis).
@@ -1502,6 +1542,7 @@ class CoopOrchestrator {
       all_axes_marked: pending.length === 0,
       per_axis: perAxis,
       branco_biome_hint: this.brancoBiomeHint,
+      timeout_warning: this.imprintTimeoutWarning,
     };
   }
 
@@ -1517,6 +1558,8 @@ class CoopOrchestrator {
     const leans = topBiome(weights);
     this.brancoBiomeHint = leans ? { leans_toward: leans, weights } : null;
     this.imprintOpen = false;
+    this._clearImprintTimer();
+    this.imprintTimeoutWarning = false;
     this._emit('imprint_hint', this.brancoBiomeHint);
     return this.brancoBiomeHint;
   }
@@ -1540,6 +1583,8 @@ class CoopOrchestrator {
 
   // Host cancel (anti-deadlock soft escape). Abandons the beat without a hint.
   cancelImprint() {
+    this._clearImprintTimer();
+    this.imprintTimeoutWarning = false;
     this.imprintOpen = false;
     this.imprintMarks.clear();
     this.imprintAssignment = null;

--- a/tests/api/coopImprintBeat.test.js
+++ b/tests/api/coopImprintBeat.test.js
@@ -161,3 +161,84 @@ test('hint is NEVER a biome assignment: weights only, no biome_id field', () => 
   const sum = Object.values(hint.weights).reduce((a, b) => a + b, 0);
   assert.ok(Math.abs(sum - 1) < 1e-9);
 });
+
+// --- warning-only deadline timer (master-dd 2026-06-23: warn, never auto-default) ---
+
+// Orchestrator with an injected fake scheduler: captures the armed callback so the test can
+// fire the deadline deterministically (mirror the lethal-consent timer tests).
+function mkTimed(hostId = 'p_h') {
+  let captured = null;
+  const co = new CoopOrchestrator({
+    roomCode: 'IMPR',
+    hostId,
+    now: () => 1000,
+    setTimeoutFn: (cb) => {
+      captured = cb;
+      return { unref() {} };
+    },
+    clearTimeoutFn: () => {},
+  });
+  return { co, fire: () => (captured ? captured() : undefined), armed: () => captured !== null };
+}
+
+test('imprint warning timer: fires -> flag + onTimeout, beat STAYS open, no auto-default', () => {
+  const { co, fire } = mkTimed();
+  let broadcasts = 0;
+  co.openImprint({
+    connectedPlayerIds: ['a', 'b', 'c', 'd'],
+    timeoutMs: 45000,
+    onTimeout: () => (broadcasts += 1),
+  });
+  assert.equal(co.imprintTally().timeout_warning, false, 'no warning before the deadline');
+  fire();
+  const t = co.imprintTally();
+  assert.equal(t.timeout_warning, true, 'flag set on fire');
+  assert.equal(t.open, true, 'beat stays OPEN (warning-only)');
+  assert.equal(t.axes_marked, 0, 'NO auto-default');
+  assert.equal(broadcasts, 1, 'onTimeout invoked so the transport re-broadcasts');
+});
+
+test('imprint warning cleared on complete / force / cancel', () => {
+  let h = mkTimed();
+  const asg = h.co.openImprint({
+    connectedPlayerIds: ['a', 'b', 'c', 'd'],
+    timeoutMs: 45000,
+    onTimeout() {},
+  }).assignment;
+  h.fire();
+  assert.equal(h.co.imprintTally().timeout_warning, true);
+  markSavana(h.co, asg);
+  assert.equal(h.co.imprintTally().timeout_warning, false, 'cleared when the quorum completes');
+
+  h = mkTimed();
+  h.co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'], timeoutMs: 45000, onTimeout() {} });
+  h.fire();
+  h.co.forceCompleteImprint();
+  assert.equal(h.co.imprintTally().timeout_warning, false, 'cleared on host force');
+
+  h = mkTimed();
+  h.co.openImprint({ connectedPlayerIds: ['a', 'b'], timeoutMs: 45000, onTimeout() {} });
+  h.fire();
+  h.co.cancelImprint();
+  assert.equal(h.co.imprintTally().timeout_warning, false, 'cleared on host cancel');
+});
+
+test('imprint timer: not armed at timeoutMs<=0; fire after close is a guarded no-op', () => {
+  const noTimer = mkTimed();
+  noTimer.co.openImprint({ connectedPlayerIds: ['a', 'b', 'c', 'd'], timeoutMs: 0 });
+  assert.equal(noTimer.armed(), false, 'no timer armed at timeoutMs=0');
+
+  const h = mkTimed();
+  const asg = h.co.openImprint({
+    connectedPlayerIds: ['a', 'b', 'c', 'd'],
+    timeoutMs: 45000,
+    onTimeout() {},
+  }).assignment;
+  markSavana(h.co, asg); // closes the beat (+ clears the timer)
+  h.fire(); // late fire
+  assert.equal(
+    h.co.imprintTally().timeout_warning,
+    false,
+    'late fire does not re-flag a closed beat',
+  );
+});


### PR DESCRIPTION
## Imprint warning-only deadline timer

master-dd ratified (2026-06-23) a **warning-only** anti-deadlock for the L'Impronta beat --
the silent auto-defaulting option was explicitly rejected.

**Behaviour:** after `IMPRINT_WARNING_TIMEOUT_MS` (env, default 45000) with the beat still
open, the orchestrator sets `timeout_warning: true` on the imprint tally and invokes
`onTimeout` so the transport re-broadcasts. The host TV can then prompt force/wait. **The
beat STAYS open** -- no auto-default, no auto-complete. Host force/cancel or the device
marks remain the only resolutions.

**Changes**
- `coopOrchestrator`: `_armImprintTimer` (DI `_setTimeoutFn` + `unref`, mirrors
  `openLethalConsent`) + `imprintTimeoutWarning` state + `timeout_warning` in `imprintTally`.
  Cleared on complete / force / cancel / reset.
- `routes/coop`: `openImprint` passes `timeoutMs` (`imprintWarningTimeoutMs()`,
  env-overridable, 0 disables) + `onTimeout = broadcastCoopState`.

**Band-neutral:** the tally field is additive (false-default); with `IMPRINT_BEAT_ENABLED`
OFF the beat never opens so the timer never arms.

**Tests:** 14/14 `coopImprintBeat` incl. 3 new timer tests (fire -> flag + onTimeout, beat
stays open, no auto-default; cleared on complete/force/cancel; not armed at timeoutMs<=0 +
late-fire guard). Prettier clean.

The Godot TV warning render (host sees a "forza o aspetta" prompt when `timeout_warning`) is
a separate Game-Godot-v2 PR.

Coding-Agent: claude-opus-4-8
Trace-Id: b81efc56
