### PR TITLE
feat(codex): ratify + promote the 13 retired-creature A.L.I.E.N.A. lore entries (#3038)

### DIFF
--- a/apps/backend/services/codex/codexEntries.js
+++ b/apps/backend/services/codex/codexEntries.js
@@ -254,7 +254,14 @@ function summarize(entry) {
 }
 
 function listCodexEntries() {
-  return loadCodexEntries().map(summarize);
+  // codex_archive entries (retired-creature lore, #3038) are intentionally absent
+  // from every roster -> they can never unlock through play. Excluding them from the
+  // regular Bestiario list avoids permanently-locked ??? rows and an impossible
+  // completion count (Codex P2 on #3076). They stay loadable by id (getCodexEntry)
+  // for the future archive surface that will expose them outside the unlock path.
+  return loadCodexEntries()
+    .filter((entry) => !entry.codex_archive)
+    .map(summarize);
 }
 
 // Detail entry: allowlisted + deep-cloned (fail-closed secret guard + no cache

--- a/data/codex/aerostatocyon_altivolans.yaml
+++ b/data/codex/aerostatocyon_altivolans.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: aerostatocyon_altivolans
   type: species
+  codex_archive: true
   display_name_it: Aerostato ascendente
   display_name_en: Aerostato ascendente
   subtitle_it: Aerostato ascendente -- Stratosfera Tempestosa (T1)
@@ -33,8 +34,7 @@ codex_entry:
     biome_hook: stabilizzare gli ancoraggi stratosferici prima del collasso
     affixes: stormfront, jetstream, thunder bloom
     neighbors: storm paladins, jetstream outriders, sky anchor techs
-    traits: sacche galleggianti ascensoriali, occhi cristallo modulare, olfatto risonanza
-      magnetica, focus frazionato, criostasi adattiva, eco interno riflesso
+    traits: sacche galleggianti ascensoriali, occhi cristallo modulare, olfatto risonanza magnetica, focus frazionato, criostasi adattiva, eco interno riflesso
     visual: un fluttuatore.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -47,17 +47,13 @@ codex_entry:
       cross_ref:
       - biome:stratosfera_tempestosa
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: Stratosfera Tempestosa -- Piattaforme aerostatiche tra nubi di tempesta, fulmini
-        e venti supersonici, dal tono di Assalti aerei tra piattaforme volanti e tempeste
-        iper-ionizzate (stormfront, jetstream, thunder bloom) -- non e' uno sfondo ma un avversario
-        costante per il aerostato ascendente. Ogni movimento e' una risposta all'ambiente.
+      content: Stratosfera Tempestosa -- Piattaforme aerostatiche tra nubi di tempesta, fulmini e venti supersonici, che comprende Assalti aerei tra piattaforme volanti e tempeste iper-ionizzate (stormfront, jetstream, thunder bloom) -- non e' uno sfondo ma un avversario costante per l'aerostato ascendente. Ogni movimento e' una risposta all'ambiente.
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: adattivo'
       - 'role_trofico: filtratore_aereo; sentient: False'
-      - 'trait_refs: sacche_galleggianti_ascensoriali, occhi_cristallo_modulare, olfatto_risonanza_magnetica,
-        focus_frazionato, criostasi_adattiva, eco_interno_riflesso'
+      - 'trait_refs: sacche_galleggianti_ascensoriali, occhi_cristallo_modulare, olfatto_risonanza_magnetica, focus_frazionato, criostasi_adattiva, eco_interno_riflesso'
       cross_ref:
       - species:aerostatocyon_altivolans
       - trait:sacche_galleggianti_ascensoriali
@@ -67,11 +63,7 @@ codex_entry:
       - trait:criostasi_adattiva
       - trait:eco_interno_riflesso
       game_impact: Archetipo adattivo.
-      content: 'Il aerostato ascendente evolve lungo le fasi un ciclo di adattamento continuo.
-        I suoi tratti -- sacche galleggianti ascensoriali, occhi cristallo modulare, olfatto
-        risonanza magnetica, focus frazionato, criostasi adattiva, eco interno riflesso --
-        non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo
-        adattivo.'
+      content: 'L''aerostato ascendente evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- sacche galleggianti ascensoriali, occhi cristallo modulare, olfatto risonanza magnetica, focus frazionato, criostasi adattiva, eco interno riflesso -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -81,9 +73,7 @@ codex_entry:
       cross_ref:
       - species:aerostatocyon_altivolans
       game_impact: Profilo da ranger (fluttuatore).
-      content: 'Morfologia: un fluttuatore. Ogni adattamento risponde a una pressione; le
-        linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la
-        forma base.'
+      content: 'Morfologia: un fluttuatore. Ogni adattamento risponde a una pressione; le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la forma base.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -92,9 +82,7 @@ codex_entry:
       cross_ref:
       - biome:stratosfera_tempestosa
       game_impact: 'encounter_role: threat.'
-      content: Nell'ecologia di Stratosfera Tempestosa il aerostato ascendente occupa la nicchia
-        di filtratore aereo (T1), accanto a storm paladins, jetstream outriders, sky anchor
-        techs. Esercita pressione sulle prede senza contendere l'apice.
+      content: Nell'ecologia di Stratosfera Tempestosa l'aerostato ascendente occupa la nicchia di filtratore aereo (T1), accanto a storm paladins, jetstream outriders, sky anchor techs. Esercita pressione sulle prede senza contendere l'apice.
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -102,8 +90,7 @@ codex_entry:
       cross_ref:
       - species:aerostatocyon_altivolans
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: Il aerostato ascendente vive in gruppi territoriali. I legami sono di natura
-        istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
+      content: L'aerostato ascendente vive in gruppi territoriali. I legami sono di natura istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -111,9 +98,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'Per l''allenatore il aerostato ascendente e'' un avversario filtratore aereo
-        (T1) che affronti in Stratosfera Tempestosa. E nel suo mondo la posta in gioco e''
-        stabilizzare gli ancoraggi stratosferici prima del collasso. E'' qui che il Codex
-        comincia: la prima forma di vita di cui annotare la verita''.'
+      content: 'Per l''allenatore l''aerostato ascendente e'' un avversario filtratore aereo (T1) che affronti in Stratosfera Tempestosa. E nel suo mondo la posta in gioco e'' stabilizzare gli ancoraggi stratosferici prima del collasso. E'' qui che il Codex comincia: la prima forma di vita di cui annotare la verita''.'
       story_hook_it: un avversario filtratore aereo (T1) che affronti in Stratosfera Tempestosa
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/amorphovenator_magneticus.yaml
+++ b/data/codex/amorphovenator_magneticus.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: amorphovenator_magneticus
   type: species
+  codex_archive: true
   display_name_it: Sondatore amorfo
   display_name_en: Sondatore amorfo
   subtitle_it: Sondatore amorfo -- Scogliera Luminescente (T1)
@@ -18,8 +19,7 @@ codex_entry:
   lore_vars:
     subject: sondatore amorfo
     biome_name: Scogliera Luminescente
-    biome_trait: Barriere coralline sintetiche con correnti luminescenti e fauna sensibile
-      alla risonanza
+    biome_trait: Barriere coralline sintetiche con correnti luminescenti e fauna sensibile alla risonanza
     lineage: forme a morfologia amorfo
     archetype: adattivo
     morphotype: amorfo
@@ -34,8 +34,7 @@ codex_entry:
     biome_hook: proteggere le colonie coralline da razzie di risonanza
     affixes: light current, coral spire
     neighbors: reef wardens, luminescent harriers, tide callers
-    traits: filamenti digestivi compattanti, olfatto risonanza magnetica, struttura elastica
-      amorfa, lamelle termoforetiche, scheletro idro regolante
+    traits: filamenti digestivi compattanti, olfatto risonanza magnetica, struttura elastica amorfa, lamelle termoforetiche, scheletro idro regolante
     visual: un amorfo.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -48,17 +47,13 @@ codex_entry:
       cross_ref:
       - biome:reef_luminescente
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: Scogliera Luminescente -- Barriere coralline sintetiche con correnti luminescenti
-        e fauna sensibile alla risonanza, dal tono di Operazioni stealth subacquee tra colonne
-        fotoniche e alveari acquatici (light current, coral spire) -- non e' uno sfondo ma
-        un avversario costante per il sondatore amorfo. Ogni movimento e' una risposta all'ambiente.
+      content: Scogliera Luminescente -- Barriere coralline sintetiche con correnti luminescenti e fauna sensibile alla risonanza, all'insegna di Operazioni stealth subacquee tra colonne fotoniche e alveari acquatici (light current, coral spire) -- non e' uno sfondo ma un avversario costante per il sondatore amorfo. Ogni movimento e' una risposta all'ambiente.
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: adattivo'
       - 'role_trofico: predatore_secondario; sentient: False'
-      - 'trait_refs: filamenti_digestivi_compattanti, olfatto_risonanza_magnetica, struttura_elastica_amorfa,
-        lamelle_termoforetiche, scheletro_idro_regolante'
+      - 'trait_refs: filamenti_digestivi_compattanti, olfatto_risonanza_magnetica, struttura_elastica_amorfa, lamelle_termoforetiche, scheletro_idro_regolante'
       cross_ref:
       - species:amorphovenator_magneticus
       - trait:filamenti_digestivi_compattanti
@@ -67,10 +62,7 @@ codex_entry:
       - trait:lamelle_termoforetiche
       - trait:scheletro_idro_regolante
       game_impact: Archetipo adattivo.
-      content: 'Il sondatore amorfo evolve lungo le fasi un ciclo di adattamento continuo.
-        I suoi tratti -- filamenti digestivi compattanti, olfatto risonanza magnetica, struttura
-        elastica amorfa, lamelle termoforetiche, scheletro idro regolante -- non sono ornamenti
-        ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
+      content: 'Il sondatore amorfo evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- filamenti digestivi compattanti, olfatto risonanza magnetica, struttura elastica amorfa, lamelle termoforetiche, scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -80,8 +72,7 @@ codex_entry:
       cross_ref:
       - species:amorphovenator_magneticus
       game_impact: Profilo da ranger (amorfo).
-      content: 'Il corpo del sondatore amorfo: un amorfo. Sotto pressione puo'' sviluppare
-        adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
+      content: 'Il corpo del sondatore amorfo: un amorfo. Sotto pressione puo'' sviluppare adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -90,9 +81,7 @@ codex_entry:
       cross_ref:
       - biome:reef_luminescente
       game_impact: 'encounter_role: threat.'
-      content: 'Il sondatore amorfo e'' predatore secondario in Scogliera Luminescente: una
-        presenza diffusa (T1) che, insieme a reef wardens, luminescent harriers, tide callers,
-        modella la catena trofica.'
+      content: 'Il sondatore amorfo e'' predatore secondario in Scogliera Luminescente: una presenza diffusa (T1) che, insieme a reef wardens, luminescent harriers, tide callers, modella la catena trofica.'
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -100,8 +89,7 @@ codex_entry:
       cross_ref:
       - species:amorphovenator_magneticus
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: 'La struttura sociale del sondatore amorfo si regge su gruppi territoriali.
-        La socialita'' e'' istintiva: coordinazione efficace senza una cultura nel senso pieno.'
+      content: 'La struttura sociale del sondatore amorfo si regge su gruppi territoriali. La socialita'' e'' istintiva: coordinazione efficace senza una cultura nel senso pieno.'
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -109,8 +97,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'un avversario predatore secondario (T1) che affronti in Scogliera Luminescente:
-        ecco perche'' il sondatore amorfo apre il Codex. Intorno a lui le storie del bioma
-        -- proteggere le colonie coralline da razzie di risonanza -- danno peso al primo incontro.'
+      content: 'un avversario predatore secondario (T1) che affronti in Scogliera Luminescente: ecco perche'' il sondatore amorfo apre il Codex. Intorno a lui le storie del bioma -- proteggere le colonie coralline da razzie di risonanza -- danno peso al primo incontro.'
       story_hook_it: un avversario predatore secondario (T1) che affronti in Scogliera Luminescente
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/auroserpens_photonicus.yaml
+++ b/data/codex/auroserpens_photonicus.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: auroserpens_photonicus
   type: species
+  codex_archive: true
   display_name_it: Auroserpe
   display_name_en: Auroserpe
   subtitle_it: Auroserpe -- Canopia Ionica (T2)
@@ -46,10 +47,7 @@ codex_entry:
       cross_ref:
       - biome:canopia_ionica
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: Canopia Ionica -- Foresta verticale sospesa da campi elettrostatici e rampicanti
-        conduttivi, dal tono di Missioni acrobatiche tra passerelle elettrostatiche e reti
-        sospese (static vines, ion lattice) -- non e' uno sfondo ma un avversario costante
-        per il auroserpe. Ogni movimento e' una risposta all'ambiente.
+      content: Canopia Ionica -- Foresta verticale sospesa da campi elettrostatici e rampicanti conduttivi, nel segno di Missioni acrobatiche tra passerelle elettrostatiche e reti sospese (static vines, ion lattice) -- non e' uno sfondo ma un avversario costante per l'auroserpe. Ogni movimento e' una risposta all'ambiente.
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
@@ -63,10 +61,7 @@ codex_entry:
       - trait:empatia_coordinativa
       - trait:risonanza_di_branco
       game_impact: Archetipo adattivo.
-      content: 'Il auroserpe evolve lungo le fasi un ciclo di adattamento continuo. I suoi
-        tratti -- adattamento volo, ali solari fotoni, empatia coordinativa, risonanza di
-        branco -- non sono ornamenti ma risposte: ognuno racconta una pressione superata,
-        in archetipo adattivo.'
+      content: 'L''auroserpe evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- adattamento volo, ali solari fotoni, empatia coordinativa, risonanza di branco -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -76,9 +71,7 @@ codex_entry:
       cross_ref:
       - species:auroserpens_photonicus
       game_impact: Profilo da warden (serpentiforme alato).
-      content: 'Morfologia: un serpentiforme alato. Ogni adattamento risponde a una pressione;
-        le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre
-        la forma base.'
+      content: 'Morfologia: un serpentiforme alato. Ogni adattamento risponde a una pressione; le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la forma base.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -87,9 +80,7 @@ codex_entry:
       cross_ref:
       - biome:canopia_ionica
       game_impact: 'encounter_role: threat.'
-      content: Nell'ecologia di Canopia Ionica il auroserpe occupa la nicchia di predatore
-        secondario (T2), accanto a sentinelle della canopia, predatori del reticolo, tessitori
-        di carica. Esercita pressione sulle prede senza contendere l'apice.
+      content: Nell'ecologia di Canopia Ionica l'auroserpe occupa la nicchia di predatore secondario (T2), accanto a sentinelle della canopia, predatori del reticolo, tessitori di carica. Esercita pressione sulle prede senza contendere l'apice.
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -97,8 +88,7 @@ codex_entry:
       cross_ref:
       - species:auroserpens_photonicus
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: 'La struttura sociale del auroserpe si regge su gruppi territoriali. La socialita''
-        e'' culturale: coordinazione efficace senza una cultura nel senso pieno.'
+      content: 'La struttura sociale dell''auroserpe si regge su gruppi territoriali. La socialita'' e'' culturale: coordinazione efficace senza una cultura nel senso pieno.'
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -106,8 +96,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'un avversario predatore secondario (T2) che affronti in Canopia Ionica: ecco
-        perche'' il auroserpe apre il Codex. Intorno a lui le storie del bioma -- sincronizzare
-        la rete ionica per aprire corridoi sicuri -- danno peso al primo incontro.'
+      content: 'un avversario predatore secondario (T2) che affronti in Canopia Ionica: ecco perche'' l''auroserpe apre il Codex. Intorno a lui le storie del bioma -- sincronizzare la rete ionica per aprire corridoi sicuri -- danno peso al primo incontro.'
       story_hook_it: un avversario predatore secondario (T2) che affronti in Canopia Ionica
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/cryptopennatus_psionicus.yaml
+++ b/data/codex/cryptopennatus_psionicus.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: cryptopennatus_psionicus
   type: species
+  codex_archive: true
   display_name_it: Esploratore di chioma
   display_name_en: Esploratore di chioma
   subtitle_it: Esploratore di chioma -- Canopia Ionica (T1)
@@ -33,8 +34,7 @@ codex_entry:
     biome_hook: sincronizzare la rete ionica per aprire corridoi sicuri
     affixes: static vines, ion lattice
     neighbors: sentinelle della canopia, predatori del reticolo, tessitori di carica
-    traits: mimetismo cromatico passivo, sacche galleggianti ascensoriali, struttura elastica
-      amorfa, focus frazionato, pathfinder, ali fono risonanti
+    traits: mimetismo cromatico passivo, sacche galleggianti ascensoriali, struttura elastica amorfa, focus frazionato, pathfinder, ali fono risonanti
     visual: un aliante mimetico.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -47,17 +47,13 @@ codex_entry:
       cross_ref:
       - biome:canopia_ionica
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: Canopia Ionica -- Foresta verticale sospesa da campi elettrostatici e rampicanti
-        conduttivi, dal tono di Missioni acrobatiche tra passerelle elettrostatiche e reti
-        sospese (static vines, ion lattice) -- non e' uno sfondo ma un avversario costante
-        per il esploratore di chioma. Ogni movimento e' una risposta all'ambiente.
+      content: Canopia Ionica -- Foresta verticale sospesa da campi elettrostatici e rampicanti conduttivi, che evoca Missioni acrobatiche tra passerelle elettrostatiche e reti sospese (static vines, ion lattice) -- non e' uno sfondo ma un avversario costante per l'esploratore di chioma. Ogni movimento e' una risposta all'ambiente.
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: adattivo'
       - 'role_trofico: esploratore; sentient: True'
-      - 'trait_refs: mimetismo_cromatico_passivo, sacche_galleggianti_ascensoriali, struttura_elastica_amorfa,
-        focus_frazionato, pathfinder, ali_fono_risonanti, spore_psichiche_silenziate, occhi_cristallo_modulare'
+      - 'trait_refs: mimetismo_cromatico_passivo, sacche_galleggianti_ascensoriali, struttura_elastica_amorfa, focus_frazionato, pathfinder, ali_fono_risonanti, spore_psichiche_silenziate, occhi_cristallo_modulare'
       cross_ref:
       - species:cryptopennatus_psionicus
       - trait:mimetismo_cromatico_passivo
@@ -69,10 +65,7 @@ codex_entry:
       - trait:spore_psichiche_silenziate
       - trait:occhi_cristallo_modulare
       game_impact: Archetipo adattivo.
-      content: 'La linea del esploratore di chioma porta i segni di mimetismo cromatico passivo,
-        sacche galleggianti ascensoriali, struttura elastica amorfa, focus frazionato, pathfinder,
-        ali fono risonanti: ogni tratto core e'' la cicatrice di una pressione del bioma.
-        Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
+      content: 'La linea dell''esploratore di chioma porta i segni di mimetismo cromatico passivo, sacche galleggianti ascensoriali, struttura elastica amorfa, focus frazionato, pathfinder, ali fono risonanti: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -82,9 +75,7 @@ codex_entry:
       cross_ref:
       - species:cryptopennatus_psionicus
       game_impact: Profilo da ranger (aliante mimetico).
-      content: 'Morfologia: un aliante mimetico. Ogni adattamento risponde a una pressione;
-        le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre
-        la forma base.'
+      content: 'Morfologia: un aliante mimetico. Ogni adattamento risponde a una pressione; le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la forma base.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -93,9 +84,7 @@ codex_entry:
       cross_ref:
       - biome:canopia_ionica
       game_impact: 'encounter_role: threat.'
-      content: 'Il esploratore di chioma e'' esploratore in Canopia Ionica: una presenza diffusa
-        (T1) che, insieme a sentinelle della canopia, predatori del reticolo, tessitori di
-        carica, modella la catena trofica.'
+      content: 'L''esploratore di chioma e'' esploratore in Canopia Ionica: una presenza diffusa (T1) che, insieme a sentinelle della canopia, predatori del reticolo, tessitori di carica, modella la catena trofica.'
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -103,8 +92,7 @@ codex_entry:
       cross_ref:
       - species:cryptopennatus_psionicus
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: Il esploratore di chioma vive in gruppi territoriali. I legami sono di natura
-        culturale -- funzionali alla sopravvivenza piu' che al racconto di se'.
+      content: L'esploratore di chioma vive in gruppi territoriali. I legami sono di natura culturale -- funzionali alla sopravvivenza piu' che al racconto di se'.
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -112,8 +100,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'un avversario esploratore (T1) che affronti in Canopia Ionica: ecco perche''
-        il esploratore di chioma apre il Codex. Intorno a lui le storie del bioma -- sincronizzare
-        la rete ionica per aprire corridoi sicuri -- danno peso al primo incontro.'
+      content: 'un avversario esploratore (T1) che affronti in Canopia Ionica: ecco perche'' l''esploratore di chioma apre il Codex. Intorno a lui le storie del bioma -- sincronizzare la rete ionica per aprire corridoi sicuri -- danno peso al primo incontro.'
       story_hook_it: un avversario esploratore (T1) che affronti in Canopia Ionica
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/filtrophagus_custos.yaml
+++ b/data/codex/filtrophagus_custos.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: filtrophagus_custos
   type: species
+  codex_archive: true
   display_name_it: Filtrofago sentinella
   display_name_en: Filtrofago sentinella
   subtitle_it: Filtrofago sentinella -- Palude Tossica (T2)
@@ -46,10 +47,7 @@ codex_entry:
       cross_ref:
       - biome:palude
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: 'Il territorio del filtrofago sentinella e'' Palude Tossica: Acque stagnanti
-        bio-luminescenti con fauna mutagena. Un mondo da Survival horror organico e diplomazia
-        con culti simbiotici, segnato da fangoso, tossico, luminescente, viti. Qui la sopravvivenza
-        detta la forma, e nulla che non si adatti dura a lungo.'
+      content: 'Il territorio del filtrofago sentinella e'' Palude Tossica: Acque stagnanti bio-luminescenti con fauna mutagena. Un mondo da Survival horror organico e diplomazia con culti simbiotici, segnato da fangoso, tossico, luminescente, viti. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.'
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
@@ -62,10 +60,7 @@ codex_entry:
       - trait:membrane_osmotiche
       - trait:carapace_fase_variabile
       game_impact: Archetipo adattivo.
-      content: 'La linea del filtrofago sentinella porta i segni di filtri bioattivi, membrane
-        osmotiche, carapace fase variabile: ogni tratto core e'' la cicatrice di una pressione
-        del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio''
-        che sopravvive.'
+      content: 'La linea del filtrofago sentinella porta i segni di filtri bioattivi, membrane osmotiche, carapace fase variabile: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -75,9 +70,7 @@ codex_entry:
       cross_ref:
       - species:filtrophagus_custos
       game_impact: Profilo da warden (bipede filtratore).
-      content: 'Il corpo del filtrofago sentinella: un bipede filtratore. Sotto pressione
-        puo'' sviluppare adattamenti ancora non catalogati, piegando la morfologia a cio''
-        che il bioma esige.'
+      content: 'Il corpo del filtrofago sentinella: un bipede filtratore. Sotto pressione puo'' sviluppare adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -86,9 +79,7 @@ codex_entry:
       cross_ref:
       - biome:palude
       game_impact: 'encounter_role: threat.'
-      content: 'Il filtrofago sentinella e'' spazzino sentinella in Palude Tossica: una presenza
-        diffusa (T2) che, insieme a custodi miasmatici, druidi delle spore, raccoglitori di
-        fluoro, modella la catena trofica.'
+      content: 'Il filtrofago sentinella e'' spazzino sentinella in Palude Tossica: una presenza diffusa (T2) che, insieme a custodi miasmatici, druidi delle spore, raccoglitori di fluoro, modella la catena trofica.'
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -96,8 +87,7 @@ codex_entry:
       cross_ref:
       - species:filtrophagus_custos
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: Il filtrofago sentinella vive in gruppi territoriali. I legami sono di natura
-        istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
+      content: Il filtrofago sentinella vive in gruppi territoriali. I legami sono di natura istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -105,9 +95,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'Per l''allenatore il filtrofago sentinella e'' un avversario spazzino sentinella
-        (T2) che affronti in Palude Tossica. E nel suo mondo la posta in gioco e'' recuperare
-        reagenti bio-luminescenti per le squadre mediche. E'' qui che il Codex comincia: la
-        prima forma di vita di cui annotare la verita''.'
+      content: 'Per l''allenatore il filtrofago sentinella e'' un avversario spazzino sentinella (T2) che affronti in Palude Tossica. E nel suo mondo la posta in gioco e'' recuperare reagenti bio-luminescenti per le squadre mediche. E'' qui che il Codex comincia: la prima forma di vita di cui annotare la verita''.'
       story_hook_it: un avversario spazzino sentinella (T2) che affronti in Palude Tossica
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/heliopteryx_radians.yaml
+++ b/data/codex/heliopteryx_radians.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: heliopteryx_radians
   type: species
+  codex_archive: true
   display_name_it: Aliradiante solare
   display_name_en: Aliradiante solare
   subtitle_it: Aliradiante solare -- Savana Ionizzata (T1)
@@ -33,8 +34,7 @@ codex_entry:
     biome_hook: recuperare convogli cristallizzati e nodi di risonanza sepolti
     affixes: termico, luminescente, spore diluite, sabbia
     neighbors: predoni nomadi, guardiani delle dune, cartografi erranti
-    traits: adattamento volo, aura scudo radianza, ali solari fotoni, empatia coordinativa,
-      risonanza di branco
+    traits: adattamento volo, aura scudo radianza, ali solari fotoni, empatia coordinativa, risonanza di branco
     visual: un alato veliero.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -47,17 +47,13 @@ codex_entry:
       cross_ref:
       - biome:savana
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: 'Il territorio del aliradiante solare e'' Savana Ionizzata: Dune fotoniche
-        con branchi adattivi e rovine sepolte. Un mondo da Western sci-fi e sopravvivenza
-        carovaniera, segnato da termico, luminescente, spore diluite, sabbia. Qui la sopravvivenza
-        detta la forma, e nulla che non si adatti dura a lungo.'
+      content: 'Il territorio dell''aliradiante solare e'' Savana Ionizzata: Dune fotoniche con branchi adattivi e rovine sepolte. Un mondo da Western sci-fi e sopravvivenza carovaniera, segnato da termico, luminescente, spore diluite, sabbia. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.'
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: adattivo'
       - 'role_trofico: predatore_secondario; sentient: False'
-      - 'trait_refs: adattamento_volo, aura_scudo_radianza, ali_solari_fotoni, empatia_coordinativa,
-        risonanza_di_branco'
+      - 'trait_refs: adattamento_volo, aura_scudo_radianza, ali_solari_fotoni, empatia_coordinativa, risonanza_di_branco'
       cross_ref:
       - species:heliopteryx_radians
       - trait:adattamento_volo
@@ -66,10 +62,7 @@ codex_entry:
       - trait:empatia_coordinativa
       - trait:risonanza_di_branco
       game_impact: Archetipo adattivo.
-      content: 'La linea del aliradiante solare porta i segni di adattamento volo, aura scudo
-        radianza, ali solari fotoni, empatia coordinativa, risonanza di branco: ogni tratto
-        core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento
-        continuo, conservando solo cio'' che sopravvive.'
+      content: 'La linea dell''aliradiante solare porta i segni di adattamento volo, aura scudo radianza, ali solari fotoni, empatia coordinativa, risonanza di branco: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -79,8 +72,7 @@ codex_entry:
       cross_ref:
       - species:heliopteryx_radians
       game_impact: Profilo da warden (alato veliero).
-      content: 'Il corpo del aliradiante solare: un alato veliero. Sotto pressione puo'' sviluppare
-        adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
+      content: 'Il corpo dell''aliradiante solare: un alato veliero. Sotto pressione puo'' sviluppare adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -89,9 +81,7 @@ codex_entry:
       cross_ref:
       - biome:savana
       game_impact: 'encounter_role: threat.'
-      content: Nell'ecologia di Savana Ionizzata il aliradiante solare occupa la nicchia di
-        predatore secondario (T1), accanto a predoni nomadi, guardiani delle dune, cartografi
-        erranti. Esercita pressione sulle prede senza contendere l'apice.
+      content: Nell'ecologia di Savana Ionizzata l'aliradiante solare occupa la nicchia di predatore secondario (T1), accanto a predoni nomadi, guardiani delle dune, cartografi erranti. Esercita pressione sulle prede senza contendere l'apice.
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -99,8 +89,7 @@ codex_entry:
       cross_ref:
       - species:heliopteryx_radians
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: Il aliradiante solare vive in gruppi territoriali. I legami sono di natura
-        istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
+      content: L'aliradiante solare vive in gruppi territoriali. I legami sono di natura istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -108,9 +97,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'un avversario predatore secondario (T1) che affronti in Savana Ionizzata:
-        ecco perche'' il aliradiante solare apre il Codex. Intorno a lui le storie del bioma
-        -- recuperare convogli cristallizzati e nodi di risonanza sepolti -- danno peso al
-        primo incontro.'
+      content: 'un avversario predatore secondario (T1) che affronti in Savana Ionizzata: ecco perche'' l''aliradiante solare apre il Codex. Intorno a lui le storie del bioma -- recuperare convogli cristallizzati e nodi di risonanza sepolti -- danno peso al primo incontro.'
       story_hook_it: un avversario predatore secondario (T1) che affronti in Savana Ionizzata
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/illusiopardus_psionicus.yaml
+++ b/data/codex/illusiopardus_psionicus.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: illusiopardus_psionicus
   type: species
+  codex_archive: true
   display_name_it: Mascheraio illusorio
   display_name_en: Mascheraio illusorio
   subtitle_it: Mascheraio illusorio -- Foresta Temperata Umida (T2)
@@ -46,10 +47,7 @@ codex_entry:
       cross_ref:
       - biome:foresta_temperata
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: Foresta Temperata Umida -- Boschi piovosi con canopy densa, nebbie calde e
-        radure bioenergetiche, dal tono di Ricognizioni stealth tra nebbie radiose e comunità
-        arboree (rainshade, canopy web, floodpulse) -- non e' uno sfondo ma un avversario
-        costante per il mascheraio illusorio. Ogni movimento e' una risposta all'ambiente.
+      content: Foresta Temperata Umida -- Boschi piovosi con canopy densa, nebbie calde e radure bioenergetiche, che richiama Ricognizioni stealth tra nebbie radiose e comunità arboree (rainshade, canopy web, floodpulse) -- non e' uno sfondo ma un avversario costante per il mascheraio illusorio. Ogni movimento e' una risposta all'ambiente.
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
@@ -62,10 +60,7 @@ codex_entry:
       - trait:tessuti_adattivi
       - trait:empatia_coordinativa
       game_impact: Archetipo adattivo.
-      content: 'La linea del mascheraio illusorio porta i segni di artigli psionici, tessuti
-        adattivi, empatia coordinativa: ogni tratto core e'' la cicatrice di una pressione
-        del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio''
-        che sopravvive.'
+      content: 'La linea del mascheraio illusorio porta i segni di artigli psionici, tessuti adattivi, empatia coordinativa: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -75,9 +70,7 @@ codex_entry:
       cross_ref:
       - species:illusiopardus_psionicus
       game_impact: Profilo da skirmisher (felino psionico).
-      content: 'Morfologia: un felino psionico. Ogni adattamento risponde a una pressione;
-        le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre
-        la forma base.'
+      content: 'Morfologia: un felino psionico. Ogni adattamento risponde a una pressione; le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la forma base.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -86,9 +79,7 @@ codex_entry:
       cross_ref:
       - biome:foresta_temperata
       game_impact: 'encounter_role: threat.'
-      content: 'Il mascheraio illusorio e'' predatore terziario in Foresta Temperata Umida:
-        una presenza diffusa (T2) che, insieme a guardiani pluviali, predatori temperati,
-        druidi pluviometrici, modella la catena trofica.'
+      content: 'Il mascheraio illusorio e'' predatore terziario in Foresta Temperata Umida: una presenza diffusa (T2) che, insieme a guardiani pluviali, predatori temperati, druidi pluviometrici, modella la catena trofica.'
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -96,8 +87,7 @@ codex_entry:
       cross_ref:
       - species:illusiopardus_psionicus
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: 'La struttura sociale del mascheraio illusorio si regge su gruppi territoriali.
-        La socialita'' e'' culturale: coordinazione efficace senza una cultura nel senso pieno.'
+      content: 'La struttura sociale del mascheraio illusorio si regge su gruppi territoriali. La socialita'' e'' culturale: coordinazione efficace senza una cultura nel senso pieno.'
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -105,10 +95,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'Per l''allenatore il mascheraio illusorio e'' un avversario predatore terziario
-        (T2) che affronti in Foresta Temperata Umida. E nel suo mondo la posta in gioco e''
-        proteggere i reattori a risonanza dagli attacchi delle maree. E'' qui che il Codex
-        comincia: la prima forma di vita di cui annotare la verita''.'
-      story_hook_it: un avversario predatore terziario (T2) che affronti in Foresta Temperata
-        Umida
-  lore_review_status: generated_pending_review
+      content: 'Per l''allenatore il mascheraio illusorio e'' un avversario predatore terziario (T2) che affronti in Foresta Temperata Umida. E nel suo mondo la posta in gioco e'' proteggere i reattori a risonanza dagli attacchi delle maree. E'' qui che il Codex comincia: la prima forma di vita di cui annotare la verita''.'
+      story_hook_it: un avversario predatore terziario (T2) che affronti in Foresta Temperata Umida
+  lore_review_status: human_reviewed

--- a/data/codex/lithoconstructus_inhibens.yaml
+++ b/data/codex/lithoconstructus_inhibens.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: lithoconstructus_inhibens
   type: species
+  codex_archive: true
   display_name_it: Litoautoma inibitore
   display_name_en: Litoautoma inibitore
   subtitle_it: Litoautoma inibitore -- Caverna Risonante (T2)
@@ -33,8 +34,7 @@ codex_entry:
     biome_hook: disinnescare camere di eco instabile prima del collasso
     affixes: eco, cristallino, fangoso, acque nere
     neighbors: guardiani risonanza, bracconieri echomantici, cartografi subsonici
-    traits: armatura pietra planare, carapace fase variabile, matrice antimagia, nuclei di
-      controllo
+    traits: armatura pietra planare, carapace fase variabile, matrice antimagia, nuclei di controllo
     visual: un costrutto corazzato.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -47,17 +47,13 @@ codex_entry:
       cross_ref:
       - biome:caverna
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: Caverna Risonante -- Gallerie cristalline dove eco e pressioni invertite modellano
-        la fauna, dal tono di Esplorazione claustrofobica guidata da acustica e luce riflessa
-        (eco, cristallino, fangoso, acque nere) -- non e' uno sfondo ma un avversario costante
-        per il litoautoma inibitore. Ogni movimento e' una risposta all'ambiente.
+      content: Caverna Risonante -- Gallerie cristalline dove eco e pressioni invertite modellano la fauna, dall'atmosfera di Esplorazione claustrofobica guidata da acustica e luce riflessa (eco, cristallino, fangoso, acque nere) -- non e' uno sfondo ma un avversario costante per il litoautoma inibitore. Ogni movimento e' una risposta all'ambiente.
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: strutturale'
       - 'role_trofico: guardiano_artificiale; sentient: False'
-      - 'trait_refs: armatura_pietra_planare, carapace_fase_variabile, matrice_antimagia,
-        nuclei_di_controllo'
+      - 'trait_refs: armatura_pietra_planare, carapace_fase_variabile, matrice_antimagia, nuclei_di_controllo'
       cross_ref:
       - species:lithoconstructus_inhibens
       - trait:armatura_pietra_planare
@@ -65,10 +61,7 @@ codex_entry:
       - trait:matrice_antimagia
       - trait:nuclei_di_controllo
       game_impact: Archetipo strutturale.
-      content: 'Il litoautoma inibitore evolve lungo le fasi un ciclo di adattamento continuo.
-        I suoi tratti -- armatura pietra planare, carapace fase variabile, matrice antimagia,
-        nuclei di controllo -- non sono ornamenti ma risposte: ognuno racconta una pressione
-        superata, in archetipo strutturale.'
+      content: 'Il litoautoma inibitore evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- armatura pietra planare, carapace fase variabile, matrice antimagia, nuclei di controllo -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -78,9 +71,7 @@ codex_entry:
       cross_ref:
       - species:lithoconstructus_inhibens
       game_impact: Profilo da warden (costrutto corazzato).
-      content: 'Morfologia: un costrutto corazzato. Ogni adattamento risponde a una pressione;
-        le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre
-        la forma base.'
+      content: 'Morfologia: un costrutto corazzato. Ogni adattamento risponde a una pressione; le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la forma base.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -89,9 +80,7 @@ codex_entry:
       cross_ref:
       - biome:caverna
       game_impact: 'encounter_role: threat.'
-      content: Nell'ecologia di Caverna Risonante il litoautoma inibitore occupa la nicchia
-        di guardiano artificiale (T2), accanto a guardiani risonanza, bracconieri echomantici,
-        cartografi subsonici. Esercita pressione sulle prede senza contendere l'apice.
+      content: Nell'ecologia di Caverna Risonante il litoautoma inibitore occupa la nicchia di guardiano artificiale (T2), accanto a guardiani risonanza, bracconieri echomantici, cartografi subsonici. Esercita pressione sulle prede senza contendere l'apice.
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -99,8 +88,7 @@ codex_entry:
       cross_ref:
       - species:lithoconstructus_inhibens
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: 'La struttura sociale del litoautoma inibitore si regge su gruppi territoriali.
-        La socialita'' e'' istintiva: coordinazione efficace senza una cultura nel senso pieno.'
+      content: 'La struttura sociale del litoautoma inibitore si regge su gruppi territoriali. La socialita'' e'' istintiva: coordinazione efficace senza una cultura nel senso pieno.'
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -108,9 +96,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'Per l''allenatore il litoautoma inibitore e'' un avversario guardiano artificiale
-        (T2) che affronti in Caverna Risonante. E nel suo mondo la posta in gioco e'' disinnescare
-        camere di eco instabile prima del collasso. E'' qui che il Codex comincia: la prima
-        forma di vita di cui annotare la verita''.'
+      content: 'Per l''allenatore il litoautoma inibitore e'' un avversario guardiano artificiale (T2) che affronti in Caverna Risonante. E nel suo mondo la posta in gioco e'' disinnescare camere di eco instabile prima del collasso. E'' qui che il Codex comincia: la prima forma di vita di cui annotare la verita''.'
       story_hook_it: un avversario guardiano artificiale (T2) che affronti in Caverna Risonante
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/pyroflagellum_meteoriticum.yaml
+++ b/data/codex/pyroflagellum_meteoriticum.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: pyroflagellum_meteoriticum
   type: species
+  codex_archive: true
   display_name_it: Flagello igneo
   display_name_en: Flagello igneo
   subtitle_it: Flagello igneo -- Abisso Vulcanico (T2)
@@ -33,8 +34,7 @@ codex_entry:
     biome_hook: stabilire condotti di raffreddamento attorno alle fucine naturali
     affixes: termico, luminescente, spore diluite, sabbia
     neighbors: abyssal forgers, magma wardens, geode listeners
-    traits: adattamento volo, frusta fiammeggiante, mantello meteoritico, armatura pietra
-      planare, artigli sette vie, carapace fase variabile
+    traits: adattamento volo, frusta fiammeggiante, mantello meteoritico, armatura pietra planare, artigli sette vie, carapace fase variabile
     visual: un alato corazzato.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -47,18 +47,13 @@ codex_entry:
       cross_ref:
       - biome:abisso_vulcanico
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: 'Il territorio del flagello igneo e'' Abisso Vulcanico: Camini abissali con
-        lava pressurizzata e fauna bio-termica. Un mondo da Assalti verticali e estrazioni
-        ad alto rischio tra geyser incandescenti, segnato da termico, luminescente, spore
-        diluite, sabbia. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura
-        a lungo.'
+      content: 'Il territorio del flagello igneo e'' Abisso Vulcanico: Camini abissali con lava pressurizzata e fauna bio-termica. Un mondo da Assalti verticali e estrazioni ad alto rischio tra geyser incandescenti, segnato da termico, luminescente, spore diluite, sabbia. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.'
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: strutturale'
       - 'role_trofico: predatore_terziario; sentient: False'
-      - 'trait_refs: adattamento_volo, frusta_fiammeggiante, mantello_meteoritico, armatura_pietra_planare,
-        artigli_sette_vie, carapace_fase_variabile'
+      - 'trait_refs: adattamento_volo, frusta_fiammeggiante, mantello_meteoritico, armatura_pietra_planare, artigli_sette_vie, carapace_fase_variabile'
       cross_ref:
       - species:pyroflagellum_meteoriticum
       - trait:adattamento_volo
@@ -68,10 +63,7 @@ codex_entry:
       - trait:artigli_sette_vie
       - trait:carapace_fase_variabile
       game_impact: Archetipo strutturale.
-      content: 'Il flagello igneo evolve lungo le fasi un ciclo di adattamento continuo. I
-        suoi tratti -- adattamento volo, frusta fiammeggiante, mantello meteoritico, armatura
-        pietra planare, artigli sette vie, carapace fase variabile -- non sono ornamenti ma
-        risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
+      content: 'Il flagello igneo evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- adattamento volo, frusta fiammeggiante, mantello meteoritico, armatura pietra planare, artigli sette vie, carapace fase variabile -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -81,9 +73,7 @@ codex_entry:
       cross_ref:
       - species:pyroflagellum_meteoriticum
       game_impact: Profilo da vanguard (alato corazzato).
-      content: 'Morfologia: un alato corazzato. Ogni adattamento risponde a una pressione;
-        le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre
-        la forma base.'
+      content: 'Morfologia: un alato corazzato. Ogni adattamento risponde a una pressione; le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la forma base.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -92,9 +82,7 @@ codex_entry:
       cross_ref:
       - biome:abisso_vulcanico
       game_impact: 'encounter_role: threat.'
-      content: Nell'ecologia di Abisso Vulcanico il flagello igneo occupa la nicchia di predatore
-        terziario (T2), accanto a abyssal forgers, magma wardens, geode listeners. Esercita
-        pressione sulle prede senza contendere l'apice.
+      content: Nell'ecologia di Abisso Vulcanico il flagello igneo occupa la nicchia di predatore terziario (T2), accanto a abyssal forgers, magma wardens, geode listeners. Esercita pressione sulle prede senza contendere l'apice.
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -102,8 +90,7 @@ codex_entry:
       cross_ref:
       - species:pyroflagellum_meteoriticum
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: Il flagello igneo vive in gruppi territoriali. I legami sono di natura istintiva
-        -- funzionali alla sopravvivenza piu' che al racconto di se'.
+      content: Il flagello igneo vive in gruppi territoriali. I legami sono di natura istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -111,8 +98,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'un avversario predatore terziario (T2) che affronti in Abisso Vulcanico: ecco
-        perche'' il flagello igneo apre il Codex. Intorno a lui le storie del bioma -- stabilire
-        condotti di raffreddamento attorno alle fucine naturali -- danno peso al primo incontro.'
+      content: 'un avversario predatore terziario (T2) che affronti in Abisso Vulcanico: ecco perche'' il flagello igneo apre il Codex. Intorno a lui le storie del bioma -- stabilire condotti di raffreddamento attorno alle fucine naturali -- danno peso al primo incontro.'
       story_hook_it: un avversario predatore terziario (T2) che affronti in Abisso Vulcanico
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/radiciforma_ancorans.yaml
+++ b/data/codex/radiciforma_ancorans.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: radiciforma_ancorans
   type: species
+  codex_archive: true
   display_name_it: Ancora radicale
   display_name_en: Ancora radicale
   subtitle_it: Ancora radicale -- Foresta Miceliale (T2)
@@ -33,8 +34,7 @@ codex_entry:
     biome_hook: mappare nodi miceliali per isolare la rete neurale
     affixes: spore bloom, myco link
     neighbors: verdant shepherds, fungal titans, myco empath
-    traits: corteccia memetica, pigmenti aurorali, radici ancora planare, reti capillari radici,
-      armatura pietra planare
+    traits: corteccia memetica, pigmenti aurorali, radici ancora planare, reti capillari radici, armatura pietra planare
     visual: un flora radicata.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -47,17 +47,13 @@ codex_entry:
       cross_ref:
       - biome:foresta_miceliale
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: Foresta Miceliale -- Canopia micotica bioluminescente dove la rete fungina
-        coordina la fauna, dal tono di Fantasia bioluminescente con rischio di simbiosi forzata
-        (spore bloom, myco link) -- non e' uno sfondo ma un avversario costante per il ancora
-        radicale. Ogni movimento e' una risposta all'ambiente.
+      content: Foresta Miceliale -- Canopia micotica bioluminescente dove la rete fungina coordina la fauna, con l'atmosfera di Fantasia bioluminescente con rischio di simbiosi forzata (spore bloom, myco link) -- non e' uno sfondo ma un avversario costante per l'ancora radicale. Ogni movimento e' una risposta all'ambiente.
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: strutturale'
       - 'role_trofico: flora_ancorata; sentient: False'
-      - 'trait_refs: corteccia_memetica, pigmenti_aurorali, radici_ancora_planare, reti_capillari_radici,
-        armatura_pietra_planare'
+      - 'trait_refs: corteccia_memetica, pigmenti_aurorali, radici_ancora_planare, reti_capillari_radici, armatura_pietra_planare'
       cross_ref:
       - species:radiciforma_ancorans
       - trait:corteccia_memetica
@@ -66,10 +62,7 @@ codex_entry:
       - trait:reti_capillari_radici
       - trait:armatura_pietra_planare
       game_impact: Archetipo strutturale.
-      content: 'La linea del ancora radicale porta i segni di corteccia memetica, pigmenti
-        aurorali, radici ancora planare, reti capillari radici, armatura pietra planare: ogni
-        tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo
-        di adattamento continuo, conservando solo cio'' che sopravvive.'
+      content: 'La linea dell''ancora radicale porta i segni di corteccia memetica, pigmenti aurorali, radici ancora planare, reti capillari radici, armatura pietra planare: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -79,9 +72,7 @@ codex_entry:
       cross_ref:
       - species:radiciforma_ancorans
       game_impact: Profilo da warden (flora radicata).
-      content: 'Morfologia: un flora radicata. Ogni adattamento risponde a una pressione;
-        le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre
-        la forma base.'
+      content: 'Morfologia: un flora radicata. Ogni adattamento risponde a una pressione; le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la forma base.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -90,9 +81,7 @@ codex_entry:
       cross_ref:
       - biome:foresta_miceliale
       game_impact: 'encounter_role: threat.'
-      content: Nell'ecologia di Foresta Miceliale il ancora radicale occupa la nicchia di
-        flora ancorata (T2), accanto a verdant shepherds, fungal titans, myco empath. Esercita
-        pressione sulle prede senza contendere l'apice.
+      content: Nell'ecologia di Foresta Miceliale l'ancora radicale occupa la nicchia di flora ancorata (T2), accanto a verdant shepherds, fungal titans, myco empath. Esercita pressione sulle prede senza contendere l'apice.
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -100,8 +89,7 @@ codex_entry:
       cross_ref:
       - species:radiciforma_ancorans
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: Il ancora radicale vive in gruppi territoriali. I legami sono di natura istintiva
-        -- funzionali alla sopravvivenza piu' che al racconto di se'.
+      content: L'ancora radicale vive in gruppi territoriali. I legami sono di natura istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -109,8 +97,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'un avversario flora ancorata (T2) che affronti in Foresta Miceliale: ecco
-        perche'' il ancora radicale apre il Codex. Intorno a lui le storie del bioma -- mappare
-        nodi miceliali per isolare la rete neurale -- danno peso al primo incontro.'
+      content: 'un avversario flora ancorata (T2) che affronti in Foresta Miceliale: ecco perche'' l''ancora radicale apre il Codex. Intorno a lui le storie del bioma -- mappare nodi miceliali per isolare la rete neurale -- danno peso al primo incontro.'
       story_hook_it: un avversario flora ancorata (T2) che affronti in Foresta Miceliale
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/rotabrachium_ferox.yaml
+++ b/data/codex/rotabrachium_ferox.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: rotabrachium_ferox
   type: species
+  codex_archive: true
   display_name_it: Rotabraccio
   display_name_en: Rotabraccio
   subtitle_it: Rotabraccio -- Abisso Vulcanico (T3)
@@ -33,8 +34,7 @@ codex_entry:
     biome_hook: stabilire condotti di raffreddamento attorno alle fucine naturali
     affixes: termico, luminescente, spore diluite, sabbia
     neighbors: abyssal forgers, magma wardens, geode listeners
-    traits: nucleo ovomotore rotante, frusta fiammeggiante, mantello meteoritico, focus frazionato,
-      artigli sette vie, coda frusta cinetica
+    traits: nucleo ovomotore rotante, frusta fiammeggiante, mantello meteoritico, focus frazionato, artigli sette vie, coda frusta cinetica
     visual: un multi arto rotante.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -47,17 +47,13 @@ codex_entry:
       cross_ref:
       - biome:abisso_vulcanico
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: 'Il territorio del rotabraccio e'' Abisso Vulcanico: Camini abissali con lava
-        pressurizzata e fauna bio-termica. Un mondo da Assalti verticali e estrazioni ad alto
-        rischio tra geyser incandescenti, segnato da termico, luminescente, spore diluite,
-        sabbia. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.'
+      content: 'Il territorio del rotabraccio e'' Abisso Vulcanico: Camini abissali con lava pressurizzata e fauna bio-termica. Un mondo da Assalti verticali e estrazioni ad alto rischio tra geyser incandescenti, segnato da termico, luminescente, spore diluite, sabbia. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.'
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: strutturale'
       - 'role_trofico: predatore_apex; sentient: False'
-      - 'trait_refs: nucleo_ovomotore_rotante, frusta_fiammeggiante, mantello_meteoritico,
-        focus_frazionato, artigli_sette_vie, coda_frusta_cinetica, empatia_coordinativa'
+      - 'trait_refs: nucleo_ovomotore_rotante, frusta_fiammeggiante, mantello_meteoritico, focus_frazionato, artigli_sette_vie, coda_frusta_cinetica, empatia_coordinativa'
       cross_ref:
       - species:rotabrachium_ferox
       - trait:nucleo_ovomotore_rotante
@@ -68,10 +64,7 @@ codex_entry:
       - trait:coda_frusta_cinetica
       - trait:empatia_coordinativa
       game_impact: Archetipo strutturale.
-      content: 'Il rotabraccio evolve lungo le fasi un ciclo di adattamento continuo. I suoi
-        tratti -- nucleo ovomotore rotante, frusta fiammeggiante, mantello meteoritico, focus
-        frazionato, artigli sette vie, coda frusta cinetica -- non sono ornamenti ma risposte:
-        ognuno racconta una pressione superata, in archetipo strutturale.'
+      content: 'Il rotabraccio evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- nucleo ovomotore rotante, frusta fiammeggiante, mantello meteoritico, focus frazionato, artigli sette vie, coda frusta cinetica -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -81,8 +74,7 @@ codex_entry:
       cross_ref:
       - species:rotabrachium_ferox
       game_impact: Profilo da vanguard (multi arto rotante).
-      content: 'Il corpo del rotabraccio: un multi arto rotante. Sotto pressione puo'' sviluppare
-        adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
+      content: 'Il corpo del rotabraccio: un multi arto rotante. Sotto pressione puo'' sviluppare adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -91,9 +83,7 @@ codex_entry:
       cross_ref:
       - biome:abisso_vulcanico
       game_impact: 'encounter_role: threat.'
-      content: 'Il rotabraccio e'' predatore apex in Abisso Vulcanico: una presenza diffusa
-        (T3) che, insieme a abyssal forgers, magma wardens, geode listeners, modella la catena
-        trofica.'
+      content: 'Il rotabraccio e'' predatore apex in Abisso Vulcanico: una presenza diffusa (T3) che, insieme a abyssal forgers, magma wardens, geode listeners, modella la catena trofica.'
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -101,8 +91,7 @@ codex_entry:
       cross_ref:
       - species:rotabrachium_ferox
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: 'La struttura sociale del rotabraccio si regge su gruppi territoriali. La socialita''
-        e'' istintiva: coordinazione efficace senza una cultura nel senso pieno.'
+      content: 'La struttura sociale del rotabraccio si regge su gruppi territoriali. La socialita'' e'' istintiva: coordinazione efficace senza una cultura nel senso pieno.'
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -110,9 +99,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'Per l''allenatore il rotabraccio e'' un avversario predatore apex (T3) che
-        affronti in Abisso Vulcanico. E nel suo mondo la posta in gioco e'' stabilire condotti
-        di raffreddamento attorno alle fucine naturali. E'' qui che il Codex comincia: la
-        prima forma di vita di cui annotare la verita''.'
+      content: 'Per l''allenatore il rotabraccio e'' un avversario predatore apex (T3) che affronti in Abisso Vulcanico. E nel suo mondo la posta in gioco e'' stabilire condotti di raffreddamento attorno alle fucine naturali. E'' qui che il Codex comincia: la prima forma di vita di cui annotare la verita''.'
       story_hook_it: un avversario predatore apex (T3) che affronti in Abisso Vulcanico
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/sonovespera_lamentans.yaml
+++ b/data/codex/sonovespera_lamentans.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: sonovespera_lamentans
   type: species
+  codex_archive: true
   display_name_it: Vespero sonoro
   display_name_en: Vespero sonoro
   subtitle_it: Vespero sonoro -- Canyon Risonanti (T2)
@@ -46,10 +47,7 @@ codex_entry:
       cross_ref:
       - biome:canyons_risonanti
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: 'Il territorio del vespero sonoro e'' Canyon Risonanti: Labirinto ventoso di
-        gole armoniche alimentate da risonanza. Un mondo da Duelli sonori e trattative con
-        tribù eco-sintonizzate, segnato da echo surge, shifting winds. Qui la sopravvivenza
-        detta la forma, e nulla che non si adatti dura a lungo.'
+      content: 'Il territorio del vespero sonoro e'' Canyon Risonanti: Labirinto ventoso di gole armoniche alimentate da risonanza. Un mondo da Duelli sonori e trattative con tribù eco-sintonizzate, segnato da echo surge, shifting winds. Qui la sopravvivenza detta la forma, e nulla che non si adatti dura a lungo.'
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
@@ -63,10 +61,7 @@ codex_entry:
       - trait:risonanza_di_branco
       - trait:spore_psichiche_silenziate
       game_impact: Archetipo adattivo.
-      content: 'La linea del vespero sonoro porta i segni di adattamento volo, ali fono risonanti,
-        risonanza di branco, spore psichiche silenziate: ogni tratto core e'' la cicatrice
-        di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando
-        solo cio'' che sopravvive.'
+      content: 'La linea del vespero sonoro porta i segni di adattamento volo, ali fono risonanti, risonanza di branco, spore psichiche silenziate: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -76,8 +71,7 @@ codex_entry:
       cross_ref:
       - species:sonovespera_lamentans
       game_impact: Profilo da invoker (alato spettrale).
-      content: 'Il corpo del vespero sonoro: un alato spettrale. Sotto pressione puo'' sviluppare
-        adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
+      content: 'Il corpo del vespero sonoro: un alato spettrale. Sotto pressione puo'' sviluppare adattamenti ancora non catalogati, piegando la morfologia a cio'' che il bioma esige.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -86,9 +80,7 @@ codex_entry:
       cross_ref:
       - biome:canyons_risonanti
       game_impact: 'encounter_role: threat.'
-      content: Nell'ecologia di Canyon Risonanti il vespero sonoro occupa la nicchia di predatore
-        secondario (T2), accanto a guardiani sibilanti, erranti dell'eco, risonatori nomadi.
-        Esercita pressione sulle prede senza contendere l'apice.
+      content: Nell'ecologia di Canyon Risonanti il vespero sonoro occupa la nicchia di predatore secondario (T2), accanto a guardiani sibilanti, erranti dell'eco, risonatori nomadi. Esercita pressione sulle prede senza contendere l'apice.
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -96,8 +88,7 @@ codex_entry:
       cross_ref:
       - species:sonovespera_lamentans
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: Il vespero sonoro vive in gruppi territoriali. I legami sono di natura istintiva
-        -- funzionali alla sopravvivenza piu' che al racconto di se'.
+      content: Il vespero sonoro vive in gruppi territoriali. I legami sono di natura istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -105,9 +96,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'un avversario predatore secondario (T2) che affronti in Canyon Risonanti:
-        ecco perche'' il vespero sonoro apre il Codex. Intorno a lui le storie del bioma --
-        stabilizzare ponti risonanti prima delle tempeste di vento -- danno peso al primo
-        incontro.'
+      content: 'un avversario predatore secondario (T2) che affronti in Canyon Risonanti: ecco perche'' il vespero sonoro apre il Codex. Intorno a lui le storie del bioma -- stabilizzare ponti risonanti prima delle tempeste di vento -- danno peso al primo incontro.'
       story_hook_it: un avversario predatore secondario (T2) che affronti in Canyon Risonanti
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/data/codex/tellurmordax_phasicus.yaml
+++ b/data/codex/tellurmordax_phasicus.yaml
@@ -6,6 +6,7 @@
 codex_entry:
   id: tellurmordax_phasicus
   type: species
+  codex_archive: true
   display_name_it: Tellumordace di fase
   display_name_en: Tellumordace di fase
   subtitle_it: Tellumordace di fase -- Calanchi Ferromagnetici (T2)
@@ -33,8 +34,7 @@ codex_entry:
     biome_hook: recuperare relè Aeon arrugginiti prima che vengano fusi
     affixes: ferrous spike, dust storm, scrap bloom
     neighbors: spazzini della ruggine, bruti ferrati, oracoli dei rottami
-    traits: carapace fase variabile, coda frusta cinetica, armatura pietra planare, scheletro
-      idro regolante
+    traits: carapace fase variabile, coda frusta cinetica, armatura pietra planare, scheletro idro regolante
     visual: un scavatore corazzato.
     lifecycle_arc: un ciclo di adattamento continuo
     mutations: adattamenti ancora non catalogati
@@ -47,17 +47,13 @@ codex_entry:
       cross_ref:
       - biome:badlands
       game_impact: 'Comparsa negli scontri: n/d.'
-      content: Calanchi Ferromagnetici -- Altipiani arrugginiti con tempeste ferrose e rovine
-        sepolte, dal tono di Scorrerie magnetiche e guerre di logoramento tra clan di recupero
-        (ferrous spike, dust storm, scrap bloom) -- non e' uno sfondo ma un avversario costante
-        per il tellumordace di fase. Ogni movimento e' una risposta all'ambiente.
+      content: Calanchi Ferromagnetici -- Altipiani arrugginiti con tempeste ferrose e rovine sepolte, con l'eco di Scorrerie magnetiche e guerre di logoramento tra clan di recupero (ferrous spike, dust storm, scrap bloom) -- non e' uno sfondo ma un avversario costante per il tellumordace di fase. Ogni movimento e' una risposta all'ambiente.
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
       - 'resistance_archetype: strutturale'
       - 'role_trofico: predatore_terziario; sentient: False'
-      - 'trait_refs: carapace_fase_variabile, coda_frusta_cinetica, armatura_pietra_planare,
-        scheletro_idro_regolante'
+      - 'trait_refs: carapace_fase_variabile, coda_frusta_cinetica, armatura_pietra_planare, scheletro_idro_regolante'
       cross_ref:
       - species:tellurmordax_phasicus
       - trait:carapace_fase_variabile
@@ -65,10 +61,7 @@ codex_entry:
       - trait:armatura_pietra_planare
       - trait:scheletro_idro_regolante
       game_impact: Archetipo strutturale.
-      content: 'Il tellumordace di fase evolve lungo le fasi un ciclo di adattamento continuo.
-        I suoi tratti -- carapace fase variabile, coda frusta cinetica, armatura pietra planare,
-        scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione
-        superata, in archetipo strutturale.'
+      content: 'Il tellumordace di fase evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- carapace fase variabile, coda frusta cinetica, armatura pietra planare, scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:
@@ -78,9 +71,7 @@ codex_entry:
       cross_ref:
       - species:tellurmordax_phasicus
       game_impact: Profilo da vanguard (scavatore corazzato).
-      content: 'Morfologia: un scavatore corazzato. Ogni adattamento risponde a una pressione;
-        le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre
-        la forma base.'
+      content: 'Morfologia: un scavatore corazzato. Ogni adattamento risponde a una pressione; le linee mutanti note (adattamenti ancora non catalogati) spingono il corpo oltre la forma base.'
     E_ecologia:
       heading: Ecologia
       key_facts:
@@ -89,9 +80,7 @@ codex_entry:
       cross_ref:
       - biome:badlands
       game_impact: 'encounter_role: threat.'
-      content: Nell'ecologia di Calanchi Ferromagnetici il tellumordace di fase occupa la
-        nicchia di predatore terziario (T2), accanto a spazzini della ruggine, bruti ferrati,
-        oracoli dei rottami. Esercita pressione sulle prede senza contendere l'apice.
+      content: Nell'ecologia di Calanchi Ferromagnetici il tellumordace di fase occupa la nicchia di predatore terziario (T2), accanto a spazzini della ruggine, bruti ferrati, oracoli dei rottami. Esercita pressione sulle prede senza contendere l'apice.
     N_norme_socio:
       heading: Norme socio
       key_facts:
@@ -99,8 +88,7 @@ codex_entry:
       cross_ref:
       - species:tellurmordax_phasicus
       game_impact: Comportamento di gruppo/solitario secondo i tag.
-      content: Il tellumordace di fase vive in gruppi territoriali. I legami sono di natura
-        istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
+      content: Il tellumordace di fase vive in gruppi territoriali. I legami sono di natura istintiva -- funzionali alla sopravvivenza piu' che al racconto di se'.
     A_ancoraggio_narrativo:
       heading: Ancoraggio narrativo
       key_facts:
@@ -108,9 +96,6 @@ codex_entry:
       - Voce codex sbloccabile via encounter_completed
       cross_ref: []
       game_impact: 'Unlock e2e: completare lo scontro sblocca questa voce.'
-      content: 'Per l''allenatore il tellumordace di fase e'' un avversario predatore terziario
-        (T2) che affronti in Calanchi Ferromagnetici. E nel suo mondo la posta in gioco e''
-        recuperare relè Aeon arrugginiti prima che vengano fusi. E'' qui che il Codex comincia:
-        la prima forma di vita di cui annotare la verita''.'
+      content: 'Per l''allenatore il tellumordace di fase e'' un avversario predatore terziario (T2) che affronti in Calanchi Ferromagnetici. E nel suo mondo la posta in gioco e'' recuperare relè Aeon arrugginiti prima che vengano fusi. E'' qui che il Codex comincia: la prima forma di vita di cui annotare la verita''.'
       story_hook_it: un avversario predatore terziario (T2) che affronti in Calanchi Ferromagnetici
-  lore_review_status: generated_pending_review
+  lore_review_status: human_reviewed

--- a/tests/api/codexEntries.test.js
+++ b/tests/api/codexEntries.test.js
@@ -126,6 +126,27 @@ test('GET /api/v1/codex/entries/:id returns the full 6-dim A.L.I.E.N.A. entry', 
   }
 });
 
