### PR TITLE
feat(form-pulse): encounter-difficulty offset for trait v2 (ratify path-1, flag-gated enemy-HP)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -178,7 +178,11 @@ const { applyStressWaveTick } = require('../services/combat/stressWave');
 // QW1 (M-018 worldgen card): biome diff_base + stress_modifiers → runtime
 // pressure / enemy HP. Same encounter on savana vs abisso_vulcanico now
 // produces different numbers, not just different texture.
-const { getBiomeModifiers, applyEnemyHpMultiplier } = require('../services/combat/biomeModifiers');
+const {
+  getBiomeModifiers,
+  applyEnemyHpMultiplier,
+  formPulseV2EnemyHpOffset,
+} = require('../services/combat/biomeModifiers');
 // TKT-PLAYTEST-SEED (2026-05-29): canonical seedable combat RNG. Unseeded
 // defaultRng === Math.random (zero prod change). The seed is recorded per
 // session (session.combatRng) and installed by sessionRoundBridge via
@@ -2240,8 +2244,15 @@ function createSessionRouter(options = {}) {
       // payload (e.g. hardcore scenarios) -> pressure_delta 0 -> WR bands unchanged.
       const seasonRaw = req.body?.season || req.body?.encounter?.season || null;
       const crossEvent = getCrossEventPressureDelta(biomeIdRaw, seasonRaw);
-      if (biomeModifiers.hp_mult !== 1.0) {
-        applyEnemyHpMultiplier(units, biomeModifiers.hp_mult);
+      // Form-Pulse trait v2 enemy-HP offset (ratify path-1): fold into the biome
+      // hp_mult so enemy HP is scaled ONCE (applyEnemyHpMultiplier is idempotent per
+      // unit via _biome_hp_applied). No-op (1.0) unless FORM_PULSE_TRAIT_V2_ENABLED is
+      // ON -> when the team buff flips on, enemies absorb a matching ~+8% so NET
+      // difficulty stays near baseline (#3017 A/B calibration).
+      const fpV2EnemyHpOffset = formPulseV2EnemyHpOffset();
+      const effectiveEnemyHpMult = biomeModifiers.hp_mult * fpV2EnemyHpOffset;
+      if (effectiveEnemyHpMult !== 1.0) {
+        applyEnemyHpMultiplier(units, effectiveEnemyHpMult);
       }
 
       // M13 P3 Phase B — apply progression perks (effectiveStats + passives).

--- a/apps/backend/services/combat/biomeModifiers.js
+++ b/apps/backend/services/combat/biomeModifiers.js
@@ -46,6 +46,17 @@ const SAVANA_BASELINE = 2;
 const PRESSURE_INITIAL_FACTOR = 5;
 const HP_MULT_FACTOR = 0.05;
 
+// Form-Pulse trait v2 enemy-HP offset (ratify path-1). When FORM_PULSE_TRAIT_V2_ENABLED
+// is ON the team carries the ~1.2/creature branco+minor grant; this offset scales enemy
+// HP so NET difficulty stays near baseline. CALIBRATED empirically (enc_savana_01 paired
+// A/B, N=12/arm, this PR): enemy-HP->rounds is SUB-linear (last-hit overkill + fixed wave
+// timing dampen it), so the naive ~+8% moved rounds ~0. Bracketed on the paired round delta
+// (treat - ctrl): offset 1.0 -> ~-1.8 rounds (buff wins), 1.5 -> ~+1.4 (offset over-corrects),
+// so the net-neutral point is ~1.3. Env-overridable (FORM_PULSE_V2_ENEMY_HP_OFFSET) for
+// re-calibration. Flag owner: services/identity/brancoTraitEmergence. N=12 is a direction
+// probe -- confirm with a full N=40 A/B before the prod flip.
+const FP_V2_ENEMY_HP_OFFSET_DEFAULT = 1.3;
+
 // Safe defaults when biome unknown / file missing / malformed.
 const SAFE_DEFAULTS = Object.freeze({
   diff_base: 1.0,
@@ -162,6 +173,23 @@ function applyEnemyHpMultiplier(units, hpMult) {
 }
 
 /**
+ * Form-Pulse trait v2 enemy-HP offset multiplier. Returns 1.0 (no-op) unless the
+ * FORM_PULSE_TRAIT_V2_ENABLED flag is ON. The caller FOLDS this into the single
+ * applyEnemyHpMultiplier call (biome hp_mult * offset) -- applyEnemyHpMultiplier is
+ * idempotent per unit (_biome_hp_applied marker), so it must be applied once. Env
+ * override FORM_PULSE_V2_ENEMY_HP_OFFSET supports A/B calibration sweeps without a
+ * code change. See the FP_V2_ENEMY_HP_OFFSET_DEFAULT header comment.
+ *
+ * @param {object} [env=process.env]
+ * @returns {number} >0 multiplier (1.0 when the flag is OFF)
+ */
+function formPulseV2EnemyHpOffset(env = process.env) {
+  if (!env || env.FORM_PULSE_TRAIT_V2_ENABLED !== 'true') return 1.0;
+  const override = Number(env.FORM_PULSE_V2_ENEMY_HP_OFFSET);
+  return Number.isFinite(override) && override > 0 ? override : FP_V2_ENEMY_HP_OFFSET_DEFAULT;
+}
+
+/**
  * 2026-05-20 — list runtime biome modifier registry (A6 pattern, gap-fill
  * Explore quick-win wave 3 #4). Used by readonly diagnostic route +
  * frontend combat UI per preload diff_base/hp_mult/pressure formula per biome.
@@ -234,6 +262,8 @@ module.exports = {
   getBiomeStressProfile,
   listBiomeStressProfiles,
   applyEnemyHpMultiplier,
+  formPulseV2EnemyHpOffset,
+  FP_V2_ENEMY_HP_OFFSET_DEFAULT,
   _resetCache,
   DEFAULT_BIOMES_YAML,
   SAFE_DEFAULTS,

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12784,6 +12784,17 @@
       "review_cycle_days": 90
     },
     {
+      "path": "docs/planning/2026-06-24-aa01-form-pulse-trait-v2-encounter-offset.md",
+      "title": "Form-Pulse trait v2 -- encounter-difficulty offset (ratify path-1, flag-gated enemy-HP)",
+      "doc_status": "review_needed",
+      "doc_owner": "claude-code",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-06-24",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90
+    },
+    {
       "path": "docs/planning/2026-06-23-aa01-imprint-axis-trait-grant-spec-draft.md",
       "title": "Imprint axis->trait grant -- design spec DRAFT (D6, NON-band-neutral, master-dd ratify)",
       "doc_status": "draft",

--- a/docs/planning/2026-06-24-aa01-form-pulse-trait-v2-encounter-offset.md
+++ b/docs/planning/2026-06-24-aa01-form-pulse-trait-v2-encounter-offset.md
@@ -1,0 +1,79 @@
+---
+title: 'Form-Pulse trait v2 -- encounter-difficulty offset (ratify path-1, flag-gated enemy-HP)'
+date: 2026-06-24
+sprint: aa01-impronta-reconciliation
+doc_status: review_needed
+doc_owner: claude-code
+workstream: cross-cutting
+last_verified: '2026-06-24'
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+---
+
+# Form-Pulse trait v2 -- encounter-difficulty offset
+
+> The LAST code/calibration blocker before the `FORM_PULSE_TRAIT_V2_ENABLED` prod flip.
+> Implements ratify path-1 (the encounter-difficulty offset) from
+> [`2026-06-23-aa01-form-pulse-trait-v2-n40-ratify.md`](2026-06-23-aa01-form-pulse-trait-v2-n40-ratify.md)
+> sec.5 + the [PR #3017](https://github.com/MasterDD-L34D/Game/pull/3017) combat A/B.
+> Coverage + cap-tier (the other ratify items) shipped in
+> [#3016](https://github.com/MasterDD-L34D/Game/pull/3016). PROPOSED until master-dd ratifies.
+
+## 1. Problem
+
+The v2 grant (always-emerge branco + per-player minor) adds ~1.2 power/creature. The #3017
+combat A/B measured that as a real pace advantage: the team clears `enc_savana_01` ~1.6-1.8
+rounds FASTER. Ratify path-1: pair the flag flip with an encounter-difficulty offset worth
+~that, so NET team power stays near baseline.
+
+## 2. Mechanism (flag-gated enemy-HP, ONE flag gates buff + offset)
+
+- `services/combat/biomeModifiers.js`: new `formPulseV2EnemyHpOffset(env)` -> returns the
+  offset multiplier (default `FP_V2_ENEMY_HP_OFFSET_DEFAULT`) when `FORM_PULSE_TRAIT_V2_ENABLED`
+  is ON, else `1.0` (strict no-op). Env-overridable via `FORM_PULSE_V2_ENEMY_HP_OFFSET` for
+  re-calibration.
+- `routes/session.js` `/start`: the offset is FOLDED into the existing biome enemy-HP step --
+  `effective = biomeModifiers.hp_mult * formPulseV2EnemyHpOffset()`, applied via the existing
+  `applyEnemyHpMultiplier` (idempotent per unit, so it must be ONE call). Enemy (`controlled_by:
+'sistema'`) units only; players untouched.
+- **One flag** (`FORM_PULSE_TRAIT_V2_ENABLED`) gates BOTH the team grant AND this enemy offset:
+  flipping it ON turns on the buff + its counter together. Flag OFF = byte-identical to today.
+- Co-op AND the A/B sim both route enemy build through `/api/session/start`, so the offset
+  applies in real play and is measured by the harness.
+
+## 3. Calibration A/B (enc_savana_01, paired N=12/arm, aggressive, 2p)
+
+Control = flag OFF + no grant. Treatment = flag ON (offset) + the v2 grant
+(`AI_SIM_FORM_PULSE_V2_GRANT=1`). Paired by seed (`fp-trait-ab-analyze.js`), so the only
+between-arm difference is the grant + its offset.
+
+| offset           | paired delta rounds (treat - ctrl) | reading                                                    |
+| ---------------- | ---------------------------------- | ---------------------------------------------------------- |
+| 1.0 (grant only) | **-1.82** (CI95 -2.93 .. -0.70)    | buff wins -- treatment clears faster (matches #3017 -1.63) |
+| **1.3**          | **+0.42** (CI95 -1.47 .. +2.31)    | **CI95 crosses 0 = net-neutral -> CALIBRATED**             |
+| 1.5              | +1.42 (CI95 +0.22 .. +2.61)        | over-corrects -- offset wins                               |
+
+**Default set to 1.3.** Key finding: enemy-HP -> rounds-to-clear is **sub-linear** (last-hit
+overkill + fixed wave-trigger timing dampen it), so the naive ~+8% (1.08) moved the delta ~0;
+the grant's ~1.8-round edge needs ~+30% enemy HP to cancel.
+
+## 4. Caveats / before the flip
+
+- **N=12 is a direction probe** (CI95 ~+-1.9 rounds). Confirm with a full **N=40** A/B (the
+  #3017 standard) before `FORM_PULSE_TRAIT_V2_ENABLED` is flipped ON in prod.
+- Calibrated on **enc_savana_01** only. The offset is a GLOBAL enemy-HP scalar (composes
+  multiplicatively with each biome's `hp_mult`); a cross-biome sweep is the N=40 follow-up.
+- AI-policy sim (passive closest-attack player AI) -> directional, not a human-play win-rate.
+
+## 5. Disposition
+
+PROPOSED. Tests: `tests/services/combat/formPulseV2EnemyHpOffset.test.js` (6/6 -- flag gate,
+env override, enemy-only + idempotent fold). `prettier --check` clean. After this + the N=40
+confirm, the FORM_PULSE flip is a single deploy step: set `FORM_PULSE_TRAIT_V2_ENABLED=true`
+in the deploy `.env` (the offset rides the same flag). See
+`Game-Godot-v2/docs/godot-v2/qa/2026-06-23-prod-flag-flip-readiness.md`. Reproduce: boot two
+backends (control: no flag; treatment: `FORM_PULSE_TRAIT_V2_ENABLED=true`), run
+`tools/sim/batch-ai-runner.js --scenarios enc_savana_01 --profiles aggressive --seed-count 12`
+against each (treatment with `AI_SIM_FORM_PULSE_V2_GRANT=1`), then
+`tools/sim/fp-trait-ab-analyze.js <control_dir> <treatment_dir>`. Cross-ref #2992 / #3016 / #3017.

--- a/tests/services/combat/formPulseV2EnemyHpOffset.test.js
+++ b/tests/services/combat/formPulseV2EnemyHpOffset.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+// Form-Pulse trait v2 enemy-HP offset (ratify path-1). Guards: the offset is a
+// strict no-op (1.0) unless FORM_PULSE_TRAIT_V2_ENABLED is ON, honors the env
+// override, and when folded into applyEnemyHpMultiplier scales ONLY sistema enemy
+// HP (players untouched, idempotent). See biomeModifiers.js header.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  formPulseV2EnemyHpOffset,
+  FP_V2_ENEMY_HP_OFFSET_DEFAULT,
+  applyEnemyHpMultiplier,
+} = require('../../../apps/backend/services/combat/biomeModifiers');
+
+test('offset is 1.0 (no-op) when the flag is unset', () => {
+  assert.equal(formPulseV2EnemyHpOffset({}), 1.0);
+});
+
+test('offset is 1.0 when the flag is explicitly not "true"', () => {
+  assert.equal(formPulseV2EnemyHpOffset({ FORM_PULSE_TRAIT_V2_ENABLED: 'false' }), 1.0);
+  assert.equal(formPulseV2EnemyHpOffset({ FORM_PULSE_TRAIT_V2_ENABLED: '1' }), 1.0);
+});
+
+test('offset is the calibrated default when the flag is ON and no override', () => {
+  const v = formPulseV2EnemyHpOffset({ FORM_PULSE_TRAIT_V2_ENABLED: 'true' });
+  assert.equal(v, FP_V2_ENEMY_HP_OFFSET_DEFAULT);
+  assert.ok(v > 1.0, 'default offset must add difficulty');
+});
+
+test('env override wins when the flag is ON', () => {
+  assert.equal(
+    formPulseV2EnemyHpOffset({
+      FORM_PULSE_TRAIT_V2_ENABLED: 'true',
+      FORM_PULSE_V2_ENEMY_HP_OFFSET: '1.15',
+    }),
+    1.15,
+  );
+});
+
+test('invalid / non-positive override falls back to the default', () => {
+  const base = { FORM_PULSE_TRAIT_V2_ENABLED: 'true' };
+  assert.equal(
+    formPulseV2EnemyHpOffset({ ...base, FORM_PULSE_V2_ENEMY_HP_OFFSET: 'nope' }),
+    FP_V2_ENEMY_HP_OFFSET_DEFAULT,
+  );
+  assert.equal(
+    formPulseV2EnemyHpOffset({ ...base, FORM_PULSE_V2_ENEMY_HP_OFFSET: '0' }),
+    FP_V2_ENEMY_HP_OFFSET_DEFAULT,
+  );
+  assert.equal(
+    formPulseV2EnemyHpOffset({ ...base, FORM_PULSE_V2_ENEMY_HP_OFFSET: '-2' }),
+    FP_V2_ENEMY_HP_OFFSET_DEFAULT,
+  );
+});
+
+test('folded multiplier scales ONLY sistema enemy HP, players untouched, idempotent', () => {
+  const offset = formPulseV2EnemyHpOffset({ FORM_PULSE_TRAIT_V2_ENABLED: 'true' }); // default
+  const biomeHpMult = 1.0; // savana baseline -> the offset is the whole multiplier
+  const effective = biomeHpMult * offset;
+
+  const units = [
+    { id: 'enemy1', controlled_by: 'sistema', max_hp: 100, hp: 100 },
+    { id: 'player1', controlled_by: 'p_abc', max_hp: 50, hp: 50 },
+  ];
+  applyEnemyHpMultiplier(units, effective);
+
+  const enemy = units.find((u) => u.id === 'enemy1');
+  const player = units.find((u) => u.id === 'player1');
+  assert.equal(
+    enemy.max_hp,
+    Math.round(100 * FP_V2_ENEMY_HP_OFFSET_DEFAULT),
+    'enemy HP scaled by offset',
+  );
+  assert.equal(enemy.hp, enemy.max_hp);
+  assert.equal(player.max_hp, 50, 'player HP untouched');
+
+  // Idempotent: a second application is a no-op (marker set).
+  const before = enemy.max_hp;
+  applyEnemyHpMultiplier(units, effective);
+  assert.equal(enemy.max_hp, before, 'enemy HP not double-scaled');
+});


### PR DESCRIPTION
## What

Implements ratify **path-1 (encounter-difficulty offset)** -- the last code/calibration blocker before the `FORM_PULSE_TRAIT_V2_ENABLED` prod flip. Coverage + cap-tier shipped in #3016; combat A/B in #3017. **Nothing is flipped** -- the flag stays default OFF (flag OFF = byte-identical to today).

## Mechanism (one flag gates buff + its counter)

- `services/combat/biomeModifiers.js`: `formPulseV2EnemyHpOffset(env)` -> offset multiplier (default **1.3**) when `FORM_PULSE_TRAIT_V2_ENABLED` is ON, else `1.0` (strict no-op). Env-overridable via `FORM_PULSE_V2_ENEMY_HP_OFFSET` for re-calibration.
- `routes/session.js` `/start`: the offset is **folded** into the existing biome enemy-HP step (`biomeModifiers.hp_mult * offset`), applied via the existing `applyEnemyHpMultiplier` (idempotent per unit -> one call). Enemy (`controlled_by: sistema`) units only.
- Flipping `FORM_PULSE_TRAIT_V2_ENABLED` ON turns on the team grant AND this enemy offset together. Co-op AND the A/B sim both route enemy build through `/api/session/start`.

## Calibration (paired A/B, enc_savana_01, N=12/arm, aggressive, 2p)

| offset | paired Δ rounds (treat − ctrl) | reading |
|---|---|---|
| 1.0 (grant only) | **−1.82** (CI95 −2.93..−0.70) | buff wins (matches #3017 −1.63) |
| **1.3** | **+0.42** (CI95 −1.47..+2.31) | **CI95 crosses 0 = net-neutral → CALIBRATED** |
| 1.5 | +1.42 (CI95 +0.22..+2.61) | over-corrects |

Key finding: enemy-HP → rounds-to-clear is **sub-linear** (last-hit overkill + fixed wave timing), so the naive ~+8% moved Δ ~0; the grant's ~1.8-round edge needs ~+30% enemy HP.

## Test / gates

`tests/services/combat/formPulseV2EnemyHpOffset.test.js` **6/6** (flag gate, env override, enemy-only + idempotent fold). `prettier --check` clean. `check_docs_governance.py --strict` **errors=0**.

## Before the prod flip

N=12 is a **direction probe** -- confirm a full **N=40** A/B (+ cross-biome sweep) before flipping `FORM_PULSE_TRAIT_V2_ENABLED` ON. Doc: `docs/planning/2026-06-24-aa01-form-pulse-trait-v2-encounter-offset.md`; flip checklist in `Game-Godot-v2/docs/godot-v2/qa/2026-06-23-prod-flag-flip-readiness.md`.

Cross-ref #2992 / #3016 / #3017. PROPOSED until master-dd ratifies.
