### PR TITLE
feat(combat): membrane_osmotiche terrain-heal (substrate consumer)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -1045,6 +1045,21 @@ function createRoundBridge(deps) {
       // best-effort: don't block round-end if the filter module is missing
     }
 
+    // membrane_osmotiche terrain-heal: a living carrier adjacent (4-neighbour) to a
+    // water/bog tile heals 1 at end-of-round. Reads the grid.terrain_features the move
+    // terrain-cost substrate (#3012) now carries onto session.grid. Best-effort,
+    // band-neutral (no sim unit carries the trait AND no grid places a water tile).
+    try {
+      const { applyTerrainHeal } = require('../services/combat/membraneOsmotiche');
+      const { terrainAtFromFeatures } = require('../services/combat/moveCost');
+      const terrainAt = terrainAtFromFeatures(session.grid?.terrain_features || []);
+      for (const unit of session.units || []) {
+        applyTerrainHeal(unit, { terrainAt });
+      }
+    } catch {
+      // best-effort: don't block round-end if the membrane/terrain module is missing
+    }
+
     // Creature-trait slice 7: pigmenti_aurorali glow -- while a carrier is HP>=50%,
     // dazzle (abbagliato, -1 atk next) the enemies ending adjacent. End-of-round sweep.
     // Best-effort, band-neutral (no sim unit carries the trait).

--- a/apps/backend/services/combat/membraneOsmotiche.js
+++ b/apps/backend/services/combat/membraneOsmotiche.js
@@ -8,18 +8,35 @@
 // Dungeon bleed-resist). A 1-turn status reduced to 0 does NOT land (fully
 // absorbed). Read at the status-apply seam in performAttack, BEFORE the cap merge.
 //
-// (The spec's second mode -- heal 1 at turn-start when adjacent to water/bog
-// terrain -- is DEFERRED: the engine has no per-tile terrain substrate at runtime
-// [unit.terrain_type is static/dormant, no 'bog' type, no grid terrain]. Surfaced
-// for master-dd alongside the move/elevation substrate.)
+// terrain-heal (the spec's second mode): heal 1 at end-of-round when the carrier is
+// adjacent (4-neighbour) to a water/bog terrain tile. UNBLOCKED by the move terrain-cost
+// substrate (phase 1, #3012), which carries the encounter-authored grid.terrain_features
+// onto the runtime session.grid -- so a per-tile terrain lookup now exists. Realized at
+// end-of-round (mirrors filtriBioattivi's once-per-round "turn-start" cleanse).
+//   NB (design-surface, flagged like prior slices): the canonical terrain tile vocabulary
+//   (packs/.../balance/movement_profiles.yaml) ships `acqua_profonda` as the only water
+//   type and NO 'bog'/'palude' tile. WATER_BOG_TERRAIN below is a small forward-compatible
+//   superset; master-dd ratifies the final set when a bog tile is authored.
 //
-// Pure. Band-neutral: no sim unit carries membrane_osmotiche, so absorbStatusDuration
-// returns the input unchanged for every existing unit.
+// Pure (applyTerrainHeal mutates unit.hp). Band-neutral: no sim unit carries
+// membrane_osmotiche AND no encounter grid currently places a water/bog tile, so both
+// absorbStatusDuration and applyTerrainHeal are no-ops for every existing unit/grid.
 
 'use strict';
 
 const MEMBRANE_TRAIT = 'membrane_osmotiche';
 const ABSORB = 1;
