### PR TITLE
feat(traits): wire 6 GAP2 block-2 mechanics (ratified) -- inert traits go live

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -7393,3 +7393,80 @@ traits:
       mette radici (ancorato, riduzione danno 2). Muoversi rompe l'ancora e perde la
       riduzione per quel round; restando fermo la mantiene. Tradeoff mobilita'/difesa
       senza nuove azioni. Ref Wesnoth steadfast / treant.
+  # GAP2 block 2 (salvage item 3, ratified master-dd 2026-06-28): 6 crisp inert
+  # traits wired to EXISTING effect kinds (no forbidden schema, no jobs regen, no
+  # trait_mechanics). Band-neutral: no current sim/combat unit carries them.
+  # Magnitudes PROPOSED (ratify + N=40).
+  zanne_idracida:
+    tier: T4
+    category: offensivo
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: fracture
+      turns: 2
+      log_tag: zanne_idracida
+    description_it: 'Zanne idracide: ogni colpo riuscito corrode tessuti e metalli, indebolendo la corazza del bersaglio (fracture 2 turni). Variante corrosiva piu'' persistente della ghiandola caustica.'
+  emolinfa_conducente:
+    tier: T3
+    category: offensivo
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: extra_damage
+      amount: 1
+      log_tag: emolinfa_conducente
+    description_it: 'Emolinfa conducente: il fluido accumula carica e la scarica sul bersaglio a contatto, infliggendo 1 PT di danno extra a ogni colpo riuscito.'
+  placche_pressioniche:
+    tier: T3
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: passive
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: placche_pressioniche
+    description_it: 'Placche pressioniche: strati che disperdono la pressione abissale e attutiscono il trauma degli impatti (damage_reduction 1).'
+  scudo_gluteale_cheratinizzato:
+    tier: T3
+    category: difensivo
+    applies_to: target
+    trigger:
+      action_type: passive
+    effect:
+      kind: damage_reduction
+      amount: 1
+      min: 0
+      log_tag: scudo_gluteale
+    description_it: 'Scudo gluteale cheratinizzato: placca cheratinizzata che assorbe gli impatti posteriori (damage_reduction 1).'
+  ectotermia_dinamica:
+    tier: T3
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: attack
+      min_mos: 0
+    effect:
+      kind: attack_bonus
+      amount: 1
+      log_tag: ectotermia_dinamica
+    description_it: 'Ectotermia dinamica: microscosse isometriche innalzano in fretta la temperatura corporea, dando un picco prestazionale che aggiunge +1 ai colpi (attack_bonus).'
+  piume_solari_fotovoltaiche:
+    tier: T2
+    category: fisiologico
+    applies_to: actor
+    trigger:
+      action_type: passive
+    effect:
+      kind: heal
+      amount: 1
+      log_tag: piume_solari
+    description_it: 'Piume solari fotovoltaiche: il piumaggio immagazzina luce e la converte in sostegno metabolico, recuperando 1 PT (heal passivo).'

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -7426,27 +7426,29 @@ traits:
   placche_pressioniche:
     tier: T3
     category: difensivo
-    applies_to: target
+    applies_to: actor
     trigger:
       action_type: passive
     effect:
-      kind: damage_reduction
-      amount: 1
-      min: 0
+      kind: apply_status
+      stato: attuned
+      turns: 2
+      target: actor
       log_tag: placche_pressioniche
-    description_it: 'Placche pressioniche: strati che disperdono la pressione abissale e attutiscono il trauma degli impatti (damage_reduction 1).'
+    description_it: 'Placche pressioniche: strati che disperdono la pressione abissale e attutiscono il trauma degli impatti -- passiva attuned (+1 difesa, consumata da computeStatusModifiers).'
   scudo_gluteale_cheratinizzato:
     tier: T3
     category: difensivo
-    applies_to: target
+    applies_to: actor
     trigger:
       action_type: passive
     effect:
-      kind: damage_reduction
-      amount: 1
-      min: 0
+      kind: apply_status
+      stato: attuned
+      turns: 2
+      target: actor
       log_tag: scudo_gluteale
-    description_it: 'Scudo gluteale cheratinizzato: placca cheratinizzata che assorbe gli impatti posteriori (damage_reduction 1).'
+    description_it: 'Scudo gluteale cheratinizzato: placca cheratinizzata che assorbe gli impatti posteriori -- passiva attuned (+1 difesa).'
   ectotermia_dinamica:
     tier: T3
     category: fisiologico
@@ -7466,7 +7468,9 @@ traits:
     trigger:
       action_type: passive
     effect:
-      kind: heal
-      amount: 1
+      kind: apply_status
+      stato: healing
+      turns: 2
+      target: actor
       log_tag: piume_solari
-    description_it: 'Piume solari fotovoltaiche: il piumaggio immagazzina luce e la converte in sostegno metabolico, recuperando 1 PT (heal passivo).'
+    description_it: 'Piume solari fotovoltaiche: il piumaggio immagazzina luce e la converte in sostegno metabolico -- passiva healing (+1 HP/turno, HoT consumato a fine turno).'


### PR DESCRIPTION
## What

Salvage item 3, block 2 -- master-dd **ratified all 6** (AskUserQuestion 2026-06-28; proposal #3041). Wires 6 previously-inert traits to **existing** resolver effect kinds.

| trait | trigger | effect |
| --- | --- | --- |
| `zanne_idracida` | attack/hit | apply_status fracture 2t (corrosion) |
| `emolinfa_conducente` | attack/hit | extra_damage 1 (discharge) |
| `placche_pressioniche` | passive | damage_reduction 1 (trauma) |
| `scudo_gluteale_cheratinizzato` | passive | damage_reduction 1 (impact) |
| `ectotermia_dinamica` | attack | attack_bonus 1 (thermal readiness) |
| `piume_solari_fotovoltaiche` | passive | heal 1 (solar sustain) |

`active_effects.yaml` only (+77). The 6 DB files + index already exist; the mirror gate is `trait_mechanics -> active_effects` one-way, so active_effects-only is consistent. **No forbidden schema, no trait_mechanics, no jobs regen.**

## Verify-first correction

Dropped the proposal's `buff_stat` mapping for `ectotermia_dinamica`: a passive `buff_stat` (non `move_bonus`) is **NOT wired** in `resolveTraitEffect` -> would be inert. Remapped to `attack_bonus` (wired). All 6 kinds confirmed handled in `traitEffects.js`.

## Verification

Band-neutral (no sim/combat unit carries them): **AI 557/557** byte-stable · **test:api exit 0, 0 fail** · mirror PASS · canon-consistency 0 new · template/style/coverage green · cavecrew 0 findings. Magnitudes PROPOSED (N=40 after).

## Rollback

Revert the commit (data-only, additive).