### PR TITLE
feat(species): guard resistance_archetype references + remap 5 strutturale orphans (O8)

### DIFF
--- a/packs/evo_tactics_pack/data/species/abisso_vulcanico/pyroflagellum-meteoriticum.yaml
+++ b/packs/evo_tactics_pack/data/species/abisso_vulcanico/pyroflagellum-meteoriticum.yaml
@@ -1,6 +1,6 @@
 id: pyroflagellum_meteoriticum
 schema_version: '1.7'
-resistance_archetype: strutturale
+resistance_archetype: adattivo
 display_name: Flagello igneo
 biomes:
 - abisso_vulcanico

--- a/packs/evo_tactics_pack/data/species/abisso_vulcanico/rotabrachium-ferox.yaml
+++ b/packs/evo_tactics_pack/data/species/abisso_vulcanico/rotabrachium-ferox.yaml
@@ -1,6 +1,6 @@
 id: rotabrachium_ferox
 schema_version: '1.7'
-resistance_archetype: strutturale
+resistance_archetype: adattivo
 display_name: Rotabraccio
 biomes:
 - abisso_vulcanico

--- a/packs/evo_tactics_pack/data/species/badlands/tellurmordax-phasicus.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/tellurmordax-phasicus.yaml
@@ -1,6 +1,6 @@
 id: tellurmordax_phasicus
 schema_version: '1.7'
-resistance_archetype: strutturale
+resistance_archetype: adattivo
 display_name: Tellumordace di fase
 biomes:
 - badlands

--- a/packs/evo_tactics_pack/data/species/caverna/lithoconstructus-inhibens.yaml
+++ b/packs/evo_tactics_pack/data/species/caverna/lithoconstructus-inhibens.yaml
@@ -1,6 +1,6 @@
 id: lithoconstructus_inhibens
 schema_version: '1.7'
-resistance_archetype: strutturale
+resistance_archetype: adattivo
 display_name: Litoautoma inibitore
 biomes:
 - caverna

--- a/packs/evo_tactics_pack/data/species/foresta_miceliale/radiciforma-ancorans.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_miceliale/radiciforma-ancorans.yaml
@@ -1,6 +1,6 @@
 id: radiciforma_ancorans
 schema_version: '1.7'
-resistance_archetype: strutturale
+resistance_archetype: adattivo
 display_name: Ancora radicale
 biomes:
 - foresta_miceliale