+test('codex_archive entries are filtered from the Bestiario list but stay fetchable by id', async () => {
+  // Retired-creature lore (#3038, codex_archive:true) is intentionally absent from
+  // every roster -> it can never unlock through play. It must NOT appear in the
+  // regular Bestiario list (else players see permanently-locked ??? rows and an
+  // impossible completion count -- Codex P2 on #3076). aerostatocyon_altivolans is
+  // a promoted archive entry; it stays loadable by id for the future archive surface.
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const list = await request(app).get('/api/v1/codex/entries').expect(200);
+    const archived = list.body.entries.find((e) => e.id === 'aerostatocyon_altivolans');
+    assert.equal(archived, undefined, 'codex_archive entry excluded from the regular list');
+
+    const detail = await request(app)
+      .get('/api/v1/codex/entries/aerostatocyon_altivolans')
+      .expect(200);
+    assert.equal(detail.body.entry.id, 'aerostatocyon_altivolans', 'still fetchable by id');
+  } finally {
+    await close();
+  }
+});
+
 test('GET /api/v1/codex/entries/:id 404 on unknown id', async () => {
   const { app, close } = createApp({ databasePath: null });
   try {

--- a/tests/codex/namespaceGuard.test.js
+++ b/tests/codex/namespaceGuard.test.js
@@ -87,6 +87,19 @@ test('validateEntry skips the orphan check when universe is null (fixture mode)'
   assert.ok(!warnings.some((w) => /orphan/.test(w)), warnings.join(' | '));
 });
 
+test('validateEntry skips the orphan check for a codex_archive entry', () => {
+  // Retired-creature lore (#3038) is intentionally absent from every current
+  // roster -- it can never unlock through play, but is kept as readable archive.
+  // codex_archive:true marks that intent so the orphan SOFT-warn does not fire.
+  const errors = [];
+  const warnings = [];
+  const doc = entry('retired_creature_xyz');
+  doc.codex_entry.codex_archive = true;
+  validateEntry('archive.yaml', doc, errors, warnings, new Set(['dune_stalker']));
+  assert.equal(errors.length, 0, errors.join('\n'));
+  assert.ok(!warnings.some((w) => /orphan/.test(w)), warnings.join(' | '));
+});
+
 test('real data/codex produces no orphan namespace warning', () => {
   const r = spawnSync('node', [SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
   assert.equal(r.status, 0, r.stdout + r.stderr);

--- a/tools/js/validate_codex_aliena.js
+++ b/tools/js/validate_codex_aliena.js
@@ -217,7 +217,11 @@ function validateEntry(file, parsed, errors, warnings, universe = null) {
 
   // SOFT (SPEC-K namespace): the unlock hook keys on a sistema unit's species
   // slug, so an id absent from every roster can never unlock through play.
-  if (universe && entry.id && !universe.has(String(entry.id))) {
+  // `codex_archive: true` opts an entry out -- retired-creature lore (#3038) is
+  // intentionally absent from every current roster (kept as readable archive,
+  // surfaced outside the encounter-unlock path), so the orphan warn is not a
+  // dead-content signal for it.
+  if (universe && entry.id && !entry.codex_archive && !universe.has(String(entry.id))) {
     warnings.push(
       `${id}: id matches no sistema/enemy species in any scenario or encounter roster -> cannot unlock through play (orphan entry)`,
     );


### PR DESCRIPTION
## What

master-dd reviewed the 13 [#3038](https://github.com/MasterDD-L34D/Game/pull/3038) retired-creature A.L.I.E.N.A. lore drafts and **approved them with global prose fixes**. Applied via ruamel (round-trip, preserves YAML format), then `promote_codex_draft.js` moved each `data/codex/_drafts/<id>.yaml` → `data/codex/<id>.yaml`.

### Prose fixes (per master-dd)
- Replaced the over-used **"dal tono di X"** with **varied** gender-neutral synonyms per entry: `che comprende` / `all'insegna di` / `nel segno di` / `che evoca` / `che richiama` / `dall'atmosfera di` / `con l'atmosfera di` / `con l'eco di`.
- Fixed the Tracery **elision** tells on the 5 vowel-initial subjects (`il aerostato` → `l'aerostato`, `del aliradiante` → `dell'aliradiante`, …).
- Fixed a **mojibake** (`comunit�` → `comunità`) in illusiopardus.
- Set `lore_review_status: human_reviewed`.

### Namespace-guard reconciliation (SPEC-K #2851)
The 13 tripped the namespace guard: retired-creature lore is intentionally absent from every current roster, so it can't unlock through the encounter path — the orphan SOFT-warn flagged all 13 as "dead content". Per master-dd, **exempt retired-lore**:
- add `codex_archive: true` to the 13 entries;
- `validate_codex_aliena.js` skips the orphan check for `codex_archive` entries — a **narrow, explicit opt-out** (a hallucinated/typo'd id without the flag still warns);
- +unit test pinning the exemption.

## Verification
- prettier clean (`data/codex/*.yaml`); namespace test **6/6**; validator **0 orphan / 0 error** on all 23 codex files; `npm run test:api` **RC=0**. `cavecrew`: **no issues** (prose readability + elisions + YAML structure spot-checked).

## Scope / merge
Canon-DATA (+ tool/test) → surface green, **master-dd merge**.

**Follow-ups (out of scope):** (1) retired-lore needs a read surface (a bestiary archive outside the encounter-unlock path) — the entries are valid-but-unreachable until then; (2) the Tracery generator still emits `dal tono di` + the elision tells for future batches — a generator fix would prevent re-introduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)