### PR TITLE
fix(canon): map 2 orphan biomes to canonical via aliases (laguna->reef, mangrovieto->palude)

### DIFF
--- a/data/core/biome_aliases.yaml
+++ b/data/core/biome_aliases.yaml
@@ -62,3 +62,11 @@ aliases:
     canonical: atollo_obsidiana
     status: alias
     notes: "Variante ortografica IT (doppia 's') usata dal swarm trait-curator (artifact 2026-04-24). Promosso OD-012 2026-04-25."
+  laguna_bioreattiva:
+    canonical: reef_luminescente
+    status: expansion
+    notes: "Laguna bioreattiva costiera (filtri planctonici, maree risonanti) ricondotta al profilo littorale del Reef Luminescente."
+  mangrovieto_cinetico:
+    canonical: palude
+    status: expansion
+    notes: "Mangrovieto cinetico (pneumatofori, fango coesivo) ricondotto al profilo wetland della Palude."

--- a/data/core/biomes.yaml
+++ b/data/core/biomes.yaml
@@ -352,6 +352,8 @@ biomes:
       hooks:
       - Recuperare reagenti bio-luminescenti per le squadre mediche.
       - Placare le colonie simbiotiche prima che scatenino la nube tossica.
+    aliases:
+    - mangrovieto_cinetico
   dorsale_termale_tropicale:
     legacy_slug: dorsale_termale_tropicale
     biome_class: geothermal
@@ -644,6 +646,8 @@ biomes:
       hooks:
       - Proteggere le colonie coralline da razzie di risonanza.
       - Convincere i custodi del reef a condividere i filtri luminescenti.
+    aliases:
+    - laguna_bioreattiva
   savana:
     legacy_slug: savana
     biome_class: arid

--- a/packs/evo_tactics_pack/data/biome_aliases.yaml
+++ b/packs/evo_tactics_pack/data/biome_aliases.yaml
@@ -58,3 +58,11 @@ aliases:
     canonical: frattura_abissale_sinaptica
     status: expansion
     notes: "Alias T1 legato alle creste superficiali luminescenti del nuovo bioma."
+  laguna_bioreattiva:
+    canonical: reef_luminescente
+    status: expansion
+    notes: "Laguna bioreattiva costiera (filtri planctonici, maree risonanti) ricondotta al profilo littorale del Reef Luminescente."
+  mangrovieto_cinetico:
+    canonical: palude
+    status: expansion
+    notes: "Mangrovieto cinetico (pneumatofori, fango coesivo) ricondotto al profilo wetland della Palude."

--- a/packs/evo_tactics_pack/data/biomes.yaml
+++ b/packs/evo_tactics_pack/data/biomes.yaml
@@ -315,6 +315,8 @@ biomes:
       hooks:
       - Recuperare reagenti bio-luminescenti per le squadre mediche.
       - Placare le colonie simbiotiche prima che scatenino la nube tossica.
+    aliases:
+    - mangrovieto_cinetico
   dorsale_termale_tropicale:
     label: Dorsale Termale Tropicale
     summary: Catena montuosa sommersa con fumarole calde e fauna simbiotica.
@@ -575,6 +577,8 @@ biomes:
       hooks:
       - Proteggere le colonie coralline da razzie di risonanza.
       - Convincere i custodi del reef a condividere i filtri luminescenti.
+    aliases:
+    - laguna_bioreattiva
   savana:
     label: Savana Ionizzata
     summary: Dune fotoniche con branchi adattivi e rovine sepolte.

--- a/packs/evo_tactics_pack/data/species/laguna_bioreattiva/laguna-bioreattiva-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/laguna_bioreattiva/laguna-bioreattiva-trait-keeper.yaml
@@ -1,8 +1,8 @@
 resistance_archetype: adattivo
 id: laguna-bioreattiva-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
-environment_affinity:
-  biome_class: laguna_bioreattiva
+biomes:
+- laguna_bioreattiva
 derived_from_environment:
   suggested_traits:
   - antenne_flusso_mareale

--- a/packs/evo_tactics_pack/data/species/mangrovieto_cinetico/mangrovieto-cinetico-trait-keeper.yaml
+++ b/packs/evo_tactics_pack/data/species/mangrovieto_cinetico/mangrovieto-cinetico-trait-keeper.yaml
@@ -1,8 +1,8 @@
 resistance_archetype: adattivo
 id: mangrovieto-cinetico-trait-keeper
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
-environment_affinity:
-  biome_class: mangrovieto_cinetico
+biomes:
+- mangrovieto_cinetico
 derived_from_environment:
   suggested_traits:
   - artigli_radice


### PR DESCRIPTION
## What

Closes the last 2 of the 5 `env_affinity` keepers — **TKT-KEEPER-CANON-5BIOMI 5/5**. `laguna_bioreattiva` and `mangrovieto_cinetico` had no canonical home, so their keepers used `environment_affinity.biome_class` — which the canon-consistency biome-refs gate does **not** inspect (a structural gate-dodge). Map each to the nearest canonical biome via the same mechanism as [#3060](https://github.com/MasterDD-L34D/Game/pull/3060):

| orphan | -> canonical | rationale (keeper traits) |
| --- | --- | --- |
| `laguna_bioreattiva` | `reef_luminescente` | littoral / luminescent — `filtri_planctonici`, `appendici_risonanti_marea`, `branchie_dual_mode`, `ghiandole_cambio_salino` |
| `mangrovieto_cinetico` | `palude` | wetland / mud — `membrane_pneumatofori` (mangrove roots), `ghiandole_fango_coesivo`, `artigli_radice` |

## Change set (mirror #3060)

- Declare both in `data/core/biome_aliases.yaml` (`canonical: X`, `status: expansion`).
- Add each orphan id to the canonical biome's `aliases:` list in **both** `data/core/biomes.yaml` and `packs/evo_tactics_pack/data/biomes.yaml` (`sync_core` copies core→pack, so both must carry it — the #3060 Codex-P1 lesson).
- Flip each keeper `environment_affinity.biome_class: X` → `biomes:\n- X`, so the canon gate now **exercises** the refs (honest) instead of being structurally bypassed.

## Verification

- canon gate (`check-canon-consistency.cjs`): **total=0 new=0 OK** — refs resolve via the alias union, no gate-dodge.
- `validate_datasets.py` RC=0; repro guard **normal + --deep** RC=0 (bundle-neutral — keepers are `is_creature`-excluded from the bridge).
- AI **560/560**; `test:api` **RC=0**; all 5 YAML files parse. `caveman:cavecrew-reviewer`: **no issues**.

## Scope / merge

Canon-DATA → surface green, **master-dd merge**. The mapping is a proposed nearest-match (these 2 weren't pre-declared in `biome_aliases.yaml`); reversible by reverting. Band-neutral (inert keeper stubs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)