### PR TITLE
feat(combat): wire D8 chain-lightning propagation (flag-OFF, PROPOSED)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -259,6 +259,8 @@ const {
 // Lazy require + try/catch in call sites: missing module never breaks combat.
 const {
   reactTile: terrainReactTile,
+  chainLightningStrike,
+  isChainLightningEnabled,
   ELEMENTS: TERRAIN_ELEMENTS,
 } = require('../services/combat/terrainReactions');
 
@@ -1331,6 +1333,44 @@ function createSessionRouter(options = {}) {
               if (pr) killOccurred = Number(target.hp) <= 0;
             } catch {
               /* symbiont bond optional */
+            }
+          }
+
+          // D8 (aa01 CAP-07 carve-out): chain-lightning propagation. When this
+          // reaction electrifies the tile (lightning + water), BFS-spread through
+          // adjacent water tiles and shock their occupants (chainLightningStrike).
+          // Flag-gated OFF = byte-identical (only the single-tile electrify burst
+          // above fires). PROPOSED conservative radius/shock ratify via N=40. Chained
+          // occupants are FLOORED at 1 HP (weaken, never kill -> no mid-attack death
+          // pipeline on a non-target unit). Friendly-fire by design (telegraph).
+          if (
+            isChainLightningEnabled() &&
+            reaction.nextState.type === 'electrified' &&
+            Array.isArray(reaction.effects) &&
+            reaction.effects.includes('chain_trigger')
+          ) {
+            try {
+              const chain = chainLightningStrike(
+                target.position,
+                session.tile_state_map,
+                session.units || [],
+                { actorId: actor.id },
+              );
+              for (const hit of chain.hits) {
+                if (hit.shock_damage > 0 && session.damage_taken) {
+                  session.damage_taken[hit.actor_id] =
+                    (session.damage_taken[hit.actor_id] || 0) + hit.shock_damage;
+                }
+              }
+              if (chain.electrified_tiles.length > 0 && terrainReactionResult) {
+                terrainReactionResult.chain = chain;
+              }
+            } catch (chainErr) {
+              // eslint-disable-next-line no-console
+              console.warn(
+                '[terrain-chain] skipped:',
+                chainErr && chainErr.message ? chainErr.message : chainErr,
+              );
             }
           }
         }

--- a/apps/backend/services/combat/terrainReactions.js
+++ b/apps/backend/services/combat/terrainReactions.js
@@ -26,6 +26,29 @@ const DEFAULT_TTL = {
   electrified: 1,
 };
 
