### PR TITLE
feat(calibration): drop PE term -- contestedness falsified at canonical multi-policy N=40

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ data/core/balance/ratify-provenance/
 # Historical runs already committed stay tracked; this stops NEW runs from
 # cluttering git status. To intentionally keep a run: git add -f.
 docs/playtest/parallel-hardcore_*
+# PE_ratio multi-policy re-run scratch (corpora/logs/driver; seed-pinned, regenerable --
+# see docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md reproduce section).
+docs/playtest/_*

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12801,6 +12801,19 @@
       "review_cycle_days": 90,
       "primary": false,
       "track": "migrated"
+    },
+    {
+      "path": "docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md",
+      "title": "PE_ratio contestedness -- canonical MULTI-POLICY N=40 re-run -> drop-PE recommendation (master-dd ratify)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "ops-qa",
+      "last_verified": "2026-06-23",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 30,
+      "primary": false,
+      "track": "authored"
     }
   ]
 }

--- a/docs/planning/2026-06-20-pe-ratio-contestedness-switch-handoff.md
+++ b/docs/planning/2026-06-20-pe-ratio-contestedness-switch-handoff.md
@@ -83,10 +83,27 @@ oracles where pressure saturated.
   composite gate, and say so in the selection report. Do not force a marginal band.
 - **Do NOT** auto-ratify, auto-flip P4/P5, or write the manifest band without master-dd.
 
-## Status
+## Status -- RESOLVED 2026-06-23 (negative result, PE term DROPPED)
+
+- The contestedness experiment ran on canonical MULTI-POLICY corpora (Restricted-Play
+  `[random,greedy,lookahead2,utility]`, N=40, 6 oracles, seed 424242, node 22). It
+  FALSIFIED the contestedness PE source too: `E_dmg_margin` is degenerate on timer-race
+  oracles (hardcore_07 zero damage telemetry) and an outcome-proxy on skilled policies
+  (`|corr|` 0.68-0.71); no WR-orthogonal tension axis exists with current instrumentation.
+- master-dd ratified (SDMG) **(c) drop the PE term**. `composite_metric` is now
+  `0.70*win_rate + 0.30*kd_ratio` (renormalized original weights). pe_ratio machinery is
+  dormant (diagnostic only, no longer gates). Evidence + harsh-review:
+  `docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md`.
+- Verify-first correction folded in: canonical multi-policy = Restricted-Play (the
+  composite's regime per `canonical-suite.yaml`), NOT MBTI/`full-loop-batch.js` (that's the
+  separate meta-loop gate). The handoff's MBTI framing was superseded.
+- Follow-up (open): "is ANY non-WR-collinear axis viable" needs new instrumentation
+  (AP-usage spread / positional entropy / state-change frequency).
+
+### Historical (pre-resolution)
 
 - PE-from-pressure band `[0.236, 0.815]` = DROPPED (not ratified, not in manifest).
 - `attach_composite_terms` wiring (#2867) + the badlands/foresta instrumentation (#2869)
   stay -- the composite is still computable; only the PE SOURCE changes.
 - Next owner action = the contestedness experiment above (single-owner, with the G2 N=40
-  leverage ticket).
+  leverage ticket). [DONE -> negative result above.]