--- a/tests/services/speciesArchetypeReferences.test.js
+++ b/tests/services/speciesArchetypeReferences.test.js
@@ -1,0 +1,102 @@
+// TKT-SALVAGE-A2 (O8) — species resistance_archetype reference guard.
+//
+// resistanceEngine.js resolves a unit's resistances from its `resistance_archetype`
+// against packs/evo_tactics_pack/data/balance/species_resistances.yaml, and SILENTLY
+// falls back to `default_archetype` when the id is unknown. So a species declaring a
+// typo'd / non-canonical archetype (e.g. `strutturale`, absent from the resistance
+// table) gets the wrong resistance profile with no error. This guard pins that every
+// authored species' resistance_archetype is a canonical archetype (or absent -> the
+// engine default is intentional).
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const RESIST_PATH = path.join(
+  REPO_ROOT,
+  'packs',
+  'evo_tactics_pack',
+  'data',
+  'balance',
+  'species_resistances.yaml',
+);
+const SPECIES_DIRS = [
+  path.join(REPO_ROOT, 'data', 'core', 'species'),
+  path.join(REPO_ROOT, 'packs', 'evo_tactics_pack', 'data', 'species'),
+];
+
+// Canonical archetype set = the species_archetypes keys + the default_archetype, the
+// exact ids resistanceEngine.getArchetypeResistances() matches against.
+function canonicalArchetypes() {
+  const data = yaml.load(fs.readFileSync(RESIST_PATH, 'utf8'));
+  const set = new Set(Object.keys((data && data.species_archetypes) || {}));
+  if (data && data.default_archetype) set.add(String(data.default_archetype));
+  return set;
+}
+
+function* speciesFiles() {
+  for (const dir of SPECIES_DIRS) {
+    if (!fs.existsSync(dir)) continue;
+    const stack = [dir];
+    while (stack.length) {
+      const cur = stack.pop();
+      for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+        const p = path.join(cur, entry.name);
+        if (entry.isDirectory()) stack.push(p);
+        else if (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml')) yield p;
+      }
+    }
+  }
+}
+
+// resistance_archetype is top-level on keeper/spec files but may be nested in a
+// `species:`-wrapped doc -> collect every occurrence so the guard cannot be dodged
+// by nesting.
+function collectArchetypes(node, out) {
+  if (Array.isArray(node)) {
+    for (const v of node) collectArchetypes(v, out);
+  } else if (node && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node)) {
+      if (k === 'resistance_archetype' && (typeof v === 'string' || v == null)) {
+        if (v != null) out.push(String(v));
+      } else {
+        collectArchetypes(v, out);
+      }
+    }
+  }
+  return out;
+}
+
+test('species_resistances.yaml defines the expected canonical archetype set', () => {
+  const set = canonicalArchetypes();
+  for (const a of ['corazzato', 'bioelettrico', 'psionico', 'termico', 'adattivo']) {
+    assert.ok(set.has(a), `canonical archetype '${a}' present in species_resistances.yaml`);
+  }
+});
+
+test('every species resistance_archetype references a canonical archetype (no silent fallback)', () => {
+  const set = canonicalArchetypes();
+  const offenders = [];
+  for (const f of speciesFiles()) {
+    let doc;
+    try {
+      doc = yaml.load(fs.readFileSync(f, 'utf8'));
+    } catch {
+      continue; // malformed authoring file is another gate's problem
+    }
+    for (const arch of collectArchetypes(doc, [])) {
+      if (!set.has(arch)) offenders.push(`${path.relative(REPO_ROOT, f)}: '${arch}'`);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `non-canonical resistance_archetype -> silent fallback to the default (wrong resistances). ` +
+      `Valid: ${[...set].join(', ')}. Offenders:\n  ${offenders.join('\n  ')}`,
+  );
+});


### PR DESCRIPTION
## What (close-out O8 / TKT-SALVAGE-A2)

`resistanceEngine.js` resolves a unit's resistances from `resistance_archetype` against `species_resistances.yaml` and **silently falls back** to the default (`adattivo`) on an unknown id — so a typo'd / non-canonical archetype applies the wrong resistance profile with no error.

**Verify-first surfaced a real bug**: 5 retired-creature species (#3032 — `pyroflagellum_meteoriticum`, `rotabrachium_ferox`, `tellurmordax_phasicus`, `lithoconstructus_inhibens`, `radiciforma_ancorans`) declare `resistance_archetype: strutturale`, which is **not** in the canonical set (`corazzato/bioelettrico/psionico/termico/adattivo`) → silent fallback to `adattivo`.

- **Remap the 5 → `adattivo`** (their actual effective archetype today via the fallback) — the declaration is now honest with **zero resistance change** (band-neutral). The 5 are retired (no current roster), so no encounter is affected either way (master-dd chose this over adding a `strutturale` archetype / remapping to `corazzato`).
- **Add `tests/services/speciesArchetypeReferences.test.js`** — every authored species' `resistance_archetype` must reference a canonical archetype (recursive collector so a nested doc can't dodge it). Runs in `test:api` via the `tests/services/*.test.js` glob.

## Verification

- Guard **2/2 GREEN**; **non-no-op proven** (injecting a bogus archetype fails the guard and names the offender).
- The 5 are **not** in `species_catalog.json` and `resistance_archetype` is not a catalog field → `check_derived_reproducible` **RC=0** (derived-neutral); `validate_datasets` RC=0; **AI 560/560**; `test:api` **RC=0**. `cavecrew`: no code/test issues.

## Close-out round (this session)

- **O1** SPEC-J `SCAR_TRAIT_MAP` → **ratified as-built** (#2994; the flip stays N=40-gated). Register marker `PROPOSED → RATIFIED` (recorded).
- **O7** GAP2-next → **deferred** (45-boilerplate = prose-rewrite design; clusters = need new forbidden-schema primitives).

## Follow-up (out of scope — flagged by cavecrew)

The 5 promoted codex entries (#3076) echo the old `strutturale` in `lore_vars.archetype` / `key_facts` / `game_impact` / the player-facing `content` prose ("in archetipo strutturale"). The combat field and the narrative flavor are conflated there. The prose was **master-dd-reviewed in #3076**, so it's left untouched (boundary: player-facing prose = master-dd ratify) — a coherent codex pass (generator-source fix + prose review) should reconcile it.

## Scope / merge

Canon-DATA (+ test) → surface green, **master-dd merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)