### PR TITLE
test(generation): characterize translatePathfinderStatblock output

### DIFF
--- a/tests/services/biomeSynthesizerPathfinder.test.js
+++ b/tests/services/biomeSynthesizerPathfinder.test.js
@@ -6,16 +6,21 @@ const { translatePathfinderStatblock } = require('../../services/generation/biom
 test('translatePathfinderStatblock throws Error on invalid statblock', () => {
   assert.throws(
     () => translatePathfinderStatblock(null),
-    (err) => err.message.includes('Statblock Pathfinder non valido')
+    (err) => err.message.includes('Statblock Pathfinder non valido'),
   );
   assert.throws(
     () => translatePathfinderStatblock(42),
-    (err) => err.message.includes('Statblock Pathfinder non valido')
+    (err) => err.message.includes('Statblock Pathfinder non valido'),
   );
 });
 
 test('translatePathfinderStatblock characterizes minimal valid statblock without context', () => {
-  const result = translatePathfinderStatblock({ id: 'gob', name: 'Goblin', type: 'Humanoid', axes: {} });
+  const result = translatePathfinderStatblock({
+    id: 'gob',
+    name: 'Goblin',
+    type: 'Humanoid',
+    axes: {},
+  });
 
   assert.equal(result.id, 'pathfinder-gob');
   assert.equal(result.display_name, 'Goblin');
@@ -31,7 +36,7 @@ test('translatePathfinderStatblock characterizes minimal valid statblock without
 test('translatePathfinderStatblock characterizes context with biomeId set', () => {
   const result = translatePathfinderStatblock(
     { id: 'gob', type: 'Humanoid', axes: {} },
-    { biomeId: 'foresta' }
+    { biomeId: 'foresta' },
   );
 
   assert.deepEqual(result.biomes, ['foresta']);
@@ -49,7 +54,7 @@ test('translatePathfinderStatblock characterizes display_name fallbacks', () => 
 test('translatePathfinderStatblock characterizes fallbackTraits in context', () => {
   const result = translatePathfinderStatblock(
     { id: 'gob', genetic_traits: ['z', 'x'], axes: {} },
-    { fallbackTraits: ['x', 'pathfinder', 'y'] }
+    { fallbackTraits: ['x', 'pathfinder', 'y'] },
   );
 
   assert.deepEqual(result.traits.core, ['pathfinder', 'z', 'x', 'y']);

--- a/tests/services/biomeSynthesizerPathfinder.test.js
+++ b/tests/services/biomeSynthesizerPathfinder.test.js
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { translatePathfinderStatblock } = require('../../services/generation/biomeSynthesizer');
+
+test('translatePathfinderStatblock throws Error on invalid statblock', () => {
+  assert.throws(
+    () => translatePathfinderStatblock(null),
+    (err) => err.message.includes('Statblock Pathfinder non valido')
+  );
+  assert.throws(
+    () => translatePathfinderStatblock(42),
+    (err) => err.message.includes('Statblock Pathfinder non valido')
+  );
+});
+
+test('translatePathfinderStatblock characterizes minimal valid statblock without context', () => {
+  const result = translatePathfinderStatblock({ id: 'gob', name: 'Goblin', type: 'Humanoid', axes: {} });
+
+  assert.equal(result.id, 'pathfinder-gob');
+  assert.equal(result.display_name, 'Goblin');
+  assert.ok(result.functional_tags.includes('pathfinder'));
+  assert.ok(result.functional_tags.includes('humanoid'));
+  assert.deepEqual(result.biomes, []);
+  assert.equal(result.playable_unit, false);
+  assert.equal(result.environment_affinity.biome_class, 'pathfinder_unknown');
+  assert.ok(result.traits.core.includes('pathfinder'));
+  assert.equal(result.source_dataset.profile_id, 'gob');
+});
+
+test('translatePathfinderStatblock characterizes context with biomeId set', () => {
+  const result = translatePathfinderStatblock(
+    { id: 'gob', type: 'Humanoid', axes: {} },
+    { biomeId: 'foresta' }
+  );
+
+  assert.deepEqual(result.biomes, ['foresta']);
+  assert.equal(result.environment_affinity.biome_class, 'foresta');
+});
+
+test('translatePathfinderStatblock characterizes display_name fallbacks', () => {
+  const resultIdOnly = translatePathfinderStatblock({ id: 'gob', axes: {} });
+  assert.equal(resultIdOnly.display_name, 'gob');
+
+  const resultNoNameNoId = translatePathfinderStatblock({ axes: {} });
+  assert.equal(resultNoNameNoId.display_name, 'Creatura Pathfinder');
+});
+
+test('translatePathfinderStatblock characterizes fallbackTraits in context', () => {
+  const result = translatePathfinderStatblock(
+    { id: 'gob', genetic_traits: ['z', 'x'], axes: {} },
+    { fallbackTraits: ['x', 'pathfinder', 'y'] }
+  );
+
+  assert.deepEqual(result.traits.core, ['pathfinder', 'z', 'x', 'y']);
+});


### PR DESCRIPTION
Characterization tests for the exported translatePathfinderStatblock (services/generation/biomeSynthesizer.js). Test-only -- production freeze-path UNCHANGED (only tests/services/biomeSynthesizerPathfinder.test.js added). Salvaged from Jules session (delivery-miss). Merge = Eduardo (external-repo boundary); Game CI validates the test run.