### PR TITLE
feat(traits): slot_profile tail backfill -- 2 traits (gap to 0)

### DIFF
--- a/data/traits/difensivo/radici_ancora_planare.json
+++ b/data/traits/difensivo/radici_ancora_planare.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Difensivo/Protezione",
   "fattore_mantenimento_energetico": "Medio (situazionale)",
   "tier": "T2",
+  "slot_profile": {
+    "core": "difensivo",
+    "complementare": "protezione"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/fisiologico/adattamento_volo.json
+++ b/data/traits/fisiologico/adattamento_volo.json
@@ -5,6 +5,10 @@
   "famiglia_tipologia": "Fisiologico/Morfologia",
   "fattore_mantenimento_energetico": "Basso (passivo)",
   "tier": "T1",
+  "slot_profile": {
+    "core": "fisiologico",
+    "complementare": "morfologia"
+  },
   "slot": [],
   "sinergie": [],
   "conflitti": [],

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -15518,6 +15518,10 @@
       "famiglia_tipologia": "Fisiologico/Morfologia",
       "fattore_mantenimento_energetico": "Basso (passivo)",
       "tier": "T1",
+      "slot_profile": {
+        "core": "fisiologico",
+        "complementare": "morfologia"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],
@@ -15536,6 +15540,10 @@
       "famiglia_tipologia": "Difensivo/Protezione",
       "fattore_mantenimento_energetico": "Medio (situazionale)",
       "tier": "T2",
+      "slot_profile": {
+        "core": "difensivo",
+        "complementare": "protezione"
+      },
       "slot": [],
       "sinergie": [],
       "conflitti": [],


### PR DESCRIPTION
Tail of #3023. Two traits (adattamento_volo, radici_ancora_planare) entered index.json from the #3020 volo/substrate work AFTER #3023 branched, so they missed the 69-trait backfill.

Same deterministic rule + family defaults already ratified in #3021:
- adattamento_volo -> core=fisiologico, complementare=morfologia (Fisiologico/Morfologia)
- radici_ancora_planare -> core=difensivo, complementare=protezione (Difensivo/Protezione)

Per-trait file + index mirror. Verify: index missing slot_profile 69->0->now 0 (gap closed); jsonschema 0 fails; 16 insertions, 0 deletions. No code/runtime change.

üü§ñ Generated with [Claude Code](https://claude.com/claude-code)