### PR TITLE
fix(audit): resolve 6 Codex P2 findings on merged PRs

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -18689,7 +18689,11 @@
       },
       "spinta_selettiva": "i18n:traits.artigli_sette_vie_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.artigli_sette_vie_2.uso_funzione"
+      "uso_funzione": "i18n:traits.artigli_sette_vie_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     },
     "coda_frusta_cinetica_2": {
       "schema_version": "2.0",
@@ -18708,7 +18712,11 @@
       },
       "spinta_selettiva": "i18n:traits.coda_frusta_cinetica_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.coda_frusta_cinetica_2.uso_funzione"
+      "uso_funzione": "i18n:traits.coda_frusta_cinetica_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     },
     "criostasi_adattiva_2": {
       "schema_version": "2.0",
@@ -18727,7 +18735,11 @@
       },
       "spinta_selettiva": "i18n:traits.criostasi_adattiva_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.criostasi_adattiva_2.uso_funzione"
+      "uso_funzione": "i18n:traits.criostasi_adattiva_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     },
     "focus_frazionato_2": {
       "schema_version": "2.0",
@@ -18746,7 +18758,11 @@
       },
       "spinta_selettiva": "i18n:traits.focus_frazionato_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.focus_frazionato_2.uso_funzione"
+      "uso_funzione": "i18n:traits.focus_frazionato_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     },
     "risonanza_di_branco_2": {
       "schema_version": "2.0",
@@ -18765,7 +18781,11 @@
       },
       "spinta_selettiva": "i18n:traits.risonanza_di_branco_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.risonanza_di_branco_2.uso_funzione"
+      "uso_funzione": "i18n:traits.risonanza_di_branco_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     },
     "sacche_galleggianti_ascensoriali_2": {
       "schema_version": "2.0",
@@ -18784,7 +18804,11 @@
       },
       "spinta_selettiva": "i18n:traits.sacche_galleggianti_ascensoriali_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.sacche_galleggianti_ascensoriali_2.uso_funzione"
+      "uso_funzione": "i18n:traits.sacche_galleggianti_ascensoriali_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     },
     "scheletro_idro_regolante_2": {
       "schema_version": "2.0",
@@ -18803,7 +18827,11 @@
       },
       "spinta_selettiva": "i18n:traits.scheletro_idro_regolante_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.scheletro_idro_regolante_2.uso_funzione"
+      "uso_funzione": "i18n:traits.scheletro_idro_regolante_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     },
     "struttura_elastica_amorfa_2": {
       "schema_version": "2.0",
@@ -18822,7 +18850,11 @@
       },
       "spinta_selettiva": "i18n:traits.struttura_elastica_amorfa_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.struttura_elastica_amorfa_2.uso_funzione"
+      "uso_funzione": "i18n:traits.struttura_elastica_amorfa_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     },
     "tattiche_di_branco_2": {
       "schema_version": "2.0",
@@ -18841,7 +18873,11 @@
       },
       "spinta_selettiva": "i18n:traits.tattiche_di_branco_2.spinta_selettiva",
       "tier": "T1",
-      "uso_funzione": "i18n:traits.tattiche_di_branco_2.uso_funzione"
+      "uso_funzione": "i18n:traits.tattiche_di_branco_2.uso_funzione",
+      "data_origin": "appendix_a_variant_deep_research_grounded",
+      "completion_flags": {
+        "design_stub": true
+      }
     }
   }
 }

--- a/scripts/generate_derived_analysis.py
+++ b/scripts/generate_derived_analysis.py
@@ -225,7 +225,7 @@ def render_readme(manifest: dict[str, object]) -> str:
         "## Ultima rigenerazione",
         "",
         f"- Comando: `{command}`",
-        f"- Manifest con checksum: `{ANALYSIS_ROOT / 'manifest.json'}`",
+        f"- Manifest con checksum: `{(ANALYSIS_ROOT / 'manifest.json').as_posix()}`",
         f"- Log operativo: `logs/agent_activity.md` → `[{log_tag}]`",
         "",
         "## Output attesi",

