### PR TITLE
docs(form-pulse): combat A/B confirms the v2 grant offset is real (verdict condition)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12740,6 +12740,17 @@
       "review_cycle_days": 90
     },
     {
+      "path": "docs/planning/2026-06-23-aa01-form-pulse-trait-v2-combat-ab.md",
+      "title": "Form-Pulse trait v2 -- combat A/B (rounds-to-victory + derived win-rate, verdict-condition evidence)",
+      "doc_status": "review_needed",
+      "doc_owner": "claude-code",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-06-23",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90
+    },
+    {
       "path": "docs/planning/2026-06-23-aa01-imprint-axis-trait-grant-spec-draft.md",
       "title": "Imprint axis->trait grant -- design spec DRAFT (D6, NON-band-neutral, master-dd ratify)",
       "doc_status": "draft",

--- a/docs/planning/2026-06-23-aa01-form-pulse-trait-v2-combat-ab.md
+++ b/docs/planning/2026-06-23-aa01-form-pulse-trait-v2-combat-ab.md
@@ -1,0 +1,138 @@
+---
+title: 'Form-Pulse trait v2 -- combat A/B (rounds-to-victory + derived win-rate)'
+date: 2026-06-23
+sprint: aa01-impronta-reconciliation
+doc_status: review_needed
+doc_owner: claude-code
+workstream: cross-cutting
+last_verified: '2026-06-23'
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+---
+
+# Form-Pulse trait v2 -- combat A/B
+
+> **L-069 posture: this REPORTS; the encounter-offset ratification is a master-dd verdict.**
+> Closes the follow-up the N=40/N=200 grant-power probe flagged
+> ([`2026-06-23-aa01-form-pulse-trait-v2-n40-ratify.md`](2026-06-23-aa01-form-pulse-trait-v2-n40-ratify.md)
+> sec. 6): "a full combat A/B (`ai-driven-sim.js` with the granted traits) is the follow-up if
+> master-dd wants a win-rate, not a power estimate." The ratify verdict made this A/B a
+> **condition before the `FORM_PULSE_TRAIT_V2_ENABLED` flip**.
+
+## 1. Question
+
+The grant-power proxy estimated the v2 grant (shared branco trait + per-player COMPLEMENT minor)
+at **~1.21 effective-power / creature** (N=200, CI95 1.14..1.29). The proxy is a heuristic --
+it cannot model encounter terrain / enemy composition. **Does that power translate to a real,
+measurable combat advantage in the live engine?** If yes, the encounter-difficulty offset
+(ratify recommendation path 1) is justified; the A/B sizes its direction.
+
+## 2. Method
+
+Real-engine end-to-end A/B on `tests/smoke/ai-driven-sim.js` (the same harness the nightly /
+sweep CI drive), batched via `tools/sim/batch-ai-runner.js`, against a local backend.
+
+- **Two arms, same seeds (paired).** `batch-ai-runner` uses deterministic seeds (`1000+idx`),
+  so both arms run seeds 1001..1040; seed variance cancels. The ONLY between-arm difference is
+  the granted trait set.
+  - **control**: no grant (`AI_SIM_FORM_PULSE_V2_GRANT` unset).
+  - **treatment**: `AI_SIM_FORM_PULSE_V2_GRANT=1` -> every player creature carries the branco
+    trait + one per-slot COMPLEMENT minor.
+- **Treatment is a KNOWN, fixed ~1.2/creature buff.** IDs derived offline from the REAL engine
+  (`emergeBrancoTrait` threshold 0 + `emergePlayerMinorTrait`) for a representative 2-player
+  team whose effective-power proxy == **1.20/creature** (canonical N=200 = 1.21):
+  - branco (all creatures): `zampe_a_molla` (axis `agile_robust`, proxy 0.15)
+  - per-slot minor: `denti_seghettati` (proxy 1.5), `antenne_dustsense` (proxy 0.6)
+  - per-creature = (2x0.15 + 1.5 + 0.6) / 2 = **1.20**.
+- **Scenario chosen for headroom (anti-ceiling).** The tutorial encounters saturate at ~100%
+  player WR (aggressive/balanced sistema) -- a WR A/B there is a null 100%-vs-100%. The "hard"
+  reinforcement scenarios saturate the OTHER way (perpetual timeout). `enc_savana_01` (aggressive
+  sistema, 2 players, `--load-yaml`) resolves to victory with a **rounds-to-clear spread of
+  20-27** -- so the non-saturating signal is **rounds-to-victory**, with a post-hoc
+  "cleared within K rounds" win-rate derived from the same data.
+- **N=40 / arm, `--max-rounds 40`** (generous budget -> every run reaches victory -> true
+  rounds-to-clear is read, never censored by the round cap).
+
+## 3. Results
+
+Paired seeds (both arms): **40** | both-victory pairs: **40/40** (no censoring).
+
+### Outcome distribution
+
+| arm       | victory | victory-rate |
+| --------- | ------- | ------------ |
+| control   | 40      | 100.0%       |
+| treatment | 40      | 100.0%       |
+
+Both arms clear within the 40-round budget on every seed (expected -- the budget is generous on
+purpose; the signal is HOW FAST, not WHETHER).
+
+### Rounds-to-victory (paired)
+
+| metric                                    | value                               |
+| ----------------------------------------- | ----------------------------------- |
+| control mean rounds                       | 22.10 (CI95 21.48 .. 22.72)         |
+| treatment mean rounds                     | 20.48 (CI95 19.96 .. 20.99)         |
+| **paired delta rounds (treat - control)** | **-1.63** (CI95 **-2.45 .. -0.80**) |
+
+### Derived win-rate -- cleared within K rounds
+
+| K rounds | control | treatment | delta pp |
+| -------: | ------: | --------: | -------: |
+|     <=18 |    0.0% |     10.0% |    +10.0 |
+|     <=20 |   27.5% |     62.5% |    +35.0 |
+|     <=22 |   60.0% |     85.0% |    +25.0 |
+|     <=24 |   85.0% |     97.5% |    +12.5 |
+
+## 4. Reading
+
+- **The ~1.2/creature buff is REAL and significant in the live engine.** Treatment clears
+  **~1.6 rounds faster** (paired delta -1.63, CI95 -2.45..-0.80 -- does **not** cross 0). On a
+  20-27-round encounter that is a ~7% reduction in fight length per the buff.
+- **Win-rate framing (the requested deliverable):** at a fixed round budget the buff is a large
+  WR lever -- **+35 pp** at a <=20-round budget, **+25 pp** at <=22. A team carrying the v2 grant
+  wins a budgeted fight far more often.
+- **This confirms the proxy direction.** The grant-power estimate was not an artifact: granting
+  ~1.2 power/creature buys a measurable, repeatable combat advantage. The encounter-difficulty
+  offset (ratify recommendation path 1) is therefore **justified**, and its direction is set:
+  an offset that costs the team roughly the equivalent of ~1.6 rounds (savana_01 scale) keeps net
+  difficulty near baseline.
+
+## 5. Caveats
+
+- **One scenario, one sistema profile, one fixed grant.** This A/B sizes the DIRECTION on a
+  single representative encounter (`enc_savana_01` / aggressive) with a single ~1.2/creature grant.
+  The exact offset NUMBER per encounter family (savana vs caverna vs frattura) and the per-axis
+  grant spread (a `cervello_predittivo` T3 branco team would buff harder than this `zampe_a_molla`
+  one) are NOT measured here -- they are the residual calibration if master-dd fixes a precise
+  offset rather than a tier cap.
+- **Player AI policy = closest-enemy + attack.** The on-hit minors (`denti_seghettati`) realize
+  their power under this policy; a more passive policy might realize less. The signal is a lower
+  bound for an attack-leaning team.
+- **Scale, not floor.** rounds-to-victory is an interval metric on this encounter; do not read
+  "-1.6 rounds" as a universal constant -- read it as "the buff is real and worth offsetting".
+
+## 6. Disposition
+
+**Evidence delivered; the offset ratification + exact number stay a master-dd verdict.** No flag
+is flipped on this report. The combat-A/B verdict-condition is now **met** (the buff is
+confirmed real); on ratify, set the encounter offset / minor-tier cap before
+`FORM_PULSE_TRAIT_V2_ENABLED` is ever turned ON.
+
+**Reproduce** (local backend on `PORT=3335` HTTP + `LOBBY_WS_PORT=3342` WS):
+
+```sh
+# control
+AI_SIM_WS_URL=ws://127.0.0.1:3342/ws AI_SIM_LOAD_YAML=1 \
+  node tools/sim/batch-ai-runner.js --tunnel http://127.0.0.1:3335 \
+    --seed-count 40 --concurrency 4 --profiles aggressive \
+    --scenarios enc_savana_01 --max-rounds 40 --players 1 --load-yaml
+# treatment (same, + grant)
+AI_SIM_FORM_PULSE_V2_GRANT=1 AI_SIM_WS_URL=ws://127.0.0.1:3342/ws AI_SIM_LOAD_YAML=1 \
+  node tools/sim/batch-ai-runner.js --tunnel http://127.0.0.1:3335 \
+    --seed-count 40 --concurrency 4 --profiles aggressive \
+    --scenarios enc_savana_01 --max-rounds 40 --players 1 --load-yaml
+# pair + analyze
+node tools/sim/fp-trait-ab-analyze.js <control_batch_dir> <treatment_batch_dir> --out report.md
+```

--- a/tests/smoke/ai-driven-sim.js
+++ b/tests/smoke/ai-driven-sim.js
@@ -485,6 +485,18 @@ function logSistemaDecisions(round, body) {
   // real attack; the skiv_pulse_fired event is genuine engine output, not
   // fabricated (emitted only when getRevealedTiles really returns tiles).
   const ECHO_TRAIT = 'sensori_geomagnetici';
+  // Form-Pulse trait v2 combat A/B (verdict condition 2026-06-23 — confirm the
+  // ~1.2 power/creature offset translates to a real combat advantage before the
+  // FORM_PULSE_TRAIT_V2_ENABLED flip). Env-gated: default OFF = zero behaviour
+  // change for the nightly/sweep CI. When AI_SIM_FORM_PULSE_V2_GRANT=1 the player
+  // team carries the v2 grant — the shared branco trait on EVERY creature + one
+  // per-player COMPLEMENT minor (round-robin by slot). IDs derived offline from
+  // the REAL engine (emergeBrancoTrait threshold 0 + emergePlayerMinorTrait) for
+  // a representative team whose effective-power proxy == 1.20/creature (canonical
+  // N=200 = 1.21); see docs/planning/2026-06-23-aa01-form-pulse-trait-v2-combat-ab.md.
+  const FP_V2_GRANT = process.env.AI_SIM_FORM_PULSE_V2_GRANT === '1';
+  const FP_V2_BRANCO = 'zampe_a_molla';
+  const FP_V2_MINORS = ['denti_seghettati', 'antenne_dustsense'];
   const characters = rawCharacters.map((ch, idx) => ({
     ...ch,
     traits: Array.from(
@@ -494,6 +506,8 @@ function logSistemaDecisions(round, body) {
         // Only the host (idx 0 = Skiv custode) carries echolocation so the
         // OD-026 path mirrors the diegetic design (Skiv personal sprint).
         ...(idx === 0 ? [ECHO_TRAIT] : []),
+        // v2 A/B treatment arm (gated): branco on every creature + per-slot minor.
+        ...(FP_V2_GRANT ? [FP_V2_BRANCO, FP_V2_MINORS[idx % FP_V2_MINORS.length]] : []),
       ]),
     ),
     ...(idx === 0
@@ -513,6 +527,18 @@ function logSistemaDecisions(round, body) {
       : {}),
     status: { ...(ch.status && typeof ch.status === 'object' ? ch.status : {}), ferito: 1 },
   }));
+
+  if (FP_V2_GRANT) {
+    // Cite the exact treatment so the A/B report is reproducible from the JSONL.
+    log('form_pulse_v2_grant', {
+      branco: FP_V2_BRANCO,
+      minors: characters.map((_, i) => FP_V2_MINORS[i % FP_V2_MINORS.length]),
+      proxy_power_per_creature: 1.2,
+    });
+    console.log(
+      `Form-Pulse v2 A/B grant ACTIVE: branco=${FP_V2_BRANCO} minors=${FP_V2_MINORS.join(',')}`,
+    );
+  }
 
   // --- session/start ---
   logSection('session/start');

--- a/tools/sim/fp-trait-ab-analyze.js
+++ b/tools/sim/fp-trait-ab-analyze.js
@@ -1,0 +1,175 @@
+'use strict';
+// fp-trait-ab-analyze -- pair two batch-ai-runner summary.csv files (control vs
+// treatment) by seed and report the Form-Pulse trait v2 combat A/B signal:
+// rounds-to-victory paired delta (+CI95), victory-rate, and a post-hoc
+// "cleared within K rounds" win-rate for a few K thresholds.
+//
+// L-069 posture: this REPORTS; the encounter-offset ratification is a master-dd
+// verdict. Pairing is by deterministic seed (batch-ai-runner seeds = 1000+idx),
+// so seed variance cancels (same scenario, same sistema policy, the ONLY
+// between-arm difference is the granted trait set).
+//
+// Usage: node tools/sim/fp-trait-ab-analyze.js <control_dir> <treatment_dir> [--out report.md]
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function arg(name, dflt) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] != null ? process.argv[i + 1] : dflt;
+}
+
+const controlDir = process.argv[2];
+const treatDir = process.argv[3];
+const OUT = arg('--out', null);
+if (!controlDir || !treatDir) {
+  console.error('usage: node fp-trait-ab-analyze.js <control_dir> <treatment_dir> [--out file]');
+  process.exit(2);
+}
+
+function readRuns(dir) {
+  const csv = fs.readFileSync(path.join(dir, 'summary.csv'), 'utf8').trim().split('\n');
+  const headers = csv[0].split(',');
+  const idx = (h) => headers.indexOf(h);
+  const seedI = idx('seed');
+  const outI = idx('outcome');
+  const roundsI = idx('rounds');
+  const rows = csv.slice(1).map((line) => {
+    const c = line.split(',');
+    return { seed: Number(c[seedI]), outcome: c[outI], rounds: Number(c[roundsI]) };
+  });
+  return new Map(rows.map((r) => [r.seed, r]));
+}
+
+function stats(xs) {
+  const n = xs.length;
+  if (n === 0) return { n: 0, mean: 0, std: 0, ci95: 0, ci95_lo: 0, ci95_hi: 0 };
+  const mean = xs.reduce((a, b) => a + b, 0) / n;
+  const variance = xs.reduce((a, b) => a + (b - mean) ** 2, 0) / Math.max(1, n - 1);
+  const std = Math.sqrt(variance);
+  const ci95 = 1.96 * (std / Math.sqrt(n));
+  return { n, mean, std, ci95, ci95_lo: mean - ci95, ci95_hi: mean + ci95 };
+}
+
+const ctrl = readRuns(controlDir);
+const treat = readRuns(treatDir);
+
+// Pair by seed; keep only seeds present in BOTH arms AND ending in victory in
+// both (rounds-to-victory is only defined for a victory; timeouts/defeats are
+// reported separately as outcome-rate shifts).
+const seeds = [...ctrl.keys()].filter((s) => treat.has(s)).sort((a, b) => a - b);
+const paired = [];
+const outcomeCounts = { control: {}, treatment: {} };
+for (const s of seeds) {
+  const c = ctrl.get(s);
+  const t = treat.get(s);
+  outcomeCounts.control[c.outcome] = (outcomeCounts.control[c.outcome] || 0) + 1;
+  outcomeCounts.treatment[t.outcome] = (outcomeCounts.treatment[t.outcome] || 0) + 1;
+  if (c.outcome === 'victory' && t.outcome === 'victory') {
+    paired.push({ seed: s, ctrl: c.rounds, treat: t.rounds, delta: t.rounds - c.rounds });
+  }
+}
+
+const deltaStats = stats(paired.map((p) => p.delta));
+const ctrlRounds = stats(paired.map((p) => p.ctrl));
+const treatRounds = stats(paired.map((p) => p.treat));
+const victoryRate = (m) => {
+  const v = [...m.values()].filter((r) => r.outcome === 'victory').length;
+  return v / m.size;
+};
+// Post-hoc derived win-rate: fraction of runs that CLEARED within K rounds
+// (a victory at rounds<=K), computed over all paired seeds (a non-victory or a
+// victory slower than K both count as "not cleared within K").
+function clearedWithin(m, K) {
+  let c = 0;
+  for (const s of seeds) {
+    const r = m.get(s);
+    if (r.outcome === 'victory' && r.rounds <= K) c += 1;
+  }
+  return c / seeds.length;
+}
+const Ks = [18, 20, 22, 24];
+
+const f2 = (x) => x.toFixed(2);
+const pct = (x) => `${(100 * x).toFixed(1)}%`;
+const lines = [];
+lines.push('# Form-Pulse trait v2 — combat A/B (rounds-to-victory + derived WR)');
+lines.push('');
+lines.push(`Control dir: \`${controlDir}\``);
+lines.push(`Treatment dir: \`${treatDir}\``);
+lines.push(
+  `Paired seeds (both arms): **${seeds.length}** | both-victory pairs: **${paired.length}**`,
+);
+lines.push('');
+lines.push('## Outcome distribution');
+lines.push('');
+const allOutcomes = [
+  ...new Set([...Object.keys(outcomeCounts.control), ...Object.keys(outcomeCounts.treatment)]),
+];
+lines.push('| arm | ' + allOutcomes.join(' | ') + ' | victory-rate |');
+lines.push('|' + '---|'.repeat(allOutcomes.length + 2));
+lines.push(
+  '| control | ' +
+    allOutcomes.map((o) => outcomeCounts.control[o] || 0).join(' | ') +
+    ` | ${pct(victoryRate(ctrl))} |`,
+);
+lines.push(
+  '| treatment | ' +
+    allOutcomes.map((o) => outcomeCounts.treatment[o] || 0).join(' | ') +
+    ` | ${pct(victoryRate(treat))} |`,
+);
+lines.push('');
+lines.push('## Rounds-to-victory (paired, both-victory seeds)');
+lines.push('');
+lines.push('| metric | value |');
+lines.push('|---|---|');
+lines.push(
+  `| control mean rounds | ${f2(ctrlRounds.mean)} (CI95 ${f2(ctrlRounds.ci95_lo)}..${f2(ctrlRounds.ci95_hi)}) |`,
+);
+lines.push(
+  `| treatment mean rounds | ${f2(treatRounds.mean)} (CI95 ${f2(treatRounds.ci95_lo)}..${f2(treatRounds.ci95_hi)}) |`,
+);
+lines.push(
+  `| **paired Δ rounds (treat − ctrl)** | **${f2(deltaStats.mean)}** (CI95 ${f2(deltaStats.ci95_lo)}..${f2(deltaStats.ci95_hi)}) |`,
+);
+lines.push('');
+lines.push(
+  '_Negative Δ = treatment clears FASTER (the buff helps). CI95 crossing 0 = no significant effect._',
+);
+lines.push('');
+lines.push('## Derived win-rate: cleared within K rounds');
+lines.push('');
+lines.push('| K rounds | control | treatment | Δ pp |');
+lines.push('|---:|---:|---:|---:|');
+for (const K of Ks) {
+  const c = clearedWithin(ctrl, K);
+  const t = clearedWithin(treat, K);
+  lines.push(`| ≤${K} | ${pct(c)} | ${pct(t)} | ${((t - c) * 100).toFixed(1)} |`);
+}
+lines.push('');
+
+const report = {
+  control_dir: controlDir,
+  treatment_dir: treatDir,
+  paired_seeds: seeds.length,
+  both_victory_pairs: paired.length,
+  outcome_counts: outcomeCounts,
+  victory_rate: { control: victoryRate(ctrl), treatment: victoryRate(treat) },
+  rounds_control: ctrlRounds,
+  rounds_treatment: treatRounds,
+  paired_delta_rounds: deltaStats,
+  cleared_within: Ks.map((K) => ({
+    K,
+    control: clearedWithin(ctrl, K),
+    treatment: clearedWithin(treat, K),
+  })),
+  per_seed: paired,
+};
+
+const md = lines.join('\n');
+console.log(md);
+if (OUT) {
+  fs.writeFileSync(OUT, md + '\n');
+  fs.writeFileSync(OUT.replace(/\.md$/, '.json'), JSON.stringify(report, null, 2) + '\n');
+  console.log(`\n-> ${OUT} (+ .json)`);
+}


