### PR TITLE
feat(traits): re-baseline trait bridge + pack-scope the guard (slice gamma, C2)

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -419,7 +419,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ali_solari_fotoni": {
       "id": "ali_solari_fotoni",
@@ -572,7 +581,16 @@
       "biome_tags": [
         "laguna_bioreattiva"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "barriere_miasma_glaciale": {
       "conflitti": [],
@@ -626,7 +644,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "bozzolo_magnetico": {
       "id": "bozzolo_magnetico",
@@ -740,7 +767,16 @@
       "biome_tags": [
         "reef_luminescente"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "reef-luminescente-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "campo_di_interferenza_acustica": {
       "id": "campo_di_interferenza_acustica",
@@ -858,7 +894,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "circolazione_bifasica": {
       "conflitti": [],
@@ -912,7 +957,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cisti_di_ibernazione_minerale": {
       "id": "cisti_di_ibernazione_minerale",
@@ -1026,7 +1080,16 @@
       "biome_tags": [
         "steppe_algoritmiche"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cute_resistente_sali": {
       "conflitti": [],
@@ -1089,6 +1152,20 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "badlands-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -1144,7 +1221,16 @@
       "biome_tags": [
         "reef_luminescente"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "reef-luminescente-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "filtri_planctonici": {
       "conflitti": [],
@@ -1198,7 +1284,16 @@
       "biome_tags": [
         "laguna_bioreattiva"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_fango_coesivo": {
       "conflitti": [],
@@ -1252,7 +1347,16 @@
       "biome_tags": [
         "mangrovieto_cinetico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "giunti_antitorsione": {
       "conflitti": [],
@@ -1306,7 +1410,16 @@
       "biome_tags": [
         "mangrovieto_cinetico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "lingua_cristallina": {
       "conflitti": [],
@@ -1360,7 +1473,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "membrana_plastica_continua": {
       "id": "membrana_plastica_continua",
@@ -1476,7 +1598,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "pelage_idrorepellente_avanzato": {
       "id": "pelage_idrorepellente_avanzato",
@@ -1754,6 +1885,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -1831,6 +1969,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -1952,6 +2097,20 @@
           "weight": 1
         },
         {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "thaw-rot",
           "roles": [
             "optional"
@@ -2040,6 +2199,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         },
         {
           "species_id": "ferrocolonia-magnetotattica",
@@ -2141,6 +2307,13 @@
         },
         {
           "species_id": "blight-micotico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -3615,6 +3788,20 @@
           "weight": 1
         },
         {
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "dune-stalker",
           "roles": [
             "optional"
@@ -3623,6 +3810,13 @@
         },
         {
           "species_id": "echo-wing",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "orbita-psionica-inversa-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -4457,7 +4651,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "antenne_wideband": {
       "conflitti": [],
@@ -4511,7 +4714,16 @@
       "biome_tags": [
         "steppe_algoritmiche"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_sette_vie": {
       "conflitti": [],
@@ -4617,7 +4829,21 @@
           "weight": 3
         },
         {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -4694,7 +4920,16 @@
       "biome_tags": [
         "calotte_glaciali"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "barbigli_sensori_plasma": {
       "conflitti": [],
@@ -4748,7 +4983,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "branchie_metalloidi": {
       "conflitti": [],
@@ -4802,7 +5046,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "capillari_fotovoltaici": {
       "conflitti": [],
@@ -4856,7 +5109,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cartilagine_flessotermica_venti": {
       "conflitti": [
@@ -4923,7 +5185,16 @@
       "biome_tags": [
         "gole_ventose"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "chemiorecettori_bromuro": {
       "conflitti": [],
@@ -4977,7 +5248,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "coda_contrappeso": {
       "conflitti": [],
@@ -5031,7 +5311,16 @@
       "biome_tags": [
         "mangrovieto_cinetico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "coda_frusta_cinetica": {
       "conflitti": [],
@@ -5143,6 +5432,13 @@
           "weight": 3
         },
         {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "dune-stalker",
           "roles": [
             "optional"
@@ -5203,7 +5499,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "enzimi_antifase_termica": {
       "conflitti": [],
@@ -5257,7 +5562,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "filamenti_termoconduzione": {
       "conflitti": [],
@@ -5311,7 +5625,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_fango_calde": {
       "conflitti": [],
@@ -5365,7 +5688,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_ventosa": {
       "conflitti": [],
@@ -5419,7 +5751,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "linfa_tampone": {
       "conflitti": [],
@@ -5473,7 +5814,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "mucose_aderenza_sonica": {
       "conflitti": [],
@@ -5527,7 +5877,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "zampe_a_molla": {
       "conflitti": [],
@@ -5690,7 +6049,16 @@
       "biome_tags": [
         "steppe_risonanti"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "rostro_linguale_prensile": {
       "id": "rostro_linguale_prensile",
@@ -5803,7 +6171,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "appendici_thermotattiche": {
       "conflitti": [],
@@ -5857,7 +6234,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "batteri_endosimbionti_chemio": {
       "conflitti": [],
@@ -5911,7 +6297,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "branchie_solfatiche": {
       "conflitti": [],
@@ -5965,7 +6360,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "carapace_segmenti_logici": {
       "conflitti": [],
@@ -6019,7 +6423,16 @@
       "biome_tags": [
         "steppe_algoritmiche"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "circolazione_bifasica_palude": {
       "conflitti": [
@@ -6075,7 +6488,16 @@
       "biome_tags": [
         "paludi_gas_luminescenti"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "circolazione_cooling_loop": {
       "conflitti": [],
@@ -6129,7 +6551,16 @@
       "biome_tags": [
         "steppe_algoritmiche"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "coda_stabilizzatrice_filo": {
       "conflitti": [],
@@ -6183,7 +6614,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "criostasi_adattiva": {
       "conflitti": [
@@ -6368,6 +6808,13 @@
           "weight": 1
         },
         {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "nebulocornis-mollis",
           "roles": [
             "optional"
@@ -6466,6 +6913,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -6521,7 +6975,16 @@
       "biome_tags": [
         "laguna_bioreattiva"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_grafene": {
       "conflitti": [],
@@ -6575,7 +7038,16 @@
       "biome_tags": [
         "steppe_algoritmiche"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "grassi_termici": {
       "conflitti": [],
@@ -6647,6 +7119,13 @@
         },
         {
           "species_id": "evento-ondata-termica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "global-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -6727,7 +7206,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "sonno_emisferico_alternato": {
       "conflitti": [],
@@ -6798,6 +7286,13 @@
             "optional"
           ],
           "weight": 1
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -6853,7 +7348,16 @@
       "biome_tags": [
         "laguna_bioreattiva"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_induzione": {
       "conflitti": [],
@@ -6907,7 +7411,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_ipo_termici": {
       "id": "artigli_ipo_termici",
@@ -7139,7 +7652,16 @@
       "biome_tags": [
         "steppe_algoritmiche"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "camere_anticorrosione": {
       "conflitti": [],
@@ -7193,7 +7715,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cannone_sonico_a_raggio": {
       "id": "cannone_sonico_a_raggio",
@@ -7368,7 +7899,16 @@
       "biome_tags": [
         "reef_luminescente"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "reef-luminescente-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "circolazione_supercritica": {
       "conflitti": [],
@@ -7422,7 +7962,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "coda_stabilizzatrice_vortex": {
       "conflitti": [],
@@ -7476,7 +8025,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "denti_chelatanti": {
       "conflitti": [],
@@ -7530,7 +8088,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "elettromagnete_biologico": {
       "id": "elettromagnete_biologico",
@@ -7644,7 +8211,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "estroflessione_gastrica_acida": {
       "id": "estroflessione_gastrica_acida",
@@ -7759,7 +8335,16 @@
       "biome_tags": [
         "mangrovieto_cinetico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "frusta_fiammeggiante": {
       "conflitti": [
@@ -7835,6 +8420,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -7965,7 +8557,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "gusci_magnesio": {
       "conflitti": [],
@@ -8019,7 +8620,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "mantelli_geotermici": {
       "conflitti": [],
@@ -8073,7 +8683,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "rostro_emostatico_litico": {
       "id": "rostro_emostatico_litico",
@@ -8219,6 +8838,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         },
         {
           "species_id": "nano-rust-bloom",
@@ -8419,7 +9045,16 @@
       "biome_tags": [
         "delta_salmastri"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "lamelle_termoforetiche": {
       "conflitti": [
@@ -8482,6 +9117,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -8538,7 +9180,16 @@
       "biome_tags": [
         "laghi_alcalini"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "polmoni_cristallini_alta_quota": {
       "conflitti": [
@@ -8593,7 +9244,16 @@
       "biome_tags": [
         "picchi_cristallini"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "respiro_a_scoppio": {
       "conflitti": [],
@@ -8658,6 +9318,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         },
         {
           "species_id": "dune-stalker",
@@ -8875,7 +9542,28 @@
           "weight": 4
         },
         {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "ferriscroba-detrita",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "orbita-psionica-inversa-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -8953,7 +9641,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "antenne_plasmatiche_tempesta": {
       "conflitti": [],
@@ -9019,7 +9716,16 @@
       "biome_tags": [
         "cicloni_psionici"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "antenne_waveguide": {
       "conflitti": [],
@@ -9074,7 +9780,16 @@
       "biome_tags": [
         "reef_luminescente"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "reef-luminescente-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "baffi_mareomotori": {
       "conflitti": [],
@@ -9129,7 +9844,16 @@
       "biome_tags": [
         "mangrovieto_cinetico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "branchie_eoliche": {
       "conflitti": [],
@@ -9184,7 +9908,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "capillari_fluoridici": {
       "conflitti": [],
@@ -9239,7 +9972,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cavita_risonanti_tundra": {
       "conflitti": [],
@@ -9305,7 +10047,16 @@
       "biome_tags": [
         "tundra_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cervelletto_equilibrio_statico": {
       "conflitti": [],
@@ -9360,7 +10111,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "coda_balanciere": {
       "conflitti": [],
@@ -9417,7 +10177,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cuore_multicamera_bassa_pressione": {
       "conflitti": [],
@@ -9472,7 +10241,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "echi_risonanti": {
       "conflitti": [],
@@ -9528,7 +10306,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "eco_interno_riflesso": {
       "conflitti": [],
@@ -9622,6 +10409,13 @@
           "weight": 1
         },
         {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "thaw-rot",
           "roles": [
             "optional"
@@ -9683,7 +10477,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_eco_mappanti": {
       "conflitti": [],
@@ -9738,7 +10541,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_resina_conduttiva": {
       "conflitti": [],
@@ -9793,7 +10605,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "integumento_bipolare": {
       "id": "integumento_bipolare",
@@ -9910,7 +10731,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "lingua_tattile_trama": {
       "conflitti": [],
@@ -10043,7 +10873,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "occhi_analizzatori_di_tensione": {
       "id": "occhi_analizzatori_di_tensione",
@@ -10340,6 +11179,13 @@
           "weight": 1
         },
         {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "lupus-temperatus",
           "roles": [
             "optional"
@@ -10447,7 +11293,28 @@
           "weight": 1
         },
         {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "dune-stalker",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "orbita-psionica-inversa-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -10574,7 +11441,16 @@
       "biome_tags": [
         "pianure_magnetiche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "sistemi_chimio_sonici": {
       "id": "sistemi_chimio_sonici",
@@ -10751,7 +11627,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_scivolo_silente": {
       "conflitti": [],
@@ -10805,7 +11690,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "biofilm_iperarido": {
       "conflitti": [],
@@ -10859,7 +11753,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "bulbi_radici_permafrost": {
       "conflitti": [],
@@ -10924,7 +11827,16 @@
       "biome_tags": [
         "permafrost_psionico"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "camere_nutrienti_vent": {
       "conflitti": [],
@@ -10978,7 +11890,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cartilagini_flessoacustiche": {
       "conflitti": [],
@@ -11032,7 +11953,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "chioma_parassita_canopica": {
       "conflitti": [],
@@ -11086,7 +12016,16 @@
       "biome_tags": [
         "canopie_sospese"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ciste_salmastre": {
       "conflitti": [],
@@ -11140,7 +12079,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "coralli_partner": {
       "conflitti": [],
@@ -11194,7 +12142,16 @@
       "biome_tags": [
         "reef_luminescente"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "reef-luminescente-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "denti_silice_termici": {
       "conflitti": [],
@@ -11248,7 +12205,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "epitelio_fosforescente": {
       "conflitti": [],
@@ -11302,7 +12268,16 @@
       "biome_tags": [
         "reef_luminescente"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "reef-luminescente-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_cambio_salino": {
       "conflitti": [],
@@ -11356,7 +12331,16 @@
       "biome_tags": [
         "laguna_bioreattiva"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_nebbia_acida": {
       "conflitti": [],
@@ -11410,7 +12394,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "lamelle_sincroniche": {
       "conflitti": [],
@@ -11464,7 +12457,16 @@
       "biome_tags": [
         "steppe_algoritmiche"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "steppe-algoritmiche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "membrane_planata_vectored": {
       "conflitti": [],
@@ -11518,7 +12520,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "mucillagine_simbionte_mangrovie": {
       "conflitti": [
@@ -11589,7 +12600,16 @@
       "biome_tags": [
         "mangrovie_risonanti"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "nodi_micorrizici_oracolari": {
       "conflitti": [
@@ -11660,7 +12680,16 @@
       "biome_tags": [
         "reti_micorriziche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "sacche_spore_stratosferiche": {
       "conflitti": [
@@ -11715,7 +12744,16 @@
       "biome_tags": [
         "stratosfera_portante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "sinapsi_coraline_polifoniche": {
       "conflitti": [
@@ -11785,7 +12823,16 @@
       "biome_tags": [
         "barriere_coralline_psioniche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "antenne_microonde_cavernose": {
       "conflitti": [],
@@ -11840,7 +12887,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_radice": {
       "conflitti": [],
@@ -11894,7 +12950,16 @@
       "biome_tags": [
         "mangrovieto_cinetico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "biofilm_glow": {
       "conflitti": [],
@@ -11959,6 +13024,13 @@
             "optional"
           ],
           "weight": 1
+        },
+        {
+          "species_id": "reef-luminescente-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -12016,7 +13088,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cartilagini_desertiche": {
       "conflitti": [],
@@ -12070,7 +13151,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ciste_riduttive": {
       "conflitti": [],
@@ -12125,7 +13215,16 @@
       "biome_tags": [
         "laguna_bioreattiva"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "colonne_vibromagnetiche": {
       "conflitti": [],
@@ -12181,7 +13280,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "denti_ossidoferro": {
       "conflitti": [],
@@ -12243,6 +13351,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -12298,7 +13413,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "focus_frazionato": {
       "conflitti": [],
@@ -12434,7 +13558,21 @@
           "weight": 2
         },
         {
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "lupus-temperatus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "orbita-psionica-inversa-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -12502,7 +13640,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_minerali": {
       "conflitti": [],
@@ -12556,7 +13703,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "lamelle_shear": {
       "conflitti": [],
@@ -12611,7 +13767,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "membrane_captura_rugiada": {
       "conflitti": [],
@@ -12666,7 +13831,16 @@
       "biome_tags": [
         "pianura_salina_iperarida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "pianura-salina-iperarida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "pathfinder": {
       "conflitti": [],
@@ -12904,6 +14078,13 @@
       ],
       "species_affinity": [
         {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "sentinella-radice",
           "roles": [
             "optional"
@@ -13073,7 +14254,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_vetrificati": {
       "conflitti": [],
@@ -13127,7 +14317,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "branchie_dual_mode": {
       "conflitti": [],
@@ -13181,7 +14380,16 @@
       "biome_tags": [
         "laguna_bioreattiva"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "laguna-bioreattiva-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "capillari_criogenici": {
       "conflitti": [],
@@ -13235,7 +14443,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "carapace_fase_variabile": {
       "conflitti": [
@@ -13457,7 +14674,16 @@
       "biome_tags": [
         "abisso_luminescente"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cartilagini_pseudometalliche": {
       "conflitti": [],
@@ -13511,7 +14737,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cisti_iperbariche": {
       "conflitti": [],
@@ -13565,7 +14800,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cromofori_alert_acido": {
       "conflitti": [],
@@ -13619,7 +14863,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "denti_tuning_fork": {
       "conflitti": [],
@@ -13673,7 +14926,16 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "filamenti_magnetotrofi": {
       "conflitti": [],
@@ -13727,7 +14989,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_condensa_ozono": {
       "conflitti": [],
@@ -13781,7 +15052,16 @@
       "biome_tags": [
         "stratosfera_tempestosa"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "stratosfera-tempestosa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_nebbia_ionica": {
       "conflitti": [],
@@ -13835,7 +15115,16 @@
       "biome_tags": [
         "canopia_ionica"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "canopia-ionica-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "lamine_filtranti_aeree": {
       "conflitti": [],
@@ -13889,7 +15178,16 @@
       "biome_tags": [
         "mangrovieto_cinetico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "membrane_pneumatofori": {
       "conflitti": [],
@@ -13951,6 +15249,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "mangrovieto-cinetico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -14062,6 +15367,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         },
         {
           "species_id": "rust-scavenger",
@@ -14185,6 +15497,27 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -14242,6 +15575,13 @@
       ],
       "data_origin": "coverage_q4_2025",
       "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
         {
           "species_id": "rubrospina-velox",
           "roles": [
@@ -14303,7 +15643,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "aura_scudo_radianza": {
       "conflitti": [
@@ -14371,6 +15720,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -14426,7 +15782,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "branchie_turbina": {
       "conflitti": [],
@@ -14480,7 +15845,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "carapaci_ferruginosi": {
       "conflitti": [],
@@ -14542,6 +15916,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -14597,7 +15978,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "coda_stabilizzatrice_geiser": {
       "conflitti": [],
@@ -14651,7 +16041,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cuticole_neutralizzanti": {
       "conflitti": [],
@@ -14705,7 +16104,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "empatia_coordinativa": {
       "conflitti": [],
@@ -14886,7 +16294,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "foliage_fotocatodico": {
       "conflitti": [],
@@ -14940,7 +16357,16 @@
       "biome_tags": [
         "foresta_acida"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "foresta-acida-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiandole_inchiostro_luce": {
       "conflitti": [],
@@ -14994,7 +16420,16 @@
       "biome_tags": [
         "reef_luminescente"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "reef-luminescente-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "gusci_criovetro": {
       "conflitti": [],
@@ -15048,7 +16483,16 @@
       "biome_tags": [
         "caldera_glaciale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "caldera-glaciale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "luminescenza_hydrotermica": {
       "conflitti": [],
@@ -15102,7 +16546,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "abisso-vulcanico-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "risonanza_di_branco": {
       "conflitti": [],
@@ -15327,6 +16780,20 @@
             "optional"
           ],
           "weight": 1
+        },
+        {
+          "species_id": "canopia-psionica-leggera-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ]
     },
@@ -15385,7 +16852,16 @@
       "biome_tags": [
         "altipiani_solari"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "secrezione_rallentante_palmi": {
       "conflitti": [
@@ -15451,6 +16927,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         },
         {
           "species_id": "thaw-rot",
@@ -15524,7 +17007,16 @@
       "biome_tags": [
         "dune_cristalline"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "vello_condensatore_nebbie": {
       "conflitti": [],
@@ -15578,7 +17070,16 @@
       "biome_tags": [
         "foreste_nubose"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "coscienza_dalveare_diffusa": {
       "id": "coscienza_dalveare_diffusa",

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -487,18 +487,20 @@
       },
       "species_affinity": [
         {
+          "species_id": "auroserpens_photonicus",
           "roles": [
+            "core",
             "optional"
           ],
-          "species_id": "archon-solare",
-          "weight": 1
+          "weight": 4
         },
         {
+          "species_id": "heliopteryx_radians",
           "roles": [
+            "core",
             "optional"
           ],
-          "species_id": "couatl-aurora",
-          "weight": 1
+          "weight": 4
         }
       ],
       "completion_flags": {
@@ -1078,7 +1080,17 @@
       "biome_tags": [
         "badlands"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "evento-tempesta-ferrosa",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "enzimi_antipredatori_algali": {
       "conflitti": [],
@@ -1525,7 +1537,16 @@
       "usage_tags": [
         "tank"
       ],
-      "debolezza": "i18n:traits.pelage_idrorepellente_avanzato.debolezza"
+      "debolezza": "i18n:traits.pelage_idrorepellente_avanzato.debolezza",
+      "species_affinity": [
+        {
+          "species_id": "arboryxis-lenis",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "scudo_gluteale_cheratinizzato": {
       "id": "scudo_gluteale_cheratinizzato",
@@ -1702,7 +1723,39 @@
       "biome_tags": [
         "rovine_planari"
       ],
-      "data_origin": "pathfinder_dataset"
+      "data_origin": "pathfinder_dataset",
+      "species_affinity": [
+        {
+          "species_id": "lithoconstructus_inhibens",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "tellurmordax_phasicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "pyroflagellum_meteoriticum",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "radiciforma_ancorans",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "mantello_meteoritico": {
       "conflitti": [
@@ -1761,7 +1814,25 @@
       "biome_tags": [
         "rovine_planari"
       ],
-      "data_origin": "pathfinder_dataset"
+      "data_origin": "pathfinder_dataset",
+      "species_affinity": [
+        {
+          "species_id": "pyroflagellum_meteoriticum",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "rotabrachium_ferox",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "filamenti_digestivi_compattanti": {
       "conflitti": [],
@@ -1840,7 +1911,54 @@
         "caverna_risonante",
         "falde_magnetiche_psioniche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "amorphovenator_magneticus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "nano-rust-bloom",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "rust-scavenger",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "ferriscroba-detrita",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "blight-micotico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "thaw-rot",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ventriglio_gastroliti": {
       "conflitti": [],
@@ -1906,7 +2024,38 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "rust-scavenger",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "ferriscroba-detrita",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "ferrocolonia-magnetotattica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "steppe-bison-mini",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "spore_psichiche_silenziate": {
       "conflitti": [
@@ -1969,18 +2118,40 @@
       ],
       "species_affinity": [
         {
+          "species_id": "nano-rust-bloom",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "cryptopennatus_psionicus",
           "roles": [
             "core"
           ],
-          "species_id": "banshee-risonante",
           "weight": 3
         },
         {
+          "species_id": "sonovespera_lamentans",
           "roles": [
-            "synergy"
+            "core"
           ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 2
+          "weight": 3
+        },
+        {
+          "species_id": "blight-micotico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "thaw-rot",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "completion_flags": {
@@ -3403,7 +3574,68 @@
         "canopia_psionica_leggera",
         "orbita_psionica_inversa"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "aerostatocyon_altivolans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "cryptopennatus_psionicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "sand-burrower",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "arboryxis-lenis",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "aurora-gull",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "echo-wing",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "steppe-bison-mini",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ali_fono_risonanti": {
       "id": "ali_fono_risonanti",
@@ -3472,18 +3704,19 @@
       },
       "species_affinity": [
         {
+          "species_id": "sonovespera_lamentans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "cryptopennatus_psionicus",
           "roles": [
             "core"
           ],
-          "species_id": "banshee-risonante",
           "weight": 3
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 2
         }
       ],
       "version": "1.0.0",
@@ -3551,7 +3784,15 @@
         "core": "locomotivo",
         "complementare": "terrestre"
       },
-      "species_affinity": [],
+      "species_affinity": [
+        {
+          "species_id": "arboryxis-lenis",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -3617,7 +3858,6 @@
         "core": "locomotivo",
         "complementare": "terrestre"
       },
-      "species_affinity": [],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -3683,7 +3923,6 @@
         "core": "locomotivo",
         "complementare": "terrestre"
       },
-      "species_affinity": [],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -3751,7 +3990,6 @@
         "core": "locomotivo",
         "complementare": "arboricolo"
       },
-      "species_affinity": [],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -3818,7 +4056,6 @@
         "core": "locomotivo",
         "complementare": "terrestre"
       },
-      "species_affinity": [],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -3887,7 +4124,6 @@
         "core": "locomotivo",
         "complementare": "terrestre"
       },
-      "species_affinity": [],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -3960,7 +4196,6 @@
         "core": "locomotivo",
         "complementare": "balistico"
       },
-      "species_affinity": [],
       "debolezza": "i18n:traits.scheletro_idraulico_a_pistoni.debolezza"
     },
     "scheletro_pneumatico_a_maglie": {
@@ -4023,7 +4258,15 @@
         "core": "locomotivo",
         "complementare": "terrestre"
       },
-      "species_affinity": [],
+      "species_affinity": [
+        {
+          "species_id": "nebulocornis-mollis",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -4089,7 +4332,6 @@
         "core": "locomotivo",
         "complementare": "terrestre"
       },
-      "species_affinity": [],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -4155,7 +4397,6 @@
         "core": "locomotivo",
         "complementare": "arboricolo"
       },
-      "species_affinity": [],
       "version": "1.0.0",
       "versioning": {
         "created": "2025-11-04",
@@ -4336,7 +4577,60 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "resonant-claw-hunter",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "pyroflagellum_meteoriticum",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "rotabrachium_ferox",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "rubrospina-velox",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "ferrimordax-rutilus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_sghiaccio_glaciale": {
       "conflitti": [],
@@ -4831,7 +5125,31 @@
         "falde_magnetiche_psioniche",
         "orbita_psionica_inversa"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "tellurmordax_phasicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "rotabrachium_ferox",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cuscinetti_elettrostatici": {
       "conflitti": [],
@@ -5286,7 +5604,37 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "arboryxis-lenis",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "rubrospina-velox",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "sand-burrower",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "zoccoli_risonanti_steppe": {
       "conflitti": [
@@ -5905,7 +6253,44 @@
         "canopia_psionica_leggera",
         "orbita_psionica_inversa"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "aerostatocyon_altivolans",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "aurora-gull",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "rubrospina-velox",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "cuticole_cerose": {
       "conflitti": [],
@@ -5959,7 +6344,58 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "cactus-weaver",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "evento-brinastorm",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "evento-ondata-termica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "nebulocornis-mollis",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "noctule-termico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "silica-bloom",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "thermo-raptor",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "enzimi_chelanti": {
       "conflitti": [],
@@ -6014,7 +6450,24 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "evento-tempesta-ferrosa",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "ferriscroba-detrita",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "flagelli_ancoranti": {
       "conflitti": [],
@@ -6176,7 +6629,51 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "cactus-weaver",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "evento-brinastorm",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "evento-ondata-termica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "noctule-termico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "silica-bloom",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "thermo-raptor",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "luminescenza_aurorale": {
       "conflitti": [],
@@ -6285,7 +6782,24 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "echo-wing",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "aurora-gull",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "antenne_flusso_mareale": {
       "conflitti": [],
@@ -7304,7 +7818,25 @@
       "biome_tags": [
         "rovine_planari"
       ],
-      "data_origin": "pathfinder_dataset"
+      "data_origin": "pathfinder_dataset",
+      "species_affinity": [
+        {
+          "species_id": "pyroflagellum_meteoriticum",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "rotabrachium_ferox",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "ghiandola_caustica": {
       "conflitti": [],
@@ -7357,17 +7889,10 @@
       },
       "species_affinity": [
         {
-          "roles": [
-            "core"
-          ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 3
-        },
-        {
+          "species_id": "blight-micotico",
           "roles": [
             "optional"
           ],
-          "species_id": "sentinella-radice",
           "weight": 1
         }
       ],
@@ -7685,7 +8210,31 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "ferrocolonia-magnetotattica",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "nano-rust-bloom",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "thaw-rot",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "seta_conduttiva_elettrica": {
       "id": "seta_conduttiva_elettrica",
@@ -7925,7 +8474,16 @@
       "biome_tags": [
         "sorgenti_geotermiche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "amorphovenator_magneticus",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "membrane_eliofiltranti": {
       "conflitti": [],
@@ -8091,7 +8649,38 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "rust-scavenger",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "ferriscroba-detrita",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "steppe-bison-mini",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ermafroditismo_cronologico": {
       "id": "ermafroditismo_cronologico",
@@ -8270,18 +8859,34 @@
       ],
       "species_affinity": [
         {
+          "species_id": "rotabrachium_ferox",
           "roles": [
-            "core"
+            "core",
+            "optional"
           ],
-          "species_id": "marilith-vault",
-          "weight": 3
+          "weight": 4
         },
         {
+          "species_id": "sand-burrower",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "ferriscroba-detrita",
           "roles": [
             "optional"
           ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 2
+          "weight": 1
+        },
+        {
+          "species_id": "rust-scavenger",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "completion_flags": {
@@ -8992,7 +9597,38 @@
         "canopia_psionica_leggera",
         "falde_magnetiche_psioniche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "echo-wing",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "aerostatocyon_altivolans",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "aurora-gull",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "thaw-rot",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "filamenti_superconduttivi": {
       "conflitti": [],
@@ -9328,7 +9964,30 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "blight-micotico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "echo-wing",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "ferrocolonia-magnetotattica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "midollo_antivibrazione": {
       "conflitti": [],
@@ -9595,18 +10254,19 @@
       ],
       "species_affinity": [
         {
+          "species_id": "aerostatocyon_altivolans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "cryptopennatus_psionicus",
           "roles": [
             "core"
           ],
-          "species_id": "orbital-ascendant",
           "weight": 3
-        },
-        {
-          "roles": [
-            "optional"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 2
         }
       ],
       "debolezza": "i18n:traits.occhi_cristallo_modulare.debolezza"
@@ -9662,7 +10322,31 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "echo-wing",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "aurora-gull",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "lupus-temperatus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "olfatto_risonanza_magnetica": {
       "conflitti": [],
@@ -9730,7 +10414,46 @@
         "falde_magnetiche_psioniche",
         "orbita_psionica_inversa"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "aerostatocyon_altivolans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "amorphovenator_magneticus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "ferrimordax-rutilus",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "organi_sismici_cutanei": {
       "id": "organi_sismici_cutanei",
@@ -11228,7 +11951,16 @@
       "biome_tags": [
         "reef_luminescente"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "nebulocornis-mollis",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "camere_mirage": {
       "conflitti": [],
@@ -11503,7 +12235,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "ferrimordax-rutilus",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "epidermide_dielettrica": {
       "conflitti": [],
@@ -11641,7 +12382,72 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "aerostatocyon_altivolans",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "cryptopennatus_psionicus",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "rotabrachium_ferox",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "arboryxis-lenis",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "nebulocornis-mollis",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "rubrospina-velox",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "lupus-temperatus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "sentinella-radice",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "ghiaccio_piezoelettrico": {
       "conflitti": [],
@@ -11925,17 +12731,17 @@
       "data_origin": "controllo_psionico",
       "species_affinity": [
         {
+          "species_id": "cryptopennatus_psionicus",
           "roles": [
             "core"
           ],
-          "species_id": "psionic-canopy-scout",
           "weight": 3
         },
         {
+          "species_id": "sentinella-radice",
           "roles": [
             "optional"
           ],
-          "species_id": "sentinella-radice",
           "weight": 1
         }
       ],
@@ -12028,7 +12834,16 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "sentinella-radice",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "random": {
       "conflitti": [],
@@ -12089,25 +12904,11 @@
       ],
       "species_affinity": [
         {
-          "roles": [
-            "optional"
-          ],
           "species_id": "sentinella-radice",
-          "weight": 1
-        },
-        {
-          "roles": [
-            "synergy"
-          ],
-          "species_id": "psionic-canopy-scout",
-          "weight": 3
-        },
-        {
           "roles": [
             "optional"
           ],
-          "species_id": "orbital-ascendant",
-          "weight": 2
+          "weight": 1
         }
       ],
       "spinta_selettiva": "i18n:traits.random.spinta_selettiva",
@@ -12201,7 +13002,23 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "lupus-temperatus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "antenne_tesla": {
       "conflitti": [],
@@ -12512,7 +13329,68 @@
         "canopia_psionica_leggera",
         "falde_magnetiche_psioniche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "filtrophagus_custos",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "lithoconstructus_inhibens",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "tellurmordax_phasicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "pyroflagellum_meteoriticum",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "nano-rust-bloom",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "sand-burrower",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "steppe-bison-mini",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "carapace_luminiscente_abissale": {
       "conflitti": [
@@ -13065,7 +13943,16 @@
       "biome_tags": [
         "mangrovieto_cinetico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "nebulocornis-mollis",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "scheletro_idro_regolante": {
       "conflitti": [
@@ -13136,7 +14023,61 @@
       "biome_tags": [
         "caverna_risonante"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "nano-rust-bloom",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "sand-burrower",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "amorphovenator_magneticus",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "tellurmordax_phasicus",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "rust-scavenger",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "steppe-bison-mini",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "struttura_elastica_amorfa": {
       "conflitti": [],
@@ -13219,7 +14160,33 @@
         "canopia_psionica_leggera",
         "falde_magnetiche_psioniche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "amorphovenator_magneticus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "cryptopennatus_psionicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "antenne_eco_turbina": {
       "conflitti": [],
@@ -13273,7 +14240,16 @@
       "biome_tags": [
         "dorsale_termale_tropicale"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "rubrospina-velox",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_acidofagi": {
       "conflitti": [],
@@ -13386,7 +14362,17 @@
       "biome_tags": [
         "rovine_planari"
       ],
-      "data_origin": "pathfinder_dataset"
+      "data_origin": "pathfinder_dataset",
+      "species_affinity": [
+        {
+          "species_id": "heliopteryx_radians",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "batteri_termofili_endosimbiosi": {
       "conflitti": [],
@@ -13548,7 +14534,16 @@
       "biome_tags": [
         "abisso_vulcanico"
       ],
-      "data_origin": "coverage_q4_2025"
+      "data_origin": "coverage_q4_2025",
+      "species_affinity": [
+        {
+          "species_id": "ferrimordax-rutilus",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "circolazione_doppia": {
       "conflitti": [],
@@ -13784,7 +14779,60 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "auroserpens_photonicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "illusiopardus_psionicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "heliopteryx_radians",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "rotabrachium_ferox",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "nebulocornis-mollis",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "lupus-temperatus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "sentinella-radice",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "enzimi_chelatori_rapidi": {
       "conflitti": [],
@@ -14136,7 +15184,45 @@
       "biome_tags": [
         "foresta_miceliale"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "sonovespera_lamentans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "auroserpens_photonicus",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "heliopteryx_radians",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "dune-stalker",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "lupus-temperatus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "mimetismo_cromatico_passivo": {
       "conflitti": [],
@@ -14217,7 +15303,32 @@
         "canopia_psionica_leggera",
         "falde_magnetiche_psioniche"
       ],
-      "data_origin": "controllo_psionico"
+      "data_origin": "controllo_psionico",
+      "species_affinity": [
+        {
+          "species_id": "cryptopennatus_psionicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "ferrocolonia-magnetotattica",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "blight-micotico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "piume_solari_fotovoltaiche": {
       "conflitti": [
@@ -14334,18 +15445,19 @@
       ],
       "species_affinity": [
         {
+          "species_id": "ferrocolonia-magnetotattica",
           "roles": [
-            "core"
+            "core",
+            "optional"
           ],
-          "species_id": "sentinella-radice",
-          "weight": 3
+          "weight": 4
         },
         {
+          "species_id": "thaw-rot",
           "roles": [
             "optional"
           ],
-          "species_id": "laguna-bioreattiva-trait-keeper",
-          "weight": 2
+          "weight": 1
         }
       ],
       "completion_flags": {
@@ -14629,7 +15741,16 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "rubrospina-velox",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "aura_glaciale": {
       "schema_version": "2.0",
@@ -14717,7 +15838,23 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "arboryxis-lenis",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "nebulocornis-mollis",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "pelli_anti_ustione": {
       "schema_version": "2.0",
@@ -14739,7 +15876,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "evento-tempesta-ferrosa",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "pelli_fitte": {
       "schema_version": "2.0",
@@ -14761,7 +15908,16 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "evento-seme-uragano",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "sensori_sismici": {
       "schema_version": "2.0",
@@ -14783,7 +15939,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "resonant-claw-hunter",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "tela_appiccicosa": {
       "schema_version": "2.0",
@@ -14893,7 +16059,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "apex_predatore",
+          "roles": [
+            "core",
+            "synergy"
+          ],
+          "weight": 5
+        }
+      ]
     },
     "intimidatore": {
       "schema_version": "2.0",
@@ -14937,7 +16113,16 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "arboryxis-lenis",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        }
+      ]
     },
     "marchio_predatorio": {
       "schema_version": "2.0",
@@ -14959,7 +16144,16 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "ferrimordax-rutilus",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        }
+      ]
     },
     "midollo_iperattivo": {
       "schema_version": "2.0",
@@ -15113,7 +16307,23 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "apex_predatore",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "ferrimordax-rutilus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "pungiglione_paralizzante": {
       "schema_version": "2.0",
@@ -15201,7 +16411,51 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "cactus-weaver",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "evento-brinastorm",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "evento-ondata-termica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "noctule-termico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "silica-bloom",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "thermo-raptor",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "senso_magnetico": {
       "schema_version": "2.0",
@@ -15355,7 +16609,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "lithoconstructus_inhibens",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "nuclei_di_controllo": {
       "schema_version": "2.0",
@@ -15377,7 +16641,16 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "lithoconstructus_inhibens",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        }
+      ]
     },
     "corteccia_memetica": {
       "schema_version": "2.0",
@@ -15399,7 +16672,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "radiciforma_ancorans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "artigli_psionici": {
       "schema_version": "2.0",
@@ -15421,7 +16704,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "illusiopardus_psionicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "tessuti_adattivi": {
       "schema_version": "2.0",
@@ -15443,7 +16736,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "illusiopardus_psionicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "filtri_bioattivi": {
       "schema_version": "2.0",
@@ -15465,7 +16768,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "filtrophagus_custos",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "membrane_osmotiche": {
       "schema_version": "2.0",
@@ -15487,7 +16800,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "filtrophagus_custos",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "pigmenti_aurorali": {
       "schema_version": "2.0",
@@ -15509,7 +16832,59 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "radiciforma_ancorans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "cactus-weaver",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "evento-brinastorm",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "evento-ondata-termica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "noctule-termico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "silica-bloom",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "thermo-raptor",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "adattamento_volo": {
       "schema_version": "2.0",
@@ -15531,7 +16906,41 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "auroserpens_photonicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "heliopteryx_radians",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "pyroflagellum_meteoriticum",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
+          "species_id": "sonovespera_lamentans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "radici_ancora_planare": {
       "schema_version": "2.0",
@@ -15553,7 +16962,17 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": true
-      }
+      },
+      "species_affinity": [
+        {
+          "species_id": "radiciforma_ancorans",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        }
+      ]
     },
     "eco_sismico": {
       "schema_version": "2.0",

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -2111,6 +2111,20 @@
           "weight": 1
         },
         {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "thaw-rot",
           "roles": [
             "optional"
@@ -2209,6 +2223,13 @@
         },
         {
           "species_id": "ferrocolonia-magnetotattica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -2314,6 +2335,20 @@
         },
         {
           "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -3816,6 +3851,13 @@
           "weight": 1
         },
         {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "orbita-psionica-inversa-trait-keeper",
           "roles": [
             "optional"
@@ -4851,6 +4893,13 @@
         },
         {
           "species_id": "ferrimordax-rutilus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -6724,6 +6773,13 @@
           "weight": 1
         },
         {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "rubrospina-velox",
           "roles": [
             "optional"
@@ -7289,6 +7345,13 @@
         },
         {
           "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -8486,6 +8549,13 @@
             "optional"
           ],
           "weight": 1
+        },
+        {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "spinta_selettiva": "i18n:traits.ghiandola_caustica.spinta_selettiva",
@@ -8841,6 +8911,13 @@
         },
         {
           "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -9335,6 +9412,13 @@
         },
         {
           "species_id": "ferriscroba-detrita",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -10416,6 +10500,13 @@
           "weight": 1
         },
         {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "thaw-rot",
           "roles": [
             "optional"
@@ -10812,6 +10903,13 @@
         },
         {
           "species_id": "ferrocolonia-magnetotattica",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "foresta-miceliale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -11308,6 +11406,13 @@
         },
         {
           "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -13565,6 +13670,13 @@
           "weight": 1
         },
         {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "lupus-temperatus",
           "roles": [
             "optional"
@@ -13912,6 +14024,13 @@
           "weight": 3
         },
         {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "sentinella-radice",
           "roles": [
             "optional"
@@ -14010,6 +14129,13 @@
       ],
       "data_origin": "controllo_psionico",
       "species_affinity": [
+        {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
         {
           "species_id": "sentinella-radice",
           "roles": [
@@ -14191,6 +14317,13 @@
             "synergy"
           ],
           "weight": 2
+        },
+        {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         },
         {
           "species_id": "lupus-temperatus",
@@ -14581,6 +14714,13 @@
         },
         {
           "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -15376,6 +15516,13 @@
           "weight": 1
         },
         {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "rust-scavenger",
           "roles": [
             "optional"
@@ -15514,6 +15661,13 @@
         },
         {
           "species_id": "falde-magnetiche-psioniche-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "foresta-miceliale-trait-keeper",
           "roles": [
             "optional"
           ],
@@ -16227,6 +16381,13 @@
           "weight": 2
         },
         {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "lupus-temperatus",
           "roles": [
             "optional"
@@ -16669,6 +16830,13 @@
           "weight": 2
         },
         {
+          "species_id": "foresta-miceliale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "lupus-temperatus",
           "roles": [
             "optional"
@@ -16790,6 +16958,13 @@
         },
         {
           "species_id": "dorsale-termale-tropicale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "mezzanotte-orbitale-trait-keeper",
           "roles": [
             "optional"
           ],

--- a/data/traits/species_affinity.json
+++ b/data/traits/species_affinity.json
@@ -1,4117 +1,1687 @@
 {
   "schema_version": "2.0",
+  "aculei_velenosi": [
+    {
+      "species_id": "rubrospina-velox",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    }
+  ],
   "adattamento_volo": [
     {
+      "species_id": "auroserpens_photonicus",
       "roles": [
-        "core"
+        "core",
+        "optional"
       ],
-      "species_id": "archon-solare",
-      "weight": 3
+      "weight": 4
     },
     {
+      "species_id": "heliopteryx_radians",
       "roles": [
-        "core"
+        "core",
+        "optional"
       ],
-      "species_id": "balor-fission",
-      "weight": 3
+      "weight": 4
     },
     {
+      "species_id": "pyroflagellum_meteoriticum",
       "roles": [
-        "core"
+        "core",
+        "optional"
       ],
-      "species_id": "banshee-risonante",
-      "weight": 3
+      "weight": 4
     },
     {
+      "species_id": "sonovespera_lamentans",
       "roles": [
-        "core"
+        "core",
+        "optional"
       ],
-      "species_id": "couatl-aurora",
-      "weight": 3
+      "weight": 4
     }
   ],
   "ali_fono_risonanti": [
     {
+      "species_id": "sonovespera_lamentans",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
+      "species_id": "cryptopennatus_psionicus",
       "roles": [
         "core"
       ],
-      "species_id": "banshee-risonante",
       "weight": 3
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 2
-    }
-  ],
-  "ali_fulminee": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ali_ioniche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ali_membrana_sonica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
     }
   ],
   "ali_solari_fotoni": [
     {
+      "species_id": "auroserpens_photonicus",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "archon-solare",
-      "weight": 1
+      "weight": 4
     },
     {
+      "species_id": "heliopteryx_radians",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "couatl-aurora",
-      "weight": 1
-    }
-  ],
-  "antenne_dustsense": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
+      "weight": 4
     }
   ],
   "antenne_eco_turbina": [
     {
+      "species_id": "rubrospina-velox",
       "roles": [
         "optional"
       ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "antenne_flusso_mareale": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "antenne_microonde_cavernose": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "antenne_plasmatiche_tempesta": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "cicloni-psionici-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "antenne_reagenti": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "antenne_tesla": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "antenne_waveguide": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "reef-luminescente-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "antenne_wideband": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "steppe-algoritmiche-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "appendici_risonanti_marea": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "appendici_thermotattiche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
       "weight": 1
     }
   ],
   "armatura_pietra_planare": [
     {
+      "species_id": "lithoconstructus_inhibens",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "golem-runico",
       "weight": 4
     },
     {
+      "species_id": "tellurmordax_phasicus",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "balor-fission",
-      "weight": 1
+      "weight": 4
     },
     {
+      "species_id": "pyroflagellum_meteoriticum",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "bulette-fase",
-      "weight": 1
+      "weight": 3
     },
     {
+      "species_id": "radiciforma_ancorans",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "treant-portale",
-      "weight": 1
+      "weight": 3
     }
   ],
   "articolazioni_a_leva_idraulica": [
     {
+      "species_id": "arboryxis-lenis",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "articolazioni_multiassiali": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "artigli_acidofagi": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "artigli_induzione": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "artigli_ipo_termici": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
+      "weight": 3
     }
   ],
   "artigli_psionici": [
     {
+      "species_id": "illusiopardus_psionicus",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "rakshasa-corte",
-      "weight": 1
-    }
-  ],
-  "artigli_radice": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovieto-cinetico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "artigli_scivolo_silente": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
+      "weight": 4
     }
   ],
   "artigli_sette_vie": [
     {
-      "roles": [
-        "core",
-        "optional"
-      ],
       "species_id": "dune-stalker",
-      "weight": 4
-    },
-    {
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "magneto-ridge-hunter",
       "weight": 4
     },
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "balor-fission",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "couatl-aurora",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "cryo-lynx",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "marilith-vault",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "otyugh-sentinella",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
       "species_id": "resonant-claw-hunter",
-      "weight": 1
-    }
-  ],
-  "artigli_sghiaccio_glaciale": [
-    {
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "calotte-glaciali-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "artigli_vetrificati": [
+      "weight": 4
+    },
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "artiglio_cinetico_a_urto": [
-    {
+      "species_id": "pyroflagellum_meteoriticum",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "assenza_respirazione": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "banshee-risonante",
       "weight": 3
     },
     {
+      "species_id": "rotabrachium_ferox",
       "roles": [
         "core"
       ],
-      "species_id": "golem-runico",
       "weight": 3
-    }
-  ],
-  "aura_di_dispersione_mentale": [
+    },
     {
+      "species_id": "rubrospina-velox",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
+      "weight": 3
+    },
+    {
+      "species_id": "cryo-lynx",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "ferrimordax-rutilus",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "aura_scudo_radianza": [
     {
+      "species_id": "heliopteryx_radians",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "archon-solare",
       "weight": 4
-    }
-  ],
-  "baffi_mareomotori": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovieto-cinetico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "barbigli_sensori_plasma": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "barriere_miasma_glaciale": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "batteri_endosimbionti_chemio": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "batteri_termofili_endosimbiosi": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "bioantenne_gravitiche": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "biochip_memoria": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "steppe-algoritmiche-trait-keeper",
-      "weight": 1
     }
   ],
   "biofilm_glow": [
     {
+      "species_id": "nebulocornis-mollis",
       "roles": [
         "optional"
       ],
-      "species_id": "reef-luminescente-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "biofilm_iperarido": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "bozzolo_magnetico": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "branchie_dual_mode": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "branchie_eoliche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "branchie_metalloidi": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "branchie_microfiltri": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "reef-luminescente-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "branchie_osmotiche_salmastra": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "delta-salmastri-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "branchie_solfatiche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "branchie_turbina": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "bulbi_radici_permafrost": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "permafrost-psionico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "camere_anticorrosione": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "camere_mirage": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "camere_nutrienti_vent": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "camere_risonanza_abyssal": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "leviatano_risonante",
-      "weight": 4
-    }
-  ],
-  "campo_di_interferenza_acustica": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "cannone_sonico_a_raggio": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "canto_infrasonico_tattico": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "canto_risonante": [
-    {
-      "roles": [
-        "temp"
-      ],
-      "species_id": "polpo_araldo_sinaptico",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "temp"
-      ],
-      "species_id": "leviatano_risonante",
-      "weight": 2
-    }
-  ],
-  "capillari_criogenici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "capillari_fluoridici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "capillari_fotovoltaici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "capsule_paracadute": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
       "weight": 1
     }
   ],
   "carapace_fase_variabile": [
     {
+      "species_id": "filtrophagus_custos",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "balor-fission",
-      "weight": 1
+      "weight": 4
     },
     {
+      "species_id": "lithoconstructus_inhibens",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "bulette-fase",
-      "weight": 1
+      "weight": 4
     },
     {
+      "species_id": "tellurmordax_phasicus",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "canopia-psionica-leggera-trait-keeper",
-      "weight": 1
+      "weight": 4
     },
     {
+      "species_id": "pyroflagellum_meteoriticum",
       "roles": [
-        "optional"
+        "core"
       ],
+      "weight": 3
+    },
+    {
       "species_id": "cryo-lynx",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "falde-magnetiche-psioniche-trait-keeper",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "golem-runico",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
       "species_id": "nano-rust-bloom",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "otyugh-sentinella",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "sand-burrower",
-      "weight": 1
-    }
-  ],
-  "carapace_luminiscente_abissale": [
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "abisso-luminescente-trait-keeper",
       "weight": 1
-    }
-  ],
-  "carapace_segmenti_logici": [
+    },
     {
+      "species_id": "steppe-bison-mini",
       "roles": [
         "optional"
       ],
-      "species_id": "steppe-algoritmiche-trait-keeper",
       "weight": 1
     }
   ],
   "carapaci_ferruginosi": [
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cartilagine_flessotermica_venti": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "gole-ventose-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cartilagini_biofibre": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "reef-luminescente-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cartilagini_desertiche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cartilagini_flessoacustiche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cartilagini_pseudometalliche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cavita_risonanti_tundra": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "tundra-risonante-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cervelletto_equilibrio_statico": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cervello_a_bassa_latenza": [
-    {
+      "species_id": "ferrimordax-rutilus",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "chemiorecettori_bromuro": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "chioma_parassita_canopica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopie-sospese-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ciclo_vitale_anomalo": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "banshee-risonante",
       "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "golem-runico",
-      "weight": 3
-    }
-  ],
-  "ciclo_vitale_completo": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "archon-solare",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "balor-fission",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "bulette-fase",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "couatl-aurora",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "marilith-vault",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "otyugh-sentinella",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "rakshasa-corte",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "treant-portale",
-      "weight": 3
-    }
-  ],
-  "cinghia_iper_ciliare": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "circolazione_bifasica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "circolazione_bifasica_palude": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "paludi-gas-luminescenti-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "circolazione_cooling_loop": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "steppe-algoritmiche-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "circolazione_doppia": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "circolazione_supercritica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ciste_riduttive": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ciste_salmastre": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cisti_di_ibernazione_minerale": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "cisti_iperbariche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "coda_balanciere": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "coda_contrappeso": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovieto-cinetico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "coda_coppia_retroattiva": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "steppe-algoritmiche-trait-keeper",
-      "weight": 1
     }
   ],
   "coda_frusta_cinetica": [
     {
+      "species_id": "tellurmordax_phasicus",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "dune-stalker",
       "weight": 4
     },
     {
-      "roles": [
-        "core",
-        "optional"
-      ],
-      "species_id": "magneto-ridge-hunter",
-      "weight": 4
-    },
-    {
-      "roles": [
-        "core",
-        "optional"
-      ],
-      "species_id": "slag-veil-ambusher",
-      "weight": 4
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "bulette-fase",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "falde-magnetiche-psioniche-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "marilith-vault",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "orbita-psionica-inversa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "coda_prensile_muscolare": [
-    {
+      "species_id": "rotabrachium_ferox",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "coda_stabilizzatrice_filo": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "coda_stabilizzatrice_geiser": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "coda_stabilizzatrice_vortex": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "colonne_vibromagnetiche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "comunicazione_fotonica_coda_coda": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "coralli_partner": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "reef-luminescente-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "coralli_sinaptici_fotofase": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "polpo_araldo_sinaptico",
       "weight": 3
-    }
-  ],
-  "corazze_ferro_magnetico": [
+    },
     {
+      "species_id": "dune-stalker",
       "roles": [
-        "core"
+        "optional"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "corna_psico_conduttive": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
   "corteccia_memetica": [
     {
+      "species_id": "radiciforma_ancorans",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "treant-portale",
-      "weight": 1
-    }
-  ],
-  "coscienza_d_alveare_diffusa": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "coscienza_dalveare_diffusa": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
+      "weight": 4
     }
   ],
   "criostasi_adattiva": [
     {
+      "species_id": "aerostatocyon_altivolans",
       "roles": [
-        "optional"
+        "core"
       ],
+      "weight": 3
+    },
+    {
       "species_id": "aurora-gull",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     },
     {
+      "species_id": "cryo-lynx",
       "roles": [
         "optional"
       ],
-      "species_id": "canopia-psionica-leggera-trait-keeper",
       "weight": 1
     },
     {
+      "species_id": "dune-stalker",
       "roles": [
         "optional"
       ],
-      "species_id": "orbita-psionica-inversa-trait-keeper",
       "weight": 1
     },
     {
+      "species_id": "rubrospina-velox",
       "roles": [
         "optional"
       ],
-      "species_id": "orbital-ascendant",
-      "weight": 1
-    }
-  ],
-  "cromofori_alert_acido": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cuore_multicamera_bassa_pressione": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "cuscinetti_elettrostatici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
       "weight": 1
     }
   ],
   "cute_resistente_sali": [
     {
+      "species_id": "evento-tempesta-ferrosa",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "evento-tempesta-ferrosa",
       "weight": 4
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "badlands-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "global-trait-keeper",
-      "weight": 1
     }
   ],
   "cuticole_cerose": [
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "cactus-weaver",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-brinastorm",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-ondata-termica",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "global-trait-keeper",
       "weight": 1
     },
     {
+      "species_id": "nebulocornis-mollis",
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "noctule-termico",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "silica-bloom",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "thermo-raptor",
-      "weight": 1
-    }
-  ],
-  "cuticole_neutralizzanti": [
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "denti_chelatanti": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
       "weight": 1
     }
   ],
   "denti_ossidoferro": [
     {
+      "species_id": "ferrimordax-rutilus",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "denti_silice_termici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "denti_tuning_fork": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "echi_risonanti": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
+      "weight": 3
     }
   ],
   "eco_interno_riflesso": [
     {
+      "species_id": "echo-wing",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "echo-wing",
       "weight": 4
     },
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "aurora-bridge-runner",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "aurora-gull",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-psionica-leggera-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "falde-magnetiche-psioniche-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "orbital-ascendant",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "zephyr-spore-courier",
-      "weight": 1
-    }
-  ],
-  "eco_sismico": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "banshee-risonante",
-      "weight": 1
-    }
-  ],
-  "ectotermia_dinamica": [
-    {
+      "species_id": "aerostatocyon_altivolans",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "elettromagnete_biologico": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "emettitori_voidsong": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "leviatano_risonante",
       "weight": 3
-    }
-  ],
-  "emolinfa_conducente": [
+    },
     {
+      "species_id": "aurora-gull",
       "roles": [
-        "core"
+        "optional"
       ],
-      "species_id": "autogen_trait_carrier",
+      "weight": 1
+    },
+    {
+      "species_id": "thaw-rot",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "empatia_coordinativa": [
     {
+      "species_id": "auroserpens_photonicus",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "archon-solare",
-      "weight": 1
+      "weight": 4
     },
     {
+      "species_id": "illusiopardus_psionicus",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "balor-fission",
-      "weight": 1
+      "weight": 4
     },
     {
+      "species_id": "heliopteryx_radians",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "couatl-aurora",
-      "weight": 1
+      "weight": 3
     },
     {
+      "species_id": "rotabrachium_ferox",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "glowcap-weaver",
-      "weight": 1
+      "weight": 3
     },
     {
+      "species_id": "nebulocornis-mollis",
       "roles": [
-        "optional"
+        "synergy"
       ],
+      "weight": 2
+    },
+    {
       "species_id": "lupus-temperatus",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     },
     {
+      "species_id": "sentinella-radice",
       "roles": [
         "optional"
       ],
-      "species_id": "marilith-vault",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "myco-spire-warden",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "rakshasa-corte",
-      "weight": 1
-    }
-  ],
-  "enzimi_antifase_termica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "enzimi_antipredatori_algali": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "reef-luminescente-trait-keeper",
       "weight": 1
     }
   ],
   "enzimi_chelanti": [
     {
+      "species_id": "evento-tempesta-ferrosa",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "evento-tempesta-ferrosa",
       "weight": 4
     },
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "global-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "enzimi_chelatori_rapidi": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "enzimi_metanoossidanti": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "epidermide_dielettrica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "epitelio_fosforescente": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "reef-luminescente-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ermafroditismo_cronologico": [
-    {
+      "species_id": "ferriscroba-detrita",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
+      "weight": 3
     }
   ],
-  "estroflessione_gastrica_acida": [
+  "ferocia": [
     {
+      "species_id": "apex_predatore",
       "roles": [
-        "core"
+        "core",
+        "synergy"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "fagocitosi_assorbente": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
+      "weight": 5
     }
   ],
   "filamenti_digestivi_compattanti": [
     {
+      "species_id": "amorphovenator_magneticus",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "magnet-fathom-surveyor",
       "weight": 4
     },
     {
-      "roles": [
-        "core",
-        "optional"
-      ],
       "species_id": "nano-rust-bloom",
-      "weight": 4
-    },
-    {
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "rust-scavenger",
       "weight": 4
     },
     {
+      "species_id": "rust-scavenger",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
+      "species_id": "ferriscroba-detrita",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "blight-micotico",
       "roles": [
         "optional"
       ],
-      "species_id": "caverna-risonante-trait-keeper",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "falde-magnetiche-psioniche-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "glowcap-weaver",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "myco-spire-warden",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
       "species_id": "thaw-rot",
-      "weight": 1
-    }
-  ],
-  "filamenti_echo": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "filamenti_guidalampo": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "filamenti_magnetotrofi": [
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "filamenti_superconduttivi": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "filamenti_termoconduzione": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "filtrazione_osmotica": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
   "filtri_bioattivi": [
     {
+      "species_id": "filtrophagus_custos",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "otyugh-sentinella",
-      "weight": 1
-    }
-  ],
-  "filtri_planctonici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "filtro_metallofago": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "fisiologia_predatoria": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "bulette-fase",
-      "weight": 3
-    }
-  ],
-  "flagelli_ancoranti": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "flusso_ameboide_controllato": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
+      "weight": 4
     }
   ],
   "focus_frazionato": [
     {
-      "roles": [
-        "core",
-        "optional"
-      ],
-      "species_id": "orbital-ascendant",
-      "weight": 4
-    },
-    {
-      "roles": [
-        "core",
-        "optional"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 4
-    },
-    {
+      "species_id": "aerostatocyon_altivolans",
       "roles": [
         "core"
       ],
-      "species_id": "marilith-vault",
       "weight": 3
     },
     {
+      "species_id": "cryptopennatus_psionicus",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "rotabrachium_ferox",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "arboryxis-lenis",
       "roles": [
         "synergy"
       ],
-      "species_id": "archon-solare",
       "weight": 2
     },
     {
+      "species_id": "dune-stalker",
       "roles": [
         "synergy"
       ],
-      "species_id": "balor-fission",
       "weight": 2
     },
     {
+      "species_id": "nebulocornis-mollis",
       "roles": [
         "synergy"
       ],
-      "species_id": "banshee-risonante",
       "weight": 2
     },
     {
+      "species_id": "rubrospina-velox",
       "roles": [
         "synergy"
       ],
-      "species_id": "couatl-aurora",
       "weight": 2
     },
     {
+      "species_id": "lupus-temperatus",
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "sentinella-radice",
-      "weight": 1
-    }
-  ],
-  "foliage_fotocatodico": [
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "foliaggio_spugna": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovieto-cinetico-trait-keeper",
       "weight": 1
     }
   ],
   "frusta_fiammeggiante": [
     {
+      "species_id": "pyroflagellum_meteoriticum",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "balor-fission",
       "weight": 4
     },
     {
+      "species_id": "rotabrachium_ferox",
       "roles": [
-        "core"
-      ],
-      "species_id": "marilith-vault",
-      "weight": 3
-    }
-  ],
-  "ghiaccio_piezoelettrico": [
-    {
-      "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
+      "weight": 4
     }
   ],
   "ghiandola_caustica": [
     {
-      "roles": [
-        "core"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 3
-    },
-    {
+      "species_id": "blight-micotico",
       "roles": [
         "optional"
       ],
-      "species_id": "sentinella-radice",
-      "weight": 1
-    }
-  ],
-  "ghiandole_cambio_salino": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_condensa_ozono": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_eco_mappanti": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_fango_calde": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_fango_coesivo": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovieto-cinetico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_grafene": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "steppe-algoritmiche-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_inchiostro_luce": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "reef-luminescente-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_iodoattive": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_minerali": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_mnemoniche": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "ghiandole_nebbia_acida": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_nebbia_ionica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_nettare_memetico": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "couatl-aurora",
-      "weight": 1
-    }
-  ],
-  "ghiandole_resina_conduttiva": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "ghiandole_ventosa": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "giunti_antitorsione": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovieto-cinetico-trait-keeper",
       "weight": 1
     }
   ],
   "grassi_termici": [
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "cactus-weaver",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-brinastorm",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-ondata-termica",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "global-trait-keeper",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "noctule-termico",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "silica-bloom",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "thermo-raptor",
-      "weight": 1
-    }
-  ],
-  "gusci_criovetro": [
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "gusci_magnesio": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "impulsi_bioluminescenti": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "polpo_araldo_sinaptico",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "leviatano_risonante",
-      "weight": 2
-    }
-  ],
-  "intangibilita_parziale": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "banshee-risonante",
-      "weight": 1
-    }
-  ],
-  "integumento_bipolare": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "ipertrofia_muscolare_massiva": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "lamelle_shear": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-tempestosa-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "lamelle_sincroniche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "steppe-algoritmiche-trait-keeper",
       "weight": 1
     }
   ],
   "lamelle_termoforetiche": [
     {
+      "species_id": "amorphovenator_magneticus",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "bulette-fase",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "couatl-aurora",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "magnet-fathom-surveyor",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "otyugh-sentinella",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "sorgenti-geotermiche-trait-keeper",
-      "weight": 1
+      "weight": 3
     }
   ],
-  "lamenti_diradanti": [
+  "legame_di_branco": [
     {
+      "species_id": "arboryxis-lenis",
       "roles": [
-        "optional"
+        "synergy"
       ],
-      "species_id": "banshee-risonante",
-      "weight": 1
-    }
-  ],
-  "lamine_filtranti_aeree": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovieto-cinetico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "lamine_scudo_silice": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dorsale-termale-tropicale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "linfa_tampone": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foresta-acida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "lingua_cristallina": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
+      "weight": 2
     }
   ],
   "lingua_tattile_trama": [
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "blight-micotico",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "caverna-risonante-trait-keeper",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "echo-wing",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "ferrocolonia-magnetotattica",
-      "weight": 1
-    }
-  ],
-  "lobi_risonanti_crepuscolo": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "polpo_araldo_sinaptico",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "leviatano_risonante",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "simbionte_corallino_riflesso",
-      "weight": 2
-    }
-  ],
-  "locomozione_miriapode_ibrida": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "luminescenza_aurorale": [
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "caldera-glaciale-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "luminescenza_hydrotermica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "mantelli_geotermici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caldera-glaciale-trait-keeper",
       "weight": 1
     }
   ],
   "mantello_meteoritico": [
     {
+      "species_id": "pyroflagellum_meteoriticum",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "balor-fission",
       "weight": 4
     },
     {
+      "species_id": "rotabrachium_ferox",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    }
+  ],
+  "marchio_predatorio": [
+    {
+      "species_id": "ferrimordax-rutilus",
+      "roles": [
+        "synergy"
+      ],
+      "weight": 2
+    }
+  ],
+  "martello_osseo": [
+    {
+      "species_id": "apex_predatore",
       "roles": [
         "core"
       ],
-      "species_id": "marilith-vault",
       "weight": 3
-    }
-  ],
-  "maschera_illusoria": [
+    },
     {
+      "species_id": "ferrimordax-rutilus",
       "roles": [
         "optional"
       ],
-      "species_id": "rakshasa-corte",
       "weight": 1
     }
   ],
   "matrice_antimagia": [
     {
+      "species_id": "lithoconstructus_inhibens",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "golem-runico",
-      "weight": 1
-    }
-  ],
-  "membrana_plastica_continua": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "membrane_captura_rugiada": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianura-salina-iperarida-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "membrane_eliofiltranti": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laghi-alcalini-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "membrane_fotoconvoglianti": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
+      "weight": 4
     }
   ],
   "membrane_osmotiche": [
     {
+      "species_id": "filtrophagus_custos",
       "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "otyugh-sentinella",
-      "weight": 1
-    }
-  ],
-  "membrane_planata_vectored": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-ionica-trait-keeper",
-      "weight": 1
+      "weight": 4
     }
   ],
   "membrane_pneumatofori": [
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovieto-cinetico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "metabolismo_attivo": [
-    {
+      "species_id": "nebulocornis-mollis",
       "roles": [
         "core"
       ],
-      "species_id": "archon-solare",
       "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "balor-fission",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "bulette-fase",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "couatl-aurora",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "marilith-vault",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "otyugh-sentinella",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "rakshasa-corte",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "treant-portale",
-      "weight": 3
-    }
-  ],
-  "metabolismo_di_condivisione_energetica": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "metabolismo_sostentato": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "banshee-risonante",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "golem-runico",
-      "weight": 3
-    }
-  ],
-  "midollo_antivibrazione": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
     }
   ],
   "mimetismo_cromatico_passivo": [
     {
+      "species_id": "cryptopennatus_psionicus",
       "roles": [
         "core",
         "optional"
       ],
+      "weight": 4
+    },
+    {
       "species_id": "ferrocolonia-magnetotattica",
-      "weight": 4
-    },
-    {
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "psionic-canopy-scout",
       "weight": 4
     },
     {
+      "species_id": "blight-micotico",
       "roles": [
         "optional"
       ],
-      "species_id": "aurora-bridge-runner",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-psionica-leggera-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "falde-magnetiche-psioniche-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "zephyr-spore-courier",
-      "weight": 1
-    }
-  ],
-  "moltiplicazione_per_fusione": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "motore_biologico_silenzioso": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "mucillagine_simbionte_mangrovie": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "mangrovie-risonanti-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "mucose_aderenza_sonica": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "mucose_barofile": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "abisso-vulcanico-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "nebbia_mnesica": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "sciame_larve_neurali",
-      "weight": 3
-    }
-  ],
-  "nodi_micorrizici_oracolari": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "reti-micorriziche-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "nodi_sinaptici_superficiali": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
   "nuclei_di_controllo": [
     {
+      "species_id": "lithoconstructus_inhibens",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "golem-runico",
-      "weight": 1
+      "weight": 3
     }
   ],
   "nucleo_ovomotore_rotante": [
     {
+      "species_id": "rotabrachium_ferox",
       "roles": [
-        "core"
+        "core",
+        "optional"
       ],
-      "species_id": "marilith-vault",
-      "weight": 3
+      "weight": 4
     },
     {
+      "species_id": "sand-burrower",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
+      "species_id": "ferriscroba-detrita",
       "roles": [
         "optional"
       ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 2
-    }
-  ],
-  "occhi_analizzatori_di_tensione": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
       "weight": 1
-    }
-  ],
-  "occhi_cinetici": [
+    },
     {
+      "species_id": "rust-scavenger",
       "roles": [
-        "core"
+        "optional"
       ],
-      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
   "occhi_cristallo_modulare": [
     {
-      "roles": [
-        "core"
-      ],
-      "species_id": "orbital-ascendant",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 2
-    }
-  ],
-  "occhi_infrarosso_composti": [
-    {
+      "species_id": "aerostatocyon_altivolans",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "echo-wing",
       "weight": 4
     },
     {
+      "species_id": "cryptopennatus_psionicus",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    }
+  ],
+  "occhi_infrarosso_composti": [
+    {
+      "species_id": "echo-wing",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
+      "species_id": "aurora-gull",
       "roles": [
         "optional"
       ],
-      "species_id": "caverna-risonante-trait-keeper",
+      "weight": 1
+    },
+    {
+      "species_id": "lupus-temperatus",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "olfatto_risonanza_magnetica": [
     {
+      "species_id": "aerostatocyon_altivolans",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "magnet-fathom-surveyor",
       "weight": 4
     },
     {
+      "species_id": "amorphovenator_magneticus",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "orbital-ascendant",
       "weight": 4
     },
     {
+      "species_id": "ferrimordax-rutilus",
       "roles": [
-        "core",
-        "optional"
+        "synergy"
       ],
-      "species_id": "slag-veil-ambusher",
-      "weight": 4
+      "weight": 2
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "cryo-lynx",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "dune-stalker",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "falde-magnetiche-psioniche-trait-keeper",
       "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "magneto-ridge-hunter",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "orbita-psionica-inversa-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 1
-    }
-  ],
-  "organi_metacronici": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "organi_sismici_cutanei": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "origine_artificiale": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "banshee-risonante",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "golem-runico",
-      "weight": 3
     }
   ],
   "pathfinder": [
     {
+      "species_id": "cryptopennatus_psionicus",
       "roles": [
         "core"
       ],
-      "species_id": "psionic-canopy-scout",
       "weight": 3
     },
     {
+      "species_id": "sentinella-radice",
       "roles": [
         "optional"
       ],
-      "species_id": "sentinella-radice",
       "weight": 1
     }
   ],
   "pelage_idrorepellente_avanzato": [
     {
+      "species_id": "arboryxis-lenis",
       "roles": [
-        "core"
+        "optional"
       ],
-      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
-  "pelle_piezo_satura": [
+  "pelle_elastomera": [
     {
+      "species_id": "arboryxis-lenis",
       "roles": [
-        "temp"
+        "core"
       ],
-      "species_id": "leviatano_risonante",
-      "weight": 2
+      "weight": 3
+    },
+    {
+      "species_id": "nebulocornis-mollis",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
     }
   ],
   "pelli_anti_ustione": [
     {
+      "species_id": "evento-tempesta-ferrosa",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "evento-tempesta-ferrosa",
       "weight": 4
     }
   ],
   "pelli_cave": [
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "cactus-weaver",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-brinastorm",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-ondata-termica",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "global-trait-keeper",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "noctule-termico",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "silica-bloom",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "thermo-raptor",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "pelli_fitte": [
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "evento-seme-uragano",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "global-trait-keeper",
       "weight": 1
     }
   ],
   "pianificatore": [
     {
+      "species_id": "sentinella-radice",
       "roles": [
         "optional"
       ],
-      "species_id": "sentinella-radice",
       "weight": 1
     }
   ],
   "pigmenti_aurorali": [
     {
+      "species_id": "radiciforma_ancorans",
       "roles": [
+        "core",
         "optional"
       ],
+      "weight": 4
+    },
+    {
       "species_id": "cactus-weaver",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-brinastorm",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-ondata-termica",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "global-trait-keeper",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "noctule-termico",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "silica-bloom",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "thermo-raptor",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "treant-portale",
       "weight": 1
     }
   ],
   "pigmenti_termici": [
     {
+      "species_id": "evento-tempesta-ferrosa",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "evento-tempesta-ferrosa",
       "weight": 4
-    }
-  ],
-  "piume_solari_fotovoltaiche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "altipiani-solari-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "placca_diffusione_foschia": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "placche_pressioniche": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "polmoni_cristallini_alta_quota": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "picchi-cristallini-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "proboscide_polifaga": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "otyugh-sentinella",
-      "weight": 1
     }
   ],
   "proteine_shock_termico": [
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "cactus-weaver",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-brinastorm",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-ondata-termica",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "global-trait-keeper",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "noctule-termico",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "silica-bloom",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "thermo-raptor",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "radici_ancora_planare": [
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "treant-portale",
-      "weight": 1
-    }
-  ],
-  "random": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "sentinella-radice",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "synergy"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "orbital-ascendant",
-      "weight": 2
-    }
-  ],
-  "respirazione_biologica": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "archon-solare",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "balor-fission",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "bulette-fase",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "couatl-aurora",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "marilith-vault",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "otyugh-sentinella",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "rakshasa-corte",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "treant-portale",
-      "weight": 3
-    }
-  ],
-  "respiro_a_scoppio": [
-    {
+      "species_id": "radiciforma_ancorans",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "rust-scavenger",
       "weight": 4
-    },
+    }
+  ],
+  "random": [
     {
+      "species_id": "sentinella-radice",
       "roles": [
         "optional"
       ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "dune-stalker",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "magneto-ridge-hunter",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "slag-veil-ambusher",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "steppe-bison-mini",
       "weight": 1
     }
   ],
-  "rete_filtro_polmonare": [
+  "respiro_a_scoppio": [
     {
+      "species_id": "rust-scavenger",
       "roles": [
-        "core"
+        "core",
+        "optional"
       ],
-      "species_id": "autogen_trait_carrier",
+      "weight": 4
+    },
+    {
+      "species_id": "dune-stalker",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "ferriscroba-detrita",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "steppe-bison-mini",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "reti_capillari_radici": [
     {
+      "species_id": "radiciforma_ancorans",
       "roles": [
-        "optional"
+        "core"
       ],
+      "weight": 3
+    },
+    {
       "species_id": "cactus-weaver",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-brinastorm",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "evento-ondata-termica",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "global-trait-keeper",
       "weight": 1
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "noctule-termico",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "silica-bloom",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "thermo-raptor",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "treant-portale",
       "weight": 1
     }
   ],
   "risonanza_di_branco": [
     {
+      "species_id": "sonovespera_lamentans",
       "roles": [
-        "optional",
-        "synergy"
+        "core",
+        "optional"
       ],
-      "species_id": "archon-solare",
-      "weight": 3
+      "weight": 4
     },
     {
+      "species_id": "auroserpens_photonicus",
       "roles": [
         "core"
       ],
-      "species_id": "banshee-risonante",
       "weight": 3
     },
     {
+      "species_id": "heliopteryx_radians",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "dune-stalker",
       "roles": [
         "synergy"
       ],
-      "species_id": "couatl-aurora",
       "weight": 2
     },
     {
-      "roles": [
-        "synergy"
-      ],
-      "species_id": "rakshasa-corte",
-      "weight": 2
-    },
-    {
-      "roles": [
-        "synergy"
-      ],
-      "species_id": "treant-portale",
-      "weight": 2
-    },
-    {
+      "species_id": "lupus-temperatus",
       "roles": [
         "optional"
       ],
-      "species_id": "lupus-temperatus",
-      "weight": 1
-    }
-  ],
-  "riverbero_memetico": [
-    {
-      "roles": [
-        "temp"
-      ],
-      "species_id": "sciame_larve_neurali",
-      "weight": 2
-    },
-    {
-      "roles": [
-        "temp"
-      ],
-      "species_id": "simbionte_corallino_riflesso",
-      "weight": 1
-    }
-  ],
-  "rostro_emostatico_litico": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "rostro_linguale_prensile": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
   "sacche_galleggianti_ascensoriali": [
     {
+      "species_id": "aerostatocyon_altivolans",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "orbital-ascendant",
       "weight": 4
     },
     {
+      "species_id": "cryptopennatus_psionicus",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "psionic-canopy-scout",
       "weight": 4
     },
     {
-      "roles": [
-        "core",
-        "optional"
-      ],
       "species_id": "sand-burrower",
+      "roles": [
+        "core",
+        "optional"
+      ],
       "weight": 4
     },
     {
+      "species_id": "arboryxis-lenis",
       "roles": [
         "optional"
       ],
-      "species_id": "aurora-bridge-runner",
       "weight": 1
     },
     {
+      "species_id": "aurora-gull",
       "roles": [
         "optional"
       ],
-      "species_id": "canopia-psionica-leggera-trait-keeper",
       "weight": 1
     },
     {
+      "species_id": "dune-stalker",
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "echo-wing",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     },
     {
+      "species_id": "steppe-bison-mini",
       "roles": [
         "optional"
       ],
-      "species_id": "orbita-psionica-inversa-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "zephyr-spore-courier",
-      "weight": 1
-    }
-  ],
-  "sacche_spore_stratosferiche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "stratosfera-portante-trait-keeper",
       "weight": 1
     }
   ],
   "sangue_piroforico": [
     {
+      "species_id": "ferrocolonia-magnetotattica",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "ferrocolonia-magnetotattica",
       "weight": 4
     },
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
       "species_id": "nano-rust-bloom",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
-      "species_id": "thaw-rot",
       "weight": 1
-    }
-  ],
-  "scheletro_idraulico_a_pistoni": [
+    },
     {
+      "species_id": "thaw-rot",
       "roles": [
-        "core"
+        "optional"
       ],
-      "species_id": "autogen_trait_carrier",
       "weight": 1
     }
   ],
   "scheletro_idro_regolante": [
     {
-      "roles": [
-        "core",
-        "optional"
-      ],
       "species_id": "dune-stalker",
-      "weight": 4
-    },
-    {
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "magneto-ridge-hunter",
       "weight": 4
     },
     {
-      "roles": [
-        "core",
-        "optional"
-      ],
       "species_id": "nano-rust-bloom",
-      "weight": 4
-    },
-    {
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "sand-burrower",
       "weight": 4
     },
     {
+      "species_id": "sand-burrower",
       "roles": [
-        "synergy"
-      ],
-      "species_id": "slag-veil-ambusher",
-      "weight": 2
-    },
-    {
-      "roles": [
+        "core",
         "optional"
       ],
-      "species_id": "bulette-fase",
-      "weight": 1
+      "weight": 4
     },
     {
+      "species_id": "amorphovenator_magneticus",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
+      "weight": 3
     },
     {
+      "species_id": "tellurmordax_phasicus",
       "roles": [
-        "optional"
+        "core"
       ],
-      "species_id": "magnet-fathom-surveyor",
-      "weight": 1
+      "weight": 3
     },
     {
-      "roles": [
-        "optional"
-      ],
       "species_id": "rust-scavenger",
-      "weight": 1
-    },
-    {
       "roles": [
         "optional"
       ],
+      "weight": 1
+    },
+    {
       "species_id": "steppe-bison-mini",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "scheletro_pneumatico_a_maglie": [
     {
+      "species_id": "nebulocornis-mollis",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "scintilla_sinaptica": [
-    {
-      "roles": [
-        "temp"
-      ],
-      "species_id": "polpo_araldo_sinaptico",
-      "weight": 2
-    },
-    {
-      "roles": [
-        "temp"
-      ],
-      "species_id": "simbionte_corallino_riflesso",
-      "weight": 1
-    }
-  ],
-  "scivolamento_magnetico": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "scudo_gluteale_cheratinizzato": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
+      "weight": 3
     }
   ],
   "secrezione_rallentante_palmi": [
     {
-      "roles": [
-        "core"
-      ],
-      "species_id": "sentinella-radice",
-      "weight": 3
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "laguna-bioreattiva-trait-keeper",
-      "weight": 2
-    }
-  ],
-  "secrezioni_antistatiche": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "sensori_chimici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "otyugh-sentinella",
-      "weight": 1
-    }
-  ],
-  "sensori_geomagnetici": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "bulette-fase",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "couatl-aurora",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "marilith-vault",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "pianure-magnetiche-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "sensori_planctonici": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "seta_conduttiva_elettrica": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "siero_anti_gelo_naturale": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "sinapsi_coraline_polifoniche": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "barriere-coralline-psioniche-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "sistemi_chimio_sonici": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "sonno_emisferico_alternato": [
-    {
+      "species_id": "ferrocolonia-magnetotattica",
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "echo-wing",
       "weight": 4
     },
     {
+      "species_id": "thaw-rot",
       "roles": [
         "optional"
       ],
-      "species_id": "aurora-gull",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
       "weight": 1
     }
   ],
-  "spicole_canalizzatrici": [
+  "sensori_sismici": [
     {
+      "species_id": "resonant-claw-hunter",
       "roles": [
-        "core"
+        "core",
+        "optional"
       ],
-      "species_id": "autogen_trait_carrier",
+      "weight": 4
+    }
+  ],
+  "sonno_emisferico_alternato": [
+    {
+      "species_id": "echo-wing",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
+      "species_id": "aurora-gull",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "spore_psichiche_silenziate": [
     {
+      "species_id": "nano-rust-bloom",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
+      "species_id": "cryptopennatus_psionicus",
       "roles": [
         "core"
       ],
-      "species_id": "banshee-risonante",
       "weight": 3
     },
     {
-      "roles": [
-        "synergy"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 2
-    }
-  ],
-  "squame_diffusori_ionici": [
-    {
+      "species_id": "sonovespera_lamentans",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "squame_rifrangenti_deserto": [
+      "weight": 3
+    },
     {
+      "species_id": "blight-micotico",
       "roles": [
         "optional"
       ],
-      "species_id": "dune-cristalline-trait-keeper",
+      "weight": 1
+    },
+    {
+      "species_id": "thaw-rot",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ],
   "struttura_elastica_amorfa": [
     {
+      "species_id": "amorphovenator_magneticus",
       "roles": [
         "core",
         "optional"
       ],
+      "weight": 4
+    },
+    {
+      "species_id": "cryptopennatus_psionicus",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
       "species_id": "dune-stalker",
-      "weight": 4
-    },
-    {
       "roles": [
         "core",
         "optional"
       ],
-      "species_id": "magnet-fathom-surveyor",
       "weight": 4
-    },
-    {
-      "roles": [
-        "core",
-        "optional"
-      ],
-      "species_id": "psionic-canopy-scout",
-      "weight": 4
-    },
-    {
-      "roles": [
-        "core",
-        "optional"
-      ],
-      "species_id": "slag-veil-ambusher",
-      "weight": 4
-    },
-    {
-      "roles": [
-        "synergy"
-      ],
-      "species_id": "magneto-ridge-hunter",
-      "weight": 2
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "canopia-psionica-leggera-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "falde-magnetiche-psioniche-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "glowcap-weaver",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "myco-spire-warden",
-      "weight": 1
     }
   ],
   "tattiche_di_branco": [
     {
+      "species_id": "dune-stalker",
       "roles": [
         "synergy"
       ],
-      "species_id": "magneto-ridge-hunter",
       "weight": 2
     },
     {
-      "roles": [
-        "synergy"
-      ],
-      "species_id": "slag-veil-ambusher",
-      "weight": 2
-    },
-    {
+      "species_id": "lupus-temperatus",
       "roles": [
         "optional"
       ],
-      "species_id": "lupus-temperatus",
       "weight": 1
     }
   ],
   "tessuti_adattivi": [
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "rakshasa-corte",
-      "weight": 1
-    }
-  ],
-  "traits_aggregate": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "unghie_a_micro_adesione": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "vello_condensatore_nebbie": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "foreste-nubose-trait-keeper",
-      "weight": 1
-    }
-  ],
-  "vello_di_assorbimento_totale": [
-    {
-      "roles": [
-        "core"
-      ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "ventriglio_gastroliti": [
-    {
+      "species_id": "illusiopardus_psionicus",
       "roles": [
         "core",
         "optional"
       ],
+      "weight": 4
+    }
+  ],
+  "ventriglio_gastroliti": [
+    {
       "species_id": "rust-scavenger",
+      "roles": [
+        "core",
+        "optional"
+      ],
       "weight": 4
     },
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "caverna-risonante-trait-keeper",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "ferrocolonia-magnetotattica",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "steppe-bison-mini",
-      "weight": 1
-    }
-  ],
-  "visione_multi_spettrale_amplificata": [
-    {
+      "species_id": "ferriscroba-detrita",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "visione_spettrale": [
+      "weight": 3
+    },
     {
+      "species_id": "ferrocolonia-magnetotattica",
       "roles": [
         "optional"
       ],
-      "species_id": "archon-solare",
       "weight": 1
     },
     {
+      "species_id": "steppe-bison-mini",
       "roles": [
         "optional"
       ],
-      "species_id": "marilith-vault",
-      "weight": 1
-    }
-  ],
-  "voce_spettrale": [
-    {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "banshee-risonante",
-      "weight": 1
-    }
-  ],
-  "vortice_nera_flash": [
-    {
-      "roles": [
-        "temp"
-      ],
-      "species_id": "sciame_larve_neurali",
-      "weight": 1
-    },
-    {
-      "roles": [
-        "temp"
-      ],
-      "species_id": "leviatano_risonante",
       "weight": 1
     }
   ],
   "zampe_a_molla": [
     {
-      "roles": [
-        "optional"
-      ],
-      "species_id": "sand-burrower",
-      "weight": 1
-    }
-  ],
-  "zanne_idracida": [
-    {
+      "species_id": "arboryxis-lenis",
       "roles": [
         "core"
       ],
-      "species_id": "autogen_trait_carrier",
-      "weight": 1
-    }
-  ],
-  "zoccoli_risonanti_steppe": [
+      "weight": 3
+    },
     {
+      "species_id": "rubrospina-velox",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "cryo-lynx",
       "roles": [
         "optional"
       ],
-      "species_id": "steppe-risonanti-trait-keeper",
+      "weight": 1
+    },
+    {
+      "species_id": "sand-burrower",
+      "roles": [
+        "optional"
+      ],
       "weight": 1
     }
   ]

--- a/data/traits/species_affinity.json
+++ b/data/traits/species_affinity.json
@@ -370,6 +370,13 @@
         "optional"
       ],
       "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "artigli_sghiaccio_glaciale": [
@@ -655,6 +662,13 @@
     },
     {
       "species_id": "cryo-lynx",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -1012,6 +1026,13 @@
       "weight": 1
     },
     {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "rubrospina-velox",
       "roles": [
         "optional"
@@ -1220,6 +1241,13 @@
       "weight": 1
     },
     {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "thaw-rot",
       "roles": [
         "optional"
@@ -1264,6 +1292,13 @@
         "synergy"
       ],
       "weight": 2
+    },
+    {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     },
     {
       "species_id": "lupus-temperatus",
@@ -1422,6 +1457,20 @@
       "weight": 1
     },
     {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "thaw-rot",
       "roles": [
         "optional"
@@ -1542,6 +1591,13 @@
       "weight": 1
     },
     {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "lupus-temperatus",
       "roles": [
         "optional"
@@ -1618,6 +1674,13 @@
   "ghiandola_caustica": [
     {
       "species_id": "blight-micotico",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "foresta-miceliale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -1919,6 +1982,13 @@
         "optional"
       ],
       "weight": 1
+    },
+    {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "luminescenza_aurorale": [
@@ -2103,6 +2173,13 @@
     },
     {
       "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -2308,6 +2385,13 @@
       "weight": 1
     },
     {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "orbita-psionica-inversa-trait-keeper",
       "roles": [
         "optional"
@@ -2322,6 +2406,13 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     },
     {
       "species_id": "sentinella-radice",
@@ -2420,6 +2511,13 @@
     }
   ],
   "pianificatore": [
+    {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
     {
       "species_id": "sentinella-radice",
       "roles": [
@@ -2609,6 +2707,13 @@
       "weight": 1
     },
     {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "steppe-bison-mini",
       "roles": [
         "optional"
@@ -2698,6 +2803,13 @@
       "weight": 2
     },
     {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "lupus-temperatus",
       "roles": [
         "optional"
@@ -2773,6 +2885,13 @@
       "weight": 1
     },
     {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "orbita-psionica-inversa-trait-keeper",
       "roles": [
         "optional"
@@ -2807,6 +2926,13 @@
     },
     {
       "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -2868,6 +2994,13 @@
     },
     {
       "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -2971,6 +3104,13 @@
         "optional"
       ],
       "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "spore_psichiche_silenziate": [
@@ -3005,6 +3145,20 @@
     },
     {
       "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -3072,6 +3226,13 @@
         "optional"
       ],
       "weight": 1
+    },
+    {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "tattiche_di_branco": [
@@ -3081,6 +3242,13 @@
         "synergy"
       ],
       "weight": 2
+    },
+    {
+      "species_id": "foresta-miceliale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     },
     {
       "species_id": "lupus-temperatus",
@@ -3134,6 +3302,13 @@
     },
     {
       "species_id": "ferrocolonia-magnetotattica",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "mezzanotte-orbitale-trait-keeper",
       "roles": [
         "optional"
       ],

--- a/data/traits/species_affinity.json
+++ b/data/traits/species_affinity.json
@@ -60,6 +60,33 @@
       "weight": 3
     }
   ],
+  "ali_fulminee": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ali_ioniche": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ali_membrana_sonica": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "ali_solari_fotoni": [
     {
       "species_id": "auroserpens_photonicus",
@@ -78,9 +105,106 @@
       "weight": 4
     }
   ],
+  "antenne_dustsense": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "antenne_eco_turbina": [
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "rubrospina-velox",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "antenne_flusso_mareale": [
+    {
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "antenne_microonde_cavernose": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "antenne_plasmatiche_tempesta": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "antenne_reagenti": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "antenne_tesla": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "antenne_waveguide": [
+    {
+      "species_id": "reef-luminescente-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "antenne_wideband": [
+    {
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "appendici_risonanti_marea": [
+    {
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "appendici_thermotattiche": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -117,6 +241,13 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "articolazioni_a_leva_idraulica": [
@@ -128,6 +259,24 @@
       "weight": 3
     }
   ],
+  "artigli_acidofagi": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "artigli_induzione": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "artigli_psionici": [
     {
       "species_id": "illusiopardus_psionicus",
@@ -136,6 +285,24 @@
         "optional"
       ],
       "weight": 4
+    }
+  ],
+  "artigli_radice": [
+    {
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "artigli_scivolo_silente": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "artigli_sette_vie": [
@@ -177,6 +344,13 @@
       "weight": 3
     },
     {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "cryo-lynx",
       "roles": [
         "optional"
@@ -184,7 +358,32 @@
       "weight": 1
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "ferrimordax-rutilus",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "artigli_sghiaccio_glaciale": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "artigli_vetrificati": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -199,11 +398,223 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "baffi_mareomotori": [
+    {
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "barbigli_sensori_plasma": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "barriere_miasma_glaciale": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "batteri_endosimbionti_chemio": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "batteri_termofili_endosimbiosi": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "biochip_memoria": [
+    {
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "biofilm_glow": [
     {
       "species_id": "nebulocornis-mollis",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "reef-luminescente-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "biofilm_iperarido": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "branchie_dual_mode": [
+    {
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "branchie_eoliche": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "branchie_metalloidi": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "branchie_microfiltri": [
+    {
+      "species_id": "reef-luminescente-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "branchie_osmotiche_salmastra": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "branchie_solfatiche": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "branchie_turbina": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "bulbi_radici_permafrost": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "camere_anticorrosione": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "camere_mirage": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "camere_nutrienti_vent": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "capillari_criogenici": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "capillari_fluoridici": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "capillari_fotovoltaici": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "capsule_paracadute": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -271,6 +682,24 @@
       "weight": 1
     }
   ],
+  "carapace_luminiscente_abissale": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "carapace_segmenti_logici": [
+    {
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "carapaci_ferruginosi": [
     {
       "species_id": "ferrimordax-rutilus",
@@ -278,6 +707,193 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cartilagine_flessotermica_venti": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cartilagini_biofibre": [
+    {
+      "species_id": "reef-luminescente-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cartilagini_desertiche": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cartilagini_flessoacustiche": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cartilagini_pseudometalliche": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cavita_risonanti_tundra": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cervelletto_equilibrio_statico": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "chemiorecettori_bromuro": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "chioma_parassita_canopica": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "circolazione_bifasica": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "circolazione_bifasica_palude": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "circolazione_cooling_loop": [
+    {
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "circolazione_doppia": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "circolazione_supercritica": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ciste_riduttive": [
+    {
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ciste_salmastre": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cisti_iperbariche": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "coda_balanciere": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "coda_contrappeso": [
+    {
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "coda_coppia_retroattiva": [
+    {
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "coda_frusta_cinetica": [
@@ -297,7 +913,59 @@
       "weight": 3
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "dune-stalker",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "coda_stabilizzatrice_filo": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "coda_stabilizzatrice_geiser": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "coda_stabilizzatrice_vortex": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "colonne_vibromagnetiche": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "coralli_partner": [
+    {
+      "species_id": "reef-luminescente-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -351,6 +1019,33 @@
       "weight": 1
     }
   ],
+  "cromofori_alert_acido": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cuore_multicamera_bassa_pressione": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "cuscinetti_elettrostatici": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "cute_resistente_sali": [
     {
       "species_id": "evento-tempesta-ferrosa",
@@ -359,6 +1054,20 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "badlands-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "cuticole_cerose": [
@@ -378,6 +1087,13 @@
     },
     {
       "species_id": "evento-ondata-termica",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "global-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -412,6 +1128,24 @@
       "weight": 1
     }
   ],
+  "cuticole_neutralizzanti": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "denti_chelatanti": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "denti_ossidoferro": [
     {
       "species_id": "ferrimordax-rutilus",
@@ -419,6 +1153,40 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "denti_silice_termici": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "denti_tuning_fork": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "echi_risonanti": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "eco_interno_riflesso": [
@@ -439,6 +1207,13 @@
     },
     {
       "species_id": "aurora-gull",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -505,6 +1280,24 @@
       "weight": 1
     }
   ],
+  "enzimi_antifase_termica": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "enzimi_antipredatori_algali": [
+    {
+      "species_id": "reef-luminescente-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "enzimi_chelanti": [
     {
       "species_id": "evento-tempesta-ferrosa",
@@ -520,6 +1313,49 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "enzimi_chelatori_rapidi": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "enzimi_metanoossidanti": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "epidermide_dielettrica": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "epitelio_fosforescente": [
+    {
+      "species_id": "reef-luminescente-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "ferocia": [
@@ -572,7 +1408,48 @@
       "weight": 1
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "thaw-rot",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "filamenti_magnetotrofi": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "filamenti_superconduttivi": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "filamenti_termoconduzione": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -587,6 +1464,24 @@
         "optional"
       ],
       "weight": 4
+    }
+  ],
+  "filtri_planctonici": [
+    {
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "flagelli_ancoranti": [
+    {
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "focus_frazionato": [
@@ -640,6 +1535,13 @@
       "weight": 2
     },
     {
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "lupus-temperatus",
       "roles": [
         "optional"
@@ -647,7 +1549,32 @@
       "weight": 1
     },
     {
+      "species_id": "orbita-psionica-inversa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "sentinella-radice",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "foliage_fotocatodico": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "foliaggio_spugna": [
+    {
+      "species_id": "mangrovieto-cinetico-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -670,11 +1597,153 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiaccio_piezoelettrico": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "ghiandola_caustica": [
     {
       "species_id": "blight-micotico",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_cambio_salino": [
+    {
+      "species_id": "laguna-bioreattiva-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_condensa_ozono": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_eco_mappanti": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_fango_calde": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_fango_coesivo": [
+    {
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_grafene": [
+    {
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_inchiostro_luce": [
+    {
+      "species_id": "reef-luminescente-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_iodoattive": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_minerali": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_nebbia_acida": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_nebbia_ionica": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_resina_conduttiva": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "ghiandole_ventosa": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "giunti_antitorsione": [
+    {
+      "species_id": "mangrovieto-cinetico-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -704,6 +1773,13 @@
       "weight": 1
     },
     {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "noctule-termico",
       "roles": [
         "optional"
@@ -725,6 +1801,42 @@
       "weight": 1
     }
   ],
+  "gusci_criovetro": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "gusci_magnesio": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "lamelle_shear": [
+    {
+      "species_id": "stratosfera-tempestosa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "lamelle_sincroniche": [
+    {
+      "species_id": "steppe-algoritmiche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "lamelle_termoforetiche": [
     {
       "species_id": "amorphovenator_magneticus",
@@ -732,6 +1844,31 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "lamine_filtranti_aeree": [
+    {
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "lamine_scudo_silice": [
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "legame_di_branco": [
@@ -741,6 +1878,24 @@
         "synergy"
       ],
       "weight": 2
+    }
+  ],
+  "linfa_tampone": [
+    {
+      "species_id": "foresta-acida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "lingua_cristallina": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "lingua_tattile_trama": [
@@ -766,6 +1921,33 @@
       "weight": 1
     }
   ],
+  "luminescenza_aurorale": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "luminescenza_hydrotermica": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "mantelli_geotermici": [
+    {
+      "species_id": "caldera-glaciale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "mantello_meteoritico": [
     {
       "species_id": "pyroflagellum_meteoriticum",
@@ -782,6 +1964,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "marchio_predatorio": [
@@ -819,6 +2008,24 @@
       "weight": 4
     }
   ],
+  "membrane_captura_rugiada": [
+    {
+      "species_id": "pianura-salina-iperarida-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "membrane_eliofiltranti": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "membrane_osmotiche": [
     {
       "species_id": "filtrophagus_custos",
@@ -829,6 +2036,15 @@
       "weight": 4
     }
   ],
+  "membrane_planata_vectored": [
+    {
+      "species_id": "canopia-ionica-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "membrane_pneumatofori": [
     {
       "species_id": "nebulocornis-mollis",
@@ -836,6 +2052,22 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "mangrovieto-cinetico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "midollo_antivibrazione": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "mimetismo_cromatico_passivo": [
@@ -857,6 +2089,56 @@
     },
     {
       "species_id": "blight-micotico",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "mucillagine_simbionte_mangrovie": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "mucose_aderenza_sonica": [
+    {
+      "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "mucose_barofile": [
+    {
+      "species_id": "abisso-vulcanico-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "nodi_micorrizici_oracolari": [
+    {
+      "species_id": "global-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -890,7 +2172,28 @@
       "weight": 4
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "ferriscroba-detrita",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "orbita-psionica-inversa-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -938,6 +2241,13 @@
       "weight": 1
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "lupus-temperatus",
       "roles": [
         "optional"
@@ -977,7 +2287,28 @@
       "weight": 1
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "dune-stalker",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "orbita-psionica-inversa-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -1159,6 +2490,24 @@
       "weight": 4
     }
   ],
+  "piume_solari_fotovoltaiche": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "polmoni_cristallini_alta_quota": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "proteine_shock_termico": [
     {
       "species_id": "cactus-weaver",
@@ -1215,6 +2564,13 @@
   ],
   "random": [
     {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "sentinella-radice",
       "roles": [
         "optional"
@@ -1230,6 +2586,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     },
     {
       "species_id": "dune-stalker",
@@ -1382,6 +2745,20 @@
       "weight": 1
     },
     {
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "dune-stalker",
       "roles": [
         "optional"
@@ -1396,7 +2773,23 @@
       "weight": 1
     },
     {
+      "species_id": "orbita-psionica-inversa-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "steppe-bison-mini",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "sacche_spore_stratosferiche": [
+    {
+      "species_id": "global-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -1411,6 +2804,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     },
     {
       "species_id": "nano-rust-bloom",
@@ -1467,6 +2867,13 @@
       "weight": 3
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "rust-scavenger",
       "roles": [
         "optional"
@@ -1500,7 +2907,23 @@
       "weight": 4
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "thaw-rot",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "sensori_geomagnetici": [
+    {
+      "species_id": "global-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -1517,6 +2940,15 @@
       "weight": 4
     }
   ],
+  "sinapsi_coraline_polifoniche": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "sonno_emisferico_alternato": [
     {
       "species_id": "echo-wing",
@@ -1528,6 +2960,13 @@
     },
     {
       "species_id": "aurora-gull",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -1565,7 +3004,23 @@
       "weight": 1
     },
     {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "thaw-rot",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "squame_rifrangenti_deserto": [
+    {
+      "species_id": "global-trait-keeper",
       "roles": [
         "optional"
       ],
@@ -1596,6 +3051,27 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "canopia-psionica-leggera-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "falde-magnetiche-psioniche-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "tattiche_di_branco": [
@@ -1624,6 +3100,15 @@
       "weight": 4
     }
   ],
+  "vello_condensatore_nebbie": [
+    {
+      "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "ventriglio_gastroliti": [
     {
       "species_id": "rust-scavenger",
@@ -1639,6 +3124,13 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "dorsale-termale-tropicale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     },
     {
       "species_id": "ferrocolonia-magnetotattica",
@@ -1679,6 +3171,15 @@
     },
     {
       "species_id": "sand-burrower",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
+  "zoccoli_risonanti_steppe": [
+    {
+      "species_id": "global-trait-keeper",
       "roles": [
         "optional"
       ],

--- a/packs/evo_tactics_pack/data/species/abisso_vulcanico/abisso-vulcanico-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/abisso_vulcanico/abisso-vulcanico-trait-keeper.yaml
@@ -1,3 +1,20 @@
 resistance_archetype: adattivo
 id: abisso-vulcanico-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- abisso_vulcanico
+derived_from_environment:
+  suggested_traits:
+  - appendici_thermotattiche
+  - batteri_endosimbionti_chemio
+  - branchie_metalloidi
+  - carapaci_ferruginosi
+  - cartilagini_pseudometalliche
+  - circolazione_supercritica
+  - cisti_iperbariche
+  - denti_ossidoferro
+  - enzimi_metanoossidanti
+  - filamenti_magnetotrofi
+  - ghiandole_fango_calde
+  - luminescenza_hydrotermica
+  - mucose_barofile

--- a/packs/evo_tactics_pack/data/species/badlands/badlands-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/badlands-trait-keeper.yaml
@@ -13,7 +13,8 @@ spawn_rules:
   densita: moderata
 balance:
   encounter_role: minion
-environment_affinity: {}
-derived_from_environment: {}
+derived_from_environment:
+  suggested_traits:
+  - cute_resistente_sali
 receipt:
   source: runtime-generator

--- a/packs/evo_tactics_pack/data/species/caldera_glaciale/caldera-glaciale-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/caldera_glaciale/caldera-glaciale-trait-keeper.yaml
@@ -1,3 +1,19 @@
 resistance_archetype: termico
 id: caldera-glaciale-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- caldera_glaciale
+derived_from_environment:
+  suggested_traits:
+  - artigli_vetrificati
+  - barriere_miasma_glaciale
+  - branchie_solfatiche
+  - capillari_criogenici
+  - circolazione_bifasica
+  - enzimi_antifase_termica
+  - filamenti_superconduttivi
+  - ghiaccio_piezoelettrico
+  - ghiandole_ventosa
+  - gusci_criovetro
+  - luminescenza_aurorale
+  - mantelli_geotermici

--- a/packs/evo_tactics_pack/data/species/canopia_ionica/canopia-ionica-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_ionica/canopia-ionica-trait-keeper.yaml
@@ -1,3 +1,16 @@
 resistance_archetype: bioelettrico
 id: canopia-ionica-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- canopia_ionica
+derived_from_environment:
+  suggested_traits:
+  - ali_ioniche
+  - antenne_tesla
+  - artigli_induzione
+  - capillari_fotovoltaici
+  - cervelletto_equilibrio_statico
+  - coda_stabilizzatrice_filo
+  - ghiandole_nebbia_ionica
+  - ghiandole_resina_conduttiva
+  - membrane_planata_vectored

--- a/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/canopia-psionica-leggera-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/canopia-psionica-leggera-trait-keeper.yaml
@@ -1,3 +1,11 @@
 resistance_archetype: bioelettrico
 id: canopia-psionica-leggera-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+environment_affinity:
+  biome_class: canopia_psionica_leggera
+derived_from_environment:
+  suggested_traits:
+  - focus_frazionato
+  - mimetismo_cromatico_passivo
+  - sacche_galleggianti_ascensoriali
+  - struttura_elastica_amorfa

--- a/packs/evo_tactics_pack/data/species/caverna_risonante/caverna-risonante-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/caverna_risonante/caverna-risonante-trait-keeper.yaml
@@ -1,3 +1,19 @@
 resistance_archetype: adattivo
 id: caverna-risonante-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- caverna_risonante
+derived_from_environment:
+  suggested_traits:
+  - ali_membrana_sonica
+  - antenne_microonde_cavernose
+  - artigli_scivolo_silente
+  - artigli_sette_vie
+  - cartilagini_flessoacustiche
+  - coda_balanciere
+  - colonne_vibromagnetiche
+  - denti_tuning_fork
+  - echi_risonanti
+  - ghiandole_eco_mappanti
+  - midollo_antivibrazione
+  - mucose_aderenza_sonica

--- a/packs/evo_tactics_pack/data/species/dorsale_termale_tropicale/dorsale-termale-tropicale-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/dorsale_termale_tropicale/dorsale-termale-tropicale-trait-keeper.yaml
@@ -1,3 +1,35 @@
 resistance_archetype: adattivo
 id: dorsale-termale-tropicale-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- dorsale_termale_tropicale
+derived_from_environment:
+  suggested_traits:
+  - antenne_eco_turbina
+  - artigli_sette_vie
+  - batteri_termofili_endosimbiosi
+  - branchie_turbina
+  - camere_nutrienti_vent
+  - circolazione_doppia
+  - coda_frusta_cinetica
+  - coda_stabilizzatrice_geiser
+  - denti_silice_termici
+  - eco_interno_riflesso
+  - filamenti_digestivi_compattanti
+  - filamenti_termoconduzione
+  - ghiandole_minerali
+  - gusci_magnesio
+  - lamine_scudo_silice
+  - mimetismo_cromatico_passivo
+  - nucleo_ovomotore_rotante
+  - occhi_infrarosso_composti
+  - olfatto_risonanza_magnetica
+  - respiro_a_scoppio
+  - sacche_galleggianti_ascensoriali
+  - sangue_piroforico
+  - scheletro_idro_regolante
+  - secrezione_rallentante_palmi
+  - sonno_emisferico_alternato
+  - spore_psichiche_silenziate
+  - struttura_elastica_amorfa
+  - ventriglio_gastroliti

--- a/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/falde-magnetiche-psioniche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/falde-magnetiche-psioniche-trait-keeper.yaml
@@ -1,3 +1,11 @@
 resistance_archetype: bioelettrico
 id: falde-magnetiche-psioniche-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+environment_affinity:
+  biome_class: falde_magnetiche_psioniche
+derived_from_environment:
+  suggested_traits:
+  - filamenti_digestivi_compattanti
+  - nucleo_ovomotore_rotante
+  - olfatto_risonanza_magnetica
+  - struttura_elastica_amorfa

--- a/packs/evo_tactics_pack/data/species/foresta_acida/foresta-acida-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_acida/foresta-acida-trait-keeper.yaml
@@ -1,3 +1,18 @@
 resistance_archetype: adattivo
 id: foresta-acida-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- foresta_acida
+derived_from_environment:
+  suggested_traits:
+  - antenne_reagenti
+  - artigli_acidofagi
+  - camere_anticorrosione
+  - capillari_fluoridici
+  - cromofori_alert_acido
+  - cuticole_neutralizzanti
+  - denti_chelatanti
+  - enzimi_chelatori_rapidi
+  - foliage_fotocatodico
+  - ghiandole_nebbia_acida
+  - linfa_tampone

--- a/packs/evo_tactics_pack/data/species/foresta_miceliale/foresta-miceliale-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_miceliale/foresta-miceliale-trait-keeper.yaml
@@ -1,0 +1,18 @@
+resistance_archetype: adattivo
+id: foresta-miceliale-trait-keeper
+notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- foresta_miceliale
+derived_from_environment:
+  suggested_traits:
+  - empatia_coordinativa
+  - filamenti_digestivi_compattanti
+  - focus_frazionato
+  - ghiandola_caustica
+  - lingua_tattile_trama
+  - pathfinder
+  - pianificatore
+  - risonanza_di_branco
+  - spore_psichiche_silenziate
+  - struttura_elastica_amorfa
+  - tattiche_di_branco

--- a/packs/evo_tactics_pack/data/species/global/global-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/global/global-trait-keeper.yaml
@@ -1,3 +1,35 @@
 resistance_archetype: adattivo
 id: global-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+derived_from_environment:
+  suggested_traits:
+  - antenne_plasmatiche_tempesta
+  - armatura_pietra_planare
+  - artigli_sghiaccio_glaciale
+  - aura_scudo_radianza
+  - branchie_osmotiche_salmastra
+  - bulbi_radici_permafrost
+  - carapace_luminiscente_abissale
+  - cartilagine_flessotermica_venti
+  - cavita_risonanti_tundra
+  - chioma_parassita_canopica
+  - circolazione_bifasica_palude
+  - cute_resistente_sali
+  - cuticole_cerose
+  - enzimi_chelanti
+  - frusta_fiammeggiante
+  - grassi_termici
+  - lamelle_termoforetiche
+  - mantello_meteoritico
+  - membrane_eliofiltranti
+  - mucillagine_simbionte_mangrovie
+  - nodi_micorrizici_oracolari
+  - piume_solari_fotovoltaiche
+  - polmoni_cristallini_alta_quota
+  - random
+  - sacche_spore_stratosferiche
+  - sensori_geomagnetici
+  - sinapsi_coraline_polifoniche
+  - squame_rifrangenti_deserto
+  - vello_condensatore_nebbie
+  - zoccoli_risonanti_steppe

--- a/packs/evo_tactics_pack/data/species/laguna_bioreattiva/laguna-bioreattiva-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/laguna_bioreattiva/laguna-bioreattiva-trait-keeper.yaml
@@ -1,3 +1,14 @@
 resistance_archetype: adattivo
 id: laguna-bioreattiva-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+environment_affinity:
+  biome_class: laguna_bioreattiva
+derived_from_environment:
+  suggested_traits:
+  - antenne_flusso_mareale
+  - appendici_risonanti_marea
+  - branchie_dual_mode
+  - ciste_riduttive
+  - filtri_planctonici
+  - flagelli_ancoranti
+  - ghiandole_cambio_salino

--- a/packs/evo_tactics_pack/data/species/mangrovieto_cinetico/mangrovieto-cinetico-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/mangrovieto_cinetico/mangrovieto-cinetico-trait-keeper.yaml
@@ -1,3 +1,15 @@
 resistance_archetype: adattivo
 id: mangrovieto-cinetico-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+environment_affinity:
+  biome_class: mangrovieto_cinetico
+derived_from_environment:
+  suggested_traits:
+  - artigli_radice
+  - baffi_mareomotori
+  - coda_contrappeso
+  - foliaggio_spugna
+  - ghiandole_fango_coesivo
+  - giunti_antitorsione
+  - lamine_filtranti_aeree
+  - membrane_pneumatofori

--- a/packs/evo_tactics_pack/data/species/mezzanotte_orbitale/mezzanotte-orbitale-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/mezzanotte_orbitale/mezzanotte-orbitale-trait-keeper.yaml
@@ -1,0 +1,21 @@
+resistance_archetype: adattivo
+id: mezzanotte-orbitale-trait-keeper
+notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- mezzanotte_orbitale
+derived_from_environment:
+  suggested_traits:
+  - artigli_sette_vie
+  - carapace_fase_variabile
+  - criostasi_adattiva
+  - eco_interno_riflesso
+  - filamenti_digestivi_compattanti
+  - mimetismo_cromatico_passivo
+  - olfatto_risonanza_magnetica
+  - respiro_a_scoppio
+  - sacche_galleggianti_ascensoriali
+  - sangue_piroforico
+  - scheletro_idro_regolante
+  - sonno_emisferico_alternato
+  - spore_psichiche_silenziate
+  - ventriglio_gastroliti

--- a/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbita-psionica-inversa-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbita-psionica-inversa-trait-keeper.yaml
@@ -1,3 +1,11 @@
 resistance_archetype: bioelettrico
 id: orbita-psionica-inversa-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+environment_affinity:
+  biome_class: orbita_psionica_inversa
+derived_from_environment:
+  suggested_traits:
+  - focus_frazionato
+  - nucleo_ovomotore_rotante
+  - olfatto_risonanza_magnetica
+  - sacche_galleggianti_ascensoriali

--- a/packs/evo_tactics_pack/data/species/pianura_salina_iperarida/pianura-salina-iperarida-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/pianura_salina_iperarida/pianura-salina-iperarida-trait-keeper.yaml
@@ -1,3 +1,17 @@
 resistance_archetype: adattivo
 id: pianura-salina-iperarida-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- pianura_salina_iperarida
+derived_from_environment:
+  suggested_traits:
+  - antenne_dustsense
+  - biofilm_iperarido
+  - camere_mirage
+  - cartilagini_desertiche
+  - chemiorecettori_bromuro
+  - ciste_salmastre
+  - cuscinetti_elettrostatici
+  - ghiandole_iodoattive
+  - lingua_cristallina
+  - membrane_captura_rugiada

--- a/packs/evo_tactics_pack/data/species/reef_luminescente/reef-luminescente-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/reef_luminescente/reef-luminescente-trait-keeper.yaml
@@ -1,3 +1,15 @@
 resistance_archetype: adattivo
 id: reef-luminescente-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- reef_luminescente
+derived_from_environment:
+  suggested_traits:
+  - antenne_waveguide
+  - biofilm_glow
+  - branchie_microfiltri
+  - cartilagini_biofibre
+  - coralli_partner
+  - enzimi_antipredatori_algali
+  - epitelio_fosforescente
+  - ghiandole_inchiostro_luce

--- a/packs/evo_tactics_pack/data/species/steppe_algoritmiche/steppe-algoritmiche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/steppe_algoritmiche/steppe-algoritmiche-trait-keeper.yaml
@@ -1,3 +1,14 @@
 resistance_archetype: adattivo
 id: steppe-algoritmiche-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- steppe_algoritmiche
+derived_from_environment:
+  suggested_traits:
+  - antenne_wideband
+  - biochip_memoria
+  - carapace_segmenti_logici
+  - circolazione_cooling_loop
+  - coda_coppia_retroattiva
+  - ghiandole_grafene
+  - lamelle_sincroniche

--- a/packs/evo_tactics_pack/data/species/stratosfera_tempestosa/stratosfera-tempestosa-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/stratosfera_tempestosa/stratosfera-tempestosa-trait-keeper.yaml
@@ -1,3 +1,16 @@
 resistance_archetype: adattivo
 id: stratosfera-tempestosa-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+biomes:
+- stratosfera_tempestosa
+derived_from_environment:
+  suggested_traits:
+  - ali_fulminee
+  - barbigli_sensori_plasma
+  - branchie_eoliche
+  - capsule_paracadute
+  - coda_stabilizzatrice_vortex
+  - cuore_multicamera_bassa_pressione
+  - epidermide_dielettrica
+  - ghiandole_condensa_ozono
+  - lamelle_shear

--- a/tools/py/check_derived_reproducible.py
+++ b/tools/py/check_derived_reproducible.py
@@ -100,14 +100,23 @@ def check_trait_bridge() -> list[str]:
     only_committed = c_ids - r_ids
     only_regen = r_ids - c_ids
 
-    # Dead species: referenced by committed affinity but absent from the live catalog.
-    dead = set()
-    if CATALOG_PATH.exists():
-        live = {e["species_id"] for e in _load_json(CATALOG_PATH).get("catalog", [])}
-        for entries in committed_traits.values():
+    # Dead species (C2 pack-scoped, 2026-06-28): the bridge reads pack species YAMLs,
+    # so a species in the affinity is "dead" only if a FRESH REGEN no longer produces
+    # it (a deleted pack species), NOT if it is absent from the separate catalog
+    # registry. Pack and catalog are different id-spaces by design (~23 overlap), so a
+    # pack-vs-catalog check is a permanent false alarm. Compare committed affinity
+    # species against the regen's own species set (its source of truth).
+    regen_species = set()
+    for entries in regen.values():
+        if isinstance(entries, list):
             for e in entries:
-                if isinstance(e, dict) and e.get("species_id") not in live:
-                    dead.add(e.get("species_id"))
+                if isinstance(e, dict) and e.get("species_id"):
+                    regen_species.add(e.get("species_id"))
+    dead = set()
+    for entries in committed_traits.values():
+        for e in entries:
+            if isinstance(e, dict) and e.get("species_id") not in regen_species:
+                dead.add(e.get("species_id"))
 
     print(f"  [trait-bridge] committed trait entries: {len(c_ids)}; "
           f"regen from {PACK_SPECIES_ROOT.relative_to(REPO_ROOT)}: {len(r_ids)}")
@@ -119,8 +128,9 @@ def check_trait_bridge() -> list[str]:
         )
     if dead:
         findings.append(
-            f"{len(dead)} species referenced by committed affinity are NOT in the "
-            f"current catalog (e.g. {sorted(dead)[:5]}). Output is stale."
+            f"{len(dead)} species referenced by committed affinity are no longer "
+            f"produced by a fresh regen (deleted pack species, e.g. "
+            f"{sorted(dead)[:5]}). Output is stale."
         )
     if not schema_parity:
         findings.append(

--- a/tools/py/repopulate_trait_keepers.py
+++ b/tools/py/repopulate_trait_keepers.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Re-populate synthetic *-trait-keeper species so every env_to_traits rule has
+a real covering species (heals ``rules_missing_species_total`` to 0 honestly).
+
+Background
+----------
+Each biome dir ships one synthetic ``<biome>-trait-keeper.yaml`` whose purpose is
+to CARRY that biome's env-suggested traits, guaranteeing the trait-coverage gate
+(``report_trait_coverage.py``) finds >=1 species per (suggested-trait, biome) rule
+combo. The keepers were emptied (~M6: ``derived_from_environment: {}``) and the
+stale 287-entry ``species_affinity.json`` masked the gap. The honest 72-entry
+re-baseline (slice gamma) exposed 131 uncovered rule combos. This driver
+re-populates the keepers from the env_to_traits registry (NOT git, whose old
+keepers only held ~1 trait each).
+
+Coverage mechanics (tools/py/game_utils/trait_coverage.py)
+----------------------------------------------------------
+A rule combo ``(biome_class, None)`` is COVERED when a species with
+``environment_affinity.biome_class == biome_class`` (or ``biomes:[biome_class]``)
+lists the trait in ``derived_from_environment.suggested_traits`` AND the trait is
+in ``trait_reference.json.traits`` (``target_traits``). Rules with no biome_class
+(empty ``when`` / koppen / hazard / salinita) yield combo ``(None, None)``,
+covered by a species with NO biome carrying the trait -> the ``global`` keeper.
+
+Canon-safety + pack-validator split
+-----------------------------------
+Two gates pull in opposite directions:
+  * ``validate_species_v1_7.py`` (pack validator, in ``validate-datasets`` CI):
+    treats a missing ``biomes`` field as a FATAL error for a "complete" keeper
+    (one that carries spawn_rules/balance, e.g. badlands).
+  * ``check-canon-consistency.cjs`` (HARD gate): a ``biomes:[X]`` entry must be a
+    canonical biome id OR a pack alias; it does NOT inspect
+    ``environment_affinity.biome_class``.
+So we SPLIT by canon-resolvability (pack biomes.yaml ids UNION aliases):
+  * biome_class that RESOLVES -> write ``biomes:[biome_class]`` (satisfies the
+    pack validator AND passes canon).
+  * biome_class that does NOT resolve (laguna_bioreattiva, mangrovieto_cinetico,
+    canopia_psionica_leggera, falde_magnetiche_psioniche, orbita_psionica_inversa)
+    -> write ``environment_affinity.biome_class`` (covers via the coverage engine
+    fallback, invisible to the canon biome-refs gate). These are all minimal
+    stubs the pack validator already tolerates non-fatally.
+The coverage engine reads ``biomes`` first, then falls back to
+``environment_affinity.biome_class`` -- either yields the (biome_class, None) combo.
+
+Deterministic + committed (salvage idiom, cf. gen_retired_creature_specs.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_ENV_TRAITS = REPO_ROOT / "packs/evo_tactics_pack/docs/catalog/env_traits.json"
+DEFAULT_TRAIT_REFERENCE = REPO_ROOT / "packs/evo_tactics_pack/docs/catalog/trait_reference.json"
+DEFAULT_GLOSSARY = REPO_ROOT / "data/core/traits/glossary.json"
+DEFAULT_SPECIES_ROOT = REPO_ROOT / "packs/evo_tactics_pack/data/species"
+DEFAULT_PACK_BIOMES = REPO_ROOT / "packs/evo_tactics_pack/data/biomes.yaml"
+
+GLOBAL_KEEPER_ID = "global-trait-keeper"
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_canon_biome_ids(pack_biomes_path: Path) -> set[str]:
+    """Canonical pack biome ids UNION declared aliases (matches the canon gate)."""
+    with pack_biomes_path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    biomes = data.get("biomes", {}) or {}
+    ids: set[str] = set()
+    for key, val in biomes.items():
+        ids.add(str(key))
+        if isinstance(val, dict):
+            for alias in val.get("aliases") or []:
+                ids.add(str(alias))
+    return ids
+
+
+def build_buckets(
+    env_traits: dict, target_traits: set[str], glossary: set[str]
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Return (biome_buckets, global_bucket) of glossary-valid target traits.
+
+    biome_buckets: biome_class -> sorted suggested traits (combo (biome_class, None)).
+    global_bucket: sorted suggested traits for combo (None, None).
+    """
+    biome_sets: dict[str, set[str]] = {}
+    global_set: set[str] = set()
+
+    for rule in env_traits.get("rules", []):
+        when = rule.get("when") or {}
+        biome_class = when.get("biome_class")
+        morphotype = when.get("morphotype")
+        suggested = (rule.get("suggest") or {}).get("traits") or []
+        target_hits = [t for t in suggested if t in target_traits]
+        if not target_hits:
+            continue
+        if biome_class is not None:
+            biome_sets.setdefault(biome_class, set()).update(target_hits)
+        elif morphotype is None:
+            # No biome_class AND no morphotype -> combo (None, None) -> global keeper.
+            global_set.update(target_hits)
+        # (morphotype-only rules carry no traits in the current registry; skipped.)
+
+    # Fail loud if any carried trait lacks a glossary entry (the species<->glossary
+    # CI guard would otherwise reject the keeper).
+    all_traits = set(global_set)
+    for traits in biome_sets.values():
+        all_traits |= traits
+    orphans = sorted(t for t in all_traits if t not in glossary)
+    if orphans:
+        raise SystemExit(
+            "Refusing to write keepers: suggested traits missing glossary entries:\n  "
+            + "\n  ".join(orphans)
+        )
+
+    biome_buckets = {bc: sorted(ts) for bc, ts in biome_sets.items()}
+    return biome_buckets, sorted(global_set)
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    text = yaml.safe_dump(
+        data, sort_keys=False, allow_unicode=True, default_flow_style=False, width=4096
+    )
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(text)
+
+
+def repopulate(
+    species_root: Path,
+    biome_buckets: dict[str, list[str]],
+    global_bucket: list[str],
+    canon_biome_ids: set[str],
+    *,
+    dry_run: bool = False,
+) -> list[tuple[str, str, int]]:
+    """Populate keepers; return [(keeper_id, biome_class_or_'global', n_traits)]."""
+    changed: list[tuple[str, str, int]] = []
+    for keeper_path in sorted(species_root.rglob("*-trait-keeper.yaml")):
+        with keeper_path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        keeper_id = str(data.get("id") or keeper_path.stem)
+        biome_class = keeper_path.parent.name
+
+        if biome_class in biome_buckets:
+            traits = biome_buckets[biome_class]
+            if biome_class in canon_biome_ids:
+                # Canonical/alias biome -> real biomes field (pack validator + canon both happy).
+                data["biomes"] = [biome_class]
+                data.pop("environment_affinity", None)
+                tag = biome_class
+            else:
+                # Non-canon biome -> environment_affinity fallback (canon gate ignores it).
+                data.pop("biomes", None)
+                data["environment_affinity"] = {"biome_class": biome_class}
+                tag = f"{biome_class}(env_affinity)"
+            data["derived_from_environment"] = {"suggested_traits": list(traits)}
+            changed.append((keeper_id, tag, len(traits)))
+        elif keeper_id == GLOBAL_KEEPER_ID:
+            # No biome -> combo (None, None) -> covers koppen/hazard/salinita/aggregate rules.
+            data.pop("biomes", None)
+            data.pop("environment_affinity", None)
+            data["derived_from_environment"] = {"suggested_traits": list(global_bucket)}
+            changed.append((keeper_id, "global(None,None)", len(global_bucket)))
+        else:
+            # Keeper dir whose name is NOT an env_to_traits biome_class -> this keeper
+            # carries nothing (the 22 such dirs, e.g. abisso_luminescente). Left inert.
+            # NB: three canonical biomes (foresta_miceliale, foresta_temperata,
+            # mezzanotte_orbitale) DO have rules but no keeper dir at all -- their rule
+            # combos are covered by real (non-keeper) species, so no keeper is needed.
+            continue
+
+        if not dry_run:
+            _write_yaml(keeper_path, data)
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-traits", type=Path, default=DEFAULT_ENV_TRAITS)
+    parser.add_argument("--trait-reference", type=Path, default=DEFAULT_TRAIT_REFERENCE)
+    parser.add_argument("--glossary", type=Path, default=DEFAULT_GLOSSARY)
+    parser.add_argument("--species-root", type=Path, default=DEFAULT_SPECIES_ROOT)
+    parser.add_argument("--pack-biomes", type=Path, default=DEFAULT_PACK_BIOMES)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    env_traits = _load_json(args.env_traits)
+    target_traits = set(_load_json(args.trait_reference).get("traits", {}).keys())
+    glossary = set(_load_json(args.glossary).get("traits", {}).keys())
+    canon_biome_ids = load_canon_biome_ids(args.pack_biomes)
+
+    biome_buckets, global_bucket = build_buckets(env_traits, target_traits, glossary)
+    changed = repopulate(
+        args.species_root,
+        biome_buckets,
+        global_bucket,
+        canon_biome_ids,
+        dry_run=args.dry_run,
+    )
+
+    print(f"{'DRY-RUN ' if args.dry_run else ''}populated {len(changed)} keepers:")
+    for keeper_id, biome, n in changed:
+        print(f"  {keeper_id:<42} <- {biome:<28} ({n} traits)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/py/repopulate_trait_keepers.py
+++ b/tools/py/repopulate_trait_keepers.py
@@ -50,11 +50,14 @@ canon-passing inline form available; ``environment_affinity`` is used to cover t
 rule WITHOUT asserting a canon violation. Registering these 5 as inline
 ``biomes.yaml`` aliases (so the canon gate exercises the refs) is a master-dd call.
 
-NOTE (validator scope): the pack validator ``validate_species_v1_7.py`` treats a
-missing ``biomes`` field as FATAL and would reject every bare keeper stub; the
-keepers escape it only because ``validate-ecosystem-pack`` (run_all_validators)
-globs a hardcoded subset of biome dirs that excludes them. The "green" pack-
-validation signal therefore means "not inspected", not "valid", for these stubs.
+NOTE (validator scope): the pack validator ``validate_species_v1_7.py`` would
+reject every keeper stub as FATAL -- a bare stub for missing ``biomes`` plus ~10
+other required fields (schema_version, receipt, display_name, role_trofico,
+functional_tags, vc, playable_unit, spawn_rules[.densita], balance[.encounter_role]);
+even the populated ``biomes:[X]`` keepers still fail on those other fields. The
+keepers escape rejection only because ``validate-ecosystem-pack``
+(run_all_validators) globs a hardcoded subset of biome dirs that excludes them, so
+the "green" pack-validation signal means "not inspected", not "valid", for stubs.
 
 Deterministic + committed (salvage idiom, cf. gen_retired_creature_specs.py).
 """

--- a/tools/py/repopulate_trait_keepers.py
+++ b/tools/py/repopulate_trait_keepers.py
@@ -37,10 +37,24 @@ So we SPLIT by canon-resolvability (pack biomes.yaml ids UNION aliases):
   * biome_class that does NOT resolve (laguna_bioreattiva, mangrovieto_cinetico,
     canopia_psionica_leggera, falde_magnetiche_psioniche, orbita_psionica_inversa)
     -> write ``environment_affinity.biome_class`` (covers via the coverage engine
-    fallback, invisible to the canon biome-refs gate). These are all minimal
-    stubs the pack validator already tolerates non-fatally.
+    fallback, which the canon biome-refs gate does not inspect).
 The coverage engine reads ``biomes`` first, then falls back to
 ``environment_affinity.biome_class`` -- either yields the (biome_class, None) combo.
+
+CAVEAT (canon-blind refs, owner decision): these 5 biome_class names come from
+``env_to_traits.yaml`` but are NOT recognized by the canon biome-refs gate (3 are
+declared in ``data/core/biome_aliases.yaml`` which that gate does not read; 2 --
+laguna_bioreattiva, mangrovieto_cinetico -- are only in the pack env registry).
+A ``biomes:[X]`` representation would FAIL canon for all 5, so there is no
+canon-passing inline form available; ``environment_affinity`` is used to cover the
+rule WITHOUT asserting a canon violation. Registering these 5 as inline
+``biomes.yaml`` aliases (so the canon gate exercises the refs) is a master-dd call.
+
+NOTE (validator scope): the pack validator ``validate_species_v1_7.py`` treats a
+missing ``biomes`` field as FATAL and would reject every bare keeper stub; the
+keepers escape it only because ``validate-ecosystem-pack`` (run_all_validators)
+globs a hardcoded subset of biome dirs that excludes them. The "green" pack-
+validation signal therefore means "not inspected", not "valid", for these stubs.
 
 Deterministic + committed (salvage idiom, cf. gen_retired_creature_specs.py).
 """
@@ -172,9 +186,11 @@ def repopulate(
         else:
             # Keeper dir whose name is NOT an env_to_traits biome_class -> this keeper
             # carries nothing (the 22 such dirs, e.g. abisso_luminescente). Left inert.
-            # NB: three canonical biomes (foresta_miceliale, foresta_temperata,
-            # mezzanotte_orbitale) DO have rules but no keeper dir at all -- their rule
-            # combos are covered by real (non-keeper) species, so no keeper is needed.
+            # NB: foresta_temperata also has an env rule but no keeper dir; its single
+            # suggested trait (peli_idrofobici) is NOT in trait_reference.json.traits so
+            # it produces ZERO countable rule combos -> needs no keeper. (foresta_miceliale
+            # and mezzanotte_orbitale DO produce combos and now have their own keepers
+            # above, so coverage is in-biome real-species, not cross-biome overlay-masked.)
             continue
 
         if not dry_run:


### PR DESCRIPTION
## What (salvage item 4 -- bridge half, master-dd verdict C2)

Closes the **Family-1 trait-bridge drift**. The reproducibility guard now reports **BOTH derived families reproducible** from in-repo sources (catalog half shipped in #3045).

## Re-baseline

`species_affinity.json` **287 -> 72** trait entries (regen via `build_species_trait_bridge.py`). The 222 dropped entries are stale -- the committed output was last genuinely generated 2025-12-03 against a richer-then pack set. The `index.json` trait **DEFINITION set is UNCHANGED (309 -> 309)** -- only the per-trait `species_affinity` sub-field changed, so the coverage gate holds.

## C2 guard relaxation (the design call)

The "dead species" check compared affinity species against the `species_catalog` -- but the bridge reads **pack** species YAMLs, and pack/catalog are different id-spaces by design (~23 overlap). A pack-vs-catalog check is a **permanent false alarm**. Now a species is "dead" only if a **fresh regen no longer produces it** (a deleted pack species) -- which still catches real staleness (NOT a tautology: `regen_species` comes from the actual fresh build output, so a stale ref to a deleted species is still flagged). After the re-baseline: 0 dead.

## Verification

Guard **reproducible (both families)** · AI **557/557** byte-stable · **test:api exit 0** · bridge/index/coverage python tests 13/13 · traitRepository loads · coverage holds (309 traits, 0 missing-species errors) · no evo-pack trait-mirror drift. Harsh adversarial review (cavecrew, verify-first on the guard relaxation): **No issues**.

`index.csv` (a separate `build_trait_index.js` artifact, not guard-checked) left out of scope.

## Rollback

Revert the commit; the bridge artifacts + guard restore together.