### PR TITLE
feat(traits): backfill slot_profile on 69 traits (applies #3021)

### DIFF
--- a/data/traits/cognitivo/artigli_psionici.json
+++ b/data/traits/cognitivo/artigli_psionici.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Mentale/Cognizione",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "cognitivo",
+    "complementare": "cognizione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/cognitivo/cervello_predittivo.json
+++ b/data/traits/cognitivo/cervello_predittivo.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Mentale/Cognizione",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T3",
+  "slot_profile": {
+    "core": "cognitivo",
+    "complementare": "cognizione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/cognitivo/mente_lucida.json
+++ b/data/traits/cognitivo/mente_lucida.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Mentale/Cognizione",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "cognitivo",
+    "complementare": "cognizione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/difensivo/corteccia_memetica.json
+++ b/data/traits/difensivo/corteccia_memetica.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Difensivo/Protezione",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "protezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/difensivo/pelli_cave.json
+++ b/data/traits/difensivo/pelli_cave.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Difensivo/Protezione",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "protezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/aculei_velenosi.json
+++ b/data/traits/fisiologico/aculei_velenosi.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/aura_glaciale.json
+++ b/data/traits/fisiologico/aura_glaciale.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/cuore_in_furia.json
+++ b/data/traits/fisiologico/cuore_in_furia.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/denti_seghettati.json
+++ b/data/traits/fisiologico/denti_seghettati.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/filtri_bioattivi.json
+++ b/data/traits/fisiologico/filtri_bioattivi.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/membrane_osmotiche.json
+++ b/data/traits/fisiologico/membrane_osmotiche.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/pelle_elastomera.json
+++ b/data/traits/fisiologico/pelle_elastomera.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/pelli_anti_ustione.json
+++ b/data/traits/fisiologico/pelli_anti_ustione.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/pelli_fitte.json
+++ b/data/traits/fisiologico/pelli_fitte.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/sensori_sismici.json
+++ b/data/traits/fisiologico/sensori_sismici.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/tela_appiccicosa.json
+++ b/data/traits/fisiologico/tela_appiccicosa.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/tentacoli_uncinati.json
+++ b/data/traits/fisiologico/tentacoli_uncinati.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/tessuti_adattivi.json
+++ b/data/traits/fisiologico/tessuti_adattivi.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/zampe_radianti.json
+++ b/data/traits/fisiologico/zampe_radianti.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/frattura_abissale_sinaptica/bioantenne_gravitiche.json
+++ b/data/traits/frattura_abissale_sinaptica/bioantenne_gravitiche.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "gravitazionale"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/camere_risonanza_abyssal.json
+++ b/data/traits/frattura_abissale_sinaptica/camere_risonanza_abyssal.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "risonanza"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/canto_risonante.json
+++ b/data/traits/frattura_abissale_sinaptica/canto_risonante.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "risonanza"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/coralli_sinaptici_fotofase.json
+++ b/data/traits/frattura_abissale_sinaptica/coralli_sinaptici_fotofase.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "supporto"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/corazze_ferro_magnetico.json
+++ b/data/traits/frattura_abissale_sinaptica/corazze_ferro_magnetico.json
@@ -26,6 +26,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "magnetico"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/emettitori_voidsong.json
+++ b/data/traits/frattura_abissale_sinaptica/emettitori_voidsong.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "anomalia"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/emolinfa_conducente.json
+++ b/data/traits/frattura_abissale_sinaptica/emolinfa_conducente.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "energetico"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/filamenti_echo.json
+++ b/data/traits/frattura_abissale_sinaptica/filamenti_echo.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "risonanza"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/filamenti_guidalampo.json
+++ b/data/traits/frattura_abissale_sinaptica/filamenti_guidalampo.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "logistica"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/ghiandole_mnemoniche.json
+++ b/data/traits/frattura_abissale_sinaptica/ghiandole_mnemoniche.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "copia"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/impulsi_bioluminescenti.json
+++ b/data/traits/frattura_abissale_sinaptica/impulsi_bioluminescenti.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "illuminazione"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/lobi_risonanti_crepuscolo.json
+++ b/data/traits/frattura_abissale_sinaptica/lobi_risonanti_crepuscolo.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "crepuscolo"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/membrane_fotoconvoglianti.json
+++ b/data/traits/frattura_abissale_sinaptica/membrane_fotoconvoglianti.json
@@ -26,6 +26,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "elettrico"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/nebbia_mnesica.json
+++ b/data/traits/frattura_abissale_sinaptica/nebbia_mnesica.json
@@ -26,6 +26,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "memoria"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/nodi_sinaptici_superficiali.json
+++ b/data/traits/frattura_abissale_sinaptica/nodi_sinaptici_superficiali.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "sensore"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/organi_metacronici.json
+++ b/data/traits/frattura_abissale_sinaptica/organi_metacronici.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "sequenziamento"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/pelle_piezo_satura.json
+++ b/data/traits/frattura_abissale_sinaptica/pelle_piezo_satura.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "difesa"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/placca_diffusione_foschia.json
+++ b/data/traits/frattura_abissale_sinaptica/placca_diffusione_foschia.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "foschia"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/placche_pressioniche.json
+++ b/data/traits/frattura_abissale_sinaptica/placche_pressioniche.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "pressione"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/riverbero_memetico.json
+++ b/data/traits/frattura_abissale_sinaptica/riverbero_memetico.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "memoria"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/scintilla_sinaptica.json
+++ b/data/traits/frattura_abissale_sinaptica/scintilla_sinaptica.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "scarica"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/secrezioni_antistatiche.json
+++ b/data/traits/frattura_abissale_sinaptica/secrezioni_antistatiche.json
@@ -26,6 +26,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "antistatico"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/sensori_planctonici.json
+++ b/data/traits/frattura_abissale_sinaptica/sensori_planctonici.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "sensori_planctonici"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/spicole_canalizzatrici.json
+++ b/data/traits/frattura_abissale_sinaptica/spicole_canalizzatrici.json
@@ -24,6 +24,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "assorbimento"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/squame_diffusori_ionici.json
+++ b/data/traits/frattura_abissale_sinaptica/squame_diffusori_ionici.json
@@ -26,6 +26,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "elettrico"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/frattura_abissale_sinaptica/vortice_nera_flash.json
+++ b/data/traits/frattura_abissale_sinaptica/vortice_nera_flash.json
@@ -26,6 +26,10 @@
       }
     }
   ],
