### PR TITLE
feat(calib): PE contestedness orthogonality N=100 -- E_dmg_margin selected (PROPOSED)

### DIFF
--- a/docs/planning/2026-06-23-residual-gate-register.md
+++ b/docs/planning/2026-06-23-residual-gate-register.md
@@ -52,7 +52,7 @@ l'harness ma **content + esperimento + ratifica**.
 
 | Residuo | Workstream | Gate preciso | Stato |
 | --- | --- | --- | --- |
-| **PE_ratio -> contestedness** (sblocca SPEC-J + SPEC-H) | G2 calib | ✅ **step-1 candidati D/E/F MERGED #3000 `f7253761`** (`pe_candidates.py`, aggregate-form, leggono turns_avg/dmg_taken_avg/dmg_dealt_avg esistenti). Restano: run N=100 (maintainer, backend :3400 NON prod) -> orthogonality 3.2-3.4 -> ratifica banda SDMG (single-owner). PE-from-pressure REJECTED (sec 4.5). Handoff `docs/planning/2026-06-20-pe-ratio-contestedness-switch-handoff.md` |
+| **PE_ratio -> contestedness** (sblocca SPEC-J + SPEC-H) | G2 calib | ✅ candidati #3000 + ✅ **N=100 orthogonality RUN #3008** (`E_dmg_margin` selezionato, 0.499<0.6) MA 🔴 **banda FALSIFICATA da harsh-review** (single-policy diagnostic corpora + banda 3-punti outlier-artifact). **FIX = re-run su corpora MULTI-POLICY canonici** = harness-work (`calibrate_parallel` greedy-only; full-loop = granularita' campagna) -> **chip calib-session** `task_<see-chip>`. Selezione E regge; banda no. Ratifica SDMG dopo il re-run canonico. Evidence `docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md` |
 | **SPEC-J `LETHAL_MISSIONS_ENABLED` flip** | SPEC-J | (1) autora >=1 encounter `lethal:true` (content, master-dd: biome/roster/banda-attrition) + (2) lethal-mission N=40 in banda via G2 | OPEN. Backend+Godot consent UI DONE; #2865 DEFER |
 | **SPEC-H HA1 flip** `aliena_enforcement.enabled:true` + `strength` | SPEC-H | N=40 su `enc_badlands_pilot_01` (WR in banda + no regressione) | OPEN. Machinery+surface COMPLETE; e' l'unico residuo sostanziale |
 | **SPEC-I ER7 flag-ON** (population tick per ruolo trofico) | SPEC-I | N=40 flag-ON | OPEN. ER7 build flag-OFF gia' shipped #2723 |

--- a/docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md
+++ b/docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md
@@ -79,3 +79,33 @@ mean = 0.403, sd = 0.099, k = 2.0 ->
 Write `E_dmg_margin` + the band into `canonical-suite.yaml`; set `SELECTED_CANDIDATE` in
 `pe_candidates.py`; update CANONICAL + the composite spec; flip P4 gate-2/4b + P5 to consume
 the real composite band. That unblocks the SPEC-J + SPEC-H flips (the band is the gate).
