### PR TITLE
feat(sim): move terrain-cost N=40 band probe + evidence -- phase 4 (band-neutral on foresta)

### DIFF
--- a/docs/reports/2026-06-28-move-terrain-n40-evidence.md
+++ b/docs/reports/2026-06-28-move-terrain-n40-evidence.md
@@ -1,0 +1,92 @@
+---
+title: 'Move terrain-cost substrate -- Phase 4 N=40 band evidence (preliminary)'
+date: 2026-06-28
+doc_status: draft
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-06-28'
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+tags: [combat, movement, terrain-cost, substrate, n40, band, evidence, volo]
+---
+
+# Move terrain-cost substrate -- Phase 4 N=40 band evidence (preliminary)
+
+> **Scopo**: misurare l'impatto sul win-rate del flip `MOVE_TERRAIN_COST_ENABLED` sul pilot encounter
+> (`enc_foresta_temperata_radici`), con un roster che esercita il kit volo. **Io misuro, master-dd ratifica
+> la banda** (SDMG). Preliminare: roster hand-rostered (Path B), banda = direction-probe non calibrazione.
+
+## 1. Metodo
+
+- **In-process** (`supertest` `createApp`, NO prod), **node 22** (`process.version` registrato nell'output;
+  il combat-sim NON e' bit-deterministico cross-node -- misurato e gate sullo stesso node di CI/prod).
+- **Paired-seed**: stesso `seed` per il braccio ON e OFF -> l'UNICA differenza e' il flag (isola il substrate).
+- Harness: `tools/sim/move-terrain-n40-probe.js` -> `combat-adapter.runEncounter` con `terrainFeatures` inline
+  (il pilot encounter vive in `data/encounters/`, NON nella dir di `encounterLoader` -> il terreno e' iniettato).
+  Outcome = eliminazione (nessun objective caricato -> alive-count).
+- **Roster**: 3 flyer volo (`echo_wing` g1 / `aurora_gull` g2 / `noctule_termico` g3, esenti dal costo-terreno
+  per grado) + 1 unita' a terra non-volo (paga il costo ON). Nemici = roster foresta scalato. Terreno =
+  i 4 tile tipati del pilot (vegetazione_densa x2 / roccia / radura).
+- **radici ESCLUSO dal delta-flip**: e' always-on (flag-independent) -> presente in ENTRAMBI i bracci, si
+  cancella dal delta; inoltre un'unita' sessile range-1 non traversa (lo scenario non si risolve). La sua
+  banda e' una domanda separata carrier-vs-non-carrier, NON il gate del flip.
+
+## 2. Risultati
+
+### 2a. Banda foresta (N=40, paired-seed)
+
+```json
+{
+  "N": 40,
+  "enemyScale": 0.3,
+  "flag_on": { "wins": 16, "defeats": 0, "timeouts": 24, "win_rate": 0.4, "avg_rounds": 29.7 },
+  "flag_off": { "wins": 16, "defeats": 0, "timeouts": 24, "win_rate": 0.4, "avg_rounds": 29.7 },
+  "wr_delta": 0,
+  "avg_rounds_delta": 0,
+  "node": "v22.22.3"
+}
+```
+
+**ON identico a OFF** (16/16 vittorie, 24/24 timeout, 29.7/29.7 round): `wr_delta = 0`, `avg_rounds_delta = 0`.
+Il flip e' **band-neutral** sul pilot foresta. (Nota: 24/40 timeout = scenario ad attrito; ma essendo ON==OFF
+byte-identico il null regge a prescindere dal tasso di timeout.)
+
+### 2b. Sanity flag-applies (il flag MORDE quando si traversa terreno costoso)
+
+Un'unita' heavy (morphotype `corazzato` -> profilo heavy, roccia 2.0) forzata ad attraversare un corridoio
+di roccia (1..4, y4) per raggiungere il nemico:
+
+| seed | ON (rounds) | OFF (rounds) |
+| ---- | ----------- | ------------ |
+| 1    | victory r7  | victory r9   |
+| 2    | victory r7  | victory r9   |
+| 3    | victory r9  | victory r9   |
+
+Il flag CAMBIA i run quando le unita' traversano terreno costoso -> l'harness applica correttamente il
+substrate; il delta-0 sul foresta NON e' un bug.
+
+## 3. Interpretazione
+
+- **Il substrate e' meccanicamente vivo** (sanity 2b + unit/integration test gia' verdi: roccia 2 AP vs 1,
+  lava g3 1 AP vs g1 2).
+- **Sul pilot foresta il flip e' band-neutral** perche': (a) i profili medium pagano ~0 su questo terreno
+  (vegetazione_densa = 1.0 = gratis per medium; SOLO roccia = 1.5, su un tile spesso fuori-percorso);
+  (b) i flyer volo sono esenti per design. Le unita' non traversano abbastanza terreno costoso per spostare
+  l'outcome.
+- **Il substrate e' una leva di level-design, non uno shifter passivo del WR**: morde su terreno costoso
+  (profili heavy / hazard lava+acqua_profonda / corridoi forzati). Su un encounter mite l'effetto WR ~0.
+
+## 4. Raccomandazione (master-dd ratifica)
+
+- **Flip LOW-RISK sul pilot foresta** (banda-neutrale). Il rischio-banda emerge solo dove il terreno e'
+  costoso -> e' una scelta di chi-disegna-gli-encounter, non un effetto globale.
+- **Caveat SDMG**: roster hand-rostered, banda = direction-probe (non calibrazione N=100). Il delta-0 e'
+  STRUTTURALE (le unita' non attraversano tile costosi su questo terreno), non un equilibrio fine.
+- Per una banda che ESERCITI i gradi g2/g3 servirebbe terreno hazard (lava/acqua_profonda) -- assente dal
+  pilot foresta: scelta di design separata.
+
+## 5. Boundary
+
+Io ho costruito l'harness + misurato; **master-dd ratifica la banda + la decisione di flip** (fase 5,
+owner-gated, post Gate-5 Godot telegraph). La banda always-on di radici = misura separata carrier-vs-noncarrier.

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -49,6 +49,12 @@ async function runEncounter(
     // 10x10 reinforcement entry tiles off-grid; a preset (e.g. 'duo_hardcore',
     // deployed 8 -> 10x10) restores the authored board. Absent -> byte-identical.
     modulation = null,
+    // Move terrain-cost substrate N=40: opt-in inline encounter terrain (see startBody).
+    // The canonical pilot encounter lives in data/encounters/, NOT the encounterLoader
+    // dir, so encounter_id cannot load its terrain -- the probe inlines it here. Absent
+    // -> byte-identical start body.
+    terrainFeatures = null,
+    gridSize = null,
   } = {},
 ) {
   const rosterIds = (roster || []).map((u) => u.id);
@@ -75,6 +81,20 @@ async function runEncounter(
       ? { pressure_start: Number(pressureStart), sistema_pressure_start: Number(pressureStart) }
       : {}),
     ...(modulation ? { modulation } : {}),
+    // Move terrain-cost substrate N=40: inline terrain so the move-gate prices typed
+    // tiles. /api/session/start carries req.body.encounter.grid.terrain_features into
+    // session.grid (session.js ~2414). Absent -> byte-identical start body.
+    ...(Array.isArray(terrainFeatures) && terrainFeatures.length
+      ? {
+          encounter: {
+            grid: {
+              width: Number(gridSize) || 6,
+              height: Number(gridSize) || 6,
+              terrain_features: terrainFeatures,
+            },
+          },
+        }
+      : {}),
   };
   const start = await http.post('/api/session/start', startBody);
   if (start.status !== 200 && start.status !== 201) {

--- a/tools/sim/move-terrain-n40-probe.js
+++ b/tools/sim/move-terrain-n40-probe.js
@@ -1,0 +1,183 @@
+'use strict';
+// Move terrain-cost substrate -- Phase 4 N=40 band probe.
+//
+// Measures the win-rate / pace impact of flipping MOVE_TERRAIN_COST_ENABLED on the
+// pilot terrain (enc_foresta_temperata_radici: vegetazione_densa/roccia/radura), with
+// a roster that exercises the volo creature kit. Paired-seed (same seed ON vs OFF ->
+// the only difference is the flag), in-process (supertest createApp, NO prod), node 22.
+// Elimination outcome (no objective loaded -> runEncounter uses alive-count).
+//
+// METHODOLOGY:
+// - The flip toggles terrain-cost (all units pay terrain-weighted move AP) + volo relief
+//   (carriers exempt by grade). radici (DR2 anchor) is ALWAYS-ON (flag-independent) ->
+//   it would be present in BOTH arms and cancel from the delta, AND a sessile range-1
+//   unit cannot traverse to engage (the scenario never resolves). So radici is OUT of
+//   the flip-delta probe; its band is a separate carrier-vs-non-carrier question.
+// - The roster MUST traverse the typed terrain for the cost to bite: 3 volo flyers
+//   (g1/g2/g3, exempt) + 1 non-volo skirmisher (pays the cost ON) start bottom-left and
+//   close on enemies top-right across the typed tiles.
+// - Sensitive metrics: win-rate delta + avg rounds-to-completion delta (terrain-cost
+//   slows traversal -> pace shifts even when WR is near a ceiling).
+//
+// Usage: node tools/sim/move-terrain-n40-probe.js [N] [enemyScale]
+
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runEncounter } = require('./combat-adapter');
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+function supertestHttp(app) {
+  return {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+// Pilot terrain (data/encounters/enc_foresta_temperata_radici.yaml).
+const TERRAIN = [
+  { x: 2, y: 2, type: 'vegetazione_densa' },
+  { x: 4, y: 3, type: 'vegetazione_densa' },
+  { x: 1, y: 4, type: 'roccia' },
+  { x: 5, y: 5, type: 'radura' },
+];
+
+// Player roster: 3 volo flyers (g1/g2/g3, terrain-exempt by grade) + 1 non-volo
+// skirmisher (pays terrain cost when ON). All start bottom-left, must cross the typed
+// tiles to reach the enemies (so the move-cost actually bites).
+function roster() {
+  const volo = [
+    ['echo_wing', 1, { x: 0, y: 0 }],
+    ['aurora_gull', 2, { x: 0, y: 1 }],
+    ['noctule_termico', 3, { x: 1, y: 0 }],
+  ].map(([id, grade, position]) => ({
+    id,
+    species: id,
+    job: 'skirmisher',
+    hp: 14,
+    max_hp: 14,
+    ap: 3,
+    mod: 6,
+    dc: 10,
+    attack_range: 2,
+    initiative: 14,
+    position,
+    controlled_by: 'player',
+    traits: ['adattamento_volo'],
+    volo_grade: grade,
+    status: {},
+  }));
+  const ground = [
+    {
+      id: 'ground_skirmisher',
+      species: 'velox',
+      job: 'skirmisher',
+      hp: 14,
+      max_hp: 14,
+      ap: 3,
+      mod: 6,
+      dc: 10,
+      attack_range: 2,
+      initiative: 12,
+      position: { x: 1, y: 1 },
+      controlled_by: 'player',
+      traits: [],
+      status: {},
+    },
+  ];
+  return [...volo, ...ground];
+}
+
+// Enemies start top-right and advance toward the party across the same typed tiles.
+function enemies(scale) {
+  const defs = [
+    ['umbroid_lurker', 12, 3, 11, { x: 5, y: 5 }],
+    ['mud_sentinel', 11, 2, 11, { x: 4, y: 5 }],
+    ['echo_seer', 10, 2, 10, { x: 5, y: 4 }],
+  ];
+  return defs.map(([id, hp, mod, dc, position]) => ({
+    id,
+    species: id,
+    hp: Math.round(hp * scale),
+    max_hp: Math.round(hp * scale),
+    ap: 3,
+    mod: Math.round(mod * scale),
+    dc,
+    attack_range: 2,
+    initiative: 10,
+    position,
+    controlled_by: 'sistema',
+    status: {},
+  }));
+}
+
+async function runArm(flagOn, seed, scale) {
+  if (flagOn) process.env.MOVE_TERRAIN_COST_ENABLED = 'true';
+  else delete process.env.MOVE_TERRAIN_COST_ENABLED;
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const http = supertestHttp(app);
+    const r = await runEncounter(http, {
+      roster: roster(),
+      enemies: enemies(scale),
+      seed,
+      maxRounds: 30,
+      terrainFeatures: TERRAIN,
+      gridSize: 6,
+    });
+    return { outcome: r.outcome, rounds: r.rounds };
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+function summarize(arr) {
+  const wins = arr.filter((r) => r.outcome === 'victory').length;
+  const defeats = arr.filter((r) => r.outcome === 'defeat').length;
+  const timeouts = arr.filter((r) => r.outcome === 'timeout').length;
+  const avgRounds = arr.reduce((s, r) => s + (r.rounds || 0), 0) / (arr.length || 1);
+  return {
+    wins,
+    defeats,
+    timeouts,
+    win_rate: Number((wins / arr.length).toFixed(4)),
+    avg_rounds: Number(avgRounds.toFixed(2)),
+  };
+}
+
+async function main() {
+  const N = Number(process.argv[2]) || 40;
+  const scale = Number(process.argv[3]) || 1.0;
+  const on = [];
+  const off = [];
+  for (let s = 1; s <= N; s += 1) {
+    on.push(await runArm(true, s, scale));
+    off.push(await runArm(false, s, scale));
+    if (s % 10 === 0) process.stderr.write(`  ${s}/${N}\n`);
+  }
+  const sOn = summarize(on);
+  const sOff = summarize(off);
+  const out = {
+    N,
+    enemyScale: scale,
+    flag_on: sOn,
+    flag_off: sOff,
+    wr_delta: Number((sOn.win_rate - sOff.win_rate).toFixed(4)),
+    avg_rounds_delta: Number((sOn.avg_rounds - sOff.avg_rounds).toFixed(2)),
+    node: process.version,
+  };
+  console.log(JSON.stringify(out, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Phase 4 — N=40 band probe + evidence (move terrain-cost substrate)

Per the ratified plan (all carriers + ecology grades + **Path B** + proceed to N=40), this builds the in-process N=40 harness and measures the substrate flip's band on the pilot encounter. **I measure; you ratify the band** (SDMG).

### What
- **`combat-adapter.js`**: opt-in `terrainFeatures` param → inline encounter terrain in `/start` (the pilot encounter lives in `data/encounters/`, outside `encounterLoader`'s `docs/planning/encounters/` dir, so `encounter_id` can't load its terrain). Additive, absent → byte-identical; **sim tests 10/10**.
- **`tools/sim/move-terrain-n40-probe.js`**: paired-seed (same seed ON vs OFF → only the flag differs), in-process `supertest`, **node 22**, foresta terrain. Roster = 3 volo flyers (g1/g2/g3) + 1 non-volo. **radici excluded from the flip-delta** (always-on → cancels from the delta; a sessile range-1 unit can't traverse).
- **`docs/reports/2026-06-28-move-terrain-n40-evidence.md`**.

### Result
**N=40 foresta = band-NEUTRAL.** ON identical to OFF: 16/16 wins, 24/24 timeouts, 29.7/29.7 avg rounds → `wr_delta 0`, `avg_rounds_delta 0`.

**Sanity (flag DOES bite):** a heavy unit forced across a roccia corridor → ON r7 vs OFF r9. So the foresta null is **real, not a bug**: medium profiles pay ~0 on the mild foresta terrain (vegetazione_densa = 1.0 free, roccia off-path) + volo flyers are exempt. The substrate is a **terrain-design lever**, not a passive WR shifter.

### Recommendation (you ratify)
- **Flip is LOW-RISK on the foresta pilot** (band-neutral). Band risk only emerges on costly terrain (heavy profiles / hazard lava+acqua_profonda / forced corridors) = a level-design choice.
- **Caveat (SDMG)**: hand-rostered direction-probe, not a calibrated N=100. The delta-0 is **structural** (units don't cross costly tiles on this terrain).
- radici's always-on band = a separate carrier-vs-non-carrier measure.

### Merge
Evidence + sim tooling. **No auto-merge** — awaits your band ratification (gates phase 5 flip). No forbidden-path files, no new deps.