+  "slot_profile": {
+    "core": "frattura_abissale_sinaptica",
+    "complementare": "traslazione"
+  },
   "completion_flags": {
     "has_biome": true,
     "has_data_origin": true,

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -2448,6 +2448,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "gravitazionale"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2479,6 +2483,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "risonanza"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2510,6 +2518,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "risonanza"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2542,6 +2554,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "supporto"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2573,6 +2589,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "magnetico"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2604,6 +2624,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "anomalia"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2635,6 +2659,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "energetico"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2666,6 +2694,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "risonanza"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2697,6 +2729,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "logistica"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2728,6 +2764,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "copia"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2759,6 +2799,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "illuminazione"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2790,6 +2834,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "crepuscolo"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2821,6 +2869,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "elettrico"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2852,6 +2904,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "memoria"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2883,6 +2939,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "sensore"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2914,6 +2974,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "sequenziamento"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2945,6 +3009,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "difesa"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -2976,6 +3044,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "foschia"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -3007,6 +3079,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "pressione"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -3038,6 +3114,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "memoria"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -3069,6 +3149,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "scarica"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -3100,6 +3184,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "antistatico"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -3131,6 +3219,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "sensori_planctonici"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -3162,6 +3254,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "assorbimento"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -3193,6 +3289,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "elettrico"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -3224,6 +3324,10 @@
           }
         }
       ],