+
+## Harsh-review 2026-06-23 (SDMG falsification -- master-dd chose "harsh-review first")
+
+> The external `balance-illuminator` subagent died on a transient infra 500 mid-run; the
+> review below is the INLINE compensating pass (data-backed). An external re-run is advised
+> when infra recovers.
+
+**VERDICT: do NOT ratify the band as-is -> FIX (re-run on canonical MULTI-POLICY corpora).**
+The SELECTION (E least-collinear) is directionally defensible; the BAND is not.
+
+Confirmed flaws (data-backed):
+
+1. **Single-policy diagnostic corpora (HIGH).** All 3 corpora are `policy_mode=greedy-only` /
+   `oracle_status="diagnostic -- single-policy (greedy); NOT a multi-policy canonical"`. The
+   composite gates MULTI-POLICY canonical balance (N=40) -> the band is from the wrong policy
+   regime; greedy-only damage dynamics need not match the canonical policy mix.
+2. **Band = 3-point outlier artifact (HIGH).** All 3 -> [0.205, 0.600] (sd 0.099). Dropping the
+   badlands_elite point (0.541) -> [0.299, 0.368] (sd 0.017): the band COLLAPSES (width 0.395 ->
+   0.069) and shifts. n=3 mean+/-2sd is dominated by one oracle -> not ratifiable.
+3. **0.499 moderate + E ~ outcome-proxy (MEDIUM-HIGH).** E = `dmg_taken/(taken+dealt)` is ~1.0 on
+   a wipe and ~0 on a clean win -> it partly RELABELS the outcome (hence |corr| = 0.499). It clears
+   the 0.6 reject line but adds limited WR-orthogonal signal.
+4. **No head-to-head vs pressure (LOW-MED).** These corpora lack the pressure-trajectory keys, so
+   pressure-vs-contestedness is not compared on the same data (pressure stays rejected from PR2).
+
+**FIX path (verify-first):** "re-run on canonical corpora" is NOT a quick re-analysis -- NO
+multi-policy per-combat corpora exist committed; `calibrate_parallel` is greedy-only (no policy
+flag; its default `--base-port 3341` is a PROD WS port, must override); the canonical multi-policy
+harness is `full-loop-batch` (campaign granularity, not per-combat). Generating canonical
+multi-policy per-combat corpora needs HARNESS WORK -> a dedicated calib-session, NOT crammed here.

