### PR TITLE
ci(dataset-checks): wire derived-reproducibility guard (advisory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,15 @@ jobs:
               - 'scripts/sync_evo_pack_assets.js'
               - 'scripts/utils/generatedMarker.js'
               - 'scripts/utils/jsonio.js'
+              # Reproducibility guard (PR #3059): the guard itself + the
+              # generators it checks must re-run the dataset-checks drift-guard
+              # step when their OWN logic changes, else a guard/generator edit
+              # silently bypasses the reproducibility signal (mirrors the
+              # evo-pack generator entries above).
+              - 'tools/py/check_derived_reproducible.py'
+              - 'tools/py/build_species_trait_bridge.py'
+              - 'scripts/generate_derived_analysis.py'
+              - 'tools/etl/**'
             deploy:
               - 'scripts/trait_audit.py'
               - 'scripts/run_deploy_checks.sh'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,6 +496,21 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --requirement requirements.txt
 
+      # Reproducibility guard (derived-canon salvage, 2026-06-28): reports drift if
+      # any of the three committed DERIVED families -- trait bridge
+      # (data/traits/species_affinity.json), species catalog
+      # (data/core/species/species_catalog.json), or the derived-analysis bundle
+      # (data/derived/analysis/*) -- no longer reproduces from current in-repo
+      # sources. ADVISORY for now (--warn-only -> always exit 0): surfaces
+      # "regenerate-or-die" violations in the log without redding PRs while the
+      # heuristic catalog check beds in. Flip to ENFORCING later by dropping
+      # --warn-only. MUST run on the PRISTINE checkout, BEFORE the trait-baseline /
+      # coverage regen steps below overwrite data/derived/analysis/* (same
+      # constraint as the evo-pack drift check above). See
+      # docs/guide/derived-artifacts-reproducibility.md.
+      - name: Verify derived artifacts reproduce (drift guard, advisory)
+        run: python3 tools/py/check_derived_reproducible.py --warn-only
+
       - name: Validate YAML datasets
         run: python3 tools/py/validate_datasets.py
 


### PR DESCRIPTION
⚠️ **FORBIDDEN-PATH** (`.github/workflows/`) — authored by claude-code, **master-dd merges**.

## What
Wires `tools/py/check_derived_reproducible.py` as an **advisory** (`--warn-only`, exit 0) step in the `dataset-checks` job, so drift in the 3 now-reproducible derived families (trait bridge / species catalog / derived-analysis bundle) is **surfaced in CI** without blocking PRs.

## Placement (load-bearing)
Runs after the Python-deps install and **before** the trait-baseline / coverage regen steps — those overwrite `data/derived/analysis/*`, so the hash check must see the **pristine** checkout (same constraint as the existing evo-pack drift check).

## Rollout
Advisory first (mirrors the swarm-validation 2-tier precedent): zero risk of surprise-redding PRs. **Flip to enforcing = drop `--warn-only`** once it proves quiet — that's the 1-line change that makes "regenerate-or-die" hard-enforced.

## Verified
YAML parses (14 jobs); step placed pristine-before-regen; guard `--warn-only` exit 0 on current main (3/3 families reproduce). Tool/guard itself already on main (#3057).

🤖 Generated with [Claude Code](https://claude.com/claude-code)