### PR TITLE
fix(traits): resolve dangling static_vines in aerial_canopy biome pool

### DIFF
--- a/data/core/traits/biome_pools.json
+++ b/data/core/traits/biome_pools.json
@@ -274,7 +274,7 @@
       "traits": {
         "core": [
           "cuscinetti_elettrostatici",
-          "static_vines",
+          "chioma_parassita_canopica",
           "foliage_fotocatodico",
           "antenne_waveguide"
         ],
@@ -300,7 +300,7 @@
           ],
           "preferred_traits": [
             "cuscinetti_elettrostatici",
-            "static_vines"
+            "chioma_parassita_canopica"
           ],
           "tier": 4
         },
@@ -313,7 +313,7 @@
             "energia"
           ],
           "preferred_traits": [
-            "static_vines",
+            "chioma_parassita_canopica",
             "linfa_tampone"
           ],
           "tier": 3


### PR DESCRIPTION
## Problem

`data/core/traits/biome_pools.json` references trait id `static_vines` in the `aerial_canopy` pool — 3 occurrences:

- `traits.core`
- `role_templates[apex].preferred_traits`
- `role_templates[keystone].preferred_traits`

`static_vines` exists in **no** trait catalog: it is absent from both `data/core/traits/active_effects.yaml` and `data/core/traits/glossary.json`. A biome-pools integrity scan (every pool trait id must resolve against `glossary.traits` ∪ `active_effects.traits`) flags it as the **only** dangling reference repo-wide (3 refs, 615 valid trait ids).

This is **pre-existing on `origin/main`**, unrelated to the ancestor-trait rename (#3001). `git log -S static_vines` confirms `static_vines` was never a real trait key — it leaked from the **biome affix** namespace (`biomes.yaml` → `canopia_ionica.affixes: [static_vines, ion_lattice]`, where affixes legitimately have no glossary entry, same as the sibling `ion_lattice`) into the pool's *trait* list.

## Fix

Replace the 3 references with the real canopy/tendril glossary trait **`chioma_parassita_canopica`** ("Chioma Parassita Canopica" / _"Parasitic tendrils weaving energy lanes through canopy"_).

Rationale for option (b) replace over (a) add-new:

- `static_vines` was never a real trait — adding it would fabricate a catalog entry. `chioma_parassita_canopica` is an existing, canopy-themed glossary trait that fits the pool's `Custode delle Liane` (Keeper of Lianas) keystone and the `viti conduttive` (conductive vines) ecology note.
- All sibling pool traits (`cuscinetti_elettrostatici`, `foliage_fotocatodico`, `antenne_waveguide`, `linfa_tampone`) are real Italian glossary ids; this keeps the pool internally consistent.

`biomes.yaml` is intentionally **not** touched — its `static_vines` is an affix, a separate namespace from traits (confirmed: the sibling affix `ion_lattice` likewise has no glossary entry and is not flagged anywhere).

## Verification

- biome_pools integrity: **0 dangling** (was 3) — 615 valid trait ids.
- `python tools/lint/trait_schema_gate.py --check data/core/traits/biome_pools.json --check .../glossary.json --check .../active_effects.yaml` → exit 0.
- JSON parses valid. Diff = 3 lines (string value only; indentation/structure preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