--- a/docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md
+++ b/docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md
@@ -1,0 +1,81 @@
+---
+title: 'PE_ratio contestedness orthogonality (N=100) -- selection + proposed band (master-dd ratify)'
+date: 2026-06-23
+type: playtest-evidence
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-23'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+tags: [evo-tactics, calibration, pe-ratio, contestedness, orthogonality, n100, composite]
+related: docs/planning/2026-06-20-pe-ratio-contestedness-switch-handoff.md
+---
+
+# PE_ratio contestedness orthogonality (N=100)
+
+> The handoff's keystone experiment (step 3-5), executed as a **deterministic
+> re-analysis** of the committed N=100 oracle corpora -- NO backend run, NO prod
+> (the corpora are seed-pinned 424242, node 22, from the 2026-06-18 PR2 run; the
+> analysis is pure Python). Runner: `tools/py/run_pe_contestedness_experiment.py`.
+> **PROPOSED only -- master-dd ratifies the selection AND the band (SDMG, human-only).**
+
+## Method
+
+`pe_experiment.run_to_stats` now surfaces per-run `rounds`/`dmg_taken_player`/
+`dmg_dealt_player`; `pe_candidates` adds per-run contestedness forms D/E/F (mirror
+of the aggregate forms shipped #3000). Orthogonality = `|Pearson(candidate, won)|`
+per run -- LOWER = less collinear with win-rate = better anti-false-balance.
+Threshold `DEFAULT_MAX_CORR = 0.6` (>= 0.6 -> reject the source). 3 ratified balance
+oracles (hardcore_06, badlands_elite_01, foresta_pilot_01); badlands_ambient
+excluded (designed-winnable, not an oracle).
+
+## Result (|corr(candidate, won)|, lower = better)
+
+| candidate | hc06 | badlands_elite | foresta_pilot | **POOLED (n=240)** |
+| --- | --- | --- | --- | --- |
+| **E_dmg_margin** | 0.403 | 0.478 | 0.464 | **0.499** |
+| D_turns_contest | 0.725 | 0.542 | 0.705 | 0.562 |
+| F_contest_combined | 0.469 | 0.651 | 0.677 | 0.660 |
+| A/B/C (pressure) | -- | -- | -- | 0.000* |
+
+\* pressure candidates are DEGENERATE on these corpora (they saved `pressure_final`,
+not the `frac_ge75`/`mean`/`pmax` trajectory keys `run_to_stats` reads -> constant 0).
+Not a regression: PE-from-pressure was already REJECTED in PR2 (saturated ~0.81-0.94).
+
+## Selection
+
+**E_dmg_margin** = least-collinear contestedness candidate, pooled **|corr| = 0.499 < 0.6**
+(NOT rejected), consistent across all 3 oracles (0.40-0.48). It beats F (0.66, which WOULD
+be rejected) and D (0.56). E is self-normalizing (`dmg_taken / (dmg_taken + dmg_dealt)`),
+needs no arbitrary constant, and -- unlike pressure -- does NOT saturate: it discriminates
+(hc06 0.32 / badlands_elite 0.54 / foresta_pilot 0.35 aggregate values span real range).
+
+**Contestedness works where pressure failed**: pressure was rejected for ~zero
+discrimination (saturated); E has real spread AND clears the formal collinearity threshold.
+
+## Proposed composite band (E_dmg_margin)
+
+Per-oracle aggregate value (what the composite consumes, `dmg_taken_avg / (dmg_taken_avg +
+dmg_dealt_avg)`): hc06 **0.316** / badlands_elite **0.541** / foresta_pilot **0.351**.
+mean = 0.403, sd = 0.099, k = 2.0 ->
+
+> **PROPOSED band: [0.205, 0.600]**
+
+## Caveats (for the ratification call)
+
+- **Moderate collinearity**: E's |corr| = 0.499 is below 0.6 but NOT low -- E partly tracks
+  outcome (a wipe = the party absorbed a high damage fraction). It is a tension signal, not
+  a WR-independent one. master-dd decides whether 0.499 is acceptable as the PE source, OR
+  escalates to **(c) drop the PE term** (composite = re-weighted win_rate + kd_ratio) per the
+  handoff's negative-result branch. This is a judgment call, not a hard pass/fail.
+- **Pressure not re-measured here** (corpora lack the trajectory keys); the pressure rejection
+  stands from PR2.
+- **3-oracle band** -- a low-pressure / easier oracle would widen the evidence; none was added.
+
+## If ratified
+
+Write `E_dmg_margin` + the band into `canonical-suite.yaml`; set `SELECTED_CANDIDATE` in
+`pe_candidates.py`; update CANONICAL + the composite spec; flip P4 gate-2/4b + P5 to consume
+the real composite band. That unblocks the SPEC-J + SPEC-H flips (the band is the gate).

--- a/tools/py/pe_candidates.py
+++ b/tools/py/pe_candidates.py
@@ -19,10 +19,34 @@ def candidate_C(stats):  # apex-reach (touched >= 95)
     return 1.0 if float(stats.get("pmax", 0.0)) >= APEX else 0.0
 
 
+# Per-run contestedness forms (sec 4.5): mirror the aggregate D/E/F but read a
+# SINGLE run record (rounds / dmg_taken_player / dmg_dealt_player), so the
+# orthogonality experiment (pe_experiment) can correlate them per-run vs `won`.
+# (The _AGGREGATE_FORM D/E/F below feed the composite; these feed the SELECTION.)
+# TURN_TENSION_NORM is defined below -- resolved at call time, not import time.
+def candidate_D(stats):  # turns-to-resolve tension
+    return float(stats.get("rounds", 0.0)) / TURN_TENSION_NORM
+
+
+def candidate_E(stats):  # damage-taken margin (self-normalizing)
+    taken = float(stats.get("dmg_taken_player", 0.0))
+    dealt = float(stats.get("dmg_dealt_player", 0.0))
+    total = taken + dealt
+    return taken / total if total > 0 else 0.0
+
+
+def candidate_F(stats):  # combined (geometric mean of D,E)
+    d = max(0.0, min(1.0, candidate_D(stats)))
+    return (d * candidate_E(stats)) ** 0.5
+
+
 CANDIDATES = {
     "A_sustained_threat": candidate_A,
     "B_time_avg": candidate_B,
     "C_apex_reach": candidate_C,
+    "D_turns_contest": candidate_D,
+    "E_dmg_margin": candidate_E,
+    "F_contest_combined": candidate_F,
 }
 
 

--- a/tools/py/pe_experiment.py
+++ b/tools/py/pe_experiment.py
@@ -20,6 +20,10 @@ def run_to_stats(run):
         "frac_ge75": run.get("pressure_frac_ge75", 0.0),
         "pressure_mean": run.get("pressure_mean", 0.0),
         "pmax": run.get("pressure_pmax", 0.0),
+        # contestedness (sec 4.5) -- per-run turns + party damage (already on every record).
+        "rounds": run.get("rounds", 0.0),
+        "dmg_taken_player": run.get("dmg_taken_player", 0.0),
+        "dmg_dealt_player": run.get("dmg_dealt_player", 0.0),
     }
     return stats, run.get("outcome") == "victory"
 