--- a/tools/py/author_appendix_a_variant_traits.py
+++ b/tools/py/author_appendix_a_variant_traits.py
@@ -112,6 +112,10 @@ def index_entry(v, tid):
         "spinta_selettiva": f"i18n:traits.{tid}.spinta_selettiva",
         "tier": "T1",
         "uso_funzione": f"i18n:traits.{tid}.uso_funzione",
+        # Keep parity with db_entry: per-file JSONs carry these fields and
+        # index.json must mirror them so validators / completion-dashboards agree.
+        "data_origin": "appendix_a_variant_deep_research_grounded",
+        "completion_flags": {"design_stub": True},
     }
 
 

--- a/tools/py/gen_retired_creature_lore_drafts.py
+++ b/tools/py/gen_retired_creature_lore_drafts.py
@@ -127,6 +127,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     p.add_argument("--grammar", default=gen.DEFAULT_GRAMMAR_PATH)
     p.add_argument("--out-dir", default=DEFAULT_OUT_DIR)
     p.add_argument("--print", action="store_true", help="print drafts to stdout, do not write")
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite existing draft files (default: skip existing to preserve manual edits)",
+    )
     args = p.parse_args(argv)
 
     biomes_doc = yaml.safe_load(Path(args.biomes).read_text(encoding="utf-8"))
@@ -139,6 +144,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 2
 
     out_dir = Path(args.out_dir)
+    # FIX 4: guard against bypassing the HITL promote gate
+    if out_dir.resolve() == PROMOTED_DIR.resolve():
+        print(
+            f"ERROR: --out-dir resolves to the promoted dir ({PROMOTED_DIR}). "
+            "Writing directly to data/codex/ bypasses the HITL review gate. "
+            "Use the default _drafts/ dir and promote via tools/js/promote_codex_draft.js.",
+            file=sys.stderr,
+        )
+        return 1
     out_dir.mkdir(parents=True, exist_ok=True)
     wrote = 0
     for sid in RETIRED_IDS:
@@ -151,6 +165,10 @@ def main(argv: Optional[List[str]] = None) -> int:
             print(yaml.safe_dump(draft, allow_unicode=True, sort_keys=False, width=88))
             continue
         out = out_dir / f"{sid}.yaml"