--- a/docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md
+++ b/docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md
@@ -1,0 +1,188 @@
+---
+title: 'PE_ratio contestedness -- canonical MULTI-POLICY N=40 re-run -> drop-PE recommendation (master-dd ratify)'
+date: 2026-06-23
+type: playtest-evidence
+doc_status: active
+doc_owner: master-dd
+workstream: ops-qa
+last_verified: '2026-06-23'
+source_of_truth: false
+language: en
+review_cycle_days: 30
+tags:
+  [evo-tactics, calibration, pe-ratio, contestedness, multi-policy, n40, composite, negative-result]
+related: docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md
+---
+
+# PE_ratio contestedness -- canonical MULTI-POLICY N=40 re-run
+
+> Supersedes the greedy-only band in `docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md`
+> (that band was NOT ratifiable -- single-policy diagnostic regime, 3-point outlier
+> artifact). This re-run executes the harsh-review's FIX path: canonical MULTI-POLICY
+> corpora. **Result = a valid NEGATIVE result: no robust WR-orthogonal contestedness
+> band exists -> recommend escalate to (c) drop the PE term.** PROPOSED only; master-dd
+> ratifies (SDMG, human-only).
+
+## What changed vs the committed (rejected) evidence
+
+The harsh-review of the greedy-only band raised: (1) wrong policy regime (greedy-only
+diagnostic, but the composite gates multi-policy canonical balance); (2) 3-point outlier
+artifact; (3) E moderate/outcome-proxy at 0.499. This re-run addresses (1)+(2) directly.
+
+**Verify-first correction (manifest-backed).** The PE composite
+(`0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio`) lives in
+`docs/playtest/canonical-suite.yaml`, whose canonical regime is Restricted-Play
+`policies: [random, greedy, lookahead2, utility]` (Jaffe 2012). It is **NOT** the MBTI
+regime of `tools/sim/full-loop-batch.js` -- that drives the SEPARATE meta-loop gate
+(`canonical-suite.yaml` gate.ci_workflow_metaloop, 7 metrics via
+`meta-band-aggregator.js`). The 2026-06-20 handoff framed canonical multi-policy as MBTI;
+the manifest says Restricted-Play. master-dd ratified Restricted-Play (2026-06-23). The
+multi-policy machinery was already shipped (`calibrate_policies.py` `--policy all`,
+TKT-PLAYTEST-TRIANGULATE) -- only the experiment runner needed generalizing.
+
+## Method
+
+- Regime: Restricted-Play `[random, greedy, lookahead2, utility]`, N=40 per policy
+  (= canonical ratify N), pooled per oracle (160 runs/oracle).
+- Oracles (6, master-dd-chosen broad set incl. a low-pressure one): `hardcore_06`,
+  `hardcore_07`, `foresta_pilot_01`, `badlands_pilot_01`, `badlands_elite_01`,
+  `badlands_ambient_01`.
+- Seed-pinned 424242, node 22, NON-prod backend `:3500` (prod `:3334`/`:3341` untouched).
+- Corpora generated via `batch_calibrate_<oracle>.py --policy all` (one triangulation
+  file per oracle), pooled by the generalized runner
+  `tools/py/run_pe_contestedness_experiment.py --corpora-config ...`.
+- Orthogonality = `|Pearson(candidate, won)|` per run, LOWER = less collinear = better;
+  formal reject threshold `>= 0.6`. Band = `mean +/- 2*sd` of the selected candidate's
+  per-oracle aggregate value.
+- Backend provenance: main checkout `5c547ec9`; combat behavior == `origin/main 7abe8651`
+  for these oracles -- the only drift is `radici_ancora_planare` (#3014), inert here
+  (assigned to no roster: appears only in `data/traits/species_affinity.json`, a procgen
+  weight map; `computeAnchorDR` returns 0 for every unit in all 6 oracles).
+
+## Result -- orthogonality |corr(candidate, won)| (LOWER = better)
+
+| oracle              | n       | WR   | E_dmg_margin           | F_contest_combined | D_turns_contest |
+| ------------------- | ------- | ---- | ---------------------- | ------------------ | --------------- |
+| hardcore_06         | 160     | 0.51 | **0.666**              | 0.727              | 0.882           |
+| hardcore_07         | 160     | 0.29 | **0.000** (degenerate) | 0.000              | 0.765           |
+| foresta_pilot_01    | 160     | 0.35 | 0.263                  | 0.316              | 0.713           |
+| badlands_pilot_01   | 160     | 0.38 | 0.295                  | 0.338              | 0.647           |
+| badlands_elite_01   | 160     | 0.11 | 0.359                  | 0.252              | 0.156           |
+| badlands_ambient_01 | 160     | 0.75 | 0.229                  | 0.496              | 0.979           |
+| **POOLED**          | **960** | --   | **0.301**              | 0.305              | 0.522           |
+
+Selected (least-collinear CONTEST, pooled): **E_dmg_margin 0.301 < 0.6 -> NOT formally rejected.**
+
+## Why the 0.301 does NOT support ratifying E (3 findings, both reviewers verified)
+
+1. **The 0.301 is FLATTERED by a degenerate oracle.** `hardcore_07` (pod_rush timer-race)
+   has `dmg_taken_player` AND `dmg_dealt_player` identically 0 across all 160 runs (no
+   damage telemetry -- losses are clock timeouts, not damage). So `E = dmg_taken/(taken+
+dealt) = 0` for every hc07 run: a 160-point zero-variance block that mathematically
+   drags the pooled |corr| down. **Excluding hc07: pooled |corr| = 0.479** (~= the
+   already-rejected greedy-only 0.499). hc07 cannot inform a damage-margin band -- it has
+   no damage data -- so its inclusion in the E pool is a data-validity error, not a real
+   low-collinearity signal.
+
+2. **On skilled play E is an outcome-proxy.** Per-policy E |corr| (hc07 excluded):
+   `random 0.000` (always loses -> won constant -> degenerate), `greedy 0.426`,
+   `lookahead2 0.684`, `utility 0.706`. On the policies that represent competent play
+   (lookahead2/utility), E is **above the 0.6 reject line**. A strong policy wins _by_
+   absorbing less relative damage, so E largely relabels the outcome. The low pooled
+   number survives only because `random` (constant loss) + hc07 (zero damage) dilute it.
+
+3. **The band is not ratifiable.** Per-oracle E aggregate: 0.245 / 0.000 (hc07) / 0.379 /
+   0.445 / 0.605 (badlands_elite) / 0.300 -> band **[0.000, 0.702]** (sd 0.186). Excluding
+   the degenerate hc07: **[0.144, 0.646]** (sd 0.125) -- still wide, still badlands_elite-
+   driven. No alternative candidate is better: F 0.305 (~=E), D 0.522 (worse; D is highly
+   collinear on timer/easy oracles: hc07 0.765, badlands_ambient 0.979).
+
+**Related finding (composite-wide).** `kd_ratio` -- the composite's OTHER non-WR term --
+is itself a strong outcome-proxy where per-run kd exists (hc07 skilled policies: |corr|
+0.74-0.90). The "three orthogonal axes" premise is shaky: any damage/time/kill signal in a
+win/lose tactical combat is causally downstream of the outcome.
+
+## Harsh-review (2 independent passes, both adversarial)
+
+- **balance-illuminator (calibration, quantitative): CONFIRM drop-PE.** Independently
+  recomputed every number (pooled 0.301, no-hc07 0.479, per-policy 0.000/0.426/0.684/0.706
+  -- all matched). Salvage analysis (damage-oracles-only band / alt normalization /
+  turns-only / skill-residual) -> none clean: "any damage/time signal correlates with
+  outcome by construction in a tactical combat with a winner/loser. Truly orthogonal
+  contestedness would require signals not causally downstream of winning -- e.g. AP-usage
+  spread, positional entropy, state-change frequency -- none currently instrumented."
+  Flagged the hc07 zero-variance pooling as an analysis bug (correctable; does not change
+  the verdict). Reweight proposal if dropped: ~`0.70*WR + 0.30*kd_norm` (owner ratifies).
+- **cavecrew-reviewer (adversarial): numbers sound; do NOT pre-decide.** E at 0.301 (even
+  0.479) is < the 0.6 formal threshold, so dropping E is a QUALITATIVE "materially
+  collinear" judgment, not a rule -- it requires explicit master-dd sign-off, and the hc07
+  exclusion must be stated as a principled data-validity disqualification (no damage
+  telemetry), not a post-hoc convenience. Recommendation: present master-dd the framed
+  choice, not a pre-decided escalation.
+
+Both folded in below.
+
+## Recommendation (PROPOSED) + the decision for master-dd
+
+The selection criterion formally passes (E 0.301 < 0.6). But that pass is an artifact of a
+zero-damage oracle + a constant-loss policy; on damage-capable oracles and skilled
+policies E is collinear with the outcome (0.479 pooled, 0.68-0.71 skilled), and no
+contestedness formula achieves WR-orthogonality with the current instrumentation. This is
+the handoff's escalation condition ("if contestedness ALSO proves materially collinear ...
+valid negative result"). **My recommendation: (c) drop the PE term.** It is a judgment
+call -- master-dd decides among:
+
+- **(a) Accept E at 0.301 on the 6-oracle pool.** Honors the formal threshold. Risk: locks
+  a metric whose orthogonality is a degeneracy artifact into the balance authority (the
+  SDMG anti-pattern the composite exists to prevent).
+- **(b) Drop hc07 (no damage telemetry) and accept E at 0.479 on 5 oracles.** Principled
+  exclusion, but 0.479 is moderate and skilled-policy E is 0.68-0.71 -> still largely an
+  outcome-proxy; band [0.144, 0.646] still wide.
+- **(c) Drop the PE term (RECOMMENDED).** Composite = re-weighted `win_rate + kd_ratio`
+  (illuminator suggests ~`0.70*WR + 0.30*kd_norm`; exact split = master-dd). Valid
+  negative result; matches the pressure-source rejection (both tension proxies track the
+  outcome). NB kd_ratio is itself partly collinear -> a deeper "is any non-WR axis viable"
+  question remains (would need new instrumentation: AP-spread / positional entropy), a
+  separate follow-up.
+
+## Guardrails honored
+
+- No auto-ratify, no manifest write, no P4/P5 gate flip without master-dd.
+- Worktree off origin/main; prod `:3334`/`:3341` never touched (non-prod `:3500`).
+- Harness changes are TDD'd (44 tests) and reproduce the committed greedy-only evidence
+  byte-for-byte (back-compat).
+
+## Reproduce
+
+Backend on a NON-prod port (NEVER 3334/3341), node 22, ratified knobs (committed
+`data/core/balance/damage_curves.yaml`):
+
+```
+PORT=3500 LOBBY_WS_ENABLED=false node apps/backend/index.js   # background; wait /api/health
+```
+
+Generate one multi-policy corpus per oracle (`--policy all` = the 4 Restricted-Play
+policies; seed-pinned; NB `hardcore_07` takes NO `--encounter-class`):
+
+```
+for o in "hardcore06 hardcore" "foresta_pilot_01 foresta_pilot" \
+         "badlands_pilot_01 badlands" "badlands_elite_01 badlands_elite" \
+         "badlands_ambient_01 badlands_ambient"; do
+  set -- $o
+  py tools/py/batch_calibrate_$1.py --host http://127.0.0.1:3500 --n 40 --seed 424242 \
+     --policy all --skip-health --encounter-class $2 --out docs/playtest/_pe-n40-$1-allpol.json
+done
+py tools/py/batch_calibrate_hardcore07.py --host http://127.0.0.1:3500 --n 40 --seed 424242 \
+   --policy all --skip-health --out docs/playtest/_pe-n40-hardcore_07-allpol.json   # NO --encounter-class
+```
+
+Analyze (corpora paths -> a config map, oracle -> [corpus]):
+
+```
+python tools/py/run_pe_contestedness_experiment.py \
+  --corpora-config <(echo '{"hardcore_06":["docs/playtest/_pe-n40-hardcore_06-allpol.json"], ...}') \
+  --json-out docs/playtest/_pe-n40-experiment-result.json
+```
+
+(The `_pe-n40-*` corpora are seed-pinned and gitignored -- regenerate via the above. The
+back-compat default corpora set reproduces the greedy-only PR2 evidence byte-for-byte.)

--- a/docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md
+++ b/docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md
@@ -15,6 +15,13 @@ related: docs/planning/2026-06-20-pe-ratio-contestedness-switch-handoff.md
 
 # PE_ratio contestedness orthogonality (N=100)
 
+> **SUPERSEDED 2026-06-23.** This greedy-only N=100 band was NOT ratified (single-policy
+> diagnostic regime + 3-point outlier artifact, per the harsh-review at the bottom). The
+> FIX re-run on canonical MULTI-POLICY N=40 corpora falsified `E_dmg_margin` outright
+> (degenerate on timer-race oracles + outcome-proxy on skilled policies). master-dd
+> ratified **dropping the PE term** (`composite_metric` = `0.70*win_rate + 0.30*kd_ratio`).
+> See `docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md`.
+
 > The handoff's keystone experiment (step 3-5), executed as a **deterministic
 > re-analysis** of the committed N=100 oracle corpora -- NO backend run, NO prod
 > (the corpora are seed-pinned 424242, node 22, from the 2026-06-18 PR2 run; the
@@ -33,12 +40,12 @@ excluded (designed-winnable, not an oracle).
 
 ## Result (|corr(candidate, won)|, lower = better)
 
-| candidate | hc06 | badlands_elite | foresta_pilot | **POOLED (n=240)** |
-| --- | --- | --- | --- | --- |
-| **E_dmg_margin** | 0.403 | 0.478 | 0.464 | **0.499** |
-| D_turns_contest | 0.725 | 0.542 | 0.705 | 0.562 |
-| F_contest_combined | 0.469 | 0.651 | 0.677 | 0.660 |
-| A/B/C (pressure) | -- | -- | -- | 0.000* |
+| candidate          | hc06  | badlands_elite | foresta_pilot | **POOLED (n=240)** |
+| ------------------ | ----- | -------------- | ------------- | ------------------ |
+| **E_dmg_margin**   | 0.403 | 0.478          | 0.464         | **0.499**          |
+| D_turns_contest    | 0.725 | 0.542          | 0.705         | 0.562              |
+| F_contest_combined | 0.469 | 0.651          | 0.677         | 0.660              |
+| A/B/C (pressure)   | --    | --             | --            | 0.000\*            |
 
 \* pressure candidates are DEGENERATE on these corpora (they saved `pressure_final`,
 not the `frac_ge75`/`mean`/`pmax` trajectory keys `run_to_stats` reads -> constant 0).

--- a/docs/playtest/canonical-suite.yaml
+++ b/docs/playtest/canonical-suite.yaml
@@ -25,8 +25,16 @@ repro:
   config_source: data/core/balance/damage_curves.yaml
   scenario_spawn_source: apps/backend/services/hardcoreScenario.js
 
-# Composite metric (anti false-balanced)
-composite_metric: '0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio'
+# Composite metric (anti false-balanced). PE_ratio term DROPPED 2026-06-23 (SDMG ratify,
+# master-dd): the canonical multi-policy N=40 experiment falsified every contestedness PE
+# source -- E_dmg_margin is degenerate on timer-race oracles (hardcore_07: zero damage
+# telemetry) and an outcome-proxy on skilled policies (|corr| 0.68-0.71); no WR-orthogonal
+# tension axis exists with current instrumentation. Pressure source was already rejected
+# (saturates). Evidence: docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md.
+# Re-weighted = the renormalized original weights (0.50:0.25 -> 0.70:0.30). NB kd_ratio is
+# itself partly outcome-collinear -> 'is any non-WR axis viable' is a follow-up (would need
+# new instrumentation: AP-usage spread / positional entropy / state-change frequency).
+composite_metric: '0.70*win_rate + 0.30*kd_ratio'
 
 scenarios:
   - id: enc_tutorial_06_hardcore

--- a/docs/process/CANONICAL-AI-PLAYTEST.md
+++ b/docs/process/CANONICAL-AI-PLAYTEST.md
@@ -76,7 +76,15 @@ altrimenti converge a rumore (L-073).
 | Timeout 100% + turns=max     | timer                    | turn_limit_defeat       |
 | WR ~target ma KD estremo     | swingy                   | variance                |
 
-Composite metric (anti falso-"balanced"): `0.50*WR + 0.25*KD_ratio + 0.25*PE_ratio`.
+Composite metric (anti falso-"balanced"): `0.70*WR + 0.30*KD_ratio`. **PE_ratio DROPPED
+2026-06-23** (SDMG ratify, master-dd): l'esperimento canonico multi-policy N=40 ha
+falsificato OGNI sorgente PE di contestedness -- `E_dmg_margin` degenera sugli oracoli
+timer-race (hardcore_07, zero telemetria danno) ed e' un outcome-proxy sulle policy esperte
+(`|corr|` 0.68-0.71); nessun asse di tensione ortogonale a WR esiste con la strumentazione
+attuale (la sorgente pressure era gia' rifiutata, satura). Evidenza:
+`docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md`. NB: KD_ratio e' a sua volta
+parzialmente outcome-collineare -> "esiste un asse non-WR valido?" e' un follow-up (servirebbe
+nuova strumentazione: spread uso-AP / entropia posizionale / frequenza cambi-stato).
 Metriche gia' emesse: `boss_hp_remaining_avg_on_loss`, `kd_avg`, `dmg_dealt_avg`.
 
 ### 1.4 Multi-knob discipline (L-070/L-072)

--- a/docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md
+++ b/docs/superpowers/specs/2026-06-18-composite-pe-ratio-experiment-design.md
@@ -11,6 +11,17 @@ review_cycle_days: 30
 
 # Composite PE_ratio -- experiment-first definition + composite wiring
 
+> **OUTCOME 2026-06-23 (CLOSED -- negative result).** This experiment-first design ran to
+> completion. Both PE sources were FALSIFIED: pressure saturates (~0.81-0.94, ~zero
+> discrimination); the sec-4.5 contestedness fallback (D/E/F) is degenerate on timer-race
+> oracles and an outcome-proxy on skilled policies (E |corr| 0.68-0.71) on the canonical
+> multi-policy N=40 data. master-dd ratified (SDMG) **dropping the PE term**: the composite
+> is now `0.70*win_rate + 0.30*kd_ratio`. The "experiment proposes, owner ratifies" loop
+> worked as designed -- it prevented locking a non-orthogonal metric into the balance
+> authority. Evidence: `docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md`. The
+> deeper open question ("is ANY non-WR-collinear axis viable") needs new instrumentation
+> (AP-usage spread / positional entropy / state-change frequency) -- a separate effort.
+
 > Brainstormed 2026-06-18 (G2 follow-up, unblocks the deferred composite gate). The
 > per-template calibration composite `0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio`
 > (canonical-suite.yaml:29, CANONICAL-AI-PLAYTEST.md:79) is UNCOMPUTABLE today: `pe_ratio`
@@ -63,8 +74,8 @@ experiment-first composite is standard-aligned, and Evo is ahead on the load-bea
   Modelling ... combining player analytics and simulated data", arXiv 2401.17436). Evo's
   AI-driven batch-sim playtest IS this method -- not a gap.
 - **Engagement = challenge-skill balance (flow theory)** (game-engagement-theory; dynamic-
-  difficulty-balancing literature). Tension is operationalized as *sustained challenge relative
-  to skill*. PE-as-tension maps directly: a healthy encounter keeps the AI in the "flow channel"
+  difficulty-balancing literature). Tension is operationalized as _sustained challenge relative
+  to skill_. PE-as-tension maps directly: a healthy encounter keeps the AI in the "flow channel"
   (challenging but winnable). This reinforces candidates A/B (sustained engagement) over C
   (apex-only), and gives PE an academic name (challenge-engagement, not a bespoke coinage).
 - **Win-rate alone is insufficient** -- the composite's whole premise. Community discourse
@@ -97,26 +108,32 @@ CANONICAL sec 9); promoting any gate from advisory (separate SDMG track).
 ## 3. Design (design-for-isolation)
 
 ### 3.1 Sim instrumentation (additive, deterministic)
