### PR TITLE
fix(codex): align 5 retired-creature lore to canon archetype adattivo

### DIFF
--- a/data/codex/lithoconstructus_inhibens.yaml
+++ b/data/codex/lithoconstructus_inhibens.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Caverna Risonante
     biome_trait: Gallerie cristalline dove eco e pressioni invertite modellano la fauna
     lineage: forme a morfologia costrutto corazzato
-    archetype: strutturale
+    archetype: adattivo
     morphotype: costrutto corazzato
     job: warden
     role: guardiano artificiale
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: strutturale'
+      - 'resistance_archetype: adattivo'
       - 'role_trofico: guardiano_artificiale; sentient: False'
       - 'trait_refs: armatura_pietra_planare, carapace_fase_variabile, matrice_antimagia, nuclei_di_controllo'
       cross_ref:
@@ -60,8 +60,8 @@ codex_entry:
       - trait:carapace_fase_variabile
       - trait:matrice_antimagia
       - trait:nuclei_di_controllo
-      game_impact: Archetipo strutturale.
-      content: 'Il litoautoma inibitore evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- armatura pietra planare, carapace fase variabile, matrice antimagia, nuclei di controllo -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
+      game_impact: Archetipo adattivo.
+      content: 'Il litoautoma inibitore evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- armatura pietra planare, carapace fase variabile, matrice antimagia, nuclei di controllo -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/data/codex/pyroflagellum_meteoriticum.yaml
+++ b/data/codex/pyroflagellum_meteoriticum.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Abisso Vulcanico
     biome_trait: Camini abissali con lava pressurizzata e fauna bio-termica
     lineage: forme a morfologia alato corazzato
-    archetype: strutturale
+    archetype: adattivo
     morphotype: alato corazzato
     job: vanguard
     role: predatore terziario
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: strutturale'
+      - 'resistance_archetype: adattivo'
       - 'role_trofico: predatore_terziario; sentient: False'
       - 'trait_refs: adattamento_volo, frusta_fiammeggiante, mantello_meteoritico, armatura_pietra_planare, artigli_sette_vie, carapace_fase_variabile'
       cross_ref:
@@ -62,8 +62,8 @@ codex_entry:
       - trait:armatura_pietra_planare
       - trait:artigli_sette_vie
       - trait:carapace_fase_variabile
-      game_impact: Archetipo strutturale.
-      content: 'Il flagello igneo evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- adattamento volo, frusta fiammeggiante, mantello meteoritico, armatura pietra planare, artigli sette vie, carapace fase variabile -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
+      game_impact: Archetipo adattivo.
+      content: 'Il flagello igneo evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- adattamento volo, frusta fiammeggiante, mantello meteoritico, armatura pietra planare, artigli sette vie, carapace fase variabile -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/data/codex/radiciforma_ancorans.yaml
+++ b/data/codex/radiciforma_ancorans.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Foresta Miceliale
     biome_trait: Canopia micotica bioluminescente dove la rete fungina coordina la fauna
     lineage: forme a morfologia flora radicata
-    archetype: strutturale
+    archetype: adattivo
     morphotype: flora radicata
     job: warden
     role: flora ancorata
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: strutturale'
+      - 'resistance_archetype: adattivo'
       - 'role_trofico: flora_ancorata; sentient: False'
       - 'trait_refs: corteccia_memetica, pigmenti_aurorali, radici_ancora_planare, reti_capillari_radici, armatura_pietra_planare'
       cross_ref:
@@ -61,7 +61,7 @@ codex_entry:
       - trait:radici_ancora_planare
       - trait:reti_capillari_radici
       - trait:armatura_pietra_planare
-      game_impact: Archetipo strutturale.
+      game_impact: Archetipo adattivo.
       content: 'La linea dell''ancora radicale porta i segni di corteccia memetica, pigmenti aurorali, radici ancora planare, reti capillari radici, armatura pietra planare: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico

--- a/data/codex/rotabrachium_ferox.yaml
+++ b/data/codex/rotabrachium_ferox.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Abisso Vulcanico
     biome_trait: Camini abissali con lava pressurizzata e fauna bio-termica
     lineage: forme a morfologia multi arto rotante
