### PR TITLE
feat(traits): ratify + wire the 9 GAP2 *_2 appendix-A variant traits (#3036)

### DIFF
--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -7558,3 +7558,120 @@ traits:
       turns: 99
       log_tag: emettitori_voidsong
     description_it: 'Emettitori voidsong: organi che emettono cori a frequenze profonde; il void-song destabilizza la mira del bersaglio colpito (on-hit abbagliato, -1 attacco).'
+  artigli_sette_vie_2:
+    tier: T1
+    category: offensivo
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: disorient
+      turns: 1
+      log_tag: artigli_sette_vie_2
+    description_it: 'Artigli a sette vie -- aggancio-trazione: il colpo aggancia e strattona il bersaglio destabilizzandolo (on-hit disorient; primitive pull ideale rinviato).'
+  coda_frusta_cinetica_2:
+    tier: T1
+    category: offensivo
+    applies_to: actor
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: apply_status
+      target_side: target
+      stato: disorient
+      turns: 1
+      log_tag: coda_frusta_cinetica_2
+    description_it: 'Coda frusta cinetica -- trabucco: colpo a contrappeso che stordisce il bersaglio colpito (on-hit disorient; AoE ideale rinviato, per ora single-target).'
+  criostasi_adattiva_2:
+    tier: T1
+    category: fisiologico
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 2
+      min: 0
+      log_tag: criostasi_adattiva_2
+    description_it: 'Criostasi adattiva -- torpore controllato: la stasi reversibile irrobustisce i tessuti e riduce il danno subito (damage_reduction -2).'
+  focus_frazionato_2:
+    tier: T1
+    category: sensoriale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      min_mos: 0
+    effect:
+      kind: attack_bonus
+      amount: 1
+      log_tag: focus_frazionato_2
+    description_it: 'Focus frazionato -- attenzione divisa: il tracciamento simultaneo di due bersagli affina la mira (attack_bonus +1).'
+  risonanza_di_branco_2:
+    tier: T1
+    category: difensivo
+    applies_to: actor
+    trigger:
+      action_type: passive
+    effect:
+      kind: apply_status
+      stato: attuned
+      turns: 2
+      target: actor
+      log_tag: risonanza_di_branco_2
+    description_it: 'Risonanza di branco -- segnalazione sincronizzata: i segnali coordinati allineano il gruppo e ne rinsaldano la guardia (passiva attuned, +1 difesa).'
+  sacche_galleggianti_ascensoriali_2:
+    tier: T1
+    category: difensivo
+    applies_to: actor
+    trigger:
+      action_type: passive
+    effect:
+      kind: apply_status
+      stato: attuned
+      turns: 2
+      target: actor
+      log_tag: sacche_galleggianti_ascensoriali_2
+    description_it: 'Sacche galleggianti ascensoriali -- controllo assetto: la regolazione fine del galleggiamento stabilizza la postura (passiva attuned, +1 difesa).'
+  scheletro_idro_regolante_2:
+    tier: T1
+    category: fisiologico
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 2
+      min: 0
+      log_tag: scheletro_idro_regolante_2
+    description_it: 'Scheletro idro-regolante -- idrostato muscolare: la co-contrazione multiassiale assorbe gli urti e riduce il danno subito (damage_reduction -2).'
+  struttura_elastica_amorfa_2:
+    tier: T1
+    category: fisiologico
+    applies_to: target
+    trigger:
+      action_type: attack
+      on_result: hit
+    effect:
+      kind: damage_reduction
+      amount: 2
+      min: 0
+      log_tag: struttura_elastica_amorfa_2
+    description_it: 'Struttura elastica amorfa -- fibre super-coiled: le fibre super-avvolte assorbono gli impatti riducendo il danno subito (damage_reduction -2).'
+  tattiche_di_branco_2:
+    tier: T1
+    category: comportamentale
+    applies_to: actor
+    trigger:
+      action_type: attack
+      min_mos: 0
+    effect:
+      kind: attack_bonus
+      amount: 1
+      log_tag: tattiche_di_branco_2
+    description_it: 'Tattiche di branco -- ruoli specializzati: la caccia coordinata per ruoli distinti affina i colpi del gruppo (attack_bonus +1).'

--- a/data/traits/idrostatico/sacche_galleggianti_ascensoriali_2.json
+++ b/data/traits/idrostatico/sacche_galleggianti_ascensoriali_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.sacche_galleggianti_ascensoriali_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -18692,7 +18692,7 @@
       "uso_funzione": "i18n:traits.artigli_sette_vie_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "coda_frusta_cinetica_2": {
@@ -18715,7 +18715,7 @@
       "uso_funzione": "i18n:traits.coda_frusta_cinetica_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "criostasi_adattiva_2": {
@@ -18738,7 +18738,7 @@
       "uso_funzione": "i18n:traits.criostasi_adattiva_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "focus_frazionato_2": {
@@ -18761,7 +18761,7 @@
       "uso_funzione": "i18n:traits.focus_frazionato_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "risonanza_di_branco_2": {
@@ -18784,7 +18784,7 @@
       "uso_funzione": "i18n:traits.risonanza_di_branco_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "sacche_galleggianti_ascensoriali_2": {
@@ -18807,7 +18807,7 @@
       "uso_funzione": "i18n:traits.sacche_galleggianti_ascensoriali_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "scheletro_idro_regolante_2": {
@@ -18830,7 +18830,7 @@
       "uso_funzione": "i18n:traits.scheletro_idro_regolante_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "struttura_elastica_amorfa_2": {
@@ -18853,7 +18853,7 @@
       "uso_funzione": "i18n:traits.struttura_elastica_amorfa_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "tattiche_di_branco_2": {
@@ -18876,7 +18876,7 @@
       "uso_funzione": "i18n:traits.tattiche_di_branco_2.uso_funzione",
       "data_origin": "appendix_a_variant_deep_research_grounded",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     }
   }