+
 The per-run result gains compact pressure-trajectory stats (from `pressure_stats(pressure_samples)`):
 `pressure_mean`, `pressure_frac_ge75` (share of rounds in the dangerous Critical+Apex tiers,
 pressure >= 75), `pressure_pmax`. `batch_calibrate_*.py aggregate()` then surfaces the
 aggregated forms over the run set:
+
 - `pressure_mean_avg` (mean of per-run `pressure_mean`),
 - `pressure_frac_ge75_avg` (mean of per-run sustained-threat fraction),
 - `apex_reach_rate` (fraction of runs whose `pressure_pmax` reached >= 95).
-(As-shipped PR1 keys -- the per-run `pressure_frac_ge75` + `pressure_mean` + `pressure_pmax`
-are exactly what candidates A/B/C consume; a full per-tier histogram is YAGNI until a future
-candidate needs it.) Additive keys; no behavior change; seed-pinned -> deterministic.
+  (As-shipped PR1 keys -- the per-run `pressure_frac_ge75` + `pressure_mean` + `pressure_pmax`
+  are exactly what candidates A/B/C consume; a full per-tier histogram is YAGNI until a future
+  candidate needs it.) Additive keys; no behavior change; seed-pinned -> deterministic.
 
 ### 3.2 PE candidates (`tools/py/pe_candidates.py`, pure)
+
 Each maps the trajectory stats -> a 0..1 value (higher = more sustained tension):
+
 - **A -- sustained-threat fraction:** share of rounds with pressure >= 75 (Critical+Apex).
 - **B -- time-averaged pressure:** `pressure_mean / 100` (trajectory, not endpoint-biased).
 - **C -- apex-reach rate:** fraction of runs that reached Apex (>= 95).
-Pure functions, unit-tested on synthetic trajectory dicts. New candidates are easy to add.
+  Pure functions, unit-tested on synthetic trajectory dicts. New candidates are easy to add.
 
 ### 3.3 Orthogonality analysis (`tools/py/pe_orthogonality.py`, pure)
+
 Given a per-run corpus `[(candidate_value, won_bool), ...]` for each candidate:
+
 - `abs(pearson(candidate, won))` -- the collinearity score; LOWER is better (more orthogonal).
   This is the PRIMARY selection criterion.
 - a SECONDARY discrimination check: run each oracle once more at a deliberately-EASED knob
