### PR TITLE
fix(derived): round cadence sum so skydock XP bundle is cross-CPython reproducible

### DIFF
--- a/tests/playtests/test_balance_progression.py
+++ b/tests/playtests/test_balance_progression.py
@@ -88,6 +88,24 @@ def test_helix_cipher_profile_is_on_target(progression_payload):
     assert profile["delta_vs_target_pct"] == pytest.approx(-0.0009, abs=1e-3)
 
 
+def test_duration_minutes_is_version_stable(progression_payload):
+    # CPython 3.12 added compensated (Neumaier) summation to sum() for floats, so a
+    # raw sum(cadence_minutes) yields 23.3 on 3.12 but 23.299999999999997 on 3.11.
+    # The emitted duration must be decimal-canonical so the derived artifact is
+    # byte-identical across interpreter versions (uses exact ==, not approx, on
+    # purpose -- approx would mask the precision drift this guards against).
+    duration = progression_payload["waves"]["duration_minutes"]
+    # Version-agnostic invariant: no >4-decimal summation noise survives.
+    # (23.299999999999997 != round(it, 4); 23.3 == round(it, 4).)
+    assert duration == round(duration, 4)
+    # Contract derived from the fixture data (not a hardcoded literal, so editing
+    # cadence_minutes won't make this brittle): duration is the cadence sum rounded.
+    cadence = load_mission_config(MISSION_PATH, "skydock_siege")["progression"]["waves"][
+        "cadence_minutes"
+    ]
+    assert duration == round(sum(float(x) for x in cadence), 4)
+
+
 def test_telemetry_log_is_recorded(telemetry_log):
     assert LOG_FILE.exists()
     helix_cipher_standard = telemetry_log["profiles"]["helix_cipher"]["difficulties"]["standard"]