### PR DESCRIPTION
## What

Closes the **combat-A/B verdict-condition** for the Form-Pulse trait v2 flip (`FORM_PULSE_TRAIT_V2_ENABLED`). The grant-power proxy ([#2992](https://github.com/MasterDD-L34D/Game/pull/2992) / [n40-ratify doc](docs/planning/2026-06-23-aa01-form-pulse-trait-v2-n40-ratify.md)) estimated **~1.21 power/creature**; the ratify verdict made a real combat A/B a condition before any flip. This is that A/B.

## Method

Paired (same seeds) **N=40/arm** A/B on `tests/smoke/ai-driven-sim.js` via `batch-ai-runner.js`, local backend.
- **control** = no grant · **treatment** = `AI_SIM_FORM_PULSE_V2_GRANT=1` (branco on every creature + per-slot COMPLEMENT minor).
- Treatment is a **KNOWN ~1.20/creature** grant — IDs derived from the REAL engine (`emergeBrancoTrait` threshold 0 + `emergePlayerMinorTrait`): branco `zampe_a_molla` + minors `denti_seghettati`/`antenne_dustsense`.
- Scenario `enc_savana_01` (aggressive sistema, 2 players) chosen for **rounds-to-clear headroom** — tutorials saturate at ~100% WR (null A/B); hard reinforcement scenarios saturate at perpetual timeout. Signal = **rounds-to-victory** (non-saturating) + derived "cleared within K rounds" WR.

## Result

| metric | value |
|---|---|
| paired Δ rounds (treat − control) | **−1.63** (CI95 −2.45 .. −0.80, does **not** cross 0) |
| derived WR ≤20 rounds | 27.5% → 62.5% (**+35 pp**) |
| derived WR ≤22 rounds | 60.0% → 85.0% (**+25 pp**) |

**The ~1.2/creature buff is real and significant in the live engine.** The encounter-difficulty offset (ratify recommendation path 1) is **justified**; its direction is set. L-069: this REPORTS — the exact offset number / tier-cap stays a master-dd verdict. **No flag flipped.**

## Changes

- `tests/smoke/ai-driven-sim.js` — env-gated `AI_SIM_FORM_PULSE_V2_GRANT` injection (**default OFF = zero behaviour change** for nightly/sweep CI).
- `tools/sim/fp-trait-ab-analyze.js` — pair two batch `summary.csv` by seed → rounds paired-delta + CI95 + derived cleared-within-K WR.
- `docs/planning/2026-06-23-aa01-form-pulse-trait-v2-combat-ab.md` — governed report (registry entry added).

## Verification

- `npx prettier --check` (4 files) + `python tools/check_docs_governance.py --strict` (errors=0): clean.
- A/B ran on a live local backend; reproduction command in the report doc sec. 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)