+const TERRAIN_HEAL = 1;
+// Water/bog terrain tile types that feed the osmotic membrane. `acqua_profonda` is the
+// canonical movement-profile water type; the rest are forward-compatible synonyms.
+const WATER_BOG_TERRAIN = new Set(['acqua_profonda', 'acqua', 'palude', 'fango']);
+// 4-neighbour offsets (same topology as combat/moveCost).
+const ADJ = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
 
 function hasTrait(unit, traitId) {
   const raw = unit && Array.isArray(unit.traits) ? unit.traits : [];
@@ -48,9 +65,49 @@ function absorbStatusDuration({ target, turns }) {
   return Math.max(0, n - ABSORB);
 }
 
+/**
+ * End-of-round osmotic terrain-heal. For a living membrane carrier with a water/bog
+ * tile on any 4-adjacent cell, heals TERRAIN_HEAL (capped at max_hp). Returns
+ * {healed} only when a heal actually lands; null for a non-carrier, downed unit,
+ * missing position/terrain lookup, no adjacent water, or a carrier already at full HP.
+ *
+ * @param {object} unit (mutated: unit.hp)
+ * @param {object} opts
+ * @param {(x:number,y:number)=>string|null} opts.terrainAt per-tile terrain lookup
+ * @returns {{healed:number} | null}
+ */
+function applyTerrainHeal(unit, { terrainAt } = {}) {
+  if (!unit || typeof unit !== 'object') return null;
+  if (!hasTrait(unit, MEMBRANE_TRAIT)) return null;
+  if (typeof terrainAt !== 'function') return null;
+  const pos = unit.position;
+  if (!pos || !Number.isFinite(pos.x) || !Number.isFinite(pos.y)) return null;
+  const before = Number(unit.hp);
+  if (!(before > 0)) return null; // a downed carrier does not regenerate
+
+  let adjacentWater = false;
+  for (const [dx, dy] of ADJ) {
+    const type = terrainAt(pos.x + dx, pos.y + dy);
+    if (type && WATER_BOG_TERRAIN.has(String(type))) {
+      adjacentWater = true;
+      break;
+    }
+  }
+  if (!adjacentWater) return null;
+
+  const max = Number(unit.max_hp || unit.hp || 0);
+  if (!(max > before)) return null; // already at (or above) max -> no over-heal
+  unit.hp = Math.min(max, before + TERRAIN_HEAL);
+  const healed = Number(unit.hp) - before;
+  return healed > 0 ? { healed } : null;
+}
+
 module.exports = {
   absorbStatusDuration,
+  applyTerrainHeal,
   hasTrait,
   MEMBRANE_TRAIT,
   ABSORB,
+  TERRAIN_HEAL,
+  WATER_BOG_TERRAIN,
 };

--- a/tests/services/combat/membraneOsmotiche.test.js
+++ b/tests/services/combat/membraneOsmotiche.test.js
@@ -1,10 +1,11 @@
 // tests/services/combat/membraneOsmotiche.test.js
 //
-// membrane_osmotiche (creature-trait mechanics slice 5, trait 7 -- otyugh).
+// membrane_osmotiche (creature-trait mechanics slice 5 + terrain-heal -- otyugh).
 // Spec: docs/superpowers/specs/2026-06-22-creature-trait-mechanics-design.md
-//   duration_absorb: incoming status durations -1 on apply. (The turn-start
-//   adjacent-water/bog heal is DEFERRED -- the per-tile terrain substrate does
-//   not exist; see the slice-5 PR.)
+//   duration_absorb: incoming status durations -1 on apply (slice 5).
+//   terrain-heal: heal 1 at end-of-round when adjacent to water/bog terrain --
+//   unblocked once the move terrain-cost substrate (phase 1, #3012) carries
+//   grid.terrain_features at runtime.
 // Real-module tests (CommonJS), CI-gated via tests/services/*/*.test.js.
 
 'use strict';
@@ -14,10 +15,15 @@ const assert = require('node:assert/strict');
 
 const {
   absorbStatusDuration,
+  applyTerrainHeal,
   hasTrait,
   MEMBRANE_TRAIT,
   ABSORB,
+  TERRAIN_HEAL,
+  WATER_BOG_TERRAIN,
 } = require('../../../apps/backend/services/combat/membraneOsmotiche');
+
+const { terrainAtFromFeatures } = require('../../../apps/backend/services/combat/moveCost');
 
 test('a membrane carrier absorbs 1 turn off an incoming status duration', () => {
   const u = { traits: ['membrane_osmotiche'] };
@@ -56,4 +62,89 @@ test('hasTrait + constants', () => {
   assert.equal(hasTrait({ traits: ['membrane_osmotiche'] }, MEMBRANE_TRAIT), true);
   assert.equal(MEMBRANE_TRAIT, 'membrane_osmotiche');
   assert.equal(ABSORB, 1);
+});
+
+// --- terrain-heal (heal 1 when adjacent to water/bog) ---------------------------------
+
+function carrier(overrides = {}) {
+  return {
+    traits: ['membrane_osmotiche'],
+    position: { x: 2, y: 2 },
+    hp: 5,
+    max_hp: 10,
+    ...overrides,
+  };
+}
+
+test('a membrane carrier adjacent to deep water heals 1 (capped at max_hp)', () => {
+  const u = carrier({ hp: 5, max_hp: 10 });
+  const terrainAt = terrainAtFromFeatures([{ x: 3, y: 2, type: 'acqua_profonda' }]);
+  const r = applyTerrainHeal(u, { terrainAt });
+  assert.deepEqual(r, { healed: 1 });
+  assert.equal(u.hp, 6);
+});
+
+test('heals only up to max_hp (9/10 -> 10, healed 1)', () => {
+  const u = carrier({ hp: 9, max_hp: 10 });
+  const terrainAt = terrainAtFromFeatures([{ x: 1, y: 2, type: 'acqua_profonda' }]);
+  const r = applyTerrainHeal(u, { terrainAt });
+  assert.deepEqual(r, { healed: 1 });
+  assert.equal(u.hp, 10);
+});
+
+test('a carrier already at full HP does not over-heal (null)', () => {
+  const u = carrier({ hp: 10, max_hp: 10 });
+  const terrainAt = terrainAtFromFeatures([{ x: 3, y: 2, type: 'acqua_profonda' }]);
+  assert.equal(applyTerrainHeal(u, { terrainAt }), null);
+  assert.equal(u.hp, 10);
+});
+
+test('no adjacent water/bog -> null (no heal)', () => {
+  const u = carrier({ hp: 5 });
+  const terrainAt = terrainAtFromFeatures([{ x: 5, y: 5, type: 'acqua_profonda' }]);
+  assert.equal(applyTerrainHeal(u, { terrainAt }), null);
+  assert.equal(u.hp, 5);
+});
+
+test('diagonal water does NOT trigger (4-neighbour adjacency only)', () => {
+  const u = carrier({ hp: 5, position: { x: 2, y: 2 } });
+  const terrainAt = terrainAtFromFeatures([{ x: 3, y: 3, type: 'acqua_profonda' }]);
+  assert.equal(applyTerrainHeal(u, { terrainAt }), null);
+});
+
+test('bog/water synonyms (palude, acqua) also trigger the heal', () => {
+  const palude = terrainAtFromFeatures([{ x: 2, y: 3, type: 'palude' }]);
+  assert.deepEqual(applyTerrainHeal(carrier({ hp: 5 }), { terrainAt: palude }), { healed: 1 });
+  const acqua = terrainAtFromFeatures([{ x: 2, y: 1, type: 'acqua' }]);
+  assert.deepEqual(applyTerrainHeal(carrier({ hp: 5 }), { terrainAt: acqua }), { healed: 1 });
+});
+
+test('a non-carrier adjacent to water does NOT heal (null)', () => {
+  const u = { traits: ['other'], position: { x: 2, y: 2 }, hp: 5, max_hp: 10 };
+  const terrainAt = terrainAtFromFeatures([{ x: 3, y: 2, type: 'acqua_profonda' }]);
+  assert.equal(applyTerrainHeal(u, { terrainAt }), null);
+  assert.equal(u.hp, 5);
+});
+
+test('a downed carrier (hp<=0) does not heal', () => {
+  const u = carrier({ hp: 0, max_hp: 10 });
+  const terrainAt = terrainAtFromFeatures([{ x: 3, y: 2, type: 'acqua_profonda' }]);
+  assert.equal(applyTerrainHeal(u, { terrainAt }), null);
+  assert.equal(u.hp, 0);
+});
+
+test('non-water adjacent terrain (roccia) does not trigger', () => {
+  const u = carrier({ hp: 5 });
+  const terrainAt = terrainAtFromFeatures([{ x: 3, y: 2, type: 'roccia' }]);
+  assert.equal(applyTerrainHeal(u, { terrainAt }), null);
+});
+
+test('tolerant of a carrier with no position / no terrainAt', () => {
+  assert.equal(applyTerrainHeal({ traits: ['membrane_osmotiche'], hp: 5, max_hp: 10 }, {}), null);
+  assert.equal(applyTerrainHeal(null, { terrainAt: () => 'acqua_profonda' }), null);
+});
+
+test('TERRAIN_HEAL constant + WATER_BOG_TERRAIN set', () => {
+  assert.equal(TERRAIN_HEAL, 1);
+  assert.ok(WATER_BOG_TERRAIN.has('acqua_profonda'));
 });


### PR DESCRIPTION
## Cosa
Chiude la metà differita di `membrane_osmotiche` (trait 7, otyugh). Slice 5 aveva shippato `duration_absorb`; il **terrain-heal** era gated sul move terrain-cost substrate. La phase 1 (#3012) ora porta `grid.terrain_features` su `session.grid` → lookup terreno per-tile a runtime.

## Comportamento
- `applyTerrainHeal(unit, {terrainAt})` (puro): carrier vivo, adiacente 4-neighbour a un tile water/bog → cura 1 (cap `max_hp`); `null` altrimenti. Fine-round in `sessionRoundBridge` (mirror del blocco `filtri_bioattivi`).
- `WATER_BOG_TERRAIN = {acqua_profonda (canonico) + acqua/palude/fango synonyms}`. **Design-surface flaggato**: il tile-type "bog" canonico non è ancora autorato; il set è un superset forward-compatible, master-dd ratifica quando arriva un tile bog.

## Band-neutral
Nessun sim-unit porta il trait **E** nessuna griglia piazza un tile water → inerte. `node --test tests/ai/*.test.js` **557/557** byte-stable · `tests/api/*.test.js` 0-fail · membrane suite 18/18 · prettier clean. Nessun trait nuovo / no trait_mechanics / no jobs.yaml / no schema (comportamento keyed sul trait esistente, come slice-5).

## Review
`caveman:cavecrew-reviewer` (compensativo, Codex rate-limited) → **0 findings** (ordering fine-round corretto, cap/crash-guard ok, set canon-verificato, no double-run).

## Rollback
Revert del singolo commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