--- a/tools/py/balance_progression.py
+++ b/tools/py/balance_progression.py
@@ -230,7 +230,12 @@ def simulate_xp_progression(
     class_modifiers: Mapping[str, float] = progression["class_modifiers"]
     difficulty_scalars: Mapping[str, float] = xp_model["difficulty_scalars"]
     targets = progression.get("targets", {})
-    total_duration = _sum_duration_minutes(progression["waves"])
+    # Round the cadence sum to a fixed precision: CPython 3.12 added compensated
+    # (Neumaier) float summation to sum(), so a raw sum(cadence_minutes) repr-differs
+    # across interpreter versions (23.3 on 3.12, 23.299999999999997 on 3.11). Rounding
+    # at the source makes duration_minutes -- and every xp_per_minute derived from it --
+    # decimal-canonical, so the emitted artifact is byte-identical cross-version.
+    total_duration = round(_sum_duration_minutes(progression["waves"]), 4)
     raw_profiles = profiles if profiles is not None else progression.get("profiles", {})
     normalized_profiles = (
         _normalize_profile_map(raw_profiles)

--- a/tools/py/check_derived_reproducible.py
+++ b/tools/py/check_derived_reproducible.py
@@ -225,14 +225,16 @@ def check_species_catalog() -> list[str]:
     return findings
 
 
-# Artifacts whose generator output is NOT byte-stable across Python versions, so a
-# regen-vs-committed byte compare false-positives when the running interpreter
-# differs from the one that produced the committed bundle. `skydock_siege_xp.json`
-# (balance_progression.py) carries XP floats whose repr differs between CPython
-# 3.11 and 3.12 -- a known cross-version non-determinism. Excluded from the deep
-# byte compare; the 5 coverage-data artifacts + 2 CSVs ARE stable and still cover
-# the important source-drift case (coverage vs species/trait data).
-_DEEP_FLOAT_FRAGILE = {"data/derived/analysis/progression/skydock_siege_xp.json"}
+# Hook for any derived artifact whose generator output is NOT byte-stable across
+# Python versions (a regen-vs-committed byte compare would false-positive when the
+# running interpreter differs from the one that produced the committed bundle).
+# Currently EMPTY: `skydock_siege_xp.json` (balance_progression.py) used to carry a
+# raw sum(cadence_minutes) that repr-differs between CPython 3.11 (23.299999999999997)
+# and 3.12 (23.3 -- 3.12 added compensated float summation to sum()); that sum is now
+# rounded at the source, so the whole bundle is byte-identical cross-version and gets
+# the full deep byte compare. Add a rel-path here only if a future artifact
+# reintroduces cross-version float drift.
+_DEEP_FLOAT_FRAGILE: set[str] = set()
 
 # The ONLY artifacts scripts/generate_derived_analysis.py actually writes (via
 # generate_trait_coverage + generate_progression). The other manifest artifacts
@@ -260,10 +262,10 @@ def _check_analysis_source_drift(artifact_rels: list[str]) -> list[str]:
     regen no longer produces), CHANGED (regen rewrites it differently), NET-NEW
     (regen produces a file not committed).
 
-    Restores the committed bytes in a finally (opt-in, ~seconds). Float-fragile
-    artifacts (_DEEP_FLOAT_FRAGILE) still get the orphan + net-new checks but NOT
-    the byte compare -- their repr differs across Python versions; for those, run
-    under the bundle's own interpreter.
+    Restores the committed bytes in a finally (opt-in, ~seconds). Any artifact
+    listed in _DEEP_FLOAT_FRAGILE (currently empty) still gets the orphan + net-new
+    checks but NOT the byte compare -- for cross-version-fragile floats, run under
+    the bundle's own interpreter.
     """
     findings: list[str] = []
     generator = REPO_ROOT / "scripts" / "generate_derived_analysis.py"


### PR DESCRIPTION
## What

Make the derived artifact `data/derived/analysis/progression/skydock_siege_xp.json` byte-reproducible across CPython 3.11 and 3.12, then un-gate it in the reproducibility guard so `--deep` byte-compares it. Closes the `float-stabilize balance_progression` residual of the derived-canon reproducibility ARC.

## Root cause (empirically proven)

CPython 3.12 added compensated (Neumaier) float summation to `sum()`. So `sum([3.6,3.8,4.1,3.7,3.9,4.2])` (the mission's `cadence_minutes`) is **`23.299999999999997` on 3.11** but **`23.3` on 3.12**.

Running the generator under both interpreters, the **only** differing field in the whole JSON was `waves.duration_minutes` — the lone un-rounded `total_duration` (raw cadence sum). Everything else was already `round(..., 4)`, and the ~1e-14 compensated-sum delta vanishes under that rounding (the cross-version full-file diff confirmed: 1 line). That single field is exactly why the guard kept the file in `_DEEP_FLOAT_FRAGILE`.

## Change

- `tools/py/balance_progression.py`: round `total_duration` at the source (matches the file's existing `round(..., 4)` convention). Makes `duration_minutes` — and every `xp_per_minute` derived from it — decimal-canonical.
- `tools/py/check_derived_reproducible.py`: empty `_DEEP_FLOAT_FRAGILE` (kept as the hook for any future cross-version-fragile artifact) so `--deep` now byte-compares skydock; update comment + docstring.
- `tests/playtests/test_balance_progression.py`: regression test asserting `duration_minutes` is decimal-canonical (exact `==`, not `approx` — `approx` would mask the drift) + a fixture-derived contract (not a hardcoded literal, so a `cadence_minutes` edit won't make it brittle).

The committed skydock bytes are **unchanged** (already `23.3`, 3.12-generated) — no bundle/manifest regen needed; this only makes 3.11 produce the same bytes.

## Verification

- Regression test: **RED on 3.11 pre-fix** (`23.299999999999997 == 23.3` fails), **GREEN post-fix on both 3.11 and 3.12**. `test_balance_progression.py` 6/6 on both interpreters.
- `3.11-regen == 3.12-regen == committed LF blob` (ran both `python.exe`s).
- Guard normal + `--deep` `rc=0` on **3.11 AND 3.12**. **Non-no-op proven**: reverting the round makes `--deep` flag `SOURCE-DRIFT CHANGES skydock_siege_xp.json` (`rc=1`) under 3.11.
- **Band-neutral**: no runtime/backend/combat consumer reads the bundle (only the generator, the guard, and this test reference it); no canonical data bytes change. `npm run format:check` N/A (Python-only diff; Prettier does not cover `.py`).

## Rollback

Revert the commit — restores `_DEEP_FLOAT_FRAGILE` membership and the raw cadence sum. Zero data/contract impact (tool + test only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
