### PR TITLE
feat(combat): pigmenti_aurorali ACTIVE -- intensify (-2 glow + disorient on attackers)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -126,7 +126,7 @@ const {
 const { absorbStatusDuration } = require('../services/combat/membraneOsmotiche');
 // Creature-trait slice 7: consume the single-use abbagliato dazzle on the attack it
 // weakened (pigmenti_aurorali; the end-of-round glow producer is in sessionRoundBridge).
-const { consumeAbbagliato } = require('../services/combat/pigmentiAurorali');
+const { consumeAbbagliato, disorientAttacker } = require('../services/combat/pigmentiAurorali');
 
 // Audit 2026-04-25 sera (balance-auditor): cap totale duration per status
 // type previene "sustained rage" durante kill chain (13 trait on_kill rage
@@ -1588,6 +1588,27 @@ function createSessionRouter(options = {}) {
           effect: { kind: 'channel_adaptation', channel: tessuti.channel, healed: tessuti.healed },
         });
       }
+    }
+
+    // pigmenti_aurorali (active mode): if the attacked carrier (target) is intensified,
+    // the dazzling burst disorients the attacker (actor). Fires on hit OR miss. Persist
+    // the disorient through the round-model drain so it bites the attacker's next attack.
+    // Band-neutral: no sim unit carries pigmenti_aurorali (and none is intensified).
+    const pigmentiDisorient = disorientAttacker({ carrier: target, attacker: actor });
+    if (pigmentiDisorient) {
+      if (!Array.isArray(session._pendingStatusApplies)) {
+        session._pendingStatusApplies = [];
+      }
+      session._pendingStatusApplies.push({
+        unit_id: actor.id,
+        status: pigmentiDisorient.stato,
+        duration: pigmentiDisorient.turns,
+      });
+      evaluation.trait_effects = (evaluation.trait_effects || []).concat({
+        trait: 'pigmenti_aurorali',
+        triggered: true,
+        effect: { kind: 'glow_disorient', target_id: actor.id },
+      });
     }
 
     // Sprint 6 (2026-04-27) — Beast Bond reaction trigger (AncientBeast Tier

--- a/apps/backend/services/combat/pigmentiAurorali.js
+++ b/apps/backend/services/combat/pigmentiAurorali.js
@@ -37,6 +37,16 @@ const ABBAGLIATO = 'abbagliato';
 const ABBAGLIATO_TTL = 99;
 const HP_GATE = 0.5; // glow only while HP >= 50% of max
 