+// D8 (aa01 CAP-07 carve-out, 2026-06-30): chain-lightning runtime gate + PROPOSED
+// conservative balance values. OFF by default = byte-identical legacy (the single-tile
+// electrify burst still fires; ONLY the multi-tile chain propagation is gated). The
+// radius (maxDepth) + per-tile shock are PROPOSED -- ratify via N=40 before the flip
+// (mirror IMPRINT_BEAT_ENABLED / STAMINA_FATIGUE_ENABLED gating). The helper's own
+// defaults are wider (maxDepth 5); these are the deliberately conservative wire values.
+const CHAIN_LIGHTNING_FLAG = 'TERRAIN_CHAIN_LIGHTNING_ENABLED';
+const PROPOSED_CHAIN_MAX_DEPTH = 2; // conservative blast radius (helper default is 5)
+const PROPOSED_CHAIN_SHOCK = 2; // per-tile occupant shock (== the electrify burst)
+
+// Square-grid 4-neighbour offsets for the chain BFS (mirror membraneOsmotiche ADJ).
+const CHAIN_ADJ = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+// True iff the chain flag is explicitly 'true' (mirror isImprintEnabled / isFatigueEnabled).
+function isChainLightningEnabled(env = process.env) {
+  return Boolean(env) && env[CHAIN_LIGHTNING_FLAG] === 'true';
+}
+
 /**
  * Compute next tile state + damage burst for a single element→tile interaction.
  *
@@ -163,6 +186,60 @@ function chainElectrified(origin, tileStateMap, hexKeyFn, hexNeighborsFn, opts =
   };
 }
 
+/**
+ * D8 (aa01 CAP-07): full chain-lightning strike on a SQUARE grid. BFS-spreads the
+ * electrified state from `origin` through adjacent water tiles (via chainElectrified)
+ * and applies a FLOORED shock to every occupant standing on a NEWLY-electrified tile.
+ * The origin tile is excluded (its occupant already took the single-tile electrify
+ * burst at the call-site). Mutates `tileStateMap` (electrified spread) + `unit.hp`.
+ * Occupants are floored at 1 HP -- the chain weakens but never lands a killing blow
+ * (so no mid-attack death pipeline fires on a non-target unit). Friendly-fire by
+ * design (positioning telegraph). Never throws; bad origin -> empty result.
+ *
+ * @param {{x:number,y:number}} origin  hex where lightning electrified a water tile
+ * @param {Map|object} tileStateMap     keyed "x,y" (mutated)
+ * @param {Array} units                 session units (read position + hp; hp mutated)
+ * @param {object} opts { maxDepth, shockDamagePerTile, actorId }
+ * @returns {{ electrified_tiles: string[], hits: Array<{actor_id,tile,shock_damage:number}> }}
+ */
+function chainLightningStrike(origin, tileStateMap, units, opts = {}) {
+  const ox = Number(origin && origin.x);
+  const oy = Number(origin && origin.y);
+  if (!Number.isFinite(ox) || !Number.isFinite(oy)) return { electrified_tiles: [], hits: [] };
+  const maxDepth = Number.isFinite(opts.maxDepth) ? opts.maxDepth : PROPOSED_CHAIN_MAX_DEPTH;
+  const shock = Number.isFinite(opts.shockDamagePerTile)
+    ? opts.shockDamagePerTile
+    : PROPOSED_CHAIN_SHOCK;
+  const keyFn = (x, y) => `${x},${y}`;
+  const originKey = keyFn(ox, oy);
+  const chain = chainElectrified(
+    { q: ox, r: oy },
+    tileStateMap,
+    (q, r) => keyFn(q, r),
+    ({ q, r }) => CHAIN_ADJ.map(([dx, dy]) => ({ q: q + dx, r: r + dy })),
+    { maxDepth, shockDamagePerTile: shock, actorId: opts.actorId ?? null },
+  );
+  const electrified_tiles = chain.electrified.filter((k) => k !== originKey);
+  const hits = [];
+  const list = Array.isArray(units) ? units : [];
+  for (const tkey of electrified_tiles) {
+    const occupant = list.find(
+      (u) =>
+        u &&
+        u.position &&
+        keyFn(Number(u.position.x), Number(u.position.y)) === tkey &&
+        Number(u.hp) > 0,
+    );
+    if (!occupant) continue;
+    const pre = Number(occupant.hp);
+    occupant.hp = Math.max(1, pre - shock);
+    const applied = pre - occupant.hp;
+    // Only a meaningful shock is a hit (an occupant already at the 1-HP floor takes 0).
+    if (applied > 0) hits.push({ actor_id: occupant.id, tile: tkey, shock_damage: applied });
+  }
+  return { electrified_tiles, hits };
+}
+
 // ─── internals ───────────────────────────────────────────────────────────
 
 function normalizeState(state) {
@@ -183,6 +260,11 @@ function pickTtl(override, type) {
 module.exports = {
   reactTile,
   chainElectrified,
+  chainLightningStrike,
+  isChainLightningEnabled,
+  CHAIN_LIGHTNING_FLAG,
+  PROPOSED_CHAIN_MAX_DEPTH,
+  PROPOSED_CHAIN_SHOCK,
   TILE_TYPES,
   ELEMENTS,
   DEFAULT_TTL,

--- a/tests/services/terrainChainLightning.test.js
+++ b/tests/services/terrainChainLightning.test.js
@@ -1,0 +1,125 @@
+// =============================================================================
+// D8 (aa01 CAP-07 carve-out, 2026-06-30) -- chain-lightning strike helper.
+//
+// Verifies the SQUARE-grid chain propagation + floored occupant shock that the
+// session.js electrified branch wires behind TERRAIN_CHAIN_LIGHTNING_ENABLED.
+// Flag OFF (default) = the wire never calls this helper -> byte-identical legacy.
+// =============================================================================
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  chainLightningStrike,
+  isChainLightningEnabled,
+  PROPOSED_CHAIN_MAX_DEPTH,
+  PROPOSED_CHAIN_SHOCK,
+} = require('../../apps/backend/services/combat/terrainReactions');
+
+// A "x,y" -> water-tile map for the given coords.
+function waterMap(coords) {
+  const m = {};
+  for (const [x, y] of coords) m[`${x},${y}`] = { type: 'water', ttl: 2, source_actor: null };
+  return m;
+}
+
+test('flag OFF by default; only "true" enables', () => {
+  assert.equal(isChainLightningEnabled({}), false);
+  assert.equal(isChainLightningEnabled({ TERRAIN_CHAIN_LIGHTNING_ENABLED: 'false' }), false);
+  assert.equal(isChainLightningEnabled({ TERRAIN_CHAIN_LIGHTNING_ENABLED: '1' }), false);
+  assert.equal(isChainLightningEnabled({ TERRAIN_CHAIN_LIGHTNING_ENABLED: 'true' }), true);
+  assert.equal(isChainLightningEnabled(null), false);
+});
+
+test('PROPOSED values are the conservative wire defaults', () => {
+  assert.equal(PROPOSED_CHAIN_MAX_DEPTH, 2);
+  assert.equal(PROPOSED_CHAIN_SHOCK, 2);
+});
+
+test('spreads through adjacent water, excludes origin, respects maxDepth 2', () => {
+  // Origin (0,0) struck; water line (1,0),(2,0),(3,0). maxDepth 2 -> (3,0) is depth 3, dropped.
+  const map = waterMap([
+    [1, 0],
+    [2, 0],
+    [3, 0],
+  ]);
+  map['0,0'] = { type: 'electrified', ttl: 1, source_actor: null };
+  const res = chainLightningStrike({ x: 0, y: 0 }, map, []);
+  assert.deepEqual(
+    res.electrified_tiles.sort(),
+    ['1,0', '2,0'],
+    'origin excluded, (3,0) out of range',
+  );
+  assert.equal(map['1,0'].type, 'electrified');
+  assert.equal(map['2,0'].type, 'electrified');
+  assert.equal(map['3,0'].type, 'water', 'beyond maxDepth stays water');
+});
+
+test('occupants on newly-electrified tiles take floored shock; origin occupant untouched', () => {
+  const map = waterMap([
+    [1, 0],
+    [2, 0],
+  ]);
+  map['0,0'] = { type: 'electrified', ttl: 1, source_actor: null };
+  const units = [
+    { id: 'origin_unit', position: { x: 0, y: 0 }, hp: 5 }, // origin -> NOT chained
+    { id: 'foe', position: { x: 1, y: 0 }, hp: 5 }, // -2 -> 3
+    { id: 'low', position: { x: 2, y: 0 }, hp: 2 }, // floor: 2 -> 1, applied 1
+  ];
+  const res = chainLightningStrike({ x: 0, y: 0 }, map, units, { actorId: 'caster' });
+  assert.equal(units[0].hp, 5, 'origin occupant not shocked by the chain');
+  assert.equal(units[1].hp, 3);
+  assert.equal(units[2].hp, 1, 'floored at 1, never below');
+  const byId = Object.fromEntries(res.hits.map((h) => [h.actor_id, h.shock_damage]));
+  assert.deepEqual(byId, { foe: 2, low: 1 });
+});
+
+test('an occupant already at 1 HP is not a hit (0 applied), tile still electrified', () => {
+  const map = waterMap([[1, 0]]);
+  map['0,0'] = { type: 'electrified', ttl: 1, source_actor: null };
+  const units = [{ id: 'spent', position: { x: 1, y: 0 }, hp: 1 }];
+  const res = chainLightningStrike({ x: 0, y: 0 }, map, units);
+  assert.equal(units[0].hp, 1);
+  assert.deepEqual(res.electrified_tiles, ['1,0']);
+  assert.equal(res.hits.length, 0, 'no meaningful shock -> no hit recorded');
+});
+
+test('friendly-fire: allies on chained water tiles are shocked too', () => {
+  const map = waterMap([
+    [0, 1],
+    [0, -1],
+  ]);
+  map['0,0'] = { type: 'electrified', ttl: 1, source_actor: null };
+  const units = [
+    { id: 'ally_a', position: { x: 0, y: 1 }, hp: 6, team: 'players' },
+    { id: 'ally_b', position: { x: 0, y: -1 }, hp: 6, team: 'players' },
+  ];
+  const res = chainLightningStrike({ x: 0, y: 0 }, map, units);
+  assert.equal(units[0].hp, 4);
+  assert.equal(units[1].hp, 4);
+  assert.equal(res.hits.length, 2);
+});
+
+test('does not spread through non-water tiles', () => {
+  // (1,0) is fire, not water -> chain stops at the origin.
+  const map = { '1,0': { type: 'fire', ttl: 2, source_actor: null } };
+  map['0,0'] = { type: 'electrified', ttl: 1, source_actor: null };
+  const res = chainLightningStrike({ x: 0, y: 0 }, map, []);
+  assert.deepEqual(res.electrified_tiles, [], 'no adjacent water -> no spread');
+  assert.equal(map['1,0'].type, 'fire');
+});
+
+test('bad origin / no units -> safe empty result, never throws', () => {
+  assert.deepEqual(chainLightningStrike(null, {}, []), { electrified_tiles: [], hits: [] });
+  assert.deepEqual(chainLightningStrike({ x: 'nope' }, {}, []), {
+    electrified_tiles: [],
+    hits: [],
+  });
+  const map = waterMap([[1, 0]]);
+  map['0,0'] = { type: 'electrified', ttl: 1, source_actor: null };
+  const res = chainLightningStrike({ x: 0, y: 0 }, map, null);
+  assert.deepEqual(res.electrified_tiles, ['1,0']);
+  assert.equal(res.hits.length, 0);
+});


### PR DESCRIPTION
## D8 -- chain-lightning propagation (aa01 CAP-07, owner-greenlit)

Master-dd greenlit (AskUserQuestion, close-out Tier-2 aa01 cluster): **Build flag-OFF + PROPOSED conservativi**.

### What
The `chainElectrified` BFS helper has sat dormant ("no runtime wire") since M14-A. This wires it: when a lightning+water reaction electrifies a tile, the chain spreads through adjacent water tiles and shocks their occupants.

- New pure helper `chainLightningStrike(origin, tileStateMap, units, opts)` in `terrainReactions.js` (square-grid 4-neighbour adapter over the hex `chainElectrified`).
- Thin wire in `session.js` electrified branch (post-burst).
- Flag `TERRAIN_CHAIN_LIGHTNING_ENABLED` (default **OFF** = byte-identical; only the single-tile electrify burst fires).
- PROPOSED conservative values: `maxDepth 2` (helper default is 5), `shock 2/tile` (== electrify burst). **Ratify via N=40 before any flip** (mirror IMPRINT/STAMINA gating).
- Chained occupants **floor at 1 HP** (chain weakens, never kills -> no mid-attack death pipeline on a non-target unit). Friendly-fire by design (positioning telegraph).

### Tests
- `tests/services/terrainChainLightning.test.js` (8): spread/maxDepth, floored shock, origin-excluded, already-floored no-hit, friendly-fire, non-water stop, bad-input safety, flag gate.
- Regression `tests/api/terrainReactionsWire.test.js` 7/7 (flag-OFF byte-identical).
- `npm run format:check` clean on touched files.

### Rollback (03A)
Single additive commit; revert restores the dormant helper. Flag default OFF -> no runtime behavior change until a future ratified flip.

### Scope
`apps/backend/**` only (no forbidden paths, no new deps, no schema).
