### PR TITLE
fix(tooling): repoint frattura + data_health off removed data/core/species.yaml

### DIFF
--- a/scripts/evo_pack_pipeline.py
+++ b/scripts/evo_pack_pipeline.py
@@ -49,7 +49,8 @@ def copy_tree(source: Path, target: Path) -> None:
 
 def sync_core(core_root: Path, pack_root: Path) -> None:
     mapping: dict[Path, Path] = {
-        core_root / "species.yaml": pack_root / "data" / "species.yaml",
+        # data/core/species.yaml removed in #2271 (split); the species/ dir below
+        # carries the canonical catalog (species_catalog.json + per-species files).
         core_root / "species": pack_root / "data" / "species",
         core_root / "biomes.yaml": pack_root / "data" / "biomes.yaml",
         core_root / "biome_aliases.yaml": pack_root / "data" / "biome_aliases.yaml",

--- a/scripts/evo_pack_pipeline.py
+++ b/scripts/evo_pack_pipeline.py
@@ -49,8 +49,7 @@ def copy_tree(source: Path, target: Path) -> None:
 
 def sync_core(core_root: Path, pack_root: Path) -> None:
     mapping: dict[Path, Path] = {
-        # data/core/species.yaml removed in #2271 (split); the species/ dir below
-        # carries the canonical catalog (species_catalog.json + per-species files).
+        core_root / "species.yaml": pack_root / "data" / "species.yaml",
         core_root / "species": pack_root / "data" / "species",
         core_root / "biomes.yaml": pack_root / "data" / "biomes.yaml",
         core_root / "biome_aliases.yaml": pack_root / "data" / "biome_aliases.yaml",

--- a/scripts/qa/frattura_abissale_validations.py
+++ b/scripts/qa/frattura_abissale_validations.py
@@ -84,6 +84,13 @@ def check_pools_and_traits(index: Mapping[str, dict]):
 
 
 def flatten_trait_plan(species_entry: Mapping) -> Iterable[str]:
+    # Catalog entries carry a flat `trait_refs` slug list (canonical post #2271);
+    # legacy species.yaml used a nested `trait_plan`. Support both.
+    refs = species_entry.get("trait_refs")
+    if refs is not None:
+        for slug in refs or []:
+            yield slug
+        return
     plan = species_entry.get("trait_plan", {}) or {}
     for bucket in ("core", "support", "optional"):
         for slug in plan.get(bucket, []) or []:
@@ -91,8 +98,15 @@ def flatten_trait_plan(species_entry: Mapping) -> Iterable[str]:
 
 
 def check_species_and_affinity(index: Mapping[str, dict]):
-    species_data = load_yaml("data/core/species.yaml")
-    species_map = {entry.get("id"): entry for entry in species_data.get("species", []) if entry.get("id")}
+    # data/core/species.yaml removed in #2271 (split). Canonical SoT is the JSON
+    # catalog data/core/species/species_catalog.json: list under "catalog", each
+    # entry keyed by species_id + biome_affinity + trait_refs (flat slug list).
+    species_data = load_json("data/core/species/species_catalog.json")
+    species_map = {
+        entry.get("species_id"): entry
+        for entry in species_data.get("catalog", [])
+        if entry.get("species_id")
+    }
     for sid in SPECIES_IDS:
         entry = species_map.get(sid)
         assert_true(entry is not None, f"Specie {sid} mancante")

--- a/tests/test_species_catalog_repoint.py
+++ b/tests/test_species_catalog_repoint.py
@@ -1,0 +1,58 @@
+"""Regression guard for the species.yaml -> species_catalog.json repoint (B8, #2271).
+
+`data/core/species.yaml` was removed in #2271 (split into the JSON catalog
+`data/core/species/species_catalog.json`). Several QA/audit scripts kept loading
+the removed monolith -> hard crash (frattura, evo_pack_pipeline) or permanent
+false "Missing file" health issues (data_health). These tests pin the repoint so
+the dead path cannot silently reappear.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOG = REPO_ROOT / "data" / "core" / "species" / "species_catalog.json"
+
+
+def _load_module(rel_path: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / rel_path)
+    module = importlib.util.module_from_spec(spec)
+    # register before exec: dataclass field resolution needs the module in
+    # sys.modules (data_health uses @dataclass with annotation lookup).
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_canonical_catalog_exists_and_shaped():
+    assert CATALOG.exists(), "canonical species catalog missing"
+    data = json.loads(CATALOG.read_text(encoding="utf-8"))
+    assert isinstance(data.get("catalog"), list) and data["catalog"], "catalog list empty"
+    entry = data["catalog"][0]
+    assert "species_id" in entry and "biome_affinity" in entry and "trait_refs" in entry
+
+
+def test_data_health_species_rules_point_at_existing_paths():
+    dh = _load_module("tools/audit/data_health.py", "data_health_under_test")
+    paths = {str(rule.path).replace("\\", "/") for rule in dh.EXPECTED_DATASETS}
+    # the removed monolith + the never-existed pack/core path must not reappear
+    assert "data/core/species.yaml" not in paths
+    assert "packs/evo_tactics_pack/data/core/species.yaml" not in paths
+    species_rules = [r for r in dh.EXPECTED_DATASETS if "species" in str(r.path)]
+    assert species_rules, "expected at least one species DatasetRule"
+    for rule in species_rules:
+        assert rule.absolute_path().exists(), f"data_health rule path missing: {rule.path}"
+
+
+def test_frattura_species_resolve_from_catalog():
+    fr = _load_module("scripts/qa/frattura_abissale_validations.py", "frattura_under_test")
+    data = fr.load_json("data/core/species/species_catalog.json")
+    species_map = {
+        e.get("species_id"): e for e in data.get("catalog", []) if e.get("species_id")
+    }
+    for sid in fr.SPECIES_IDS:
+        assert sid in species_map, f"{sid} not resolvable from catalog"
+        assert species_map[sid].get("biome_affinity") == fr.BIOME_SLUG
+        # trait_refs is the flat slug list the repoint reads
+        assert isinstance(species_map[sid].get("trait_refs", []), list)

--- a/tools/audit/data_health.py
+++ b/tools/audit/data_health.py
@@ -121,10 +121,10 @@ EXPECTED_DATASETS: tuple[DatasetRule, ...] = (
         description="Pack tables for MBTI forms and PI shop economy.",
     ),
     DatasetRule(
-        path=Path("data/core/species.yaml"),
-        fmt="yaml",
+        path=Path("data/core/species/species_catalog.json"),
+        fmt="json",
         required_keys=("catalog",),
-        description="Slot catalog + synergies for species builder.",
+        description="Species catalog + synergies (canonical, ex data/core/species.yaml #2271).",
     ),
     DatasetRule(
         path=Path("data/core/biomes.yaml"),
@@ -198,11 +198,10 @@ EXPECTED_DATASETS: tuple[DatasetRule, ...] = (
         description="Drive sync manifest for approved assets.",
     ),
     DatasetRule(
-        path=Path("packs/evo_tactics_pack/data/core/species.yaml"),
+        path=Path("packs/evo_tactics_pack/data/species.yaml"),
         fmt="yaml",
-        required_keys=("meta", "global_rules"),
-        version_path=("meta", "version"),
-        description="Pack-level species catalog meta + global rules.",
+        required_keys=("catalog", "global_rules"),
+        description="Pack-level species catalog + global rules (synced from core).",
     ),
     DatasetRule(
         path=Path("data/traits/index.json"),


### PR DESCRIPTION
## Cosa

Tier-1 closure dal [close-out master plan](docs/planning/2026-06-29-closeout-master-plan.md) (item **B8**). `data/core/species.yaml` fu splittato nel catalog JSON `data/core/species/species_catalog.json` in #2271. Script che caricavano ancora il monolite rimosso -> crash o falso "Missing file". Repoint sul pattern #2940 (lista `catalog`, chiave `species_id`, `trait_refs` flat).

## Fix (2 target safe) + verifica live

| Script | Bug | Fix | Verifica |
| --- | --- | --- | --- |
| `scripts/qa/frattura_abissale_validations.py` | crash su `load_yaml(species.yaml)` | `load_json` catalog + `species_id` key + `flatten_trait_plan` legge `trait_refs` | isolated: 4 specie/biome_affinity/trait_refs risolvono (no crash) |
| `tools/audit/data_health.py` (x2 regole) | 2 regole puntano a file rimossi/mai-esistiti -> "Missing file" | repoint core->catalog JSON; pack->`data/species.yaml` (keys `catalog`+`global_rules`) | `missing-file` specie **2 -> 0** |

+ `tests/test_species_catalog_repoint.py` regression guard (catalog shape · data_health species-rule paths esistono · niente monolite rimosso · frattura risolve dal catalog) -> **3/3 green**.

## Codex P1 risolto (scope ridotto)

`scripts/evo_pack_pipeline.py` **rimosso da questo PR** (a93bd402). Codex P1 valido + ground-truthed: rimuovere il mapping morto `species.yaml` sbloccava `sync_core`, che poi raggiunge `copy_tree(data/core/species -> packs/.../data/species)`. Le due dir sono **strutturalmente diverse** (source flat lifecycle+catalog; target biome-subdir `badlands/`/`foresta_temperata/` consumati da derive_env_traits + validators) -> `copy_tree` rmtree+replace = corruzione. Il vecchio crash sull'exists-check mascherava questa copia morta. Revert a origin/main (safe-crash; script unused, 0 ref CI/Makefile). Il fix vero (rework di `sync_core`) -> chip follow-up dedicato. Thread Codex risolto.

## Scope / deferred

- **3 DEGRADED** (silent 0-species: `generator.py`, `build-idea-taxonomy.js`, `validate_datasets.py` ecology) -> chip B8 part-2 (il #ecology puo' far emergere data-orphan reali -> verify-green isolato).
- **evo_pack_pipeline** structural sync rework -> chip dedicato.
- **Content-gap pre-esistenti** (NON fixati): frattura `cinesica`/`species_affinity`; data_health `trait_coverage_report.generated_at` (regola stale, la reproducibility arc l'ha rimosso by-design).

## Verifica

`python -m pytest tests/test_species_catalog_repoint.py -q` -> **3 passed**. `py_compile` OK. CI: `paths-filter` pass (dataset-checks skipped via routing); Codex P1 resolved.

## Rollback

Revert del commit. Script QA/audit (non runtime); nessun cambio schema/flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)