+        # FIX 5: don't clobber manual master-dd edits unless --force is set
+        if out.exists() and not args.force:
+            print(f"SKIP {sid}: draft already exists at {out} (use --force to overwrite)", file=sys.stderr)
+            continue
         with open(out, "w", encoding="utf-8") as fh:
             fh.write(_HEADER.format(sid=sid))
             yaml.safe_dump(draft, fh, allow_unicode=True, sort_keys=False, width=88)

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -57,6 +57,9 @@ async function runEncounter(
     gridSize = null,
   } = {},
 ) {
+  if (Array.isArray(terrainFeatures) && terrainFeatures.length && scenarioId) {
+    throw new Error('combat-adapter: terrainFeatures and scenarioId are mutually exclusive');
+  }
   const rosterIds = (roster || []).map((u) => u.id);
   const startBody = {
     units: [...(roster || []), ...(enemies || [])],

--- a/tools/sim/move-terrain-hazard-probe.js
+++ b/tools/sim/move-terrain-hazard-probe.js
@@ -21,6 +21,7 @@ const { createApp } = require('../../apps/backend/app');
 const { runEncounter } = require('./combat-adapter');
 
 process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
 
 function supertestHttp(app) {
   return {

--- a/tools/sim/move-terrain-n40-probe.js
+++ b/tools/sim/move-terrain-n40-probe.js
@@ -26,6 +26,7 @@ const { createApp } = require('../../apps/backend/app');
 const { runEncounter } = require('./combat-adapter');
 
 process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
 
 function supertestHttp(app) {
   return {


### PR DESCRIPTION
## Summary

Resolves 6 confirmed Codex P2 findings on already-merged PRs. FIX 7 (trait-reference.json) was investigated and confirmed false-positive (see below).

---

### FIX 1 — `scripts/generate_derived_analysis.py` (PR #3042)
**Verified real.** Line ~228 rendered `{ANALYSIS_ROOT / 'manifest.json'}` via Python `Path.__str__()`, which produces OS-native separators (backslashes on Windows). Wrapped as `{(ANALYSIS_ROOT / 'manifest.json').as_posix()}` for reproducible forward-slash output cross-platform.

### FIX 2 — `tools/sim/move-terrain-n40-probe.js` + `move-terrain-hazard-probe.js` (PR #3038/#3056)
**Verified real in both files.** Both probes set `IDEA_ENGINE_DISABLE_STATUS_REFRESH` but omit `IDEA_ENGINE_STUB_ORCHESTRATOR`, spawning up to 80 app instances with live Python worker pools. Added `process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1'` alongside the existing env var in both files.

### FIX 3 — `tools/sim/combat-adapter.js` (PR #3038)
**Verified real.** `runEncounter()` accepted both `terrainFeatures` (inline grid) and `scenarioId` (encounter YAML path) simultaneously with no guard. `session.js` skips `encounterLoader` when `body.encounter` is truthy, silently dropping objectives. Added mutual-exclusion guard at the top of the function. Existing probes pass only one parameter; they remain unaffected.

### FIX 4 — `tools/py/gen_retired_creature_lore_drafts.py` (PR #3056)
**Verified real.** `--out-dir` accepted `data/codex/` directly, bypassing the HITL promote gate (`tools/js/promote_codex_draft.js`). Added a resolved-path equality check: if `out_dir.resolve() == PROMOTED_DIR.resolve()`, exits with error 1 and a descriptive message.

### FIX 5 — `tools/py/gen_retired_creature_lore_drafts.py` (PR #3056)
**Verified real.** Existing drafts were overwritten unconditionally, clobbering master-dd manual edits. Added `--force` flag (default `False`); without it, a SKIP message is printed and the existing draft is preserved.

### FIX 6 — `data/traits/index.json` + `tools/py/author_appendix_a_variant_traits.py` (PR #3036)
**Verified real (hand-edit + generator fix).** `author_appendix_a_variant_traits.py`'s `index_entry()` wrote per-file `data/traits/<cat>/*_2.json` with `data_origin` + `completion_flags` but omitted both from the `data/traits/index.json` aggregate. All 9 `_2` entries were schema-incomplete in the index. Hand-patched the 9 entries with the correct values copied from per-file JSONs (`appendix_a_variant_deep_research_grounded` / `{design_stub: true}`). Also fixed `index_entry()` in the generator so future `--write` runs produce parity-consistent output. **Hand-edit rationale**: the script regeneration path (`--write`) is gated on species YAMLs and documented as dangerous to re-run on a dev checkout (note in `build_species_trait_bridge.py`); patching the committed file + the generator is the safe path.

### FIX 7 — `docs/evo-tactics-pack/trait-reference.json` (PR #3036) — FALSE POSITIVE
**Not applied.** Investigation confirmed: `trait-reference.json` (174 traits) is the RFC#4 Game-Database export (`9bd883be`), a curated pack mirror. Zero `design_stub=True` traits appear in it by design — the 9 `_2` variants are `design_stub: true` and intentionally excluded. Running `npm run sync:evo-pack` would not add them; it only copies the pack mirror from `packs/evo_tactics_pack/docs/catalog/trait_reference.json`, which also excludes design stubs. The `_2` traits are correctly in `data/traits/index.json` (primary source) after FIX 6.

---

## Test plan

- [x] `python3 -m pytest tests/scripts/ -k "derived or trace" -q` — 243 passed
- [x] `node --test tests/scripts/sync_evo_pack_assets.test.js` — 3 passed
- [x] `python3 tools/py/game_cli.py validate-datasets` — all valid, 3 warnings (pre-existing)
- [x] `npm run format:check` (touched JS/JSON files) — all OK
- [x] Commit hooks (lint-staged/prettier) passed on JS/JSON commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)