@@ -124,9 +141,10 @@ Given a per-run corpus `[(candidate_value, won_bool), ...]` for each candidate:
   LOWER tension on that trivialized run than on the ratified-knob run (correct direction +
   a meaningful gap). This guards against a candidate that is orthogonal-but-flat (no signal).
 - emits a ranked **selection report** (each candidate's |corr|, discrimination gap, verdict).
-Pure (numpy-free; hand-rolled Pearson), unit-tested with synthetic correlated/uncorrelated data.
+  Pure (numpy-free; hand-rolled Pearson), unit-tested with synthetic correlated/uncorrelated data.
 
 ### 3.4 Experiment runner (maintainer/backend)
+
 A thin CLI that, for each ratified balance-oracle, runs the existing seed-pinned N=100
 harness on **node 22** (CANONICAL sec 3 rule 8), collects per-run `(pressure trajectory,
 won)`, computes A/B/C via 3.2, and feeds 3.3 -> prints the selection report. BACKEND-DEPENDENT
@@ -134,10 +152,12 @@ won)`, computes A/B/C via 3.2, and feeds 3.3 -> prints the selection report. BAC
 calls is fully unit-tested without a backend.
 
 ### 3.5 kd_ratio normalization
+
 `kd_ratio = kd_avg / (kd_avg + 1)` -- bounded (0,1), monotonic increasing, 0.8 -> ~0.44. Makes
 all three composite terms 0..1 and same-direction (higher=healthier). Pure + tested.
 
 ### 3.6 Composite band (human-ratified)
+
 Once `pe_ratio` (the selected candidate) + normalized `kd_ratio` are emitted, compute the
 composite on the in-band ratified oracles at N=100; the band = `[mean - k*half, mean + k*half]`
 derived from those healthy values (proposed, with the numbers shown). The band is

--- a/tools/py/calibrate_parallel.py
+++ b/tools/py/calibrate_parallel.py
@@ -166,15 +166,18 @@ def stop_shard(proc, fh, port):
             pass
 
 
-def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path, curves_path=None, seed=None):
-    """Subprocess wrapper -- launch batch_calibrate_*.py against one shard.
+def build_shard_cmd(script_path, host, n, out_path, jsonl_path, seed=None, policy=None, extra_args=None):
+    """Pure constructor for a per-shard batch_calibrate_*.py command line.
 
-    curves_path (OD-032 no-op-bug fix): if set, the batch CLIENT subprocess gets
-    DAMAGE_CURVES_PATH=curves_path so its scenario-override parser reads the SAME
-    staging file the backend shard reads. Without this the client silently used
-    production overrides (turn_limit/enemy_damage knobs = no-op during calibration).
+    Extracted so the --policy passthrough (PE_ratio contestedness multi-policy
+    re-run) is unit-testable without a backend. `policy` forwards a SINGLE
+    Restricted-Play policy {random,greedy,lookahead2,utility} to the batch script's
+    flat single-policy path (which writes JSONL = shard-mergeable). Omit `policy`
+    for back-compat (batch script default = greedy). 'all' is intentionally NOT a
+    valid passthrough here: the batch script's --policy all short-circuits to the
+    nested triangulation output (no JSONL) which does not compose with shard merge;
+    drive multi-policy by invoking the orchestrator once per policy instead.
     """
-    script_path = TOOLS_PY / scenario_cfg["script"]
     cmd = [
         sys.executable, "-u", str(script_path),
         "--host", host,
@@ -182,7 +185,29 @@ def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path, curve
         "--out", str(out_path),
         "--jsonl", str(jsonl_path),
         "--skip-health",
-    ] + (["--seed", str(seed)] if seed is not None else []) + scenario_cfg["extra_args"]
+    ]
+    if seed is not None:
+        cmd += ["--seed", str(seed)]
+    if policy is not None:
+        cmd += ["--policy", policy]
+    cmd += list(extra_args or [])
+    return cmd
+
+
+def run_shard_batch(host, scenario_cfg, n, out_path, jsonl_path, log_path, curves_path=None, seed=None, policy=None):
+    """Subprocess wrapper -- launch batch_calibrate_*.py against one shard.
+
+    curves_path (OD-032 no-op-bug fix): if set, the batch CLIENT subprocess gets
+    DAMAGE_CURVES_PATH=curves_path so its scenario-override parser reads the SAME
+    staging file the backend shard reads. Without this the client silently used
+    production overrides (turn_limit/enemy_damage knobs = no-op during calibration).
+
+    policy (PE_ratio contestedness): forward a single Restricted-Play policy to the
+    batch script (None = greedy default).
+    """
+    script_path = TOOLS_PY / scenario_cfg["script"]
+    cmd = build_shard_cmd(script_path, host, n, out_path, jsonl_path,
+                          seed=seed, policy=policy, extra_args=scenario_cfg["extra_args"])
     print(f"[parallel] launch shard host={host} N={n}", flush=True)
     f = open(log_path, "w", encoding="utf-8")
     env = dict(os.environ)
@@ -240,7 +265,7 @@ def aggregate_merged(runs, scenario):
     return {"error": f"no aggregate fn in {script_module}"}
 
 
-def main():
+def build_arg_parser():
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--scenario", choices=list(SCENARIO_MAP.keys()), required=True)
     p.add_argument("--n", type=int, required=True, help="Total N (split across shards)")
@@ -257,7 +282,16 @@ def main():
                    help="TKT-PLAYTEST-SEED: base seed for bit-identical runs. Each shard gets "
                         "a distinct offset (base + cumulative N) so runs never duplicate across "
                         "shards while the whole batch stays reproducible. Omit = Math.random.")
-    args = p.parse_args()
+    p.add_argument("--policy", choices=["random", "greedy", "lookahead2", "utility"], default=None,
+                   help="PE_ratio contestedness multi-policy re-run: forward a single canonical "
+                        "Restricted-Play policy to the batch script (default greedy). 'all' is NOT "
+                        "accepted here (nested triangulation output does not shard-merge) -- run the "
+                        "orchestrator once per policy and pool the corpora instead.")
+    return p
+
+
+def main():
+    args = build_arg_parser().parse_args()
 
     cfg = SCENARIO_MAP[args.scenario]
     label = args.label or time.strftime("%Y-%m-%d-%H%M%S")
@@ -341,7 +375,7 @@ def main():
         out_paths.append(out_p)
         jsonl_paths.append(jsonl_p)
         shard_seed = args.seed + seed_offsets[i] if args.seed is not None else None
-        proc, fh = run_shard_batch(host, cfg, n, out_p, jsonl_p, log_p, seed=shard_seed)
+        proc, fh = run_shard_batch(host, cfg, n, out_p, jsonl_p, log_p, seed=shard_seed, policy=args.policy)
         batch_procs.append((proc, fh, host, n, log_p))
 
     t0 = time.time()
@@ -405,6 +439,10 @@ def main():
     final = {
         "scenario": args.scenario,
         "scenario_id": cfg["scenario_id"],
+        # PE_ratio contestedness: which Restricted-Play policy this corpus was run
+        # under (None passthrough => the batch script's greedy default). The
+        # multi-policy re-run pools one corpus per policy across this field.
+        "policy_mode": args.policy or "greedy",
         "target_band": list(cfg["target_band"]),
         "total_n": args.n,
         "seed": args.seed,

--- a/tools/py/objective.py
+++ b/tools/py/objective.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Composite objective metric evaluation (G2 P1).
 
-Parses + evaluates a linear weighted-sum metric string like
-``0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio`` against a metrics dict.
+Parses + evaluates a linear weighted-sum metric string like the canonical
+``0.70*win_rate + 0.30*kd_ratio`` (the manifest `composite_metric`) against a metrics
+dict. Generic: the formula is config (canonical-suite.yaml), not hardcoded here -- the
+PE_ratio term was dropped 2026-06-23 (falsified, see that file) with no code change here.
 Safe parser (no eval): each term is ``<coef>*<metric_name>``.
 """
 

--- a/tools/py/pe_candidates.py
+++ b/tools/py/pe_candidates.py
@@ -110,11 +110,15 @@ def pe_ratio_aggregate(agg, candidate):
 
 
 def attach_composite_terms(agg, candidate=None):
-    """Idempotently add the two normalized composite terms to an aggregate() dict
-    so objective.evaluate_metric can compute `0.50*win_rate+0.25*kd_ratio+0.25*pe_ratio`.
+    """Idempotently add the normalized composite terms to an aggregate() dict.
       kd_ratio = kd_normalize(kd_avg)   (None if kd_avg absent -- surfaced, never faked)
-      pe_ratio = the experiment-selected candidate read off the aggregate pressure keys
-                 (0.0 if a scenario emits no pressure trajectory, e.g. hardcore_07).
+      pe_ratio = the contestedness candidate read off the aggregate keys.
+
+    NB: pe_ratio is DORMANT since 2026-06-23. The canonical composite dropped the PE term
+    (`composite_metric` = `0.70*win_rate + 0.30*kd_ratio`); the multi-policy N=40 experiment
+    falsified every contestedness PE source (evidence
+    docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md). pe_ratio is still emitted
+    as a cheap diagnostic (useful if PE is ever re-investigated) but no longer gates.
     No-op on an {'error': ...} dict. Returns the same dict for chaining."""
     if not isinstance(agg, dict) or "error" in agg:
         return agg
@@ -123,25 +127,21 @@ def attach_composite_terms(agg, candidate=None):
     return agg
 
 
-# SELECTED (PROVISIONAL) by the PR2 experiment (seed-pinned, node 22, 2026-06-19).
-# B_time_avg (= pressure_mean_avg/100) chosen on a PRINCIPLED basis, NOT the noisy
-# |corr| ranking: on every ratified balance oracle pressure runs HIGH (pe_ratio
-# 0.81-0.94 multi-oracle), so the candidates near-SATURATE and the |corr| ranking is
-# noise between near-flat values (N-sensitive: B@N=100 0.197, A@N=40 0.092). B is the
-# only CONTINUOUS candidate (real variance); A (sustained-threat fraction) pins ~1.0
-# and C (apex-reach) is binary -- both degenerate on high-pressure oracles. min|corr|
-# << 0.6 so pressure is not formally rejected, but the signal is MARGINAL.
-#
-# 🔴 OPEN (master-dd, NOT a blocker for this wiring): the per-run trajectory was
-# extended to badlands_elite + foresta_pilot (PR2b) so pe_ratio is now REAL on all 3
-# oracles (no longer 0.0). The composite BAND is PROPOSED ([0.236, 0.815] at k=2.0,
-# mean 0.526) but NOT written to the manifest (SDMG, human-ratified). Because pe_ratio
-# is ~0.8-0.94 everywhere it adds little DISCRIMINATION -> master-dd may instead switch
-# to the design's alternate tension source (turns-to-resolve + dmg_taken contestedness,
-# sec 4.5), telemetered on every oracle, which avoids the high-pressure saturation.
-# Evidence:
-# docs/playtest/2026-06-19-pe-ratio-experiment-n100.md.
-SELECTED_CANDIDATE = "B_time_avg"
+# PE SOURCE DROPPED 2026-06-23 (SDMG ratify, master-dd) -- the PE term is no longer in the
+# canonical composite (`composite_metric` = `0.70*win_rate + 0.30*kd_ratio`). The full
+# experiment chain falsified PE-as-tension-axis:
+#   - PRESSURE source (A/B/C): rejected -- saturates ~0.81-0.94 on every high-pressure
+#     oracle = ~zero discrimination (2026-06-19 evidence).
+#   - CONTESTEDNESS source (D/E/F, the sec-4.5 fallback): rejected on the canonical
+#     MULTI-POLICY N=40 experiment -- E_dmg_margin's apparent orthogonality (pooled 0.301)
+#     is a degeneracy artifact (hardcore_07 zero-damage timer-race + the constant-loss
+#     `random` policy); on damage-capable oracles it is 0.479 and on skilled policies
+#     0.68-0.71 = an outcome-proxy. No contestedness formula is WR-orthogonal with current
+#     instrumentation. Evidence: docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md.
+# SELECTED_CANDIDATE is retained only as the default for the now-DORMANT pe_ratio diagnostic
+# that attach_composite_terms still emits (it does not gate). E_dmg_margin = the least-bad
+# contestedness candidate found, kept here for any future re-investigation.
+SELECTED_CANDIDATE = "E_dmg_margin"
 
 
 def kd_normalize(kd_avg):

--- a/tools/py/run_pe_contestedness_experiment.py
+++ b/tools/py/run_pe_contestedness_experiment.py
@@ -1,14 +1,31 @@
 #!/usr/bin/env python3
-"""Re-analyze the committed N=100 oracle corpora with the contestedness candidates
-(D/E/F) -> per-oracle + pooled orthogonality |corr(candidate, won)| (the SELECTION)
-+ the proposed composite band for the least-collinear contestedness candidate.
+"""PE_ratio contestedness orthogonality + composite-band, generalized to the canonical
+MULTI-POLICY regime.
 
-Deterministic: pure analysis of the saved seed-pinned (424242) node-22 corpora from
-the 2026-06-18 PR2 run -- NO backend, NO prod, no randomness. The owner ratifies the
-selection + the band (SDMG); this script only proposes with numbers.
+Each ORACLE pools per-combat runs across the canonical Restricted-Play policy set
+[random, greedy, lookahead2, utility] (canonical-suite.yaml `policies`), NOT greedy-only.
+Orthogonality = |corr(candidate, won)| on the pooled per-run records (LOWER = less
+collinear with win-rate = better anti-false-balance); the composite band = mean +/- k*sd
+of the SELECTED candidate's per-oracle aggregate value across the oracles.
 
+Why this re-run: the committed N=100 evidence
+(docs/playtest/2026-06-23-pe-contestedness-orthogonality-n100.md) selected E_dmg_margin but
+its band was NOT ratifiable -- the corpora were `policy_mode=greedy-only` DIAGNOSTIC (wrong
+regime: the composite gates multi-policy canonical balance) and the band was a 3-point
+outlier artifact (dropping badlands_elite collapsed it). This runner consumes corpora
+produced by `calibrate_parallel.py --policy {random,greedy,lookahead2,utility}` (one file per
+oracle per policy) and pools them, over >=5 oracles incl. a low-pressure/easy one.
+
+Pure analysis (no backend, no randomness). The owner ratifies the selection + the band
+(SDMG, human-only); this script only proposes with numbers.
+
+  # back-compat: re-analyze the committed greedy-only corpora (reproduces PR2 evidence)
   python tools/py/run_pe_contestedness_experiment.py
+
+  # multi-policy re-run: point at a corpora config mapping oracle -> [per-policy paths]
+  python tools/py/run_pe_contestedness_experiment.py --corpora-config corpora.json --json-out out.json
 """
+import argparse
 import json
 import statistics
 import sys
@@ -20,21 +37,67 @@ from pe_candidates import CANDIDATES, candidate_value, pe_ratio_aggregate  # noq
 from pe_orthogonality import pearson, DEFAULT_MAX_CORR  # noqa: E402
 
 ROOT = Path(__file__).parent.parent.parent
-# The 3 ratified balance oracles (NOT badlands_ambient = designed-winnable, not an oracle).
-CORPORA = {
-    "hardcore_06": "docs/playtest/parallel-hardcore_06-iter5-optuna-ratify-merged.json",
-    "badlands_elite_01": "docs/playtest/2026-06-18-badlands_elite_01-n100-merged.json",
-    "foresta_pilot_01": "docs/playtest/2026-06-18-foresta_pilot_01-n100-merged.json",
+
+# Back-compat default = the committed greedy-only corpora (the PR2 evidence). The
+# multi-policy re-run overrides this via --corpora-config (oracle -> [per-policy paths]).
+DEFAULT_CORPORA = {
+    "hardcore_06": ["docs/playtest/parallel-hardcore_06-iter5-optuna-ratify-merged.json"],
+    "badlands_elite_01": ["docs/playtest/2026-06-18-badlands_elite_01-n100-merged.json"],
+    "foresta_pilot_01": ["docs/playtest/2026-06-18-foresta_pilot_01-n100-merged.json"],
 }
 CONTEST = ["D_turns_contest", "E_dmg_margin", "F_contest_combined"]
 
 
-def load_runs(path):
-    d = json.loads((ROOT / path).read_text(encoding="utf-8"))
-    return d if isinstance(d, list) else d.get("runs", [])
+def _read_corpus(path):
+    """Read one corpus file -> list of clean run records. Accepts three shapes:
+      - a bare list of run records;
+      - a single-policy report  {..., 'runs': [...]}  (calibrate_parallel merged);
+      - a multi-policy triangulation report  {..., 'policies': {pol: {'runs': [...]}}}
+        (batch_calibrate_*.py --policy all) -> flatten all policies into one pool.
+    Failed runs ({'error': ...}, no outcome/contestedness fields) are dropped so they
+    cannot pollute the correlation or the aggregate. Repo-relative paths resolve under
+    ROOT; absolute paths are read as-is (generated corpora outside the repo also load)."""
+    p = Path(path)
+    if not p.is_absolute():
+        p = ROOT / p
+    d = json.loads(p.read_text(encoding="utf-8"))
+    if isinstance(d, list):
+        runs = d
+    elif isinstance(d.get("policies"), dict):
+        runs = []
+        for pol in d["policies"].values():
+            runs.extend(pol.get("runs", []) if isinstance(pol, dict) else [])
+    else:
+        runs = d.get("runs", [])
+    return [r for r in runs if isinstance(r, dict) and "error" not in r]
+
+
+def pool_oracle_runs(paths):
+    """Concatenate the per-policy corpora for ONE oracle into a single run list
+    (each record keeps its own `policy` field). This is the multi-policy pool the
+    orthogonality + aggregate are computed over."""
+    pooled = []
+    for path in paths:
+        pooled.extend(_read_corpus(path))
+    return pooled
+
+
+def load_corpora(config):
+    """config = {oracle_name: [corpus_path, ...]} -> {oracle_name: pooled_runs}."""
+    return {name: pool_oracle_runs(paths) for name, paths in config.items()}
+
+
+def oracle_aggregate(runs):
+    """Build the composite-form aggregate keys from a corpus (mean per-run rollups)."""
+    return {
+        "turns_avg": statistics.mean(r.get("rounds", 0.0) for r in runs) if runs else 0.0,
+        "dmg_taken_avg": statistics.mean(r.get("dmg_taken_player", 0.0) for r in runs) if runs else 0.0,
+        "dmg_dealt_avg": statistics.mean(r.get("dmg_dealt_player", 0.0) for r in runs) if runs else 0.0,
+    }
 
 
 def abs_corr_table(runs):
+    """{candidate: |corr(candidate_value, won)|} over a run list + the binary wons."""
     wons, vals = [], {n: [] for n in CANDIDATES}
     for r in runs:
         stats, won = run_to_stats(r)
@@ -44,52 +107,122 @@ def abs_corr_table(runs):
     return {n: abs(pearson(vals[n], wons)) for n in CANDIDATES}, wons
 
 
-def oracle_aggregate(runs):
-    """Build the composite-form aggregate keys from a corpus (mean per-run rollups)."""
+def derive_band(values, k=2.0, candidate=None):
+    """Composite band = mean +/- k*sd over the per-oracle aggregate values, clamped
+    to [0,1]. Population stdev (the oracles ARE the population, not a sample); single
+    value -> zero spread."""
+    vals = list(values)
+    mu = statistics.mean(vals) if vals else 0.0
+    sd = statistics.pstdev(vals) if len(vals) > 1 else 0.0
     return {
-        "turns_avg": statistics.mean(r.get("rounds", 0.0) for r in runs),
-        "dmg_taken_avg": statistics.mean(r.get("dmg_taken_player", 0.0) for r in runs),
-        "dmg_dealt_avg": statistics.mean(r.get("dmg_dealt_player", 0.0) for r in runs),
+        "candidate": candidate,
+        "k": k,
+        "n": len(vals),
+        "mu": mu,
+        "sd": sd,
+        "lo": max(0.0, mu - k * sd),
+        "hi": min(1.0, mu + k * sd),
+        "values": vals,
     }
 
 
-def main():
-    print("PE_ratio contestedness orthogonality -- |corr(candidate, won)| (LOWER = less collinear = better)\n")
+def analyze(oracle_runs, candidate=None, k=2.0, max_corr=DEFAULT_MAX_CORR):
+    """Core analysis over {oracle: pooled_runs}.
+
+    - per-oracle + pooled orthogonality |corr(candidate, won)| (selection criterion);
+    - select the least-collinear CONTEST candidate on the POOLED runs (None -> all
+      rejected = escalate to drop-PE);
+    - derive the composite band for `candidate` (explicit) or the selected candidate,
+      over the per-oracle aggregate values.
+    Returns a structured dict (no printing) so callers/tests can assert on it."""
+    per_oracle = {}
     pooled = []
-    for name, path in CORPORA.items():
-        runs = load_runs(path)
-        pooled += runs
+    for name, runs in oracle_runs.items():
+        pooled.extend(runs)
         tbl, wons = abs_corr_table(runs)
-        print(f"== {name}  (n={len(runs)}, WR={sum(wons) / len(wons):.2f}) ==")
-        for n in sorted(tbl, key=tbl.get):
-            print(f"   {n:20s} |corr|={tbl[n]:.3f}")
-        print()
-
-    print(f"== POOLED (all 3 oracles, n={len(pooled)}) ==")
+        per_oracle[name] = {
+            "n": len(runs),
+            "wr": (sum(wons) / len(wons)) if wons else 0.0,
+            "orthogonality": tbl,
+            "aggregate": oracle_aggregate(runs),
+        }
     ptbl, _ = abs_corr_table(pooled)
-    for n in sorted(ptbl, key=ptbl.get):
-        print(f"   {n:20s} |corr|={ptbl[n]:.3f}")
+    sel = min(CONTEST, key=lambda n: ptbl[n]) if CONTEST else None
+    rejected = sel is None or ptbl[sel] > max_corr
+    chosen = candidate or (None if rejected else sel)
+    band = None
+    if chosen is not None:
+        vals = []
+        for name in oracle_runs:
+            v = pe_ratio_aggregate(per_oracle[name]["aggregate"], chosen)
+            per_oracle[name]["pe_value"] = v
+            vals.append(v)
+        band = derive_band(vals, k=k, candidate=chosen)
+    return {
+        "per_oracle": per_oracle,
+        "pooled_orthogonality": ptbl,
+        "selected": None if rejected else sel,
+        "rejected": rejected,
+        "band": band,
+        "max_corr": max_corr,
+    }
 
-    sel = min(CONTEST, key=lambda n: ptbl[n])
-    rejected = ptbl[sel] >= DEFAULT_MAX_CORR
-    print(f"\nLeast-collinear contestedness candidate (pooled) = {sel}  |corr|={ptbl[sel]:.3f}")
-    print(f"max_corr threshold = {DEFAULT_MAX_CORR} -> {'REJECTED (escalate: drop PE term)' if rejected else 'NOT rejected'}")
 
-    # Composite band on the SELECTED candidate: per-oracle aggregate value (what the
-    # composite consumes) -> mean +/- k*sd over the 3 oracle configs.
-    k = 2.0
-    agg_vals = []
-    for name, path in CORPORA.items():
-        agg = oracle_aggregate(load_runs(path))
-        v = pe_ratio_aggregate(agg, sel)
-        agg_vals.append(v)
-        print(f"   aggregate {sel} @ {name} = {v:.3f}")
-    mu = statistics.mean(agg_vals)
-    sd = statistics.pstdev(agg_vals) if len(agg_vals) > 1 else 0.0
-    lo, hi = max(0.0, mu - k * sd), min(1.0, mu + k * sd)
-    print(f"\nPROPOSED band on {sel} (mean +/- {k}*sd): mu={mu:.3f} sd={sd:.3f} -> [{lo:.3f}, {hi:.3f}]")
+def _print_report(config, result):
+    print("PE_ratio contestedness orthogonality (MULTI-POLICY) -- |corr(candidate, won)| "
+          "(LOWER = less collinear = better)\n")
+    for name, o in result["per_oracle"].items():
+        policies = ", ".join(Path(p).name for p in config[name])
+        print(f"== {name}  (n={o['n']}, WR={o['wr']:.2f})  corpora: {policies} ==")
+        for cand in sorted(o["orthogonality"], key=o["orthogonality"].get):
+            print(f"   {cand:20s} |corr|={o['orthogonality'][cand]:.3f}")
+        print()
+    print(f"== POOLED (all {len(result['per_oracle'])} oracles) ==")
+    ptbl = result["pooled_orthogonality"]
+    for cand in sorted(ptbl, key=ptbl.get):
+        print(f"   {cand:20s} |corr|={ptbl[cand]:.3f}")
+    sel = result["selected"]
+    if result["rejected"]:
+        worst = min(ptbl[c] for c in CONTEST)
+        print(f"\nALL contestedness candidates rejected (min |corr|={worst:.3f} > "
+              f"{result['max_corr']}) -> ESCALATE: drop the PE term (composite = re-weighted "
+              f"win_rate + kd_ratio). Valid NEGATIVE result (handoff sec Escalation).")
+    else:
+        print(f"\nLeast-collinear contestedness candidate (pooled) = {sel}  |corr|={ptbl[sel]:.3f}  "
+              f"(< {result['max_corr']} -> NOT rejected)")
+    band = result["band"]
+    if band:
+        for name, o in result["per_oracle"].items():
+            print(f"   aggregate {band['candidate']} @ {name} = {o['pe_value']:.3f}")
+        print(f"\nPROPOSED band on {band['candidate']} (mean +/- {band['k']}*sd over "
+              f"{band['n']} oracles): mu={band['mu']:.3f} sd={band['sd']:.3f} -> "
+              f"[{band['lo']:.3f}, {band['hi']:.3f}]")
     print("\nNB: PROPOSED only. master-dd ratifies the selection AND the band (SDMG, human-only).")
 
 
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--corpora-config", default=None,
+                    help="JSON file mapping oracle_name -> [per-policy corpus paths]. "
+                         "Omit = the committed greedy-only DEFAULT_CORPORA (back-compat).")
+    ap.add_argument("--k", type=float, default=2.0, help="band half-width = k*sd (default 2.0)")
+    ap.add_argument("--candidate", default=None,
+                    help="force the band candidate (default = the selected least-collinear one)")
+    ap.add_argument("--json-out", default=None, help="also write the structured result JSON here")
+    args = ap.parse_args(argv)
+
+    if args.corpora_config:
+        config = json.loads(Path(args.corpora_config).read_text(encoding="utf-8"))
+    else:
+        config = DEFAULT_CORPORA
+    oracle_runs = load_corpora(config)
+    result = analyze(oracle_runs, candidate=args.candidate, k=args.k)
+    _print_report(config, result)
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"\nWrote {args.json_out}")
+    return 0
+
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tools/py/test_calibrate_parallel.py
+++ b/tools/py/test_calibrate_parallel.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Unit tests for calibrate_parallel shard-command construction (no backend).
+
+Covers the --policy passthrough (PE_ratio contestedness multi-policy re-run): the
+sharded orchestrator must forward a single Restricted-Play policy
+{random,greedy,lookahead2,utility} to the underlying batch_calibrate_*.py so the
+per-combat corpora span the canonical multi-policy regime (canonical-suite.yaml
+policies: [random, greedy, lookahead2, utility]), not greedy-only.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import calibrate_parallel as cp  # noqa: E402
+
+
+def _adjacent(seq, a, b):
+    """True if value b immediately follows value a in seq."""
+    for i, v in enumerate(seq[:-1]):
+        if v == a and seq[i + 1] == b:
+            return True
+    return False
+
+
+def test_build_shard_cmd_includes_policy_when_set():
+    cmd = cp.build_shard_cmd(
+        "tools/py/batch_calibrate_foresta_pilot_01.py",
+        "http://127.0.0.1:3501", 10, "out.json", "out.jsonl",
+        policy="lookahead2",
+    )
+    assert _adjacent(cmd, "--policy", "lookahead2"), cmd
+
+
+def test_build_shard_cmd_omits_policy_by_default():
+    # Back-compat: no --policy => batch script default (greedy) flat path.
+    cmd = cp.build_shard_cmd(
+        "tools/py/batch_calibrate_foresta_pilot_01.py",
+        "http://127.0.0.1:3501", 10, "out.json", "out.jsonl",
+    )
+    assert "--policy" not in cmd, cmd
+
+
+def test_build_shard_cmd_threads_seed_and_extra_args():
+    cmd = cp.build_shard_cmd(
+        "tools/py/batch_calibrate_foresta_pilot_01.py",
+        "http://127.0.0.1:3501", 40, "out.json", "out.jsonl",
+        seed=424242, policy="random",
+        extra_args=["--encounter-class", "foresta_pilot"],
+    )
+    assert _adjacent(cmd, "--seed", "424242"), cmd
+    assert _adjacent(cmd, "--policy", "random"), cmd
+    assert _adjacent(cmd, "--encounter-class", "foresta_pilot"), cmd
+    # --skip-health always present (shards pre-checked healthy by the orchestrator).
+    assert "--skip-health" in cmd, cmd
+
+
+def test_build_shard_cmd_random_policy_is_a_valid_restricted_play_policy():
+    # Guard: the 4 canonical Restricted-Play policies must all be forwardable.
+    for pol in ("random", "greedy", "lookahead2", "utility"):
+        cmd = cp.build_shard_cmd(
+            "tools/py/batch_calibrate_foresta_pilot_01.py",
+            "http://127.0.0.1:3501", 10, "out.json", "out.jsonl", policy=pol,
+        )
+        assert _adjacent(cmd, "--policy", pol), (pol, cmd)
+
+
+def test_arg_parser_accepts_restricted_play_policies():
+    parser = cp.build_arg_parser()
+    for pol in ("random", "greedy", "lookahead2", "utility"):
+        args = parser.parse_args(["--scenario", "foresta_pilot_01", "--n", "10", "--policy", pol])
+        assert args.policy == pol
+
+
+def test_arg_parser_rejects_policy_all():
+    # 'all' must NOT be a valid orchestrator passthrough (nested triangulation
+    # output does not compose with shard JSONL merge -- run once per policy instead).
+    import pytest
+    parser = cp.build_arg_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--scenario", "foresta_pilot_01", "--n", "10", "--policy", "all"])
+
+
+def test_arg_parser_policy_defaults_to_none():
+    # Default None => greedy passthrough omitted => back-compat single-policy.
+    parser = cp.build_arg_parser()
+    args = parser.parse_args(["--scenario", "foresta_pilot_01", "--n", "10"])
+    assert args.policy is None

--- a/tools/py/test_pe_ratio_wiring.py
+++ b/tools/py/test_pe_ratio_wiring.py
@@ -46,8 +46,12 @@ def test_kd_normalize_bounded_monotonic():
 
 
 def test_selected_candidate_is_a_known_candidate():
-    # the ratified selection must resolve (guards a typo'd constant)
-    assert SELECTED_CANDIDATE in {"A_sustained_threat", "B_time_avg", "C_apex_reach"}
+    # The dormant pe_ratio diagnostic's default must resolve to a real candidate (guards a
+    # typo'd constant). NB pe_ratio is no longer in the canonical composite (dropped
+    # 2026-06-23, falsified) -- this just keeps the diagnostic computable. Check against the
+    # actual candidate registry, not a hardcoded subset (it was stale: pressure-only).
+    from pe_candidates import CANDIDATES  # noqa: E402
+    assert SELECTED_CANDIDATE in CANDIDATES
 
 
 def _run(outcome, *, rounds=10, players_dead=1, enemies_dead=5, pmean=80.0, frac=1.0, pmax=100.0):

--- a/tools/py/test_run_pe_contestedness_experiment.py
+++ b/tools/py/test_run_pe_contestedness_experiment.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Unit tests for the multi-policy generalization of run_pe_contestedness_experiment.
+
+The committed evidence was a 3-point band on GREEDY-ONLY corpora (harsh-review HIGH:
+wrong policy regime + 3-point outlier artifact). The re-run pools the canonical
+Restricted-Play regime [random, greedy, lookahead2, utility] (canonical-suite.yaml)
+across >=5 oracles. These tests pin the PURE pooling + band-derivation + analysis logic
+(no backend, no file I/O except pool_oracle_runs round-trip).
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import run_pe_contestedness_experiment as rx  # noqa: E402
+
+
+def _run(outcome, rounds, taken, dealt):
+    return {
+        "outcome": outcome, "rounds": rounds,
+        "dmg_taken_player": taken, "dmg_dealt_player": dealt,
+    }
+
+
+# --- derive_band: mean +/- k*sd, clamped to [0,1] -------------------------------
+
+def test_derive_band_basic_mean_and_spread():
+    b = rx.derive_band([0.2, 0.4, 0.6], k=2.0)
+    assert b["n"] == 3
+    assert abs(b["mu"] - 0.4) < 1e-9
+    assert abs(b["sd"] - 0.16329931) < 1e-6  # population stdev of [.2,.4,.6]
+    assert abs(b["lo"] - (0.4 - 2 * 0.16329931)) < 1e-6
+    assert abs(b["hi"] - (0.4 + 2 * 0.16329931)) < 1e-6
+
+
+def test_derive_band_clamps_to_unit_interval():
+    b = rx.derive_band([0.1, 0.9], k=2.0)  # mu .5 sd .4 -> [-.3, 1.3] clamps
+    assert b["lo"] == 0.0
+    assert b["hi"] == 1.0
+
+
+def test_derive_band_single_oracle_zero_spread():
+    b = rx.derive_band([0.5], k=2.0)
+    assert b["sd"] == 0.0
+    assert b["lo"] == 0.5 and b["hi"] == 0.5
+
+
+# --- pool_oracle_runs: concatenate per-policy corpora for ONE oracle ------------
+
+def test_pool_oracle_runs_concatenates_across_policy_files(tmp_path):
+    a = tmp_path / "greedy.json"
+    b = tmp_path / "random.json"
+    a.write_text(json.dumps({"policy_mode": "greedy", "runs": [_run("victory", 10, 5, 9)]}), encoding="utf-8")
+    b.write_text(json.dumps({"policy_mode": "random", "runs": [
+        _run("defeat", 40, 30, 4), _run("victory", 12, 6, 8)]}), encoding="utf-8")
+    pooled = rx.pool_oracle_runs([str(a), str(b)])
+    assert len(pooled) == 3  # 1 + 2 across the two policy corpora
+
+
+def test_pool_oracle_runs_accepts_bare_list_corpus(tmp_path):
+    p = tmp_path / "list.json"
+    p.write_text(json.dumps([_run("victory", 10, 5, 9)]), encoding="utf-8")
+    assert len(rx.pool_oracle_runs([str(p)])) == 1
+
+
+def test_pool_oracle_runs_flattens_policy_all_triangulation_file(tmp_path):
+    # A `batch_calibrate_*.py --policy all` file holds per-policy runs nested under
+    # policies[pol].runs (NOT a flat top-level `runs`). One such file = the full
+    # multi-policy pool for one oracle; pool_oracle_runs must flatten all 4 policies.
+    p = tmp_path / "allpol.json"
+    p.write_text(json.dumps({
+        "mode": "triangulation",
+        "policies": {
+            "random": {"runs": [_run("defeat", 40, 30, 4)]},
+            "greedy": {"runs": [_run("victory", 10, 5, 9), _run("victory", 12, 6, 8)]},
+            "lookahead2": {"runs": [_run("victory", 11, 5, 9)]},
+            "utility": {"runs": [_run("defeat", 38, 28, 5)]},
+        },
+    }), encoding="utf-8")
+    pooled = rx.pool_oracle_runs([str(p)])
+    assert len(pooled) == 5  # 1 + 2 + 1 + 1 across the 4 policies
+
+
+def test_pool_oracle_runs_triangulation_drops_error_records(tmp_path):
+    # run_one returns {"error": ...} on a failed run (no outcome); these must not
+    # pollute the pool (they have no contestedness fields).
+    p = tmp_path / "allpol_err.json"
+    p.write_text(json.dumps({
+        "policies": {
+            "greedy": {"runs": [_run("victory", 10, 5, 9), {"error": "session/start failed"}]},
+            "random": {"runs": [_run("defeat", 40, 30, 4)]},
+        },
+    }), encoding="utf-8")
+    pooled = rx.pool_oracle_runs([str(p)])
+    assert len(pooled) == 2  # the error record is dropped
+    assert all("error" not in r for r in pooled)
+
+
+# --- analyze: orthogonality on pooled multi-policy runs + band across oracles ----
+
+def _oracle_runs():
+    # 2 synthetic oracles; outcome tracks rounds (long fight => loss) so D/F are
+    # collinear while E (dmg margin) has its own spread. Exact corr values are not
+    # asserted (covered by pe_orthogonality tests) -- structure + wiring is.
+    o1 = [_run("victory", 8, 4, 12), _run("victory", 10, 6, 11),
+          _run("defeat", 38, 28, 5), _run("defeat", 40, 30, 6)]
+    o2 = [_run("victory", 9, 5, 10), _run("defeat", 36, 24, 7),
+          _run("victory", 11, 7, 9), _run("defeat", 39, 26, 6)]
+    return {"oracle_hi": o1, "oracle_lo": o2}
+
+
+def test_analyze_returns_per_oracle_and_pooled_orthogonality():
+    res = rx.analyze(_oracle_runs(), k=2.0)
+    assert set(res["per_oracle"]) == {"oracle_hi", "oracle_lo"}
+    for o in res["per_oracle"].values():
+        assert o["n"] == 4
+        for cand in rx.CONTEST:
+            assert cand in o["orthogonality"]
+    for cand in rx.CONTEST:
+        assert cand in res["pooled_orthogonality"]
+
+
+def test_analyze_selects_least_collinear_contestedness_candidate():
+    res = rx.analyze(_oracle_runs(), k=2.0)
+    # selected is the min-|corr| CONTEST candidate (or None if all rejected).
+    assert res["selected"] in set(rx.CONTEST) | {None}
+    if res["selected"] is not None:
+        sel_corr = res["pooled_orthogonality"][res["selected"]]
+        assert sel_corr == min(res["pooled_orthogonality"][c] for c in rx.CONTEST)
+
+
+def test_analyze_band_is_over_per_oracle_aggregate_values():
+    res = rx.analyze(_oracle_runs(), candidate="E_dmg_margin", k=2.0)
+    band = res["band"]
+    assert band["candidate"] == "E_dmg_margin"
+    assert band["n"] == 2  # one aggregate value per oracle (NOT per-run)
+    # values match pe_ratio_aggregate(oracle_aggregate(pooled_runs)) per oracle.
+    from pe_candidates import pe_ratio_aggregate  # noqa: E402
+    expect = sorted(
+        pe_ratio_aggregate(rx.oracle_aggregate(runs), "E_dmg_margin")
+        for runs in _oracle_runs().values()
+    )
+    assert sorted(band["values"]) == [round(v, 12) for v in [round(x, 12) for x in expect]] or \
+        all(abs(a - b) < 1e-9 for a, b in zip(sorted(band["values"]), expect))
+
+
+def test_analyze_rejected_flag_when_all_above_threshold():
+    # Degenerate corpus where every contestedness candidate perfectly tracks `won`
+    # (win => short+low-damage, loss => long+high-damage) -> |corr| ~ 1 -> rejected.
+    runs = [_run("victory", 5, 1, 20) for _ in range(5)] + \
+           [_run("defeat", 40, 40, 1) for _ in range(5)]
+    res = rx.analyze({"degenerate": runs}, k=2.0)
+    assert res["rejected"] is True
+    assert res["selected"] is None

--- a/tools/py/test_suite_manifest.py
+++ b/tools/py/test_suite_manifest.py
@@ -10,6 +10,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+from objective import evaluate_metric  # noqa: E402
 from suite_manifest import (  # noqa: E402
     DEFAULT_MANIFEST_PATH,
     get_scenario,
@@ -40,6 +41,21 @@ def test_objective_falls_back_to_global_composite(manifest):
     # No per-scenario objective_metric -> global composite_metric.
     obj = scenario_objective(manifest, HC06)
     assert "win_rate" in obj
+
+
+def test_composite_metric_dropped_pe_ratio(manifest):
+    # 2026-06-23 SDMG ratification (master-dd): the PE_ratio term is DROPPED. The
+    # canonical MULTI-POLICY N=40 experiment falsified every contestedness PE source
+    # (E_dmg_margin is degenerate on timer-race oracles + an outcome-proxy on skilled
+    # policies; no WR-orthogonal tension axis exists) -- evidence
+    # docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md. Composite =
+    # re-weighted win_rate + kd_ratio (0.70/0.30 = the renormalized original weights).
+    comp = manifest["composite_metric"]
+    assert "pe_ratio" not in comp, comp
+    assert comp == "0.70*win_rate + 0.30*kd_ratio", comp
+    # Must evaluate with ONLY win_rate + kd_ratio (no KeyError for a missing pe_ratio).
+    val = evaluate_metric(comp, {"win_rate": 0.5, "kd_ratio": 0.6})
+    assert val == pytest.approx(0.70 * 0.5 + 0.30 * 0.6)
 
 
 def test_unknown_scenario_raises(manifest):


### PR DESCRIPTION
## Summary

Finishes the **PE_ratio contestedness keystone**. The canonical MULTI-POLICY N=40 experiment **falsified** the contestedness PE source -- master-dd SDMG-ratified **dropping the PE term**: `composite_metric` = `0.70*win_rate + 0.30*kd_ratio` (was `0.50*win_rate + 0.25*kd_ratio + 0.25*pe_ratio`). A valid **negative result** -- it prevents locking a non-WR-orthogonal metric into the balance authority.

This unblocks the SPEC-J + SPEC-H flips (the PE band was the chokepoint; it is now removed, not derived).

## Verify-first correction (manifest-backed)

Canonical multi-policy for the PE composite = Restricted-Play `[random, greedy, lookahead2, utility]` (`canonical-suite.yaml` `policies`), **NOT** MBTI/`full-loop-batch.js` (that drives the SEPARATE meta-loop gate). The 2026-06-20 handoff framed it as MBTI; the manifest says Restricted-Play. The multi-policy machinery was already shipped (`calibrate_policies.py --policy all`) -- only the experiment runner needed generalizing. master-dd ratified the regime.

## The negative result (N=40, 6 oracles, seed 424242, node 22)

| | greedy-only (committed, rejected) | multi-policy N=40 |
|---|---|---|
| E_dmg_margin pooled \|corr\| | 0.499 | **0.301** (but flattered) |
| excl. degenerate hardcore_07 | -- | **0.479** (~= rejected greedy) |
| skilled policies (lookahead2/utility) | -- | **0.684 / 0.706** (outcome-proxy) |

- `hardcore_07` has zero damage telemetry (timer-race) -> E identically 0 -> a 160-point zero-variance block that artificially lowers the pooled `|corr|` below the 0.6 threshold.
- On skilled policies E is an outcome-proxy (a strong policy wins *by* taking less damage). No contestedness formula is WR-orthogonal with current instrumentation; `kd_ratio` is itself partly collinear (0.74-0.90 on hc07).

Both findings independently verified by 2 adversarial harsh-reviews (`balance-illuminator`: CONFIRM drop-PE, no salvage; `cavecrew-reviewer`: numbers sound, framed as master-dd's explicit choice).

## Changes

- **Harness (TDD)**: `calibrate_parallel.py` `--policy` passthrough (sharded single-policy); `run_pe_contestedness_experiment.py` generalized to multi-policy pooling (reads flat / `{runs}` / `{policies:{pol:{runs}}}` shapes, drops error records). Back-compat reproduces the committed greedy evidence byte-for-byte. New tests: `test_calibrate_parallel.py`, `test_run_pe_contestedness_experiment.py`.
- **Ratified change**: `canonical-suite.yaml` `composite_metric` -> `0.70*win_rate + 0.30*kd_ratio`; pinned by a new `test_suite_manifest` test.
- **pe_ratio dormant**: machinery kept as a diagnostic (no longer gates); `pe_candidates.py` / `objective.py` docstrings + `CANONICAL-AI-PLAYTEST.md` updated. Composite spec + handoff + the superseded N=100 evidence doc closed out.
- **Evidence**: `docs/playtest/2026-06-23-pe-contestedness-multipolicy-n40.md`.

## Verification

- `py -m pytest tools/py` -> **170 passed**.
- `npm run format:check` (changed files) -> clean.
- docs governance `--strict` -> errors=0 (new doc registered, surgical registry append).
- Non-prod backend `:3500` only; prod `3334`/`3341` never touched.

## Follow-up (open, not in scope)

"Is ANY non-WR-collinear axis viable?" needs new instrumentation (AP-usage spread / positional entropy / state-change frequency).

## Rollback

Revert this commit -> `composite_metric` returns to the 3-term form (which fail-closes on the absent pe_ratio, as before). No data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)