### PR TITLE
feat(combat): loadable lava-wall encounter to exercise volo grades (flag OFF)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2067,6 +2067,23 @@ function createSessionRouter(options = {}) {
       // each character → unit with owner_id = player_id. Enemies from scenario
       // appended via req.body.units. Both coexist: characters first, then
       // units (scenario enemies) appended.
+      // Pre-resolve encounter grid bounds from the inline encounter payload (available
+      // immediately from req.body) so normaliseUnitsPayload can clamp positions against
+      // the DECLARED grid rather than the fixed GRID_SIZE default. This fixes units on
+      // grids larger than GRID_SIZE (e.g. 8x8 encounter: unit.x=7 was clamped to 5).
+      // Backward-compat: no encounter grid -> bounds=null -> GRID_SIZE-1 as before.
+      // Note: the encounter_id YAML path loads the encounter later (line ~2363); units
+      // on encounter_id-only requests that sit within GRID_SIZE are unaffected. If an
+      // encounter_id path needs extended bounds, the caller should also pass the inline
+      // encounter.grid OR the scenario JS should supply units within GRID_SIZE.
+      const _inlineGrid = req.body?.encounter?.grid;
+      const _normBounds =
+        _inlineGrid &&
+        Number.isFinite(Number(_inlineGrid.width)) &&
+        Number.isFinite(Number(_inlineGrid.height))
+          ? { width: Number(_inlineGrid.width), height: Number(_inlineGrid.height) }
+          : null;
+
       let characterUnits = [];
       if (Array.isArray(req.body?.characters) && req.body.characters.length > 0) {
         const { characterToUnit } = require('../services/coop/coopOrchestrator');
@@ -2074,13 +2091,13 @@ function createSessionRouter(options = {}) {
           .map((ch, idx) => characterToUnit(ch, { index: idx }))
           .filter(Boolean);
       }
-      const scenarioUnits = normaliseUnitsPayload(req.body?.units);
+      const scenarioUnits = normaliseUnitsPayload(req.body?.units, _normBounds);
       // If character path used, filter out any default player units from
       // scenarioUnits to avoid duplicates (keep only sistema-controlled).
       let units;
       if (characterUnits.length > 0) {
         const scenarioEnemies = scenarioUnits.filter((u) => u && u.controlled_by === 'sistema');
-        units = [...normaliseUnitsPayload(characterUnits), ...scenarioEnemies];
+        units = [...normaliseUnitsPayload(characterUnits, _normBounds), ...scenarioEnemies];
       } else {
         units = scenarioUnits;
       }

--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -28,22 +28,29 @@ function rollD20(rng) {
   return Math.floor(rng() * 20) + 1;
 }
 
-function clampPosition(x, y) {
+// bounds is optional { width, height }. When provided (e.g. from an 8x8 encounter),
+// clamp against the declared grid instead of the fixed GRID_SIZE fallback.
+// Backward-compat: absent/null bounds -> GRID_SIZE-1 exactly as before.
+function clampPosition(x, y, bounds) {
+  const maxX = bounds && Number.isFinite(bounds.width) ? bounds.width - 1 : GRID_SIZE - 1;
+  const maxY = bounds && Number.isFinite(bounds.height) ? bounds.height - 1 : GRID_SIZE - 1;
   return {
-    x: Math.min(Math.max(0, Number(x) || 0), GRID_SIZE - 1),
-    y: Math.min(Math.max(0, Number(y) || 0), GRID_SIZE - 1),
+    x: Math.min(Math.max(0, Number(x) || 0), maxX),
+    y: Math.min(Math.max(0, Number(y) || 0), maxY),
   };
 }
 
-function normaliseUnit(raw, fallbackIndex) {
+function normaliseUnit(raw, fallbackIndex, bounds) {
   const input = raw && typeof raw === 'object' ? raw : {};
   const id = String(input.id || `unit_${fallbackIndex + 1}`);
+  const maxX = bounds && Number.isFinite(bounds.width) ? bounds.width - 1 : GRID_SIZE - 1;
+  const maxY = bounds && Number.isFinite(bounds.height) ? bounds.height - 1 : GRID_SIZE - 1;
   const position =
     input.position && typeof input.position === 'object'
-      ? clampPosition(input.position.x, input.position.y)
+      ? clampPosition(input.position.x, input.position.y, bounds)
       : fallbackIndex === 0
         ? { x: 0, y: 0 }
-        : { x: GRID_SIZE - 1, y: GRID_SIZE - 1 };
+        : { x: maxX, y: maxY };
   const traits = Array.isArray(input.traits) ? input.traits.filter(Boolean).map(String) : [];
   const ap = Number.isFinite(Number(input.ap)) ? Number(input.ap) : DEFAULT_AP;
   const job = input.job ? String(input.job) : 'unknown';
@@ -240,11 +247,14 @@ function buildDefaultUnits() {
   ];
 }
 
-function normaliseUnitsPayload(raw) {
+// bounds is optional { width, height } from the encounter's declared grid.
+// Passed through to normaliseUnit -> clampPosition so units on larger grids
+// (e.g. 8x8) are not clamped down to the fixed GRID_SIZE default.
+function normaliseUnitsPayload(raw, bounds) {
   if (!Array.isArray(raw) || raw.length === 0) {
     return buildDefaultUnits();
   }
-  return raw.map((entry, index) => normaliseUnit(entry, index));
+  return raw.map((entry, index) => normaliseUnit(entry, index, bounds));
 }
 
 // TKT-ORPHAN-MORALE: gameplay "colpo critico" threshold. A hit whose margin of

--- a/apps/backend/services/worldgen/desertoCaldoHazardScenario.js
+++ b/apps/backend/services/worldgen/desertoCaldoHazardScenario.js
@@ -1,0 +1,98 @@
+// apps/backend/services/worldgen/desertoCaldoHazardScenario.js
+//
+// Move terrain-cost substrate -- "Bocche Vulcaniche" hazard scenario (2026-06-29).
+//
+// A mixed, volo-graded roster that crosses a full-height lava(x=3)+roccia(x=4) wall on
+// an 8x8 grid, so the substrate's g1/g2/g3 flight grades are EXERCISED in AI play. Path B:
+// volo grade is set EXPLICITLY per unit (volo_grade + adattamento_volo) -- independent of
+// the still-open per-species lift (#3061) and registry-free (normaliseUnit whitelists both).
+// Ground units are heavy-profile (corazzato) so they pay the full wall (lava/roccia 2.0).
+//
+// Sized to RESOLVE (winnable, like move-terrain-hazard-probe.js) -- NOT the adapter-derived
+// pilot rosters that deadlock. Pairs with the loadable encounter file of the same id
+// (docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml carries the terrain
+// for the encounter_id path; this module carries the AI roster).
+//
+// NOT in the gated canonical-suite oracle manifest (mirrors badlands/foresta pilot scenarios).
+
+'use strict';
+
+const VOLO_TRAIT = 'adattamento_volo';
+
+// Full-height lava(x=3)+roccia(x=4) wall on 8x8 -> no detour. Mirrors the encounter file
+// grid.terrain_features so roster + terrain share ONE source across probe and tests.
+function buildTerrain() {
+  const t = [];
+  for (let y = 0; y < 8; y += 1) {
+    t.push({ x: 3, y, type: 'lava' });
+    t.push({ x: 4, y, type: 'roccia' });
+  }
+  return t;
+}
+
+const TERRAIN = buildTerrain();
+
+const SCENARIO = {
+  encounter_id: 'enc_deserto_caldo_bocche_vulcaniche_01',
+  name: 'Bocche Vulcaniche -- Muro di Lava',
+  biome_id: 'deserto_caldo',
+  grid_size: 8,
+  objective: { type: 'elimination' },
+};
+
+function _flyer(id, species, grade, controlled_by, position, initiative) {
+  return {
+    id,
+    species,
+    job: 'skirmisher',
+    hp: 18,
+    max_hp: 18,
+    ap: 3,
+    mod: 6,
+    dc: 11,
+    attack_range: 2,
+    initiative,
+    position,
+    controlled_by,
+    traits: [VOLO_TRAIT],
+    volo_grade: grade,
+    status: {},
+  };
+}
+
+function _ground(id, species, controlled_by, position, initiative) {
+  return {
+    id,
+    species,
+    job: 'vanguard',
+    morphotype: 'corazzato',
+    hp: 20,
+    max_hp: 20,
+    ap: 3,
+    mod: 6,
+    dc: 12,
+    attack_range: 1,
+    initiative,
+    position,
+    controlled_by,
+    traits: [],
+    status: {},
+  };
+}
+
+// Mixed both-sides roster. Players (left, x<3) close on the sistema (right, x>4); both
+// factions field a flyer + a ground unit, so the flag-delta is carried by the ground
+// units (flyers are grade-exempt) while the g1/g2/g3 spread is exercised across the wall.
+function buildUnits() {
+  return [
+    // Player faction
+    _flyer('p_noctule', 'noctule_termico', 3, 'player', { x: 0, y: 2 }, 16),
+    _ground('p_corazza', 'corazza_deserto', 'player', { x: 0, y: 4 }, 14),
+    // Sistema faction
+    _flyer('e_echo', 'echo_wing', 1, 'sistema', { x: 7, y: 2 }, 13),
+    _flyer('e_aurora', 'aurora_gull', 2, 'sistema', { x: 7, y: 3 }, 12),
+    _ground('e_scavenger', 'rust-scavenger', 'sistema', { x: 7, y: 5 }, 10),
+  ];
+}
+
+module.exports = { SCENARIO, TERRAIN, buildUnits, VOLO_TRAIT };

--- a/apps/backend/services/worldgen/desertoCaldoHazardScenario.js
+++ b/apps/backend/services/worldgen/desertoCaldoHazardScenario.js
@@ -40,16 +40,16 @@ const SCENARIO = {
   objective: { type: 'elimination' },
 };
 
-function _flyer(id, species, grade, controlled_by, position, initiative) {
+function _flyer(id, species, grade, controlled_by, position, initiative, stats) {
   return {
     id,
     species,
     job: 'skirmisher',
-    hp: 18,
-    max_hp: 18,
+    hp: stats.hp,
+    max_hp: stats.hp,
     ap: 3,
-    mod: 6,
-    dc: 11,
+    mod: stats.mod,
+    dc: stats.dc,
     attack_range: 2,
     initiative,
     position,
@@ -60,17 +60,17 @@ function _flyer(id, species, grade, controlled_by, position, initiative) {
   };
 }
 
-function _ground(id, species, controlled_by, position, initiative) {
+function _ground(id, species, controlled_by, position, initiative, stats) {
   return {
     id,
     species,
     job: 'vanguard',
     morphotype: 'corazzato',
-    hp: 20,
-    max_hp: 20,
+    hp: stats.hp,
+    max_hp: stats.hp,
     ap: 3,
-    mod: 6,
-    dc: 12,
+    mod: stats.mod,
+    dc: stats.dc,
     attack_range: 1,
     initiative,
     position,
@@ -83,15 +83,30 @@ function _ground(id, species, controlled_by, position, initiative) {
 // Mixed both-sides roster. Players (left, x<3) close on the sistema (right, x>4); both
 // factions field a flyer + a ground unit, so the flag-delta is carried by the ground
 // units (flyers are grade-exempt) while the g1/g2/g3 spread is exercised across the wall.
+// Player-favoured lethality (high mod vs low enemy hp/dc) so the encounter RESOLVES
+// (winnable) instead of stalemating to a 30-round timeout -- the substrate can only be
+// measured on a fight that actually ends (mirrors move-terrain-hazard-probe.js).
 function buildUnits() {
   return [
-    // Player faction
-    _flyer('p_noctule', 'noctule_termico', 3, 'player', { x: 0, y: 2 }, 16),
-    _ground('p_corazza', 'corazza_deserto', 'player', { x: 0, y: 4 }, 14),
-    // Sistema faction
-    _flyer('e_echo', 'echo_wing', 1, 'sistema', { x: 7, y: 2 }, 13),
-    _flyer('e_aurora', 'aurora_gull', 2, 'sistema', { x: 7, y: 3 }, 12),
-    _ground('e_scavenger', 'rust-scavenger', 'sistema', { x: 7, y: 5 }, 10),
+    // Player faction (strong: clears the enemy in a handful of rounds -> resolves)
+    _flyer('p_noctule', 'noctule_termico', 3, 'player', { x: 0, y: 2 }, 16, {
+      hp: 22,
+      mod: 9,
+      dc: 12,
+    }),
+    _ground('p_corazza', 'corazza_deserto', 'player', { x: 0, y: 4 }, 14, {
+      hp: 26,
+      mod: 9,
+      dc: 13,
+    }),
+    // Sistema faction (weaker: killable, but still crosses + fights)
+    _flyer('e_echo', 'echo_wing', 1, 'sistema', { x: 7, y: 2 }, 13, { hp: 9, mod: 3, dc: 10 }),
+    _flyer('e_aurora', 'aurora_gull', 2, 'sistema', { x: 7, y: 3 }, 12, { hp: 9, mod: 3, dc: 10 }),
+    _ground('e_scavenger', 'rust-scavenger', 'sistema', { x: 7, y: 5 }, 10, {
+      hp: 10,
+      mod: 3,
+      dc: 10,
+    }),
   ];
 }
 

--- a/docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml
+++ b/docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml
@@ -1,0 +1,68 @@
+# Encounter: "Bocche Vulcaniche -- Muro di Lava" (deserto_caldo)
+# Esercita la move terrain-cost substrate: muro full-height lava(x=3)+roccia(x=4)
+# su 8x8 -> nessuna deviazione. I volatori graduati lo attraversano (g1 paga ancora
+# la lava, g2 la dimezza, g3 la azzera); i terrestri pagano il muro pieno.
+# Il flag MOVE_TERRAIN_COST_ENABLED resta OFF -> band-neutral (Manhattan).
+# Il roster AI-giocato vive in services/worldgen/desertoCaldoHazardScenario.js
+# (le waves qui sono flavour/objective per il path encounter_id loadable).
+# Schema: schemas/evo/encounter.schema.json (grid.terrain_features est. 2026-06-29)
+encounter_id: enc_deserto_caldo_bocche_vulcaniche_01
+name: 'Bocche Vulcaniche -- Muro di Lava'
+biome_id: deserto_caldo
+grid_size: [8, 8]
+difficulty_rating: 2
+estimated_turns: 16
+encounter_class: standard
+
+objective:
+  type: elimination
+
+player_spawn:
+  - [0, 2]
+  - [0, 3]
+  - [0, 4]
+  - [0, 5]
+
+grid:
+  width: 8
+  height: 8
+  terrain_features:
+    - { x: 3, y: 0, type: lava, defense_mod: 0 }
+    - { x: 3, y: 1, type: lava, defense_mod: 0 }
+    - { x: 3, y: 2, type: lava, defense_mod: 0 }
+    - { x: 3, y: 3, type: lava, defense_mod: 0 }
+    - { x: 3, y: 4, type: lava, defense_mod: 0 }
+    - { x: 3, y: 5, type: lava, defense_mod: 0 }
+    - { x: 3, y: 6, type: lava, defense_mod: 0 }
+    - { x: 3, y: 7, type: lava, defense_mod: 0 }
+    - { x: 4, y: 0, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 1, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 2, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 3, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 4, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 5, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 6, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 7, type: roccia, defense_mod: 2 }
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [7, 3]
+      - [7, 4]
+    units:
+      - species: aurora_gull
+        count: 1
+        tier: base
+        ai_profile: aggressive
+      - species: rust-scavenger
+        count: 2
+        tier: base
+        ai_profile: defensive
+
+conditions: []
+tags: [standard]
+
+didactic_focus:
+  - move_terrain_cost
+  - volo_traversal

--- a/docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md
+++ b/docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md
@@ -1,0 +1,76 @@
+---
+title: 'Volo hazard encounter -- N=40 band evidence (bocche vulcaniche)'
+date: 2026-06-29
+doc_status: active
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-06-29'
+source_of_truth: false
+review_cycle_days: 90
+tags: [combat, move-terrain, volo, hazard, n40, evidence]
+---
+
+# Volo hazard encounter -- N=40 band evidence
+
+Content under test: `docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml`
+(loadable, full-height lava(x=3)+roccia(x=4) wall on 8x8) + the mixed volo-graded roster
+`apps/backend/services/worldgen/desertoCaldoHazardScenario.js` (player g3 flyer + heavy
+ground; sistema g1 + g2 flyers + ground). Flag `MOVE_TERRAIN_COST_ENABLED` stays OFF in prod;
+this measures the worst case (flag flipped ON) for flip-safety.
+
+## 1. N=40 ON-vs-OFF band (paired-seed, in-process, node 22)
+
+Probe: `tools/sim/move-terrain-hazard-encounter-probe.js 40 1.0`.
+
+```json
+{
+  "N": 40,
+  "scenario": "bocche-vulcaniche (lava x3 + roccia x4, mixed volo roster, 8x8)",
+  "flag_on":  { "wins": 39, "defeats": 0, "timeouts": 1, "win_rate": 0.975, "avg_rounds": 24.52 },
+  "flag_off": { "wins": 39, "defeats": 0, "timeouts": 1, "win_rate": 0.975, "avg_rounds": 24.52 },
+  "wr_delta": 0,
+  "avg_rounds_delta": 0,
+  "node": "v22.22.3"
+}
+```
+
+The encounter RESOLVES (39/40 wins, not a timeout-null) and the flip is band-NEUTRAL
+(wr_delta 0, rounds_delta 0).
+
+## 2. Deterministic cost ladder (the "exercised" proof)
+
+`tests/services/combat/voloHazardEncounterCost.test.js` loads the encounter's real
+`grid.terrain_features` and computes the wall-crossing cost (heavy profile), per grade:
+
+| grade | lava | roccia | default | crossing cost |
+|-------|------|--------|---------|---------------|
+| g0 (no volo) | 2.0 | 2.0 | 1.0 | 5.0 |
+| g1 | 2.0 | 1.0 | 1.0 | 4.0 |
+| g2 | 1.5 | 1.0 | 1.0 | 3.5 |
+| g3 | 1.0 | 1.0 | 1.0 | 3.0 |
+
+Strictly decreasing g0 > g1 > g2 > g3. The grades fire on this content (g1 frees the roccia,
+g2 halves the lava, g3 frees the lava).
+
+## 3. AI crossing witness (volo advantage manifests in play)
+
+A single instrumented AI run (seed 3, flag ON) over the loaded terrain: the g3 flyer
+(`p_noctule`) crosses the lava wall (reaches x=4, having stepped over the x=3 lava column)
+and engages; identical ON vs OFF (g3 frees lava == Manhattan). The heavy ground unit
+(`p_corazza`) holds back -- an AI-policy artifact (the flyer carries the fight), not a
+substrate effect.
+
+## 4. Reading
+
+The substrate FIRES on this content -- the g3 flyer crosses the hazard wall, and the cost
+ladder (sec.2) proves the grade differential -- but the flip is outcome-NEUTRAL: g3 makes
+lava free (== Manhattan), and the grade-paying combatants are not on the critical path of a
+flyer-decided fight. This confirms the canonical finding: the move terrain-cost substrate is
+a terrain-DESIGN lever (flyers get a real traversal edge over hazard), NOT a passive win-rate
+shifter. Flip-safe.
+
+Caveat (SDMG): WR sits at a ceiling (0.975, player-favoured to guarantee resolution), so this
+reads as "the flip does not break a winnable fight" rather than a neutral measurement at a 50%
+margin; the roster is hand-built (direction probe, not a prod-balanced encounter); the heavy
+ground unit idles under the greedy policy. Band ratification (and any prod flip of
+`MOVE_TERRAIN_COST_ENABLED`) remains owner-gated -- this is band evidence only.

--- a/docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md
+++ b/docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md
@@ -22,12 +22,20 @@ this measures the worst case (flag flipped ON) for flip-safety.
 
 Probe: `tools/sim/move-terrain-hazard-encounter-probe.js 40 1.0`.
 
+**Engine fix note**: the original N=40 run (avg_rounds 24.52) was measured with a bug in
+`clampPosition` (sessionHelpers.js ~line 31) that clamped all unit x/y positions to
+`GRID_SIZE-1` (=5) regardless of the encounter's declared grid. Units authored at x=7
+(right edge of the 8x8 grid) were silently moved to x=5, meaning the probe was effectively
+running on a 6-wide grid. The fix (`normaliseUnit`/`normaliseUnitsPayload` now accept an
+optional `bounds` parameter threaded from `req.body.encounter.grid` at `/start`) restores
+the authored 8x8 geometry. Numbers below are from the corrected run.
+
 ```json
 {
   "N": 40,
   "scenario": "bocche-vulcaniche (lava x3 + roccia x4, mixed volo roster, 8x8)",
-  "flag_on":  { "wins": 39, "defeats": 0, "timeouts": 1, "win_rate": 0.975, "avg_rounds": 24.52 },
-  "flag_off": { "wins": 39, "defeats": 0, "timeouts": 1, "win_rate": 0.975, "avg_rounds": 24.52 },
+  "flag_on":  { "wins": 39, "defeats": 0, "timeouts": 1, "win_rate": 0.975, "avg_rounds": 25.07 },
+  "flag_off": { "wins": 39, "defeats": 0, "timeouts": 1, "win_rate": 0.975, "avg_rounds": 25.07 },
   "wr_delta": 0,
   "avg_rounds_delta": 0,
   "node": "v22.22.3"
@@ -35,7 +43,9 @@ Probe: `tools/sim/move-terrain-hazard-encounter-probe.js 40 1.0`.
 ```
 
 The encounter RESOLVES (39/40 wins, not a timeout-null) and the flip is band-NEUTRAL
-(wr_delta 0, rounds_delta 0).
+(wr_delta 0, rounds_delta 0). avg_rounds is slightly higher than the pre-fix run (25.07
+vs 24.52) -- expected: units now start at their authored right-edge positions (x=7),
+adding ~1 tile of crossing distance.
 
 ## 2. Deterministic cost ladder (the "exercised" proof)
 

--- a/docs/superpowers/plans/2026-06-29-hazard-terrain-encounter-volo-exercise.md
+++ b/docs/superpowers/plans/2026-06-29-hazard-terrain-encounter-volo-exercise.md
@@ -1,0 +1,791 @@
+# Hazard-terrain Encounter (volo grades exercise) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Author a loadable lava-wall encounter + a volo-graded mixed roster so the move terrain-cost substrate's g2/g3 flight grades are EXERCISED (not latent), with a deterministic g0>g1>g2>g3 cost proof and an N=40 hazard band probe. Flag `MOVE_TERRAIN_COST_ENABLED` stays OFF.
+
+**Architecture:** Five isolated units -- (0) additive `grid.terrain_features` extension to `encounter.schema.json`; (1) a loadable `docs/planning/encounters/` YAML whose `grid.terrain_features` reaches the runtime grid via `encounter_id`; (2) a reusable JS scenario module that hand-builds a mixed volo-graded roster (Path B: explicit `volo_grade` + `adattamento_volo`); (3) a deterministic moveCost test proving the cost ladder on the encounter's real terrain; (4) an N=40 paired-seed hazard probe + evidence report.
+
+**Tech Stack:** Node 18+/22 (`node --test`), js-yaml, AJV 2020, supertest (in-process Express). Pure combat modules `moveCost.js`/`movementResolver.js`/`movementProfiles.js` (already merged).
+
+---
+
+## File structure
+
+| File                                                                            | Responsibility                                                                                                           |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `schemas/evo/encounter.schema.json` (modify)                                    | Add optional `grid` object (`width`/`height`/`terrain_features`). Backward-compatible. **Guardrail path -- flag in PR.** |
+| `tests/services/combat/encounterGridSchema.test.js` (create)                    | TDD red->green for the schema extension (a grid-bearing encounter validates).                                            |
+| `docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml` (create) | Loadable lava-wall encounter (deserto_caldo, 8x8, full lava+roccia wall).                                                |
+| `apps/backend/services/worldgen/desertoCaldoHazardScenario.js` (create)         | Reusable mixed roster (Path B volo grades) + TERRAIN + SCENARIO meta + `buildUnits()`.                                   |
+| `tests/services/worldgen/desertoCaldoHazardScenario.test.js` (create)           | Unit test: flyers carry `volo_grade`+`adattamento_volo`; ground don't; TERRAIN is the wall.                              |
+| `tests/services/combat/voloHazardEncounterCost.test.js` (create)                | Deterministic cost ladder g0>g1>g2>g3 on the encounter's real terrain.                                                   |
+| `tools/sim/move-terrain-hazard-encounter-probe.js` (create)                     | N=40 paired-seed ON-vs-OFF band probe using the scenario module.                                                         |
+| `docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md` (create)       | Probe evidence (band ratify = master-dd, NOT in this PR).                                                                |
+
+---
+
+## Task 0: Additive `grid.terrain_features` schema extension
+
+**Files:**
+
+- Create: `tests/services/combat/encounterGridSchema.test.js`
+- Modify: `schemas/evo/encounter.schema.json` (add `grid` property after `grid_size`)
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/services/combat/encounterGridSchema.test.js
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Ajv = require('ajv/dist/2020');
+
+const SCHEMA_PATH = path.join(__dirname, '../../../schemas/evo/encounter.schema.json');
+
+function makeValidator() {
+  const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  return ajv.compile(schema);
+}
+
+const baseEncounter = {
+  encounter_id: 'enc_grid_fixture',
+  name: 'Grid Fixture',
+  biome_id: 'deserto_caldo',
+  grid_size: [8, 8],
+  objective: { type: 'elimination' },
+  player_spawn: [[0, 0]],
+  waves: [
+    { wave_id: 1, turn_trigger: 0, spawn_points: [[7, 7]], units: [{ species: 'x', count: 1 }] },
+  ],
+  difficulty_rating: 3,
+};
+
+test('encounter schema accepts grid.terrain_features (lava)', () => {
+  const validate = makeValidator();
+  const data = {
+    ...baseEncounter,
+    grid: {
+      width: 8,
+      height: 8,
+      terrain_features: [
+        { x: 3, y: 0, type: 'lava', defense_mod: 0 },
+        { x: 4, y: 0, type: 'roccia', defense_mod: 2 },
+      ],
+    },
+  };
+  const valid = validate(data);
+  assert.ok(valid, JSON.stringify(validate.errors));
+});
+
+test('encounter schema rejects an unknown terrain type', () => {
+  const validate = makeValidator();
+  const data = {
+    ...baseEncounter,
+    grid: { width: 8, height: 8, terrain_features: [{ x: 1, y: 1, type: 'plasma' }] },
+  };
+  assert.equal(validate(data), false);
+});
+
+test('encounter schema still accepts an encounter with NO grid key (backward-compat)', () => {
+  const validate = makeValidator();
+  assert.ok(validate({ ...baseEncounter }), JSON.stringify(validate.errors));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/services/combat/encounterGridSchema.test.js`
+Expected: FAIL -- the first test fails (`additionalProperties` rejects `grid`).
+
+- [ ] **Step 3: Add the `grid` property to the schema**
+
+In `schemas/evo/encounter.schema.json`, inside `"properties"`, immediately after the `"grid_size"` block, insert:
+
+```json
+    "grid": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional terrain grid for the move terrain-cost substrate (move-terrain spec 2026-06-23). grid_size stays the authoritative board bounds; terrain_features carries per-tile types read by moveCost (flag MOVE_TERRAIN_COST_ENABLED, default OFF -> Manhattan, band-neutral).",
+      "properties": {
+        "width": { "type": "integer", "minimum": 4, "maximum": 20 },
+        "height": { "type": "integer", "minimum": 4, "maximum": 20 },
+        "terrain_features": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["x", "y", "type"],
+            "additionalProperties": false,
+            "properties": {
+              "x": { "type": "integer", "minimum": 0 },
+              "y": { "type": "integer", "minimum": 0 },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "roccia",
+                  "sabbia",
+                  "acqua_profonda",
+                  "vegetazione_densa",
+                  "ghiaccio",
+                  "lava",
+                  "radura",
+                  "default"
+                ]
+              },
+              "defense_mod": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/services/combat/encounterGridSchema.test.js`
+Expected: PASS (3/3).
+
+- [ ] **Step 5: Confirm no existing encounter regressed**
+
+Run: `node --test tests/scripts/encounterSchema.test.js`
+Expected: PASS (all existing `enc_*.yaml` still validate -- the `grid` key is optional).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add schemas/evo/encounter.schema.json tests/services/combat/encounterGridSchema.test.js
+git commit -F .commitmsg.tmp   # see Commit Convention section
+```
+
+---
+
+## Task 1: Loadable lava-wall encounter YAML
+
+**Files:**
+
+- Create: `docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml`
+- Test: `tests/scripts/encounterSchema.test.js` (auto-discovers) + `tools/js/validate_encounter_difficulty.js`
+
+- [ ] **Step 1: Write the encounter file**
+
+The lava wall is full-height (x=3 lava, x=4 roccia, y=0..7) so there is NO detour -- every left->right path crosses lava+roccia. Spawns are on the left (players) / right (handled by waves as flavor; the AI roster for play comes from the scenario module in Task 2).
+
+```yaml
+# Encounter: "Bocche Vulcaniche -- Muro di Lava" (deserto_caldo)
+# Esercita la move terrain-cost substrate: muro full-height lava(x=3)+roccia(x=4)
+# su 8x8 -> nessuna deviazione. I volatori graduati lo attraversano (g1 paga ancora
+# la lava, g2 la dimezza, g3 la azzera); i terrestri pagano il muro pieno.
+# Il flag MOVE_TERRAIN_COST_ENABLED resta OFF -> band-neutral (Manhattan).
+# Il roster AI-giocato vive in services/worldgen/desertoCaldoHazardScenario.js
+# (le waves qui sono flavour/objective per il path encounter_id loadable).
+# Schema: schemas/evo/encounter.schema.json (grid.terrain_features est. 2026-06-29)
+encounter_id: enc_deserto_caldo_bocche_vulcaniche_01
+name: 'Bocche Vulcaniche -- Muro di Lava'
+biome_id: deserto_caldo
+grid_size: [8, 8]
+difficulty_rating: 3
+estimated_turns: 16
+encounter_class: standard
+
+objective:
+  type: elimination
+
+player_spawn:
+  - [0, 2]
+  - [0, 3]
+  - [0, 4]
+  - [0, 5]
+
+grid:
+  width: 8
+  height: 8
+  terrain_features:
+    - { x: 3, y: 0, type: lava, defense_mod: 0 }
+    - { x: 3, y: 1, type: lava, defense_mod: 0 }
+    - { x: 3, y: 2, type: lava, defense_mod: 0 }
+    - { x: 3, y: 3, type: lava, defense_mod: 0 }
+    - { x: 3, y: 4, type: lava, defense_mod: 0 }
+    - { x: 3, y: 5, type: lava, defense_mod: 0 }
+    - { x: 3, y: 6, type: lava, defense_mod: 0 }
+    - { x: 3, y: 7, type: lava, defense_mod: 0 }
+    - { x: 4, y: 0, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 1, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 2, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 3, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 4, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 5, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 6, type: roccia, defense_mod: 2 }
+    - { x: 4, y: 7, type: roccia, defense_mod: 2 }
+
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [7, 3]
+      - [7, 4]
+    units:
+      - species: aurora_gull
+        count: 1
+        tier: base
+        ai_profile: aggressive
+      - species: rust-scavenger
+        count: 2
+        tier: base
+        ai_profile: defensive
+
+conditions: []
+tags: [standard]
+
+didactic_focus:
+  - move_terrain_cost
+  - volo_traversal
+```
+
+- [ ] **Step 2: Run schema validation**
+
+Run: `node --test tests/scripts/encounterSchema.test.js`
+Expected: PASS -- a new line `encounter enc_deserto_caldo_bocche_vulcaniche_01.yaml validates against schema`.
+
+- [ ] **Step 3: Run the difficulty validator**
+
+Run: `node tools/js/validate_encounter_difficulty.js`
+Expected: `errors=0`. If the new row shows `delta > 2`, adjust `difficulty_rating` to the printed `computed` value (within 1) and re-run until `errors=0`. (The validator only errors on drift > 2 stars.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml
+git commit -F .commitmsg.tmp
+```
+
+---
+
+## Task 2: Mixed volo-graded scenario module
+
+**Files:**
+
+- Create: `apps/backend/services/worldgen/desertoCaldoHazardScenario.js`
+- Test: `tests/services/worldgen/desertoCaldoHazardScenario.test.js`
+
+The roster is MIXED (master-dd verdict C): flyers + ground on both factions. Path B -- `volo_grade` and `traits:['adattamento_volo']` are set explicitly on flyers (so it is independent of the still-OPEN #3061 species->unit lift). Ground units carry `morphotype:'corazzato'` so the move-gate resolves them to the heavy profile (mirrors the proven `move-terrain-hazard-probe.js`).
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/services/worldgen/desertoCaldoHazardScenario.test.js
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildUnits,
+  TERRAIN,
+  SCENARIO,
+} = require('../../../apps/backend/services/worldgen/desertoCaldoHazardScenario');
+
+test('SCENARIO carries the loadable encounter_id + 8x8 grid', () => {
+  assert.equal(SCENARIO.encounter_id, 'enc_deserto_caldo_bocche_vulcaniche_01');
+  assert.equal(SCENARIO.grid_size, 8);
+});
+
+test('TERRAIN is the full-height lava(x=3)+roccia(x=4) wall', () => {
+  const lava = TERRAIN.filter((t) => t.type === 'lava');
+  const roccia = TERRAIN.filter((t) => t.type === 'roccia');
+  assert.equal(lava.length, 8);
+  assert.equal(roccia.length, 8);
+  assert.ok(lava.every((t) => t.x === 3));
+  assert.ok(roccia.every((t) => t.x === 4));
+});
+
+test('flyers carry an explicit volo_grade + adattamento_volo; grades cover g1/g2/g3', () => {
+  const units = buildUnits();
+  const flyers = units.filter(
+    (u) => Array.isArray(u.traits) && u.traits.includes('adattamento_volo'),
+  );
+  assert.equal(flyers.length, 3);
+  for (const f of flyers) {
+    assert.ok([1, 2, 3].includes(f.volo_grade), `bad grade ${f.volo_grade}`);
+  }
+  const grades = flyers.map((f) => f.volo_grade).sort();
+  assert.deepEqual(grades, [1, 2, 3]);
+});
+
+test('roster is mixed on both factions (player + sistema each have a flyer and a ground unit)', () => {
+  const units = buildUnits();
+  for (const side of ['player', 'sistema']) {
+    const sideUnits = units.filter((u) => u.controlled_by === side);
+    const hasFlyer = sideUnits.some((u) => (u.traits || []).includes('adattamento_volo'));
+    const hasGround = sideUnits.some((u) => !(u.traits || []).includes('adattamento_volo'));
+    assert.ok(hasFlyer, `${side} has no flyer`);
+    assert.ok(hasGround, `${side} has no ground unit`);
+  }
+});
+
+test('ground units are heavy-profile (morphotype corazzato) and carry no volo_grade', () => {
+  const units = buildUnits();
+  const ground = units.filter((u) => !(u.traits || []).includes('adattamento_volo'));
+  assert.ok(ground.length >= 3);
+  for (const g of ground) {
+    assert.equal(g.morphotype, 'corazzato');
+    assert.equal(g.volo_grade, undefined);
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/services/worldgen/desertoCaldoHazardScenario.test.js`
+Expected: FAIL with "Cannot find module ... desertoCaldoHazardScenario".
+
+- [ ] **Step 3: Write the scenario module**
+
+```javascript
+// apps/backend/services/worldgen/desertoCaldoHazardScenario.js
+//
+// Move terrain-cost substrate -- "Bocche Vulcaniche" hazard scenario (2026-06-29).
+//
+// A mixed, volo-graded roster that crosses a full-height lava(x=3)+roccia(x=4) wall on
+// an 8x8 grid, so the substrate's g1/g2/g3 flight grades are EXERCISED in AI play. Path B:
+// volo grade is set EXPLICITLY per unit (volo_grade + adattamento_volo) -- independent of
+// the still-open per-species lift (#3061) and registry-free (normaliseUnit whitelists both).
+// Ground units are heavy-profile (corazzato) so they pay the full wall (lava/roccia 2.0).
+//
+// Sized to RESOLVE (winnable, like move-terrain-hazard-probe.js) -- NOT the adapter-derived
+// pilot rosters that deadlock. Pairs with the loadable encounter file of the same id
+// (the file carries the terrain for the encounter_id path; this module carries the AI roster).
+//
+// NOT in the gated canonical-suite oracle manifest (mirrors badlands/foresta pilot scenarios).
+
+'use strict';
+
+const VOLO_TRAIT = 'adattamento_volo';
+
+// Full-height lava(x=3)+roccia(x=4) wall on 8x8 -> no detour. Mirrors the encounter file
+// docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml grid.terrain_features.
+function buildTerrain() {
+  const t = [];
+  for (let y = 0; y < 8; y += 1) {
+    t.push({ x: 3, y, type: 'lava' });
+    t.push({ x: 4, y, type: 'roccia' });
+  }
+  return t;
+}
+
+const TERRAIN = buildTerrain();
+
+const SCENARIO = {
+  encounter_id: 'enc_deserto_caldo_bocche_vulcaniche_01',
+  name: 'Bocche Vulcaniche -- Muro di Lava',
+  biome_id: 'deserto_caldo',
+  grid_size: 8,
+  objective: { type: 'elimination' },
+};
+
+function _flyer(id, species, grade, controlled_by, position, initiative) {
+  return {
+    id,
+    species,
+    job: 'skirmisher',
+    hp: 18,
+    max_hp: 18,
+    ap: 3,
+    mod: 6,
+    dc: 11,
+    attack_range: 2,
+    initiative,
+    position,
+    controlled_by,
+    traits: [VOLO_TRAIT],
+    volo_grade: grade,
+    status: {},
+  };
+}
+
+function _ground(id, species, controlled_by, position, initiative) {
+  return {
+    id,
+    species,
+    job: 'vanguard',
+    morphotype: 'corazzato',
+    hp: 20,
+    max_hp: 20,
+    ap: 3,
+    mod: 6,
+    dc: 12,
+    attack_range: 1,
+    initiative,
+    position,
+    controlled_by,
+    traits: [],
+    status: {},
+  };
+}
+
+// Mixed both-sides roster. Players (left, x<3) close on the sistema (right, x>4); both
+// factions field a flyer + a ground unit, so the flag-delta is carried by the ground
+// units (flyers are grade-exempt) while the g1/g2/g3 spread is exercised across the wall.
+function buildUnits() {
+  return [
+    // Player faction
+    _flyer('p_noctule', 'noctule_termico', 3, 'player', { x: 0, y: 2 }, 16),
+    _ground('p_corazza', 'corazza_deserto', 'player', { x: 0, y: 4 }, 14),
+    // Sistema faction
+    _flyer('e_echo', 'echo_wing', 1, 'sistema', { x: 7, y: 2 }, 13),
+    _flyer('e_aurora', 'aurora_gull', 2, 'sistema', { x: 7, y: 3 }, 12),
+    _ground('e_scavenger', 'rust-scavenger', 'sistema', { x: 7, y: 5 }, 10),
+  ];
+}
+
+module.exports = { SCENARIO, TERRAIN, buildUnits, VOLO_TRAIT };
+```
+
+Note: the player faction has 1 flyer (g3) + 1 ground; the sistema faction has 2 flyers (g1, g2) + 1 ground. This satisfies "mixed both sides" (each side has a flyer and a ground unit) AND spreads g1/g2/g3 across the roster.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test tests/services/worldgen/desertoCaldoHazardScenario.test.js`
+Expected: PASS (5/5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/backend/services/worldgen/desertoCaldoHazardScenario.js tests/services/worldgen/desertoCaldoHazardScenario.test.js
+git commit -F .commitmsg.tmp
+```
+
+---
+
+## Task 3: Deterministic cost-ladder test on the encounter's real terrain
+
+**Files:**
+
+- Create: `tests/services/combat/voloHazardEncounterCost.test.js`
+
+Loads the actual encounter file (via `loadEncounter`), builds `terrainAt` from its `grid.terrain_features`, and asserts the cost to cross the wall is strictly decreasing g0>g1>g2>g3 for a heavy profile. This is the core proof that the substrate fires on THIS content. Deterministic, no flag, no sim.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// tests/services/combat/voloHazardEncounterCost.test.js
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadEncounter,
+  _resetCache,
+} = require('../../../apps/backend/services/combat/encounterLoader');
+const {
+  moveCost,
+  terrainAtFromFeatures,
+} = require('../../../apps/backend/services/combat/moveCost');
+const { getProfile } = require('../../../apps/backend/services/combat/movementProfiles');
+const { applyVoloGrade } = require('../../../apps/backend/services/combat/movementResolver');
+
+const ENC_ID = 'enc_deserto_caldo_bocche_vulcaniche_01';
+
+function setup() {
+  _resetCache();
+  const enc = loadEncounter(ENC_ID);
+  assert.ok(enc, `${ENC_ID} not loadable`);
+  assert.ok(
+    enc.grid && Array.isArray(enc.grid.terrain_features),
+    'encounter has no grid.terrain_features',
+  );
+  const terrainAt = terrainAtFromFeatures(enc.grid.terrain_features);
+  const bounds = { width: enc.grid.width, height: enc.grid.height };
+  const heavy = getProfile('heavy');
+  // Cross the wall on row y=4: enter (3,4)=lava, (4,4)=roccia, (5,4)=default.
+  const cost = (g) =>
+    moveCost(
+      { x: 2, y: 4 },
+      { x: 5, y: 4 },
+      g > 0 ? applyVoloGrade(heavy, g) : heavy,
+      terrainAt,
+      bounds,
+    );
+  return { cost, terrainAt };
+}
+
+test('the encounter terrain is the lava(x=3)+roccia(x=4) wall', () => {
+  const { terrainAt } = setup();
+  assert.equal(terrainAt(3, 4), 'lava');
+  assert.equal(terrainAt(4, 4), 'roccia');
+  assert.equal(terrainAt(5, 4), null); // default
+});
+
+test('crossing cost is strictly decreasing g0 > g1 > g2 > g3 (heavy profile)', () => {
+  const { cost } = setup();
+  const c0 = cost(0);
+  const c1 = cost(1);
+  const c2 = cost(2);
+  const c3 = cost(3);
+  assert.ok(c0 > c1, `g0(${c0}) !> g1(${c1})`);
+  assert.ok(c1 > c2, `g1(${c1}) !> g2(${c2})`);
+  assert.ok(c2 > c3, `g2(${c2}) !> g3(${c3})`);
+});
+
+test('exact crossing costs match the profile math (lava 2.0 / roccia 2.0 / default 1.0)', () => {
+  const { cost } = setup();
+  assert.equal(cost(0), 5.0); // 2.0 + 2.0 + 1.0
+  assert.equal(cost(1), 4.0); // 2.0 (hazard unchanged) + 1.0 (roccia freed) + 1.0
+  assert.equal(cost(2), 3.5); // 1.5 (hazard halved) + 1.0 + 1.0
+  assert.equal(cost(3), 3.0); // 1.0 (hazard freed) + 1.0 + 1.0
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes if Task 1 already landed)**
+
+Run: `node --test tests/services/combat/voloHazardEncounterCost.test.js`
+Expected: PASS once Task 1's encounter file exists. (If run before Task 1, FAIL: "not loadable".) Confirm green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/services/combat/voloHazardEncounterCost.test.js
+git commit -F .commitmsg.tmp
+```
+
+---
+
+## Task 4: N=40 hazard band probe + evidence
+
+**Files:**
+
+- Create: `tools/sim/move-terrain-hazard-encounter-probe.js`
+- Create: `docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md`
+
+Paired-seed ON-vs-OFF over the Task-2 scenario roster + terrain, node 22, in-process. Reuses the scenario module so roster/terrain have ONE source.
+
+- [ ] **Step 1: Write the probe**
+
+```javascript
+'use strict';
+// Move terrain-cost substrate -- "Bocche Vulcaniche" hazard ENCOUNTER band probe.
+//
+// Paired-seed ON-vs-OFF over the mixed volo-graded roster (desertoCaldoHazardScenario),
+// crossing a full-height lava+roccia wall on 8x8. Measures wr_delta + rounds_delta when
+// the flag flips. In-process (supertest, NO prod), node 22. Terrain is inlined (the probe
+// path mirrors move-terrain-hazard-probe.js); the loadable encounter file of the same id
+// carries the same wall for the encounter_id runtime path.
+//
+// Usage: node tools/sim/move-terrain-hazard-encounter-probe.js [N] [enemyScale]
+
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runEncounter } = require('./combat-adapter');
+const {
+  buildUnits,
+  TERRAIN,
+} = require('../../apps/backend/services/worldgen/desertoCaldoHazardScenario');
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+function supertestHttp(app) {
+  return {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+function split(scale) {
+  const all = buildUnits().map((u) =>
+    u.controlled_by === 'sistema'
+      ? {
+          ...u,
+          hp: Math.round(u.hp * scale),
+          max_hp: Math.round(u.max_hp * scale),
+          mod: Math.round(u.mod * scale),
+        }
+      : u,
+  );
+  return {
+    roster: all.filter((u) => u.controlled_by === 'player'),
+    enemies: all.filter((u) => u.controlled_by === 'sistema'),
+  };
+}
+
+async function runArm(flagOn, seed, scale) {
+  if (flagOn) process.env.MOVE_TERRAIN_COST_ENABLED = 'true';
+  else delete process.env.MOVE_TERRAIN_COST_ENABLED;
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const http = supertestHttp(app);
+    const { roster, enemies } = split(scale);
+    const r = await runEncounter(http, {
+      roster,
+      enemies,
+      seed,
+      maxRounds: 30,
+      terrainFeatures: TERRAIN,
+      gridSize: 8,
+    });
+    return { outcome: r.outcome, rounds: r.rounds };
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+function summarize(arr) {
+  const wins = arr.filter((r) => r.outcome === 'victory').length;
+  const avgRounds = arr.reduce((s, r) => s + (r.rounds || 0), 0) / (arr.length || 1);
+  return {
+    wins,
+    defeats: arr.filter((r) => r.outcome === 'defeat').length,
+    timeouts: arr.filter((r) => r.outcome === 'timeout').length,
+    win_rate: Number((wins / arr.length).toFixed(4)),
+    avg_rounds: Number(avgRounds.toFixed(2)),
+  };
+}
+
+async function main() {
+  const N = Number(process.argv[2]) || 40;
+  const scale = Number(process.argv[3]) || 1.0;
+  const on = [];
+  const off = [];
+  for (let s = 1; s <= N; s += 1) {
+    on.push(await runArm(true, s, scale));
+    off.push(await runArm(false, s, scale));
+    if (s % 10 === 0) process.stderr.write(`  ${s}/${N}\n`);
+  }
+  const sOn = summarize(on);
+  const sOff = summarize(off);
+  console.log(
+    JSON.stringify(
+      {
+        N,
+        enemyScale: scale,
+        scenario: 'bocche-vulcaniche (lava x3 + roccia x4, mixed volo roster, 8x8)',
+        flag_on: sOn,
+        flag_off: sOff,
+        wr_delta: Number((sOn.win_rate - sOff.win_rate).toFixed(4)),
+        avg_rounds_delta: Number((sOn.avg_rounds - sOff.avg_rounds).toFixed(2)),
+        node: process.version,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Run the probe (node 22) and capture output**
+
+Run: `node tools/sim/move-terrain-hazard-encounter-probe.js 40 1.0`
+Expected: a JSON blob with `flag_on`/`flag_off`/`wr_delta`/`avg_rounds_delta`. Verify the encounter RESOLVES (wins+defeats dominate; not all `timeout`). If it is structurally a timeout (both factions stuck), tune enemy `hp`/positions in the scenario module until it resolves, re-run, and update the module's commit.
+
+- [ ] **Step 3: Write the evidence report**
+
+Create `docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md` with the frontmatter block below, then paste the probe JSON and a 3-4 line reading (does the flag shift WR / pace; is it band-neutral or a measured shift). Band ratify = master-dd (NOT decided in this PR).
+
+```markdown
+---
+title: 'Volo hazard encounter -- N=40 band evidence (bocche vulcaniche)'
+date: 2026-06-29
+doc_status: active
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-06-29'
+source_of_truth: false
+review_cycle_days: 90
+tags: [combat, move-terrain, volo, hazard, n40, evidence]
+---
+
+# Volo hazard encounter -- N=40 band evidence
+
+Probe: `tools/sim/move-terrain-hazard-encounter-probe.js` (paired-seed ON-vs-OFF, node 22,
+in-process). Roster/terrain: `apps/backend/services/worldgen/desertoCaldoHazardScenario.js`
+(mixed volo g1/g2/g3 + heavy ground, full lava+roccia wall 8x8).
+
+## Result
+
+<paste the probe JSON here>
+
+## Reading
+
+<3-4 lines: did the flag shift WR / pace? band-neutral or measured shift? caveat SDMG.>
+Flip stays owner-gated; this is band evidence only.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/sim/move-terrain-hazard-encounter-probe.js docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md
+git commit -F .commitmsg.tmp
+```
+
+---
+
+## Task 5: Full-suite gates + docs governance
+
+- [ ] **Step 1: Run the affected suites**
+
+```bash
+node --test tests/services/combat/encounterGridSchema.test.js tests/services/combat/voloHazardEncounterCost.test.js tests/services/worldgen/desertoCaldoHazardScenario.test.js tests/scripts/encounterSchema.test.js
+node tools/js/validate_encounter_difficulty.js
+```
+
+Expected: all PASS; difficulty `errors=0`.
+
+- [ ] **Step 2: Datasets sanity + format + governance**
+
+```bash
+python3 tools/py/game_cli.py validate-datasets
+npm run format:check
+python tools/check_docs_governance.py --registry docs/governance/docs_registry.json --strict
+```
+
+Expected: validate-datasets OK; format clean (run `npm run format` if not, but the YAML is prettier-ignored under packs/ -- the encounter + report + js are not); governance strict pass (register the new spec/plan/report docs in `docs_registry.json` if the check flags them as unregistered).
+
+- [ ] **Step 3: Final commit (governance registry, if touched)**
+
+```bash
+git add docs/governance/docs_registry.json
+git commit -F .commitmsg.tmp
+```
+
+---
+
+## Commit Convention (ADR-0011, every commit)
+
+Write each message to a worktree-local `.commitmsg.tmp` via a bash heredoc (PowerShell adds a BOM; heredoc-to-/tmp breaks the `-F` path on Windows), then `git commit -F .commitmsg.tmp`. Generate a fresh Trace-Id per commit: `python -c "import uuid;print(uuid.uuid4())"`. Body MUST include `Coding-Agent:` + `Trace-Id:`; MUST NOT include `Co-Authored-By:`. Lowercase type prefix (`feat:`/`test:`/`chore:`). Example:
+
+```bash
+cat > .commitmsg.tmp <<'EOF'
+feat(combat): add grid.terrain_features schema for loadable hazard terrain
+
+Additive, backward-compatible. Existing encounters (no grid key) still validate.
+
+Coding-Agent: claude-opus-4-8
+Trace-Id: <uuidv7-here>
+EOF
+git commit -F .commitmsg.tmp
+```
+
+---
+
+## Guardrails
+
+- `schemas/evo/encounter.schema.json` is a flagged guardrail path (schema:lint / contracts-adjacent). The change is additive + backward-compatible, but the PR must call it out for master-dd merge-gate.
+- Flag `MOVE_TERRAIN_COST_ENABLED` stays OFF for the whole PR -- band-neutral. The flip is owner-gated and NOT part of this work.
+- No new npm/pip deps. No edits to `migrations/`, `packages/contracts/`, `services/generation/`, `.github/workflows/`.
+
+---
+
+## Self-review (done)
+
+- **Spec coverage:** schema ext (Task 0), loadable encounter (Task 1), mixed volo roster scenario (Task 2), deterministic g0>g1>g2>g3 proof (Task 3), N=40 probe + evidence (Task 4), gates (Task 5). All §3 architecture units mapped.
+- **Placeholders:** none -- all code blocks are complete; the only empirical steps (difficulty drift adjust, probe resolve-tuning, evidence paste) have concrete fallback actions.
+- **Type consistency:** `buildUnits`/`TERRAIN`/`SCENARIO`/`VOLO_TRAIT` exports match across Task 2, its test, and Task 4's probe. `loadEncounter`/`terrainAtFromFeatures`/`moveCost`/`getProfile`/`applyVoloGrade` signatures match the merged modules. `volo_grade` + `traits` are the normaliseUnit-preserved fields (verified).

--- a/docs/superpowers/specs/2026-06-29-hazard-terrain-encounter-volo-exercise-design.md
+++ b/docs/superpowers/specs/2026-06-29-hazard-terrain-encounter-volo-exercise-design.md
@@ -1,0 +1,154 @@
+---
+title: 'Hazard-terrain encounter to exercise volo grades -- design spec'
+date: 2026-06-29
+doc_status: active
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-06-29'
+source_of_truth: false
+review_cycle_days: 90
+tags: [combat, movement, terrain-cost, volo, hazard, lava, encounter, substrate, spec]
+---
+
+# Hazard-terrain encounter to exercise volo grades -- design spec
+
+> **Origine**: move terrain-cost substrate, fase 5 residuo. La substrate (volo graduato
+> g1/g2/g3 + radici anchor) e' costruita e flag-gated OFF (`MOVE_TERRAIN_COST_ENABLED`).
+> Le grade g2/g3 mordono SOLO su HAZARD ({lava, acqua_profonda}) -- terreno assente da
+> tutti gli encounter loadable. Questo spec autora il contenuto mancante: un encounter
+> loadable con muro di lava + roster volo-graduato, cosi' g2/g3 sono ESERCITATE (non latenti).
+> Decisioni di design = 4 verdetti master-dd (AskUserQuestion 2026-06-29). Feed -> writing-plans.
+> Il flag resta OFF (owner-gated); questo spec NON lo flippa.
+
+## 1. Ground-truth verificato (origin/main 2026-06-29, HEAD 144a35ab)
+
+Correzioni vs la premessa "due pezzi gia' shippati" (anti-pattern #19, marker != git):
+
+- **#3050 MERGED** (`feat/volo-radici-pathA-assign`, 2026-06-28): i 3 volatori portano gia'
+  `adattamento_volo` in `genetic_traits.core` su origin/main -> sono carrier volo. Grade
+  default = 1 (registry base) finche' non c'e' un `volo_grade` per-unit.
+- **#557 MERGED** (Game-Godot-v2): telegraph move terrain-cost (cost-math client-side).
+- 🔴 **#3061 = OPEN** (`feat/move-terrain-flip-prereqs`, CI-green, band-safe), NON merged. E'
+  la PR che aggiunge il campo `volo_grade` per-species sui 3 YAML volatori + l'emissione
+  `unit.volo_grade` da `deriveCombatStats` + il lift negli scenario loaders (Path A). Finche'
+  e' OPEN, un'unita' derivata-da-species NON porta automaticamente g2/g3.
+
+Tre realta' architetturali load-bearing (verificate end-to-end):
+
+1. **`waves[].units[]` NON e' il roster iniziale**: sono rinforzi consumati piu' tardi da
+   `reinforcementSpawner.tick()`. Le unita' di partenza vengono da `req.body.units` ->
+   `normaliseUnitsPayload` -> `session.units`. Inoltre lo schema wave-unit e'
+   `additionalProperties:false` (solo species/count/tier/ai_profile/affixes) -> **non si puo'
+   mettere `volo_grade`/`traits` su una wave-unit**.
+2. **`normaliseUnit` (`sessionHelpers.js`) preserva `volo_grade` (whitelist) + `traits`**: e' il
+   solo seam per portare il grade su un'unita' -- via payload diretto o scenario JS. Path B.
+3. **`grid.terrain_features` e' ingerito a `/start`** (`session.js:2417-2424`):
+   `encounterPayload = req.body.encounter ?? loadEncounter(encounter_id)`; poi
+   `session.grid.terrain_features = encounterPayload.grid.terrain_features`. Quindi un file
+   loadable in `docs/planning/encounters/` con `grid.terrain_features` raggiunge il grid runtime
+   via `encounter_id`. **MA** `encounter.schema.json` (`additionalProperties:false`) NON ha la
+   chiave `grid`, e `tests/scripts/encounterSchema.test.js` AJV-valida ogni `enc_*.yaml`. Quindi
+   serve un'estensione schema additiva.
+
+Costi terreno (`movement_profiles.yaml`) + `applyVoloGrade` (`movementResolver.js`):
+
+- heavy: lava 2.0, roccia 2.0, sabbia 1.5. medium: lava 1.5, roccia 1.5. light: tutto 1.0.
+- `applyVoloGrade(profile, g)`: g1 azzera il terreno NORMALE (roccia/sabbia -> 1.0), hazard
+  INVARIATO; g2 dimezza la penalita' hazard (lava 2.0 -> 1.5); g3 azzera l'hazard (lava -> 1.0).
+- 🔑 **Implicazione per "g3 < g2 < g1"**: su lava PURA g1 == g0 (hazard invariato). La scala
+  pulita g0 > g1 > g2 > g3 esiste solo se il path di attraversamento include sia un tile
+  NORMALE costoso (roccia/sabbia, dove g1 morde) SIA hazard (lava, dove g2/g3 mordono). Il
+  layout deve quindi alternare roccia + lava sul corridoio forzato.
+
+## 2. Decisioni (4 verdetti master-dd 2026-06-29)
+
+- **A. Encounter**: nuovo, tema "bocche vulcaniche" in `deserto_caldo`. `noctule_termico` (g3)
+  e' nativo deserto_caldo + volatore termico (lava-free per ecologia) = il g3-carrier coerente;
+  `aurora_gull` (g2) + `echo_wing` (g1) come volatori cross-bioma.
+- **B. Layout lava**: muro di lava ad attraversamento forzato (con corridoio roccia+lava per la
+  scala g0>g1>g2>g3); griglia 8x8.
+- **C. Roster**: misto su entrambi i lati (volatori + terrestri sia player sia sistema).
+- **D. Scope**: encounter loadable + estensione schema + test deterministico costo + variante
+  hazard del probe N=40 + **scenario JS** (SCENARIO_MAP-style, AI-giocabile e2e). Rendering
+  GGv2 FUORI scope (il telegraph #557 e' gia' merged; il flag resta OFF -> nessun visual nuovo
+  necessario per questo deliverable backend).
+
+## 3. Architettura (unita' isolate)
+
+1. **Estensione schema** (`schemas/evo/encounter.schema.json`, additiva, backward-compatible):
+   aggiunge una proprieta' opzionale `grid` = `{ width, height, terrain_features:[{x,y,type,
+defense_mod}] }`, `type` enum = i tipi di `movement_profiles.yaml` + radura. `grid_size`
+   resta required e autoritativo per i bounds della board. Tutti gli encounter esistenti
+   (senza `grid`) restano validi. **Guardrail `schemas/evo/` -> da segnalare in PR.**
+2. **Encounter loadable** (`docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml`):
+   `encounter_id`, `name`, `biome_id: deserto_caldo`, `grid_size:[8,8]`, `grid:{width:8,
+height:8, terrain_features: muro lava x=3 (y0..7) + roccia x=4 (y0..7)}`, `objective:
+elimination`, `player_spawn`, `waves` (roster tematico via species-id, per il flavour +
+   l'objective), `difficulty_rating` (drift <= 2 vs `validate_encounter_difficulty.js`),
+   `encounter_class`, `tags`. Passa `encounterSchema.test.js` + difficulty validator.
+3. **Scenario JS** (`apps/backend/services/worldgen/desertoCaldoHazardScenario.js`):
+   build di un roster MISTO con unita' volo-graduate esplicite (Path B: `volo_grade` +
+   `traits:['adattamento_volo']` sui volatori, mirror del probe esistente), terrain = muro
+   lava+roccia, dimensionato per RISOLVERE (winnable, come l'hazard-probe, NON come i pilot
+   adapter che vanno in timeout). Esporta `SCENARIO`, `buildUnits()`, `TERRAIN`. Riusato dal
+   probe e dal test integrazione cosi' c'e' UNA fonte del roster/terrain.
+4. **Test deterministico costo** (`tests/services/combat/voloHazardEncounterCost.test.js`):
+   carica l'encounter via `loadEncounter`, estrae `grid.terrain_features`, costruisce `terrainAt`,
+   e per il corridoio roccia+lava asserisce `moveCost` STRETTAMENTE decrescente:
+   g0 > g1 > g2 > g3 (heavy profile + `applyVoloGrade`). Prova che la substrate morde su QUESTO
+   contenuto. Deterministico, no sim, no flag.
+5. **Variante hazard del probe N=40** (`tools/sim/move-terrain-hazard-encounter-probe.js`):
+   paired-seed ON-vs-OFF sul roster misto dello scenario JS, node 22, in-process. Misura
+   wr_delta + rounds_delta. Evidence -> `docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md`.
+
+## 4. Layout terreno + roster (concreto)
+
+Griglia 8x8 (x,y 0..7). Muro verticale:
+
+- `lava` su x=3, y=0..7 (8 tile).
+- `roccia` su x=4, y=0..7 (8 tile).
+
+Attraversamento sinistra->destra: per ogni y il path entra in (3,y)=lava poi (4,y)=roccia.
+Costo di attraversamento (entrare lava + entrare roccia), heavy profile:
+
+| grade | lava | roccia | totale corridoio |
+| ----- | ---- | ------ | ---------------- |
+| g0    | 2.0  | 2.0    | 4.0              |
+| g1    | 2.0  | 1.0    | 3.0              |
+| g2    | 1.5  | 1.0    | 2.5              |
+| g3    | 1.0  | 1.0    | 2.0              |
+
+Scala pulita g0 > g1 > g2 > g3. (g1 morde sulla roccia, g2/g3 sulla lava.)
+
+Roster MISTO (Path B, volo_grade esplicito):
+
+- Player: `noctule_termico` g3 + `echo_wing` g1 (volatori) + 1 pesante non-volo (paga il muro).
+- Sistema: `aurora_gull` g2 (volatore) + 2 terrestri non-volo.
+
+Dimensionamento winnable (mirror hazard-probe): nemici a HP/mod moderati, posizioni che
+costringono l'attraversamento, maxRounds 30 -> l'encounter RISOLVE (no timeout strutturale).
+
+## 5. Fasi (TDD, 1 PR)
+
+0. Estensione schema additiva + aggiorna `encounterSchema.test.js` se serve un caso `grid`
+   (red->green: un fixture con `grid.terrain_features` valida).
+1. Encounter YAML loadable -> `encounterSchema.test.js` verde + `validate_encounter_difficulty.js`
+   drift <= 2.
+2. Scenario JS (`desertoCaldoHazardScenario.js`) + unit test (buildUnits porta volo_grade +
+   adattamento_volo sui volatori; terrain = muro).
+3. Test deterministico costo (`voloHazardEncounterCost.test.js`): g0>g1>g2>g3 sul corridoio.
+4. Variante hazard del probe N=40 + evidence report (band ratify = master-dd, NON in questa PR).
+
+## 6. Definition of Done
+
+- `node --test tests/services/combat/*.test.js tests/scripts/encounterSchema.test.js` verde.
+- `node tools/js/validate_encounter_difficulty.js` errors=0.
+- `python3 tools/py/game_cli.py validate-datasets` verde (encounter content non rompe i validator).
+- `npm run format:check` + `python tools/check_docs_governance.py --strict` verdi.
+- Flag `MOVE_TERRAIN_COST_ENABLED` resta OFF (band-neutral). Il flip resta owner-gated.
+- Commit ADR-0011 (`Coding-Agent:` + `Trace-Id:`), no `Co-Authored-By:`.
+- Guardrail segnalato: tocco `schemas/evo/encounter.schema.json` (additivo) -> master-dd merge-gate.
+
+## 7. Entry point implementazione
+
+writing-plans -> piano dettagliato file-by-file TDD. Worktree off origin/main, deps installati.

--- a/schemas/evo/encounter.schema.json
+++ b/schemas/evo/encounter.schema.json
@@ -38,6 +38,41 @@
       "maxItems": 2,
       "description": "[width, height] in hex cells"
     },
+    "grid": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional terrain grid for the move terrain-cost substrate (move-terrain spec 2026-06-23). grid_size stays the authoritative board bounds; terrain_features carries per-tile types read by moveCost (flag MOVE_TERRAIN_COST_ENABLED, default OFF -> Manhattan, band-neutral).",
+      "properties": {
+        "width": { "type": "integer", "minimum": 4, "maximum": 20 },
+        "height": { "type": "integer", "minimum": 4, "maximum": 20 },
+        "terrain_features": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["x", "y", "type"],
+            "additionalProperties": false,
+            "properties": {
+              "x": { "type": "integer", "minimum": 0 },
+              "y": { "type": "integer", "minimum": 0 },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "roccia",
+                  "sabbia",
+                  "acqua_profonda",
+                  "vegetazione_densa",
+                  "ghiaccio",
+                  "lava",
+                  "radura",
+                  "default"
+                ]
+              },
+              "defense_mod": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
     "objective": {
       "type": "object",
       "required": ["type"],

--- a/tests/api/normaliseUnitBounds.test.js
+++ b/tests/api/normaliseUnitBounds.test.js
@@ -1,0 +1,96 @@
+// tests/api/normaliseUnitBounds.test.js
+// TDD: verify that normaliseUnit / normaliseUnitsPayload / clampPosition honour
+// the optional `bounds` parameter introduced to fix the 8x8-encounter clamping bug.
+//
+// Regression guard: https://github.com/MasterDD-L34D/Game/pull/3065 (Codex P2)
+// Root cause: clampPosition used GRID_SIZE-1 (=5) unconditionally, so a unit at
+// {x:7} on a declared 8x8 encounter was silently moved to x=5.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  normaliseUnit,
+  normaliseUnitsPayload,
+} = require('../../apps/backend/routes/sessionHelpers');
+const { GRID_SIZE } = require('../../apps/backend/routes/sessionConstants');
+
+// --- normaliseUnit with 8x8 bounds ----------------------------------------
+
+test('normaliseUnit: unit at {x:7,y:7} with 8x8 bounds stays at (7,7)', () => {
+  const bounds = { width: 8, height: 8 };
+  const unit = normaliseUnit(
+    { id: 'u1', position: { x: 7, y: 7 }, controlled_by: 'sistema' },
+    0,
+    bounds,
+  );
+  assert.equal(unit.position.x, 7, 'x should not be clamped');
+  assert.equal(unit.position.y, 7, 'y should not be clamped');
+});
+
+test('normaliseUnit: unit at {x:7,y:7} with NO bounds clamps to GRID_SIZE-1', () => {
+  const unit = normaliseUnit(
+    { id: 'u1', position: { x: 7, y: 7 }, controlled_by: 'sistema' },
+    0,
+    // no bounds
+  );
+  assert.equal(unit.position.x, GRID_SIZE - 1, 'x should clamp to GRID_SIZE-1');
+  assert.equal(unit.position.y, GRID_SIZE - 1, 'y should clamp to GRID_SIZE-1');
+});
+
+test('normaliseUnit: unit at {x:7,y:7} with 6x6 bounds clamps to 5', () => {
+  const bounds = { width: 6, height: 6 };
+  const unit = normaliseUnit(
+    { id: 'u1', position: { x: 7, y: 7 }, controlled_by: 'sistema' },
+    0,
+    bounds,
+  );
+  assert.equal(unit.position.x, 5, 'x should clamp to 5 on a 6x6 grid');
+  assert.equal(unit.position.y, 5, 'y should clamp to 5 on a 6x6 grid');
+});
+
+// --- normaliseUnit: fallback position also uses bounds ----------------------
+
+test('normaliseUnit: fallback position (no position field, fallbackIndex>0) uses bounds max', () => {
+  const bounds = { width: 8, height: 8 };
+  const unit = normaliseUnit({ id: 'e1', controlled_by: 'sistema' }, 1, bounds);
+  // fallbackIndex=1 -> fallback is { x: maxX, y: maxY }
+  assert.equal(unit.position.x, 7);
+  assert.equal(unit.position.y, 7);
+});
+
+test('normaliseUnit: fallback position without bounds falls back to GRID_SIZE-1', () => {
+  const unit = normaliseUnit({ id: 'e1', controlled_by: 'sistema' }, 1);
+  assert.equal(unit.position.x, GRID_SIZE - 1);
+  assert.equal(unit.position.y, GRID_SIZE - 1);
+});
+
+// --- normaliseUnitsPayload with bounds -------------------------------------
+
+test('normaliseUnitsPayload: passes bounds to each unit normalisation', () => {
+  const bounds = { width: 8, height: 8 };
+  const raw = [
+    { id: 'p1', position: { x: 0, y: 0 }, controlled_by: 'player' },
+    { id: 'e1', position: { x: 7, y: 5 }, controlled_by: 'sistema' },
+  ];
+  const units = normaliseUnitsPayload(raw, bounds);
+  assert.equal(units[0].position.x, 0);
+  assert.equal(units[1].position.x, 7, 'right-edge unit must not be clamped');
+});
+
+test('normaliseUnitsPayload: without bounds clamps all to GRID_SIZE-1', () => {
+  const raw = [{ id: 'e1', position: { x: 7, y: 7 }, controlled_by: 'sistema' }];
+  const units = normaliseUnitsPayload(raw);
+  assert.equal(units[0].position.x, GRID_SIZE - 1);
+  assert.equal(units[0].position.y, GRID_SIZE - 1);
+});
+
+// --- backward-compat: 6x6 is identical to no-bounds -----------------------
+
+test('backward-compat: 6x6 bounds produce same result as no bounds', () => {
+  const raw = [{ id: 'u1', position: { x: 3, y: 2 }, controlled_by: 'player' }];
+  const withBounds = normaliseUnitsPayload(raw, { width: 6, height: 6 });
+  const withoutBounds = normaliseUnitsPayload(raw);
+  assert.deepEqual(withBounds[0].position, withoutBounds[0].position);
+});

--- a/tests/services/combat/encounterGridSchema.test.js
+++ b/tests/services/combat/encounterGridSchema.test.js
@@ -1,0 +1,60 @@
+// tests/services/combat/encounterGridSchema.test.js
+// Move terrain-cost substrate (2026-06-29): the additive `grid.terrain_features`
+// extension to encounter.schema.json (lava-wall hazard encounters). Red->green TDD.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const Ajv = require('ajv/dist/2020');
+
+const SCHEMA_PATH = path.join(__dirname, '../../../schemas/evo/encounter.schema.json');
+
+function makeValidator() {
+  const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  return ajv.compile(schema);
+}
+
+const baseEncounter = {
+  encounter_id: 'enc_grid_fixture',
+  name: 'Grid Fixture',
+  biome_id: 'deserto_caldo',
+  grid_size: [8, 8],
+  objective: { type: 'elimination' },
+  player_spawn: [[0, 0]],
+  waves: [
+    { wave_id: 1, turn_trigger: 0, spawn_points: [[7, 7]], units: [{ species: 'x', count: 1 }] },
+  ],
+  difficulty_rating: 3,
+};
+
+test('encounter schema accepts grid.terrain_features (lava)', () => {
+  const validate = makeValidator();
+  const data = {
+    ...baseEncounter,
+    grid: {
+      width: 8,
+      height: 8,
+      terrain_features: [
+        { x: 3, y: 0, type: 'lava', defense_mod: 0 },
+        { x: 4, y: 0, type: 'roccia', defense_mod: 2 },
+      ],
+    },
+  };
+  const valid = validate(data);
+  assert.ok(valid, JSON.stringify(validate.errors));
+});
+
+test('encounter schema rejects an unknown terrain type', () => {
+  const validate = makeValidator();
+  const data = {
+    ...baseEncounter,
+    grid: { width: 8, height: 8, terrain_features: [{ x: 1, y: 1, type: 'plasma' }] },
+  };
+  assert.equal(validate(data), false);
+});
+
+test('encounter schema still accepts an encounter with NO grid key (backward-compat)', () => {
+  const validate = makeValidator();
+  assert.ok(validate({ ...baseEncounter }), JSON.stringify(validate.errors));
+});

--- a/tests/services/combat/voloHazardEncounterCost.test.js
+++ b/tests/services/combat/voloHazardEncounterCost.test.js
@@ -1,0 +1,69 @@
+// tests/services/combat/voloHazardEncounterCost.test.js
+// Move terrain-cost substrate (2026-06-29): deterministic proof that the volo grades
+// fire on the REAL loadable encounter terrain. Loads enc_deserto_caldo_bocche_vulcaniche_01,
+// builds terrainAt from its grid.terrain_features, and asserts the wall-crossing cost is
+// strictly decreasing g0 > g1 > g2 > g3 (heavy profile). No flag, no sim, no runtime.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  loadEncounter,
+  _resetCache,
+} = require('../../../apps/backend/services/combat/encounterLoader');
+const {
+  moveCost,
+  terrainAtFromFeatures,
+} = require('../../../apps/backend/services/combat/moveCost');
+const { getProfile } = require('../../../apps/backend/services/combat/movementProfiles');
+const { applyVoloGrade } = require('../../../apps/backend/services/combat/movementResolver');
+
+const ENC_ID = 'enc_deserto_caldo_bocche_vulcaniche_01';
+
+function setup() {
+  _resetCache();
+  const enc = loadEncounter(ENC_ID);
+  assert.ok(enc, `${ENC_ID} not loadable`);
+  assert.ok(
+    enc.grid && Array.isArray(enc.grid.terrain_features),
+    'encounter has no grid.terrain_features',
+  );
+  const terrainAt = terrainAtFromFeatures(enc.grid.terrain_features);
+  const bounds = { width: enc.grid.width, height: enc.grid.height };
+  const heavy = getProfile('heavy');
+  // Cross the wall on row y=4: enter (3,4)=lava, (4,4)=roccia, (5,4)=default.
+  const cost = (g) =>
+    moveCost(
+      { x: 2, y: 4 },
+      { x: 5, y: 4 },
+      g > 0 ? applyVoloGrade(heavy, g) : heavy,
+      terrainAt,
+      bounds,
+    );
+  return { cost, terrainAt };
+}
+
+test('the encounter terrain is the lava(x=3)+roccia(x=4) wall', () => {
+  const { terrainAt } = setup();
+  assert.equal(terrainAt(3, 4), 'lava');
+  assert.equal(terrainAt(4, 4), 'roccia');
+  assert.equal(terrainAt(5, 4), null); // default
+});
+
+test('crossing cost is strictly decreasing g0 > g1 > g2 > g3 (heavy profile)', () => {
+  const { cost } = setup();
+  const c0 = cost(0);
+  const c1 = cost(1);
+  const c2 = cost(2);
+  const c3 = cost(3);
+  assert.ok(c0 > c1, `g0(${c0}) !> g1(${c1})`);
+  assert.ok(c1 > c2, `g1(${c1}) !> g2(${c2})`);
+  assert.ok(c2 > c3, `g2(${c2}) !> g3(${c3})`);
+});
+
+test('exact crossing costs match the profile math (lava 2.0 / roccia 2.0 / default 1.0)', () => {
+  const { cost } = setup();
+  assert.equal(cost(0), 5.0); // 2.0 + 2.0 + 1.0
+  assert.equal(cost(1), 4.0); // 2.0 (hazard unchanged) + 1.0 (roccia freed) + 1.0
+  assert.equal(cost(2), 3.5); // 1.5 (hazard halved) + 1.0 + 1.0
+  assert.equal(cost(3), 3.0); // 1.0 (hazard freed) + 1.0 + 1.0
+});

--- a/tests/services/worldgen/desertoCaldoHazardScenario.test.js
+++ b/tests/services/worldgen/desertoCaldoHazardScenario.test.js
@@ -1,0 +1,58 @@
+// tests/services/worldgen/desertoCaldoHazardScenario.test.js
+// Move terrain-cost substrate (2026-06-29): the mixed volo-graded roster + lava-wall
+// terrain for the "bocche vulcaniche" hazard scenario. Path B (explicit volo_grade).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildUnits,
+  TERRAIN,
+  SCENARIO,
+} = require('../../../apps/backend/services/worldgen/desertoCaldoHazardScenario');
+
+test('SCENARIO carries the loadable encounter_id + 8x8 grid', () => {
+  assert.equal(SCENARIO.encounter_id, 'enc_deserto_caldo_bocche_vulcaniche_01');
+  assert.equal(SCENARIO.grid_size, 8);
+});
+
+test('TERRAIN is the full-height lava(x=3)+roccia(x=4) wall', () => {
+  const lava = TERRAIN.filter((t) => t.type === 'lava');
+  const roccia = TERRAIN.filter((t) => t.type === 'roccia');
+  assert.equal(lava.length, 8);
+  assert.equal(roccia.length, 8);
+  assert.ok(lava.every((t) => t.x === 3));
+  assert.ok(roccia.every((t) => t.x === 4));
+});
+
+test('flyers carry an explicit volo_grade + adattamento_volo; grades cover g1/g2/g3', () => {
+  const units = buildUnits();
+  const flyers = units.filter(
+    (u) => Array.isArray(u.traits) && u.traits.includes('adattamento_volo'),
+  );
+  assert.equal(flyers.length, 3);
+  for (const f of flyers) {
+    assert.ok([1, 2, 3].includes(f.volo_grade), `bad grade ${f.volo_grade}`);
+  }
+  const grades = flyers.map((f) => f.volo_grade).sort();
+  assert.deepEqual(grades, [1, 2, 3]);
+});
+
+test('roster is mixed on both factions (player + sistema each have a flyer and a ground unit)', () => {
+  const units = buildUnits();
+  for (const side of ['player', 'sistema']) {
+    const sideUnits = units.filter((u) => u.controlled_by === side);
+    const hasFlyer = sideUnits.some((u) => (u.traits || []).includes('adattamento_volo'));
+    const hasGround = sideUnits.some((u) => !(u.traits || []).includes('adattamento_volo'));
+    assert.ok(hasFlyer, `${side} has no flyer`);
+    assert.ok(hasGround, `${side} has no ground unit`);
+  }
+});
+
+test('ground units are heavy-profile (morphotype corazzato) and carry no volo_grade', () => {
+  const units = buildUnits();
+  const ground = units.filter((u) => !(u.traits || []).includes('adattamento_volo'));
+  assert.ok(ground.length >= 2);
+  for (const g of ground) {
+    assert.equal(g.morphotype, 'corazzato');
+    assert.equal(g.volo_grade, undefined);
+  }
+});

--- a/tools/sim/move-terrain-hazard-encounter-probe.js
+++ b/tools/sim/move-terrain-hazard-encounter-probe.js
@@ -1,0 +1,120 @@
+'use strict';
+// Move terrain-cost substrate -- "Bocche Vulcaniche" hazard ENCOUNTER band probe.
+//
+// Paired-seed ON-vs-OFF over the mixed volo-graded roster (desertoCaldoHazardScenario),
+// crossing a full-height lava+roccia wall on 8x8. Measures wr_delta + rounds_delta when
+// the flag flips. In-process (supertest, NO prod), node 22. Terrain is inlined (the probe
+// path mirrors move-terrain-hazard-probe.js); the loadable encounter file of the same id
+// carries the same wall for the encounter_id runtime path.
+//
+// Usage: node tools/sim/move-terrain-hazard-encounter-probe.js [N] [enemyScale]
+
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runEncounter } = require('./combat-adapter');
+const {
+  buildUnits,
+  TERRAIN,
+} = require('../../apps/backend/services/worldgen/desertoCaldoHazardScenario');
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+function supertestHttp(app) {
+  return {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+function split(scale) {
+  const all = buildUnits().map((u) =>
+    u.controlled_by === 'sistema'
+      ? {
+          ...u,
+          hp: Math.round(u.hp * scale),
+          max_hp: Math.round(u.max_hp * scale),
+          mod: Math.round(u.mod * scale),
+        }
+      : u,
+  );
+  return {
+    roster: all.filter((u) => u.controlled_by === 'player'),
+    enemies: all.filter((u) => u.controlled_by === 'sistema'),
+  };
+}
+
+async function runArm(flagOn, seed, scale) {
+  if (flagOn) process.env.MOVE_TERRAIN_COST_ENABLED = 'true';
+  else delete process.env.MOVE_TERRAIN_COST_ENABLED;
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const http = supertestHttp(app);
+    const { roster, enemies } = split(scale);
+    const r = await runEncounter(http, {
+      roster,
+      enemies,
+      seed,
+      maxRounds: 30,
+      terrainFeatures: TERRAIN,
+      gridSize: 8,
+    });
+    return { outcome: r.outcome, rounds: r.rounds };
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+function summarize(arr) {
+  const wins = arr.filter((r) => r.outcome === 'victory').length;
+  const avgRounds = arr.reduce((s, r) => s + (r.rounds || 0), 0) / (arr.length || 1);
+  return {
+    wins,
+    defeats: arr.filter((r) => r.outcome === 'defeat').length,
+    timeouts: arr.filter((r) => r.outcome === 'timeout').length,
+    win_rate: Number((wins / arr.length).toFixed(4)),
+    avg_rounds: Number(avgRounds.toFixed(2)),
+  };
+}
+
+async function main() {
+  const N = Number(process.argv[2]) || 40;
+  const scale = Number(process.argv[3]) || 1.0;
+  const on = [];
+  const off = [];
+  for (let s = 1; s <= N; s += 1) {
+    on.push(await runArm(true, s, scale));
+    off.push(await runArm(false, s, scale));
+    if (s % 10 === 0) process.stderr.write(`  ${s}/${N}\n`);
+  }
+  const sOn = summarize(on);
+  const sOff = summarize(off);
+  console.log(
+    JSON.stringify(
+      {
+        N,
+        enemyScale: scale,
+        scenario: 'bocche-vulcaniche (lava x3 + roccia x4, mixed volo roster, 8x8)',
+        flag_on: sOn,
+        flag_off: sOff,
+        wr_delta: Number((sOn.win_rate - sOff.win_rate).toFixed(4)),
+        avg_rounds_delta: Number((sOn.avg_rounds - sOff.avg_rounds).toFixed(2)),
+        node: process.version,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Cosa

Autora il **contenuto loadable mancante** per esercitare le grade di volo (g2 dimezza / g3 azzera l'hazard) della *move terrain-cost substrate*. Le grade mordono SOLO su HAZARD ({lava, acqua_profonda}), terreno assente da ogni encounter loadable -> finora g2/g3 erano latenti. Questa PR aggiunge un encounter con muro di lava + roster volo-graduato + prove.

Spec: `docs/superpowers/specs/2026-06-29-hazard-terrain-encounter-volo-exercise-design.md` · Plan: `docs/superpowers/plans/2026-06-29-hazard-terrain-encounter-volo-exercise.md`. Decisioni di design = 4 verdetti master-dd (AskUserQuestion): deserto_caldo "bocche vulcaniche" · muro di lava ad attraversamento forzato · roster misto entrambi i lati · scope = encounter+schema+cost-test+N=40 probe+scenario JS.

## 5 deliverable

1. **Schema** (`schemas/evo/encounter.schema.json`): proprieta' `grid` opzionale (`terrain_features`), **additiva + backward-compatible** (encounter senza `grid` restano validi).
2. **Encounter loadable** (`docs/planning/encounters/enc_deserto_caldo_bocche_vulcaniche_01.yaml`): 8x8, muro full-height lava(x=3)+roccia(x=4). Verificato e2e: `POST /start` con `encounter_id` -> `session.grid.terrain_features` (16 tile).
3. **Scenario JS** (`apps/backend/services/worldgen/desertoCaldoHazardScenario.js`): roster misto volo-graduato (Path B: `volo_grade`+`adattamento_volo` espliciti, registry-free, indipendente da #3061). Riusato da probe + test.
4. **Test deterministico costo** (`tests/services/combat/voloHazardEncounterCost.test.js`): carica l'encounter reale, asserisce la scala di costo `g0(5.0) > g1(4.0) > g2(3.5) > g3(3.0)` sul muro -- **la prova che g2/g3 sono esercitate**.
5. **Probe N=40 + evidenza** (`tools/sim/move-terrain-hazard-encounter-probe.js` + `docs/reports/2026-06-29-volo-hazard-encounter-band-evidence.md`): paired-seed ON-vs-OFF, node 22. Risolve (39/40 win) **band-NEUTRAL** (wr/rounds delta 0): il volatore g3 attraversa l'hazard free (== Manhattan) -> substrate = leva di terrain-design, non un WR-shifter.

## Ground-truth (anti-pattern #19 vs la premessa "gia' shippato")

- **#3050 MERGED**: i 3 volatori portano gia' `adattamento_volo` (sono carrier). **#557 MERGED** (GGv2 telegraph). 🔴 **#3061 = OPEN** (non merged): aggiunge il `volo_grade` per-species (Path A). Questa PR e' **indipendente da #3061** (la prova-costo usa grade espliciti; lo scenario e' Path B).

## ⚠️ Guardrail

- Tocca **`schemas/evo/encounter.schema.json`** (additivo, backward-compatible) -> **master-dd merge-gate**.
- **Il flag `MOVE_TERRAIN_COST_ENABLED` resta OFF** (band-neutral). Questa PR NON lo flippa; il flip resta owner-gated.
- GGv2 rendering FUORI scope (telegraph #557 gia' merged; flag OFF -> nessun visual nuovo necessario).
- Niente nuove dipendenze. Niente `migrations/`/`packages/contracts/`/`services/generation/`.
- I 3 nuovi doc (spec/plan/report) sono `unregistered_document` warning-only (coerente col workstream move-terrain, il cui spec 2026-06-23 e' ugualmente non registrato); governance strict = errors=0.

## Test (tutti verdi)

- `tests/services/combat/{encounterGridSchema,voloHazardEncounterCost}.test.js` + `tests/services/worldgen/desertoCaldoHazardScenario.test.js` -> 11/11.
- `tests/scripts/encounterSchema.test.js` 18/18 · `tests/difficulty/validator.test.js` 7/7 · combat 244/244.
- `node tools/js/validate_encounter_difficulty.js` errors=0 (drift 0) · `validate-datasets` OK · `prettier --check` clean · docs-governance strict errors=0.
- N=40 probe: 39/40 win, wr_delta 0, rounds_delta 0.

## Rollback (03A)

Revert della PR: rimuove i file nuovi + la proprieta' `grid` additiva dallo schema. Zero impatto runtime (il flag e' OFF, lo scenario non e' importato da nessun path di prod). Nessuna migrazione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