--- a/tools/py/run_pe_contestedness_experiment.py
+++ b/tools/py/run_pe_contestedness_experiment.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Re-analyze the committed N=100 oracle corpora with the contestedness candidates
+(D/E/F) -> per-oracle + pooled orthogonality |corr(candidate, won)| (the SELECTION)
++ the proposed composite band for the least-collinear contestedness candidate.
+
+Deterministic: pure analysis of the saved seed-pinned (424242) node-22 corpora from
+the 2026-06-18 PR2 run -- NO backend, NO prod, no randomness. The owner ratifies the
+selection + the band (SDMG); this script only proposes with numbers.
+
+  python tools/py/run_pe_contestedness_experiment.py
+"""
+import json
+import statistics
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from pe_experiment import run_to_stats  # noqa: E402
+from pe_candidates import CANDIDATES, candidate_value, pe_ratio_aggregate  # noqa: E402
+from pe_orthogonality import pearson, DEFAULT_MAX_CORR  # noqa: E402
+
+ROOT = Path(__file__).parent.parent.parent
+# The 3 ratified balance oracles (NOT badlands_ambient = designed-winnable, not an oracle).
+CORPORA = {
+    "hardcore_06": "docs/playtest/parallel-hardcore_06-iter5-optuna-ratify-merged.json",
+    "badlands_elite_01": "docs/playtest/2026-06-18-badlands_elite_01-n100-merged.json",
+    "foresta_pilot_01": "docs/playtest/2026-06-18-foresta_pilot_01-n100-merged.json",
+}
+CONTEST = ["D_turns_contest", "E_dmg_margin", "F_contest_combined"]
+
+
+def load_runs(path):
+    d = json.loads((ROOT / path).read_text(encoding="utf-8"))
+    return d if isinstance(d, list) else d.get("runs", [])
+
+
+def abs_corr_table(runs):
+    wons, vals = [], {n: [] for n in CANDIDATES}
+    for r in runs:
+        stats, won = run_to_stats(r)
+        wons.append(1.0 if won else 0.0)
+        for n in CANDIDATES:
+            vals[n].append(candidate_value(n, stats))
+    return {n: abs(pearson(vals[n], wons)) for n in CANDIDATES}, wons
+
+
+def oracle_aggregate(runs):
+    """Build the composite-form aggregate keys from a corpus (mean per-run rollups)."""
+    return {
+        "turns_avg": statistics.mean(r.get("rounds", 0.0) for r in runs),
+        "dmg_taken_avg": statistics.mean(r.get("dmg_taken_player", 0.0) for r in runs),
+        "dmg_dealt_avg": statistics.mean(r.get("dmg_dealt_player", 0.0) for r in runs),
+    }
+
+
+def main():
+    print("PE_ratio contestedness orthogonality -- |corr(candidate, won)| (LOWER = less collinear = better)\n")
+    pooled = []
+    for name, path in CORPORA.items():
+        runs = load_runs(path)
+        pooled += runs
+        tbl, wons = abs_corr_table(runs)
+        print(f"== {name}  (n={len(runs)}, WR={sum(wons) / len(wons):.2f}) ==")
+        for n in sorted(tbl, key=tbl.get):
+            print(f"   {n:20s} |corr|={tbl[n]:.3f}")
+        print()
+
+    print(f"== POOLED (all 3 oracles, n={len(pooled)}) ==")
+    ptbl, _ = abs_corr_table(pooled)
+    for n in sorted(ptbl, key=ptbl.get):
+        print(f"   {n:20s} |corr|={ptbl[n]:.3f}")
+
+    sel = min(CONTEST, key=lambda n: ptbl[n])
+    rejected = ptbl[sel] >= DEFAULT_MAX_CORR
+    print(f"\nLeast-collinear contestedness candidate (pooled) = {sel}  |corr|={ptbl[sel]:.3f}")
+    print(f"max_corr threshold = {DEFAULT_MAX_CORR} -> {'REJECTED (escalate: drop PE term)' if rejected else 'NOT rejected'}")
+
+    # Composite band on the SELECTED candidate: per-oracle aggregate value (what the
+    # composite consumes) -> mean +/- k*sd over the 3 oracle configs.
+    k = 2.0
+    agg_vals = []
+    for name, path in CORPORA.items():
+        agg = oracle_aggregate(load_runs(path))
+        v = pe_ratio_aggregate(agg, sel)
+        agg_vals.append(v)
+        print(f"   aggregate {sel} @ {name} = {v:.3f}")
+    mu = statistics.mean(agg_vals)
+    sd = statistics.pstdev(agg_vals) if len(agg_vals) > 1 else 0.0
+    lo, hi = max(0.0, mu - k * sd), min(1.0, mu + k * sd)
+    print(f"\nPROPOSED band on {sel} (mean +/- {k}*sd): mu={mu:.3f} sd={sd:.3f} -> [{lo:.3f}, {hi:.3f}]")
+    print("\nNB: PROPOSED only. master-dd ratifies the selection AND the band (SDMG, human-only).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/py/test_pe_candidates.py
+++ b/tools/py/test_pe_candidates.py
@@ -79,6 +79,20 @@ def test_unknown_candidate_raises_not_fakes_zero():
     assert raised
 
 
+def test_per_run_contestedness_forms_read_a_single_record():
+    # per-run forms (CANDIDATES) read a single run's rounds/dmg -> feed the orthogonality
+    # selection (pe_experiment correlates these per-run vs `won`).
+    assert candidate_value("D_turns_contest", {"rounds": 20.0}) == 0.5
+    assert candidate_value("D_turns_contest", {"rounds": 80.0}) == 1.0  # clamped
+    e = candidate_value("E_dmg_margin", {"dmg_taken_player": 5.0, "dmg_dealt_player": 45.0})
+    assert abs(e - 0.1) < 1e-9
+    assert candidate_value("E_dmg_margin", {"dmg_taken_player": 0.0, "dmg_dealt_player": 0.0}) == 0.0
+    f = candidate_value(
+        "F_contest_combined", {"rounds": 40.0, "dmg_taken_player": 50.0, "dmg_dealt_player": 50.0}
+    )
+    assert abs(f - (0.5 ** 0.5)) < 1e-9
+
+
 def test_attach_composite_terms_consumes_a_contestedness_candidate():
     out = attach_composite_terms(
         {"kd_avg": 1.0, "turns_avg": 20.0, "dmg_taken_avg": 30.0, "dmg_dealt_avg": 30.0},


### PR DESCRIPTION
## Cosa

Keystone experiment (handoff step 3-5) girato come **re-analisi deterministica** dei corpora N=100 committati (seed-pinned 424242, node 22, 2026-06-18) -- **NO backend, NO prod**. Aggiunge i per-run forms D/E/F (i candidati #3000 erano aggregate-only) + `run_to_stats` turns/damage + runner riproducibile + evidence doc.

## Risultato (|corr(candidate, won)|, lower = meno collineare = meglio; soglia 0.6)

| candidato | hc06 | badlands_elite | foresta_pilot | **POOLED** |
| --- | --- | --- | --- | --- |
| **E_dmg_margin** | 0.403 | 0.478 | 0.464 | **0.499** ✅ |
| D_turns_contest | 0.725 | 0.542 | 0.705 | 0.562 |
| F_contest_combined | 0.469 | 0.651 | 0.677 | 0.660 ❌ |

**E_dmg_margin SELEZIONATO** (0.499 < 0.6, consistente, self-normalizing). Contestedness funziona dove pressure saturava (~0.81-0.94 = zero discriminazione, rejected PR2).

**Banda PROPOSED su E**: aggregate per-oracle 0.316/0.541/0.351 -> mean 0.403 sd 0.099 k=2.0 -> **[0.205, 0.600]**.

## 🔴 Owner decision (SDMG, NON in questa PR)

PROPOSED only. master-dd ratifica selezione + banda. **Caveat**: 0.499 e' sotto 0.6 ma moderato (E traccia in parte l'esito) -> accetti E+banda, O escali a **(c) drop-PE** (composite = win_rate + kd_ratio ri-pesati). Se ratificato: scrivi banda in `canonical-suite.yaml` + flip P4/P5 -> sblocca flip SPEC-J + SPEC-H.

## Verifica
`test_pe_candidates.py` 13/13 + full collection 1245 (no mismatch) + governance errors=0. Evidence: `docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md`. Deterministico (2 run = output identico).