+      "slot_profile": {
+        "core": "frattura_abissale_sinaptica",
+        "complementare": "traslazione"
+      },
       "completion_flags": {
         "has_biome": true,
         "has_data_origin": true,
@@ -14468,6 +14572,10 @@
       "famiglia_tipologia": "Mentale/Cognizione",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T3",
+      "slot_profile": {
+        "core": "cognitivo",
+        "complementare": "cognizione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14486,6 +14594,10 @@
       "famiglia_tipologia": "Mentale/Cognizione",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "cognitivo",
+        "complementare": "cognizione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14504,6 +14616,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14522,6 +14638,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14540,6 +14660,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14558,6 +14682,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14576,6 +14704,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14594,6 +14726,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14612,6 +14748,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14630,6 +14770,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14648,6 +14792,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14666,6 +14814,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14684,6 +14836,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14702,6 +14858,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14720,6 +14880,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14738,6 +14902,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14756,6 +14924,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14774,6 +14946,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14792,6 +14968,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14810,6 +14990,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14828,6 +15012,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14846,6 +15034,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14864,6 +15056,10 @@
       "famiglia_tipologia": "Comportamentale/Istinto",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "strategia",
+        "complementare": "istinto"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14882,6 +15078,10 @@
       "famiglia_tipologia": "Traumatico/Offesa",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "offesa"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14900,6 +15100,10 @@
       "famiglia_tipologia": "Traumatico/Offesa",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "offesa"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14918,6 +15122,10 @@
       "famiglia_tipologia": "Traumatico/Offesa",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "offesa"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14936,6 +15144,10 @@
       "famiglia_tipologia": "Traumatico/Offesa",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "offensivo",
+        "complementare": "offesa"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14954,6 +15166,10 @@
       "famiglia_tipologia": "Neurologico/Sistema nervoso",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "nervoso",
+        "complementare": "sistema_nervoso"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14972,6 +15188,10 @@
       "famiglia_tipologia": "Difensivo/Protezione",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "protezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -14990,6 +15210,10 @@
       "famiglia_tipologia": "Sensoriale/Percezione",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "percezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15008,6 +15232,10 @@
       "famiglia_tipologia": "Sensoriale/Percezione",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "percezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15026,6 +15254,10 @@
       "famiglia_tipologia": "Sensoriale/Percezione",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "percezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15044,6 +15276,10 @@
       "famiglia_tipologia": "Sensoriale/Percezione",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "percezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15062,6 +15298,10 @@
       "famiglia_tipologia": "Sensoriale/Percezione",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "percezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15080,6 +15320,10 @@
       "famiglia_tipologia": "Sensoriale/Percezione",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "percezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15098,6 +15342,10 @@
       "famiglia_tipologia": "Neurologico/Sistema nervoso",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "nervoso",
+        "complementare": "sistema_nervoso"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15116,6 +15364,10 @@
       "famiglia_tipologia": "Neurologico/Sistema nervoso",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "nervoso",
+        "complementare": "sistema_nervoso"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15134,6 +15386,10 @@
       "famiglia_tipologia": "Difensivo/Protezione",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "protezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15152,6 +15408,10 @@
       "famiglia_tipologia": "Mentale/Cognizione",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "cognitivo",
+        "complementare": "cognizione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15170,6 +15430,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15188,6 +15452,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15206,6 +15474,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15224,6 +15496,10 @@
       "famiglia_tipologia": "Sensoriale/Percezione",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "sensoriale",
+        "complementare": "percezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],

--- a/data/traits/nervoso/matrice_antimagia.json
+++ b/data/traits/nervoso/matrice_antimagia.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Neurologico/Sistema nervoso",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "nervoso",
+    "complementare": "sistema_nervoso"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/nervoso/nuclei_di_controllo.json
+++ b/data/traits/nervoso/nuclei_di_controllo.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Neurologico/Sistema nervoso",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "nervoso",
+    "complementare": "sistema_nervoso"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/nervoso/risonanza_magnetica.json
+++ b/data/traits/nervoso/risonanza_magnetica.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Neurologico/Sistema nervoso",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "nervoso",
+    "complementare": "sistema_nervoso"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/offensivo/arco_voltaico.json
+++ b/data/traits/offensivo/arco_voltaico.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Traumatico/Offesa",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "offesa"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/offensivo/martello_osseo.json
+++ b/data/traits/offensivo/martello_osseo.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Traumatico/Offesa",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "offesa"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/offensivo/pungiglione_paralizzante.json
+++ b/data/traits/offensivo/pungiglione_paralizzante.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Traumatico/Offesa",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "offesa"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/offensivo/scarica_ionica.json
+++ b/data/traits/offensivo/scarica_ionica.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Traumatico/Offesa",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "offensivo",
+    "complementare": "offesa"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/sensoriale/equilibrio_vestibolare.json
+++ b/data/traits/sensoriale/equilibrio_vestibolare.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Sensoriale/Percezione",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "percezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/sensoriale/nocicezione.json
+++ b/data/traits/sensoriale/nocicezione.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Sensoriale/Percezione",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "percezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/sensoriale/pigmenti_aurorali.json
+++ b/data/traits/sensoriale/pigmenti_aurorali.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Sensoriale/Percezione",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "percezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/sensoriale/propriocezione.json
+++ b/data/traits/sensoriale/propriocezione.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Sensoriale/Percezione",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "percezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/sensoriale/senso_magnetico.json
+++ b/data/traits/sensoriale/senso_magnetico.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Sensoriale/Percezione",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "percezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/sensoriale/sintonia_magnetica.json
+++ b/data/traits/sensoriale/sintonia_magnetica.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Sensoriale/Percezione",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "percezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/sensoriale/termocezione.json
+++ b/data/traits/sensoriale/termocezione.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Sensoriale/Percezione",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "sensoriale",
+    "complementare": "percezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/canto_di_richiamo.json
+++ b/data/traits/strategia/canto_di_richiamo.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/ferocia.json
+++ b/data/traits/strategia/ferocia.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/intimidatore.json
+++ b/data/traits/strategia/intimidatore.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/legame_di_branco.json
+++ b/data/traits/strategia/legame_di_branco.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/marchio_predatorio.json
+++ b/data/traits/strategia/marchio_predatorio.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/midollo_iperattivo.json
+++ b/data/traits/strategia/midollo_iperattivo.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/spirito_combattivo.json
+++ b/data/traits/strategia/spirito_combattivo.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/spore_paniche.json
+++ b/data/traits/strategia/spore_paniche.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/sussurro_psichico.json
+++ b/data/traits/strategia/sussurro_psichico.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/strategia/voce_imperiosa.json
+++ b/data/traits/strategia/voce_imperiosa.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Comportamentale/Istinto",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "strategia",
+    "complementare": "istinto"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],


### PR DESCRIPTION
## What

Applies the backfill from the ratified proposal [#3021](https://github.com/MasterDD-L34D/Game/pull/3021): adds the missing `slot_profile` design field to the **69 non-ancestor traits** that had only that field missing (`tier` + `famiglia_tipologia` were already present).

Closes the soft `trait_schema_gate.py` WARN on `data/traits/index.json` (69 → 0).

## How the values were derived

- **`core` = DETERMINISTIC.** `core` == the trait's category folder under `data/traits/<folder>/`. Evidence: this holds for **all 228/228** traits that already carry `slot_profile`. Zero judgement.
- **`complementare` = proposed default** = `slug(2nd token of famiglia_tipologia)` (the pattern observed on the existing 228). Families flagged in the proposal use the default and are easy to adjust here in review:
  - `Temporaneo/*` (5 traits) → `difesa` / `memoria` / `risonanza` / `scarica` / `traslazione`
  - `Analisi/Sensori Planctonici` → `sensori_planctonici`
  - `Neurologico/Sistema nervoso` → `sistema_nervoso`

Written to **both** the per-trait file (`data/traits/<folder>/<id>.json`, the canonical source) **and** the `index.json` mirror — matching how the existing 228 carry it.

## Verification

- `trait_schema_gate.py --check data/traits/index.json` → WARN 69 → **0**.
- JSON-schema (`config/schemas/trait.schema.json`) validation: **0 fails** on all 69 modified per-trait files; pre-existing files still validate.
- Diff: **70 files, 552 insertions, 0 deletions** (pure additive). No runtime/code change.

## Review note

The only judgement is the `complementare` column. Skim the flagged families above — edit any value inline and I'll amend, or approve as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