-    archetype: strutturale
+    archetype: adattivo
     morphotype: multi arto rotante
     job: vanguard
     role: predatore apex
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: strutturale'
+      - 'resistance_archetype: adattivo'
       - 'role_trofico: predatore_apex; sentient: False'
       - 'trait_refs: nucleo_ovomotore_rotante, frusta_fiammeggiante, mantello_meteoritico, focus_frazionato, artigli_sette_vie, coda_frusta_cinetica, empatia_coordinativa'
       cross_ref:
@@ -63,8 +63,8 @@ codex_entry:
       - trait:artigli_sette_vie
       - trait:coda_frusta_cinetica
       - trait:empatia_coordinativa
-      game_impact: Archetipo strutturale.
-      content: 'Il rotabraccio evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- nucleo ovomotore rotante, frusta fiammeggiante, mantello meteoritico, focus frazionato, artigli sette vie, coda frusta cinetica -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
+      game_impact: Archetipo adattivo.
+      content: 'Il rotabraccio evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- nucleo ovomotore rotante, frusta fiammeggiante, mantello meteoritico, focus frazionato, artigli sette vie, coda frusta cinetica -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/data/codex/tellurmordax_phasicus.yaml
+++ b/data/codex/tellurmordax_phasicus.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Calanchi Ferromagnetici
     biome_trait: Altipiani arrugginiti con tempeste ferrose e rovine sepolte
     lineage: forme a morfologia scavatore corazzato
-    archetype: strutturale
+    archetype: adattivo
     morphotype: scavatore corazzato
     job: vanguard
     role: predatore terziario
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: strutturale'
+      - 'resistance_archetype: adattivo'
       - 'role_trofico: predatore_terziario; sentient: False'
       - 'trait_refs: carapace_fase_variabile, coda_frusta_cinetica, armatura_pietra_planare, scheletro_idro_regolante'
       cross_ref:
@@ -60,8 +60,8 @@ codex_entry:
       - trait:coda_frusta_cinetica
       - trait:armatura_pietra_planare
       - trait:scheletro_idro_regolante
-      game_impact: Archetipo strutturale.
-      content: 'Il tellumordace di fase evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- carapace fase variabile, coda frusta cinetica, armatura pietra planare, scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo strutturale.'
+      game_impact: Archetipo adattivo.
+      content: 'Il tellumordace di fase evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- carapace fase variabile, coda frusta cinetica, armatura pietra planare, scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:


### PR DESCRIPTION
## Codex strutturale-echo coherent pass (owner-greenlit)

Master-dd picked this lane (close-out Tier-2 follow-up). The 5 retired-creature codex entries (#3076) went stale: promoted BEFORE #3080 remapped their species `resistance_archetype` `strutturale`->`adattivo`, so their lore still echoed the old archetype.

### Change
Narrow canon-rename `strutturale`->`adattivo` (4 spots/entry; radiciforma 3): `lore_vars.archetype`, the `resistance_archetype` key_fact, and the `game_impact` + `content` prose. **19 ins / 19 del, nothing else.**

### Why narrow (not regenerate)
Verify-first: the gen-source is ALREADY correct (`codex_draft_scaffold` reads species `resistance_archetype`, now `adattivo`; default is `adattivo`). A regen diff confirmed the ONLY content delta is the archetype word -- but a full regen also reformats every line (yaml width) AND **drops `codex_archive: true`** (would re-break the #2851 namespace-guard exemption). The surgical edit preserves `codex_archive` + formatting.

### Player-facing prose (HITL)
`game_impact: Archetipo adattivo.` + `content: ...in archetipo adattivo.` -- pure canon-rename, semantically identical; "adattivo" fits the "ciclo di adattamento continuo" theme. **master-dd reviews + merges (canon-data).**

### Verification
HA2 validator 6/6 all dimensions (errors=0, warnings=0), codex entry/route tests 15/15, YAML valid, `codex_archive` preserved on all 5.

### Rollback
Revert restores the (stale) strutturale text. No code, no schema, no forbidden paths.
