### PR TITLE
fix(canon): register 3 expansion-biome aliases -> honest biomes:[X] for keepers

### DIFF
--- a/data/core/biomes.yaml
+++ b/data/core/biomes.yaml
@@ -215,6 +215,8 @@ biomes:
     affixes:
     - static_vines
     - ion_lattice
+    aliases:
+    - canopia_psionica_leggera
     hazard:
       description: Scariche elettrostatiche e cadute da piattaforme sospese.
       severity: medium
@@ -364,6 +366,7 @@ biomes:
     - shifting_winds
     aliases:
     - badlands
+    - falde_magnetiche_psioniche
     hazard:
       description: Correnti ascendenti, shock termici e micro-eruzioni sottomarine.
       severity: high
@@ -546,6 +549,7 @@ biomes:
     - alarm_cascade
     aliases:
     - cryosteppe
+    - orbita_psionica_inversa
     hazard:
       description: Zero-G intermittente, allarmi a cascata e compartimenti depressurizzati.
       severity: high

--- a/packs/evo_tactics_pack/data/biomes.yaml
+++ b/packs/evo_tactics_pack/data/biomes.yaml
@@ -190,6 +190,8 @@ biomes:
     affixes:
     - static_vines
     - ion_lattice
+    aliases:
+    - canopia_psionica_leggera
     hazard:
       description: Scariche elettrostatiche e cadute da piattaforme sospese.
       severity: medium
@@ -323,6 +325,7 @@ biomes:
     - shifting_winds
     aliases:
     - badlands
+    - falde_magnetiche_psioniche
     hazard:
       description: Correnti ascendenti, shock termici e micro-eruzioni sottomarine.
       severity: high
@@ -485,6 +488,7 @@ biomes:
     - alarm_cascade
     aliases:
     - cryosteppe
+    - orbita_psionica_inversa
     hazard:
       description: Zero-G intermittente, allarmi a cascata e compartimenti depressurizzati.
       severity: high

--- a/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/canopia-psionica-leggera-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_psionica_leggera/canopia-psionica-leggera-trait-keeper.yaml
@@ -1,11 +1,11 @@
 resistance_archetype: bioelettrico
 id: canopia-psionica-leggera-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
-environment_affinity:
-  biome_class: canopia_psionica_leggera
 derived_from_environment:
   suggested_traits:
   - focus_frazionato
   - mimetismo_cromatico_passivo
   - sacche_galleggianti_ascensoriali
   - struttura_elastica_amorfa
+biomes:
+- canopia_psionica_leggera

--- a/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/falde-magnetiche-psioniche-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/falde_magnetiche_psioniche/falde-magnetiche-psioniche-trait-keeper.yaml
@@ -1,11 +1,11 @@
 resistance_archetype: bioelettrico
 id: falde-magnetiche-psioniche-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
-environment_affinity:
-  biome_class: falde_magnetiche_psioniche
 derived_from_environment:
   suggested_traits:
   - filamenti_digestivi_compattanti
   - nucleo_ovomotore_rotante
   - olfatto_risonanza_magnetica
   - struttura_elastica_amorfa
+biomes:
+- falde_magnetiche_psioniche

--- a/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbita-psionica-inversa-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/orbita_psionica_inversa/orbita-psionica-inversa-trait-keeper.yaml
@@ -1,11 +1,11 @@
 resistance_archetype: bioelettrico
 id: orbita-psionica-inversa-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
-environment_affinity:
-  biome_class: orbita_psionica_inversa
 derived_from_environment:
   suggested_traits:
   - focus_frazionato
   - nucleo_ovomotore_rotante
   - olfatto_risonanza_magnetica
   - sacche_galleggianti_ascensoriali
+biomes:
+- orbita_psionica_inversa


### PR DESCRIPTION
Closes the Codex "gate-dodge" residual (from the #3047 keeper review) for **3 of the 5** env_affinity keepers. ⚠️ **CANON DATA** (pack biomes.yaml) → master-dd merges.

## Why
3 keepers used `environment_affinity.biome_class` — which the `check-canon-consistency.cjs` biome-refs gate does NOT inspect — only because their biome_class wasn't a canon-recognized ref. They're **already declared expansion aliases** in `data/core/biome_aliases.yaml`; this just mirrors them into the **gate-read** `packs/.../biomes.yaml`:
| alias | canonical |
|---|---|
| canopia_psionica_leggera | canopia_ionica |
| falde_magnetiche_psioniche | dorsale_termale_tropicale |
| orbita_psionica_inversa | mezzanotte_orbitale |

The driver (`repopulate_trait_keepers.py`) then auto-switches those 3 keepers from `environment_affinity.biome_class` → `biomes:[X]`, so the canon gate now **exercises** the refs (honest) instead of being structurally bypassed.

## The 2 remaining
`laguna_bioreattiva`, `mangrovieto_cinetico` have **no canonical home** in biome_aliases.yaml → kept on `environment_affinity` (documented). Giving them a canonical biome is a separate master-dd call.

## Verified
canon-consistency **0 new violations**, coverage `rules_missing=0` (unchanged), guard 3/3, validate-datasets exit 0, AI 557/557, test:api 4849/0-fail, sync:evo-pack 0 drift. No affinity change (bridge ignores the `biomes` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)