--- a/data/traits/locomotorio/artigli_sette_vie_2.json
+++ b/data/traits/locomotorio/artigli_sette_vie_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.artigli_sette_vie_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/locomotorio/coda_frusta_cinetica_2.json
+++ b/data/traits/locomotorio/coda_frusta_cinetica_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.coda_frusta_cinetica_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/metabolico/criostasi_adattiva_2.json
+++ b/data/traits/metabolico/criostasi_adattiva_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.criostasi_adattiva_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/focus_frazionato_2.json
+++ b/data/traits/strategia/focus_frazionato_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.focus_frazionato_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/tattiche_di_branco_2.json
+++ b/data/traits/strategia/tattiche_di_branco_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.tattiche_di_branco_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strutturale/scheletro_idro_regolante_2.json
+++ b/data/traits/strutturale/scheletro_idro_regolante_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.scheletro_idro_regolante_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strutturale/struttura_elastica_amorfa_2.json
+++ b/data/traits/strutturale/struttura_elastica_amorfa_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.struttura_elastica_amorfa_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/supporto/risonanza_di_branco_2.json
+++ b/data/traits/supporto/risonanza_di_branco_2.json
@@ -18,6 +18,6 @@
   "debolezza": "i18n:traits.risonanza_di_branco_2.debolezza",
   "data_origin": "appendix_a_variant_deep_research_grounded",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }


### PR DESCRIPTION
## What

Ratify + wire the 9 `*_2` appendix-A **variant** traits (the #3036 track). These are Claude-authored, **deep-research-grounded distinct variants** of their base family (each a different mechanism than its base), authored as `design_stub: true` pending master-dd ratify — the HITL gate, like the lore drafts. master-dd **ratified the designs + approved the mechanic mapping** this session.

> 🔑 Verify-first correction: an earlier read mischaracterized these as empty cruft (the glossary lookup checked the wrong fields). They have real authored `description_it`/`description_en` + biology citations (e.g. `artigli_sette_vie_2` = hook-and-pull digging, Ref. Wiley J.Anat. joa.13815). Removal would have discarded the authored work — surfaced + corrected before acting.

## Mapping (all tier T1, distinct from base)

| `_2` | wired mechanic | base |
| --- | --- | --- |
| artigli_sette_vie_2 | on-hit `disorient` (hook-pull off-balance) | extra_damage |
| coda_frusta_cinetica_2 | on-hit `disorient` (stun) | fracture |
| criostasi_adattiva_2 | `damage_reduction` 2 (stasis toughness) | buff_stat |
| scheletro_idro_regolante_2 | `damage_reduction` 2 (hydrostat absorb) | damage_reduction |
| struttura_elastica_amorfa_2 | `damage_reduction` 2 (super-coiled absorb) | buff_stat |
| focus_frazionato_2 | `attack_bonus` 1 (dual-target focus) | buff_stat |
| tattiche_di_branco_2 | `attack_bonus` 1 (coordinated roles) | not-wired |
| risonanza_di_branco_2 | passive `attuned` (+1 def) | buff_stat |
| sacche_galleggianti_ascensoriali_2 | passive `attuned` (+1 def) | buff_stat |

Two are **wired-approximations** of an ideal primitive that doesn't exist yet: `artigli_sette_vie_2` (ideal: a pull/displacement primitive) and `coda_frusta_cinetica_2` (ideal: AoE) — both use on-hit `disorient` for now; the ideal primitives are follow-up work.

## Change set (11 files)

- `active_effects.yaml`: +9 mechanic entries (407 → 416).
- 9 DB files + `index.json`: flip `completion_flags.design_stub` true → false (ratify marker). **Only the 9 _2 flipped** — `index.json` had 55 `design_stub:true` total; the diff is exactly 9/9 lines (format-preserving round-trip, no reformat).

## Verification

- PyYAML **416** + js-yaml **no dup-key**; mirror gate **PASS** (default, as CI runs it); canon gate **OK 0 new**; repro guard **normal + --deep RC=0**; `validate_datasets` RC=0; AI **560/560**; `test:api` **RC=0**. `cavecrew`: **no issues**.
- **Band-neutral**: no sim unit / encounter carries these (inert until authored onto a creature).

## Scope / merge

Canon-DATA → surface green, **master-dd merge**. Reversible by reverting.

**Follow-up (out of scope):** `data/traits/index.csv` is stale vs the DB (lists the _2 in `_drafts/` with the pre-authoring `data_origin`); `build_trait_index.js` would rewrite it — a separate pre-existing drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)