### PR TITLE
feat(imprint): scaffold D7 branco-tendency diegetic descriptor

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -22,6 +22,7 @@ const consentSM = require('./lethalConsent');
 const {
   computeImprintBiomeWeights,
   topBiome,
+  brancoTendencyHint,
   IMPRINT_AXES,
   IMPRINT_AXIS_DEFAULTS,
   isValidAxisValue,
@@ -1722,7 +1723,11 @@ class CoopOrchestrator {
     }
     const weights = computeImprintBiomeWeights([tuple]);
     const leans = topBiome(weights);
-    this.brancoBiomeHint = leans ? { leans_toward: leans, weights } : null;
+    // D7: additive diegetic tendency descriptor ("il tuo branco tende verso X").
+    // Structure only (i18n key + var); the player-facing prose is master-dd HITL.
+    this.brancoBiomeHint = leans
+      ? { leans_toward: leans, weights, tendency: brancoTendencyHint(leans) }
+      : null;
     // D6: stamp the resolved team tuple for the branco-trait emergence (stacking B).
     this.imprintTuple = tuple;
     this.imprintOpen = false;

--- a/apps/backend/services/imprint/imprintBiomeWeights.js
+++ b/apps/backend/services/imprint/imprintBiomeWeights.js
@@ -145,6 +145,28 @@ function computeImprintBiomeWeights(teamTuples, opts = {}) {
 }
 
 /**
+ * D7 (aa01 L'Impronta, 2026-06-30): the diegetic "il tuo branco tende verso X"
+ * tendency descriptor. SCAFFOLD ONLY -- the structure (i18n key + interpolation
+ * var) lives here; the player-facing PROSE is master-dd HITL (codex-lore boundary),
+ * authored in the client i18n table under `i18n_key`. The backend ships NO Italian
+ * sentence -- `placeholder` is a neutral marker so the field is never empty and the
+ * client knows to localize `i18n_key`. Additive to the existing cosmetic hint (rides
+ * the IMPRINT_BEAT_ENABLED gate; band-neutral, no own flag). null for an empty lean.
+ *
+ * @param {string} leansToward the top biome from the cosmetic affinity hint
+ * @returns {{ leans_toward, i18n_key, vars: { biome }, placeholder } | null}
+ */
+function brancoTendencyHint(leansToward) {
+  if (!leansToward || typeof leansToward !== 'string') return null;
+  return {
+    leans_toward: leansToward,
+    i18n_key: 'imprint.branco_tendency', // client resolves the diegetic prose (HITL master-dd)
+    vars: { biome: leansToward }, // "il tuo branco tende verso {biome}"
+    placeholder: 'TODO_IMPRINT_TENDENCY_PROSE',
+  };
+}
+
+/**
  * The biome with the highest weight (stable on ties), or null for empty weights.
  * Drives the cosmetic hint "leans_toward".
  *
@@ -168,6 +190,7 @@ function topBiome(weights) {
 module.exports = {
   computeImprintBiomeWeights,
   topBiome,
+  brancoTendencyHint,
   tupleKey,
   resetCache,
   IMPRINT_AXES,

--- a/tests/api/coopImprintBeat.test.js
+++ b/tests/api/coopImprintBeat.test.js
@@ -102,7 +102,17 @@ test('all 4 axes marked (4 players) -> cosmetic hint stamped, beat closes', () =
   const t = co.imprintTally();
   assert.equal(t.all_axes_marked, true);
   assert.equal(t.open, false, 'beat auto-closes on completion');
-  assert.deepEqual(t.branco_biome_hint, { leans_toward: 'savana', weights: { savana: 1 } });
+  assert.deepEqual(t.branco_biome_hint, {
+    leans_toward: 'savana',
+    weights: { savana: 1 },
+    // D7: additive diegetic tendency descriptor (structure only; prose = client HITL).
+    tendency: {
+      leans_toward: 'savana',
+      i18n_key: 'imprint.branco_tendency',
+      vars: { biome: 'savana' },
+      placeholder: 'TODO_IMPRINT_TENDENCY_PROSE',
+    },
+  });
 });
 
 test('N=2 scaling: each player owns 2 axes, all 4 -> hint', () => {

--- a/tests/services/imprintBiomeWeights.test.js
+++ b/tests/services/imprintBiomeWeights.test.js
@@ -8,6 +8,7 @@ const assert = require('node:assert/strict');
 const {
   computeImprintBiomeWeights,
   topBiome,
+  brancoTendencyHint,
   tupleKey,
 } = require('../../apps/backend/services/imprint/imprintBiomeWeights');
 
@@ -163,4 +164,33 @@ test('isImprintEnabled: OFF by default, ON only when env flag === "true"', () =>
   assert.equal(isImprintEnabled({ IMPRINT_BEAT_ENABLED: '1' }), false);
   assert.equal(isImprintEnabled({ IMPRINT_BEAT_ENABLED: 'true' }), true);
   assert.equal(isImprintEnabled(null), false);
+});
+
+// D7 -- diegetic tendency descriptor scaffold (structure only; prose = client HITL).
+test('brancoTendencyHint: structured descriptor for a non-empty lean', () => {
+  assert.deepEqual(brancoTendencyHint('palude'), {
+    leans_toward: 'palude',
+    i18n_key: 'imprint.branco_tendency',
+    vars: { biome: 'palude' },
+    placeholder: 'TODO_IMPRINT_TENDENCY_PROSE',
+  });
+});
+
+test('brancoTendencyHint: the var tracks the lean (different biome)', () => {
+  const t = brancoTendencyHint('reef');
+  assert.equal(t.vars.biome, 'reef');
+  assert.equal(t.leans_toward, 'reef');
+  assert.equal(t.i18n_key, 'imprint.branco_tendency');
+});
+
+test('brancoTendencyHint: ships NO player-facing prose (boundary)', () => {
+  // The backend must never embed the Italian sentence; only a neutral marker.
+  assert.equal(brancoTendencyHint('savana').placeholder, 'TODO_IMPRINT_TENDENCY_PROSE');
+});
+
+test('brancoTendencyHint: null/empty/invalid lean -> null', () => {
+  assert.equal(brancoTendencyHint(null), null);
+  assert.equal(brancoTendencyHint(''), null);
+  assert.equal(brancoTendencyHint(undefined), null);
+  assert.equal(brancoTendencyHint(42), null);
 });


### PR DESCRIPTION
## D7 -- branco-tendency diegetic descriptor scaffold (aa01, owner-greenlit)

Master-dd greenlit (AskUserQuestion, close-out Tier-2 aa01 cluster): **scaffold now + placeholder, prose later**.

### What
`brancoTendencyHint(leansToward)` adds a **structured** "il tuo branco tende verso X" descriptor onto the existing cosmetic imprint hint (`brancoBiomeHint.tendency`).

- Structure only: `i18n_key: 'imprint.branco_tendency'` + `vars: { biome }`.
- **Boundary respected**: the backend ships NO Italian prose. The player-facing wording is master-dd HITL (codex-lore boundary), authored client-side under `i18n_key`. The backend emits a neutral `TODO_IMPRINT_TENDENCY_PROSE` placeholder so the field is never empty.
- Additive + **band-neutral**: rides the existing `IMPRINT_BEAT_ENABLED` gate, no own flag.

### Next (master-dd HITL)
Author the diegetic prose for `imprint.branco_tendency` in the client i18n table (and optionally per-biome variants); the structure + var are already wired.

### Tests
- `tests/services/imprintBiomeWeights.test.js` (+4): descriptor shape, var tracks lean, no-prose boundary, null on empty.
- `tests/api/coopImprintBeat.test.js`: hint-shape regression updated to assert the additive tendency field.
- Format clean.

### Rollback (03A)
Additive field; revert removes `tendency` from the hint payload (clients ignore unknown fields either way).

### Scope
`apps/backend/**` + tests only. No forbidden paths, no new deps, no schema.