+// ACTIVE mode (1 AP): the carrier sets `pigmenti_intensificato` on itself (via the
+// existing apply_status ability path). While intensified: (a) the end-of-round glow
+// dazzles for -2 instead of -1 (abbagliato carries intensity 2, read in statusModifiers);
+// (b) anyone who attacks the carrier is disoriented (disorient -> -2 atk, an existing
+// status consumed in performAttack). The self-status decays normally (not persistent).
+const PIGMENTI_INTENSIFICATO = 'pigmenti_intensificato';
+const INTENSIFIED_ATK = 2; // abbagliato intensity while the glow is intensified
+const DISORIENT = 'disorient';
+const DISORIENT_TURNS = 2; // survives to the attacker's next attack, then decays
+
 function hasTrait(unit, traitId) {
   const raw = unit && Array.isArray(unit.traits) ? unit.traits : [];
   for (const t of raw) {
@@ -70,6 +80,9 @@ function applyEndRoundGlow({ carrier, units }) {
   const hp = Number(carrier.hp);
   if (!(max > 0) || !(hp >= HP_GATE * max)) return events;
 
+  // Intensified glow (active) -> the dazzle is -2 (abbagliato intensity 2).
+  const intensity =
+    Number(carrier.status && carrier.status[PIGMENTI_INTENSIFICATO]) > 0 ? INTENSIFIED_ATK : 1;
   const faction = carrier.controlled_by;
   for (const enemy of units) {
     if (!enemy || enemy === carrier || enemy.id === carrier.id) continue;
@@ -79,9 +92,37 @@ function applyEndRoundGlow({ carrier, units }) {
     if (!enemy.status || typeof enemy.status !== 'object') enemy.status = {};
     const current = Number(enemy.status[ABBAGLIATO] || 0);
     if (current < ABBAGLIATO_TTL) enemy.status[ABBAGLIATO] = ABBAGLIATO_TTL;
-    events.push({ unit_id: enemy.id ?? null, stato: ABBAGLIATO, turns: ABBAGLIATO_TTL });
+    if (intensity > 1) {
+      if (!enemy.status_intensity || typeof enemy.status_intensity !== 'object') {
+        enemy.status_intensity = {};
+      }
+      enemy.status_intensity[ABBAGLIATO] = intensity;
+    }
+    events.push({ unit_id: enemy.id ?? null, stato: ABBAGLIATO, turns: ABBAGLIATO_TTL, intensity });
   }
   return events;
+}
+
+/**
+ * On-attacked reaction (active mode): while the carrier is `pigmenti_intensificato`, the
+ * dazzling burst disorients whoever attacks it. Sets `disorient` on the attacker (an
+ * existing status -> -2 atk on its next attack, consumed in performAttack). Pure;
+ * mutates the attacker's status. Returns the event (or null on no-op).
+ *
+ * @param {object} opts
+ * @param {object} opts.carrier  the attacked pigmenti carrier
+ * @param {object} opts.attacker the unit that attacked it (mutated)
+ * @returns {{unit_id, stato, turns} | null}
+ */
+function disorientAttacker({ carrier, attacker }) {
+  if (!hasTrait(carrier, PIGMENTI_TRAIT)) return null;
+  if (!(Number(carrier.status && carrier.status[PIGMENTI_INTENSIFICATO]) > 0)) return null;
+  if (!attacker || typeof attacker !== 'object') return null;
+  if (attacker.id === carrier.id || !(Number(attacker.hp) > 0)) return null;
+  if (!attacker.status || typeof attacker.status !== 'object') attacker.status = {};
+  const current = Number(attacker.status[DISORIENT] || 0);
+  if (current < DISORIENT_TURNS) attacker.status[DISORIENT] = DISORIENT_TURNS;
+  return { unit_id: attacker.id ?? null, stato: DISORIENT, turns: DISORIENT_TURNS };
 }
 
 /**
@@ -104,10 +145,15 @@ function consumeAbbagliato(unit) {
 module.exports = {
   applyEndRoundGlow,
   consumeAbbagliato,
+  disorientAttacker,
   hasTrait,
   manhattanDistance,
   PIGMENTI_TRAIT,
+  PIGMENTI_INTENSIFICATO,
   ABBAGLIATO,
   ABBAGLIATO_TTL,
+  INTENSIFIED_ATK,
+  DISORIENT,
+  DISORIENT_TURNS,
   HP_GATE,
 };

--- a/apps/backend/services/combat/pigmentiAurorali.js
+++ b/apps/backend/services/combat/pigmentiAurorali.js
@@ -92,12 +92,12 @@ function applyEndRoundGlow({ carrier, units }) {
     if (!enemy.status || typeof enemy.status !== 'object') enemy.status = {};
     const current = Number(enemy.status[ABBAGLIATO] || 0);
     if (current < ABBAGLIATO_TTL) enemy.status[ABBAGLIATO] = ABBAGLIATO_TTL;
-    if (intensity > 1) {
-      if (!enemy.status_intensity || typeof enemy.status_intensity !== 'object') {
-        enemy.status_intensity = {};
-      }
-      enemy.status_intensity[ABBAGLIATO] = intensity;
+    // Always reflect THIS glow's intensity (1 or 2) so a later non-intensified refresh
+    // downgrades a prior intensity-2 dazzle (no stale -2 lingering).
+    if (!enemy.status_intensity || typeof enemy.status_intensity !== 'object') {
+      enemy.status_intensity = {};
     }
+    enemy.status_intensity[ABBAGLIATO] = intensity;
     events.push({ unit_id: enemy.id ?? null, stato: ABBAGLIATO, turns: ABBAGLIATO_TTL, intensity });
   }
   return events;

--- a/apps/backend/services/combat/statusModifiers.js
+++ b/apps/backend/services/combat/statusModifiers.js
@@ -233,11 +233,16 @@ function computeStatusModifiers(actor, target, units = []) {
     });
   }
   if (isPositive(actorStatus.abbagliato)) {
-    // pigmenti_aurorali glow (creature-trait slice 7): a dazzled unit strikes worse
-    // on its next attack -> -1 attack_mod. Set on adjacent enemies at end-of-round by
-    // combat/pigmentiAurorali while the carrier is HP>=50%; decays 1/round.
-    attackDelta -= 1;
-    log.push({ status: 'abbagliato', side: 'actor', effect: '-1 attack_mod (abbagliato)' });
+    // pigmenti_aurorali glow (creature-trait slice 7 + active): a dazzled unit strikes
+    // worse on its next attack -> -1 attack_mod, or -2 when the glow was intensified
+    // (the active mode sets abbagliato intensity 2). Set on adjacent enemies at
+    // end-of-round by combat/pigmentiAurorali while the carrier is HP>=50%.
+    const intensity = Number(
+      (actor && actor.status_intensity && actor.status_intensity.abbagliato) || 1,
+    );
+    const dazzle = intensity > 1 ? intensity : 1;
+    attackDelta -= dazzle;
+    log.push({ status: 'abbagliato', side: 'actor', effect: `-${dazzle} attack_mod (abbagliato)` });
   }
 
   // ─── Target-side target-defense buffs/debuffs ───────────────────

--- a/data/core/jobs.yaml
+++ b/data/core/jobs.yaml
@@ -684,6 +684,19 @@ jobs:
         rank: 1
         source: trait
         trait_id: filtri_bioattivi
+      trait_pigmenti_intensifica:
+        ability_id: pigmenti_intensifica
+        name_it: "Pigmenti Aurorali -- Intensifica"
+        description_it: "Abilità nativa del trait pigmenti_aurorali."
+        cost_ap: 1
+        cost_pi: 0
+        effect_type: apply_status
+        status_id: pigmenti_intensificato
+        status_duration: 2
+        target: self
+        rank: 1
+        source: trait
+        trait_id: pigmenti_aurorali
       trait_digest_heal:
         ability_id: digest_heal
         name_it: "Digestione Rigenerante"

--- a/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+++ b/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
@@ -114,6 +114,26 @@ traits:
         effect_type: cleanse_status
         range: 1
         target: ally
+  # Creature-kit salvage (2026-06-23): pigmenti_aurorali ACTIVE = trait-granted
+  # self-buff (apply_status pigmenti_intensificato) -- no new effect_type/schema. While
+  # intensified the end-of-round glow dazzles for -2 (abbagliato intensity 2) and anyone
+  # who attacks the carrier is disoriented -- both engine consumers in combat/
+  # pigmentiAurorali + statusModifiers + performAttack. The passive glow lives in
+  # active_effects.yaml + combat/pigmentiAurorali. Spec 2026-06-22-creature-trait-mechanics.
+  pigmenti_aurorali:
+    attack_mod: 0
+    defense_mod: 0
+    damage_step: 0
+    cost_ap: 1
+    resistances: []
+    active_effects:
+      - ability_id: pigmenti_intensifica
+        name_it: "Pigmenti Aurorali -- Intensifica"
+        cost_ap: 1
+        effect_type: apply_status
+        status_id: pigmenti_intensificato
+        status_duration: 2
+        target: self
   filamenti_digestivi_compattanti:
     attack_mod: 0
     defense_mod: 0

--- a/tests/services/combat/pigmentiAurorali.test.js
+++ b/tests/services/combat/pigmentiAurorali.test.js
@@ -150,6 +150,16 @@ test('non-intensified glow: abbagliato has no intensity boost (defaults to -1)',
   assert.ok(!(enemy.status_intensity && enemy.status_intensity[ABBAGLIATO] > 1), 'no -2 boost');
 });
 
+test('a non-intensified refresh downgrades a prior intensity-2 dazzle (no stale -2)', () => {
+  const calm = unit('treant', 'players', 0, 0, { traits: ['pigmenti_aurorali'] }); // not intensified
+  const enemy = unit('foe', 'sistema', 1, 0, {
+    status: { [ABBAGLIATO]: 99 },
+    status_intensity: { [ABBAGLIATO]: 2 },
+  });
+  applyEndRoundGlow({ carrier: calm, units: [calm, enemy] });
+  assert.equal(enemy.status_intensity[ABBAGLIATO], 1, 'stale intensity 2 downgraded to 1 (-1)');
+});
+
 test('disorientAttacker: an intensified carrier disorients whoever attacks it', () => {
   const treant = unit('treant', 'players', 0, 0, {
     traits: ['pigmenti_aurorali'],

--- a/tests/services/combat/pigmentiAurorali.test.js
+++ b/tests/services/combat/pigmentiAurorali.test.js
@@ -18,10 +18,14 @@ const assert = require('node:assert/strict');
 const {
   applyEndRoundGlow,
   consumeAbbagliato,
+  disorientAttacker,
   hasTrait,
   PIGMENTI_TRAIT,
+  PIGMENTI_INTENSIFICATO,
   ABBAGLIATO,
   ABBAGLIATO_TTL,
+  INTENSIFIED_ATK,
+  DISORIENT,
   HP_GATE,
 } = require('../../../apps/backend/services/combat/pigmentiAurorali');
 
@@ -119,4 +123,60 @@ test('hasTrait + constants', () => {
   assert.equal(ABBAGLIATO, 'abbagliato');
   assert.equal(ABBAGLIATO_TTL, 99);
   assert.equal(HP_GATE, 0.5);
+  assert.equal(PIGMENTI_INTENSIFICATO, 'pigmenti_intensificato');
+  assert.equal(INTENSIFIED_ATK, 2);
+  assert.equal(DISORIENT, 'disorient');
+});
+
+// ─── ACTIVE mode (pigmenti_intensificato): glow -2 + disorient on attackers ──────
+// The active ability (1 AP, apply_status self pigmenti_intensificato) is dispatched by
+// the existing executeApplyStatus; these are its two engine consumers.
+
+test('intensified glow: the dazzle is -2 (abbagliato intensity 2) on adjacent enemies', () => {
+  const treant = unit('treant', 'players', 0, 0, {
+    traits: ['pigmenti_aurorali'],
+    status: { [PIGMENTI_INTENSIFICATO]: 2 },
+  });
+  const enemy = unit('foe', 'sistema', 1, 0);
+  applyEndRoundGlow({ carrier: treant, units: [treant, enemy] });
+  assert.ok(Number(enemy.status[ABBAGLIATO]) > 0, 'still dazzled');
+  assert.equal(enemy.status_intensity[ABBAGLIATO], INTENSIFIED_ATK, 'intensity 2 -> -2 atk');
+});
+
+test('non-intensified glow: abbagliato has no intensity boost (defaults to -1)', () => {
+  const treant = unit('treant', 'players', 0, 0, { traits: ['pigmenti_aurorali'] });
+  const enemy = unit('foe', 'sistema', 1, 0);
+  applyEndRoundGlow({ carrier: treant, units: [treant, enemy] });
+  assert.ok(!(enemy.status_intensity && enemy.status_intensity[ABBAGLIATO] > 1), 'no -2 boost');
+});
+
+test('disorientAttacker: an intensified carrier disorients whoever attacks it', () => {
+  const treant = unit('treant', 'players', 0, 0, {
+    traits: ['pigmenti_aurorali'],
+    status: { [PIGMENTI_INTENSIFICATO]: 2 },
+  });
+  const attacker = unit('foe', 'sistema', 1, 0);
+  const ev = disorientAttacker({ carrier: treant, attacker });
+  assert.ok(ev, 'returns a disorient event');
+  assert.ok(Number(attacker.status[DISORIENT]) > 0, 'attacker disoriented');
+});
+
+test('disorientAttacker: no-op when the carrier is NOT intensified, or lacks the trait', () => {
+  const calm = unit('treant', 'players', 0, 0, { traits: ['pigmenti_aurorali'] }); // not intensified
+  const attacker = unit('foe', 'sistema', 1, 0);
+  assert.equal(disorientAttacker({ carrier: calm, attacker }), null);
+  assert.ok(!(DISORIENT in attacker.status));
+  const plain = unit('plain', 'players', 0, 0, { status: { [PIGMENTI_INTENSIFICATO]: 2 } }); // no trait
+  assert.equal(disorientAttacker({ carrier: plain, attacker }), null);
+});
+
+test('disorientAttacker: tolerant of a null/self/dead attacker', () => {
+  const treant = unit('treant', 'players', 0, 0, {
+    traits: ['pigmenti_aurorali'],
+    status: { [PIGMENTI_INTENSIFICATO]: 2 },
+  });
+  assert.equal(disorientAttacker({ carrier: treant, attacker: null }), null);
+  assert.equal(disorientAttacker({ carrier: treant, attacker: treant }), null, 'not self');
+  const dead = unit('dead', 'sistema', 1, 0, { hp: 0 });
+  assert.equal(disorientAttacker({ carrier: treant, attacker: dead }), null);
 });

--- a/tests/services/statusModifiers.test.js
+++ b/tests/services/statusModifiers.test.js
@@ -427,3 +427,11 @@ test('abbagliato (actor) -> -1 attackDelta', () => {
   assert.equal(r.attackDelta, -1);
   assert.ok(r.log.some((e) => e.status === 'abbagliato' && e.side === 'actor'));
 });
+
+// pigmenti ACTIVE: an intensified glow dazzles for -2 (abbagliato carries intensity 2).
+test('abbagliato intensified (intensity 2) -> -2 attackDelta', () => {
+  const actor = { id: 'a', status: { abbagliato: 1 }, status_intensity: { abbagliato: 2 } };
+  const target = { id: 'b', status: {} };
+  const r = computeStatusModifiers(actor, target, []);
+  assert.equal(r.attackDelta, -2);
+});


### PR DESCRIPTION
## Active-mode unlock #2: pigmenti intensify -- **active modes now COMPLETE**

Second (and last) active mode. pigmenti gains a trait-granted self-buff `pigmenti_intensifica` (1 AP). **No new schema/effect_type** -- it reuses the existing `apply_status` path (sets `pigmenti_intensificato` on self); the two effects are engine consumers. Band-neutral (AI 557/557), TDD.

### What it does
- **trait_mechanics.yaml**: pigmenti_aurorali active_effect (apply_status, `pigmenti_intensificato`, target self, 1 AP, 2t). **jobs.yaml regenerated** -- **+13 lines only** (reproducible; the re-baseline holds). SUPPORTED unchanged (still 21; apply_status already there).
- **intensified glow**: `applyEndRoundGlow` -- while intensified, the dazzle is **-2** (abbagliato carries intensity 2; `statusModifiers` reads the intensity). Always writes the current glow's intensity, so a non-intensified refresh downgrades a prior -2.
- **disorient on attackers**: `disorientAttacker` -- whoever attacks the intensified carrier gets **disorient** (an existing status -> -2 atk on their next attack). Wired in `performAttack` (fires on hit OR miss), persisted via the `_pendingStatusApplies` drain.

With this, the **active modes are complete**: matrice (#2976) + filtri (#3003) + pigmenti (here).

### Compensating review (Codex rate-limited)
`cavecrew-reviewer`: 1 P1 + 1 Q2.
- **P1 (disorient lifecycle) -- REFUTED with ground-truth**: the reviewer claimed disorient is wiped before it bites. But `disorient` is pushed to `_pendingStatusApplies`, and the drain (`applyMoraleStatus`, a GENERIC status-setter) runs AFTER the wipe in the same `syncStatusesFromRoundState` -> disorient survives + is promoted to a tracked status that decays (NOT persistent). This is the exact proven pattern used by nuclei/corteccia/risonanza/tessuti/abbagliato (all on main). The reviewer's suggested "add disorient to PERSISTENT_STATUS_KEYS" would be a **regression** -- it would make disorient permanent for ALL its producers.
- **Q2 (intensity staleness) -- FIXED** (`e2131807`): the glow now always sets `status_intensity.abbagliato`, so a non-intensified refresh can't leave a stale -2. + a regression test.

### Verification
AI **557/557**, **tests/api 1755/0-fail**, jobs reproducible, schema unchanged, prettier clean. pigmenti module 15 tests + statusModifiers intensity.

### Rollback (03A)
Revert the 2 commits. Band-neutral; the ability is only offered to units carrying pigmenti_aurorali (none in sim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)