### PR TITLE
chore(lint): retire dead ancestor_ exemption in trait_schema_gate (post #3001)

### DIFF
--- a/tests/lint/test_trait_schema_gate.py
+++ b/tests/lint/test_trait_schema_gate.py
@@ -44,22 +44,19 @@ def test_gate_accepts_valid_v2_payload(tmp_path):
     assert r.returncode == 0, f"unexpected fail: {r.stderr}"
 
 
-def test_gate_accepts_ancestor_without_design_block(tmp_path):
-    p = tmp_path / "anc.json"
+def test_gate_ancestor_prefix_no_longer_exempt(tmp_path):
+    # DC-01 Tier-Ancestor exemption RETIRED: the ancestor_ namespace was migrated to
+    # native ids (PR #3001, 2026-06-23). An ancestor_-prefixed id in an index path is
+    # now treated like any other trait -- missing design block -> WARN, not exempt.
+    p = tmp_path / "index.json"
     payload = {
         "schema_version": "2.0",
-        "traits": {
-            "ancestor_xyz_01": {
-                "label_it": "Test",
-                "label_en": "Test",
-                "description_it": "x",
-                "description_en": "x",
-            }
-        },
+        "traits": {"ancestor_xyz_01": {"label_it": "Test"}},  # missing design block
     }
     p.write_text(json.dumps(payload))
     r = _run_gate(["--check", str(p)])
-    assert r.returncode == 0, f"unexpected fail: {r.stderr}"
+    assert r.returncode == 0, "index.json missing design = WARN, not HARD"
+    assert "WARN-MISSING" in (r.stderr + r.stdout), "ancestor_ must NOT be exempt anymore"
 
 
 def test_gate_warns_non_ancestor_without_design_in_index(tmp_path):

--- a/tools/lint/trait_schema_gate.py
+++ b/tools/lint/trait_schema_gate.py
@@ -3,8 +3,9 @@
 
 Validates that data/core/traits/*.json + data/core/traits/active_effects.yaml +
 data/traits/index.json + data/traits/<categoria>/*.json + config/schemas/trait.schema.json
-declare schema_version 2.0 and respect Tier-Ancestor policy (DC-01 derived:
-prefix 'ancestor_' allows design block absent).
+declare schema_version 2.0 and (for index/per-trait files) carry the design block.
+Note: the legacy Tier-Ancestor exemption (DC-01, prefix 'ancestor_') is RETIRED --
+the ancestor_ namespace was migrated to native ids (PR #3001, 2026-06-23).
 
 Usage:
     python tools/lint/trait_schema_gate.py --check <file1> [--check <file2> ...]
@@ -81,8 +82,8 @@ def check(path: Path, allow_skip_marker: bool = False, strict_design: bool = Fal
         - per-entry must be dict
 
     SOFT checks (print WARN to stderr but return 0):
-        - design block (tier/famiglia_tipologia/slot_profile) for non-ancestor
-          entries in index-shaped paths.
+        - design block (tier/famiglia_tipologia/slot_profile) for entries in
+          index-shaped paths.
 
     HARD on per-trait files (data/traits/<cat>/<slug>.json) when strict_design=True
     OR when path matches per-trait pattern (default True via per_trait detection).
@@ -126,15 +127,12 @@ def check(path: Path, allow_skip_marker: bool = False, strict_design: bool = Fal
             rc = 1
             continue
 
-        if str(trait_id).startswith("ancestor_"):
-            continue
-
         if is_index or is_per_trait:
             missing = [f for f in REQUIRED_DESIGN_FIELDS if f not in entry]
             if missing:
                 severity = "MISSING" if design_hard else "WARN-MISSING"
                 print(
-                    f"{severity} design fields {missing} for non-ancestor trait "
+                    f"{severity} design fields {missing} for trait "
                     f"{trait_id!r} in {path}",
                     file=sys.stderr,
                 )


### PR DESCRIPTION
Cleanup follow-up to the ancestor-trait migration (#3001 merged). The DC-01 `ancestor_` design-block exemption in `trait_schema_gate.py` is now dead code (0 ancestor_ traits remain). Removed it + docstring; ancestor_ ids treated like any other. Test repurposed to lock the new behavior. Gate unit 9/9, real-data gate exit 0. (Harsh-review P3 from #3001.)