### PR TITLE
feat(codex): guard codex<->species archetype coherence (PR #3087 regression)

### DIFF
--- a/tests/codex/archetypeCoherence.test.js
+++ b/tests/codex/archetypeCoherence.test.js
@@ -1,0 +1,178 @@
+// SPEC-H -- codex<->species resistance_archetype coherence check.
+//
+// Regression guard for the failure mode fixed in PR #3087 (cb16f7bf): the 5
+// retired-creature codex entries were promoted (#3076) BEFORE #3080 remapped
+// their species resistance_archetype strutturale -> adattivo, so their
+// lore_vars.archetype + the resistance_archetype key_fact went stale silently.
+//
+// This asserts, for every promoted `data/codex/<id>.yaml` entry of type:species
+// whose id resolves to a species spec, that lore_vars.archetype AND the
+// L_linee_evolutive `resistance_archetype` key_fact match the CURRENT species
+// resistance_archetype.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  parseKeyFactArchetype,
+  checkArchetypeCoherence,
+  loadSpeciesArchetypes,
+} = require('../../tools/js/validate_codex_aliena.js');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'tools', 'js', 'validate_codex_aliena.js');
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+// Build a minimal codex_entry object for the pure comparator.
+function entry({ id = 'x', archetype, keyFactArch } = {}) {
+  const e = {
+    id,
+    type: 'species',
+    lore_vars: {},
+    aliena_dimensions: { L_linee_evolutive: { key_facts: [] } },
+  };
+  if (archetype !== undefined) e.lore_vars.archetype = archetype;
+  if (keyFactArch !== undefined) {
+    e.aliena_dimensions.L_linee_evolutive.key_facts = [
+      'role_trofico: predatore; sentient: False',
+      `resistance_archetype: ${keyFactArch}`,
+    ];
+  }
+  return e;
+}
+
+// --- parseKeyFactArchetype --------------------------------------------------
+
+test('parseKeyFactArchetype extracts the leading token', () => {
+  assert.equal(parseKeyFactArchetype(['resistance_archetype: adattivo']), 'adattivo');
+});
+
+test('parseKeyFactArchetype ignores a trailing provenance suffix', () => {
+  // The real predoni_nomadi key_fact carries a "(predoni-nomadi.yaml:3)" suffix.
+  assert.equal(
+    parseKeyFactArchetype(['resistance_archetype: adattivo (predoni-nomadi.yaml:3)']),
+    'adattivo',
+  );
+});
+
+test('parseKeyFactArchetype scans the whole key_facts list', () => {
+  assert.equal(
+    parseKeyFactArchetype(['role_trofico: x', 'resistance_archetype: strutturale']),
+    'strutturale',
+  );
+});
+
+test('parseKeyFactArchetype returns null when absent or empty', () => {
+  assert.equal(parseKeyFactArchetype(['role_trofico: x']), null);
+  assert.equal(parseKeyFactArchetype([]), null);
+  assert.equal(parseKeyFactArchetype(undefined), null);
+});
+
+// --- checkArchetypeCoherence ------------------------------------------------
+
+test('checkArchetypeCoherence: aligned entry yields no error', () => {
+  const errs = checkArchetypeCoherence(
+    entry({ id: 'a', archetype: 'adattivo', keyFactArch: 'adattivo' }),
+    'adattivo',
+  );
+  assert.deepEqual(errs, []);
+});
+
+test('checkArchetypeCoherence: provenance-suffixed key_fact still matches', () => {
+  const errs = checkArchetypeCoherence(
+    entry({
+      id: 'predoni_nomadi',
+      archetype: 'adattivo',
+      keyFactArch: 'adattivo (predoni-nomadi.yaml:3)',
+    }),
+    'adattivo',
+  );
+  assert.deepEqual(errs, []);
+});
+
+test('checkArchetypeCoherence: flags a stale lore_vars.archetype', () => {
+  const errs = checkArchetypeCoherence(entry({ id: 'a', archetype: 'strutturale' }), 'adattivo');
+  assert.equal(errs.length, 1);
+  assert.match(errs[0], /lore_vars\.archetype 'strutturale'.*'adattivo'/);
+});
+
+test('checkArchetypeCoherence: flags a stale resistance_archetype key_fact', () => {
+  const errs = checkArchetypeCoherence(entry({ id: 'a', keyFactArch: 'strutturale' }), 'adattivo');
+  assert.equal(errs.length, 1);
+  assert.match(errs[0], /key_fact 'strutturale'.*'adattivo'/);
+});
+
+test('checkArchetypeCoherence: the pre-#3087 strutturale state flags BOTH spots', () => {
+  const errs = checkArchetypeCoherence(
+    entry({
+      id: 'lithoconstructus_inhibens',
+      archetype: 'strutturale',
+      keyFactArch: 'strutturale',
+    }),
+    'adattivo',
+  );
+  assert.equal(errs.length, 2, errs.join('\n'));
+});
+
+test('checkArchetypeCoherence: skips when neither spot is authored', () => {
+  const errs = checkArchetypeCoherence(entry({ id: 'a' }), 'adattivo');
+  assert.deepEqual(errs, []);
+});
+
+// --- loadSpeciesArchetypes --------------------------------------------------
+
+test('loadSpeciesArchetypes resolves a known species id by its id field', () => {
+  // Filenames hyphenate (lithoconstructus-inhibens.yaml) but ids underscore;
+  // resolution must key on the in-file `id`, not the filename.
+  const m = loadSpeciesArchetypes(REPO_ROOT);
+  assert.equal(m.get('lithoconstructus_inhibens'), 'adattivo');
+});
+
+// --- CLI end-to-end ---------------------------------------------------------
+
+test('CLI: real data/codex is archetype-coherent (post-#3087, errors=0)', () => {
+  const r = spawnSync('node', [SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+  assert.equal(r.status, 0, `${r.stdout}\n${r.stderr}`);
+  assert.match(r.stdout, /errors=0/);
+});
+
+test('CLI: would FAIL on the pre-#3087 strutturale state (synthetic desync)', () => {
+  const dir = path.join(__dirname, '_tmp_codex_archetype_desync');
+  const filler = (c) => c.repeat(400);
+  const body = `codex_entry:
+  id: lithoconstructus_inhibens
+  type: species
+  display_name_it: Test
+  unlock:
+    triggers: [encounter_completed]
+    threshold: 1
+  lore_vars:
+    archetype: strutturale
+  aliena_dimensions:
+    A_ambiente: { heading: Ambiente, content: '${filler('a')}' }
+    L_linee_evolutive:
+      heading: Linee
+      content: '${filler('b')}'
+      key_facts:
+        - 'resistance_archetype: strutturale'
+    I_impianto: { heading: Impianto, content: '${filler('c')}' }
+    E_ecologia: { heading: Ecologia, content: '${filler('d')}' }
+    N_norme_socio: { heading: Norme, content: '${filler('e')}' }
+    A_ancoraggio_narrativo:
+      heading: Ancoraggio
+      content: '${filler('f')}'
+      story_hook_it: 'Un gancio narrativo.'
+`;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'lithoconstructus_inhibens.yaml'), body);
+    const r = spawnSync('node', [SCRIPT, '--codex', dir], { encoding: 'utf8', cwd: REPO_ROOT });
+    assert.equal(r.status, 1, `expected failure, got:\n${r.stdout}\n${r.stderr}`);
+    assert.match(r.stdout, /lore_vars\.archetype 'strutturale'/);
+    assert.match(r.stdout, /key_fact 'strutturale'/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/js/validate_codex_aliena.js
+++ b/tools/js/validate_codex_aliena.js
@@ -164,11 +164,100 @@ function collectInPlaySpecies(repoRoot) {
   return { species, sources, notes };
 }
 
+// The canonical species spec source (per-species pack YAML). Filenames hyphenate
+// (lithoconstructus-inhibens.yaml) while ids underscore, so resolution keys on the
+// in-file `id`, not the filename.
+const SPECIES_PACK_REL = 'packs/evo_tactics_pack/data/species';
+
+// Build a Map<id, resistance_archetype> from the pack species specs. Best-effort:
+// a species file that fails to parse degrades to skip, not a crash. Returns an
+// empty Map if the pack dir is absent (coherence then has nothing to check).
+function loadSpeciesArchetypes(repoRoot) {
+  const map = new Map();
+  const root = path.resolve(repoRoot, SPECIES_PACK_REL);
+  if (!fs.existsSync(root)) return map;
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const full = path.join(dir, ent.name);
+      if (ent.isDirectory()) {
+        stack.push(full);
+      } else if (/\.ya?ml$/.test(ent.name)) {
+        let parsed;
+        try {
+          parsed = yaml.load(fs.readFileSync(full, 'utf8'));
+        } catch {
+          continue;
+        }
+        if (parsed && typeof parsed === 'object' && parsed.id) {
+          const arch = parsed.resistance_archetype;
+          map.set(String(parsed.id), arch == null ? null : String(arch));
+        }
+      }
+    }
+  }
+  return map;
+}
+
+// Extract the resistance_archetype value from an L_linee_evolutive key_facts list.
+// The value is a single token; some entries append a provenance suffix
+// (e.g. 'adattivo (predoni-nomadi.yaml:3)'), so only the leading token counts.
+// Returns the token, or null if no resistance_archetype key_fact is present.
+function parseKeyFactArchetype(keyFacts) {
+  if (!Array.isArray(keyFacts)) return null;
+  for (const item of keyFacts) {
+    const m = /^resistance_archetype\s*:\s*(\S+)/.exec(String(item).trim());
+    if (m) return m[1];
+  }
+  return null;
+}
+
+// Coherence check (HARD): a type:species codex entry declares the species archetype
+// in two spots -- lore_vars.archetype and the L_linee_evolutive resistance_archetype
+// key_fact. Both MUST match the CURRENT species resistance_archetype. This catches
+// the PR #3087 failure mode: a species archetype remapped (strutturale -> adattivo,
+// #3080) after the codex was promoted (#3076), leaving the lore stale & silent.
+// Returns an array of error strings (one per desynced spot); empty when coherent or
+// when neither spot is authored. `speciesArchetype` is the canonical value.
+function checkArchetypeCoherence(entry, speciesArchetype) {
+  const errors = [];
+  if (!entry || typeof entry !== 'object') return errors;
+  const id = entry.id || '(unknown)';
+  const canon = String(speciesArchetype);
+
+  const loreVar = entry.lore_vars && entry.lore_vars.archetype;
+  if (typeof loreVar === 'string' && loreVar.trim() && loreVar.trim() !== canon) {
+    errors.push(
+      `${id}: lore_vars.archetype '${loreVar.trim()}' != species resistance_archetype '${canon}' (codex lore stale vs species canon -- see PR #3087)`,
+    );
+  }
+
+  const L = (entry.aliena_dimensions || {}).L_linee_evolutive || {};
+  const kfArch = parseKeyFactArchetype(L.key_facts);
+  if (kfArch && kfArch !== canon) {
+    errors.push(
+      `${id}: L_linee_evolutive resistance_archetype key_fact '${kfArch}' != species resistance_archetype '${canon}' (codex lore stale vs species canon -- see PR #3087)`,
+    );
+  }
+  return errors;
+}
+
 // Validate a single parsed codex file. Pushes into errors/warnings (mutated).
 // `universe` (optional Set<string>): when provided, the entry id is cross-checked
 // against the in-play species set and an orphan id warns (SOFT). null/undefined
 // skips the cross-check (fixture mode -- no roster context).
-function validateEntry(file, parsed, errors, warnings, universe = null) {
+// `speciesArchetypes` (optional Map<id, resistance_archetype>): when provided, a
+// type:species entry whose id resolves to a species with a defined archetype is
+// hard-checked for codex<->species archetype coherence (PR #3087 guard). An
+// unresolved id is out of scope here (the namespace SOFT check owns orphans).
+function validateEntry(file, parsed, errors, warnings, universe = null, speciesArchetypes = null) {
   const entry = parsed && parsed.codex_entry;
   if (!entry || typeof entry !== 'object') {
     errors.push(`${file}: missing top-level codex_entry`);
@@ -227,6 +316,15 @@ function validateEntry(file, parsed, errors, warnings, universe = null) {
     );
   }
 
+  // HARD (PR #3087 guard): codex<->species archetype coherence. Only when the
+  // type:species id resolves to a species with a defined resistance_archetype.
+  if (speciesArchetypes && entry.type === 'species' && entry.id) {
+    const speciesArch = speciesArchetypes.get(String(entry.id));
+    if (speciesArch != null && String(speciesArch).trim() !== '') {
+      for (const e of checkArchetypeCoherence(entry, String(speciesArch))) errors.push(e);
+    }
+  }
+
   return { id, dims: present };
 }
 
@@ -265,6 +363,11 @@ function main() {
     }
   }
 
+  // Archetype-coherence (PR #3087 guard) resolves against the canonical pack
+  // species specs, independent of which codex dir is under test -- a fixture that
+  // reuses a real species id is checked against that species' current archetype.
+  const speciesArchetypes = loadSpeciesArchetypes(repoRoot);
+
   for (const file of files.sort()) {
     let parsed;
     try {
@@ -273,7 +376,7 @@ function main() {
       errors.push(`${file}: YAML parse error: ${err.message}`);
       continue;
     }
-    rows.push(validateEntry(file, parsed, errors, warnings, universe));
+    rows.push(validateEntry(file, parsed, errors, warnings, universe, speciesArchetypes));
   }
 
   console.log('[codex-aliena] A.L.I.E.N.A. authoring-gate audit (HA2)');
@@ -298,6 +401,9 @@ module.exports = {
   CONTENT_MAX,
   parseArgs,
   collectInPlaySpecies,
+  loadSpeciesArchetypes,
+  parseKeyFactArchetype,
+  checkArchetypeCoherence,
   validateEntry,
 };
 


### PR DESCRIPTION
## Cosa

Aggiunge un gate HARD di coerenza codex<->species in `tools/js/validate_codex_aliena.js`:
per ogni voce promossa `data/codex/<id>.yaml` di `type: species` il cui id risolve a una
species spec del pack, `lore_vars.archetype` E il key_fact `resistance_archetype` (sotto
`aliena_dimensions.L_linee_evolutive.key_facts`) DEVONO combaciare con il
`resistance_archetype` corrente della species.

## Perche' (failure mode PR #3087)

Le 5 voci retired-creature (#3076) erano state promosse PRIMA che #3080 rimappasse il loro
`resistance_archetype` da `strutturale` -> `adattivo`, quindi la lore era diventata stale in
silenzio. PR #3087 (`cb16f7bf`) ha allineato le 5 a mano. Questo guard fa fallire la CI se un
futuro cambio di canon-species de-sincronizza di nuovo il codex.

## Dettagli implementazione

- `loadSpeciesArchetypes(repoRoot)` -- `Map<id, resistance_archetype>` da
  `packs/evo_tactics_pack/data/species/**/*.yaml`; risoluzione sull'`id` in-file (i filename
  usano trattini, gli id underscore).
- `parseKeyFactArchetype(keyFacts)` -- tiene solo il token iniziale, cosi' un suffisso di
  provenance (es. `predoni_nomadi`: `adattivo (predoni-nomadi.yaml:3)`) combacia ancora.
- `checkArchetypeCoherence(entry, speciesArchetype)` -- ritorna 1 errore chiaro per ogni spot
  desincronizzato.
- Id non risolti = skip (gli orphan restano competenza del namespace SOFT check).
- Wiring CI: nuovo `tests/codex/archetypeCoherence.test.js`, auto-eseguito dal glob
  `node --test tests/codex/*.test.js` gia' presente in `scripts/run-test-api.cjs`.

## Verifica

- `tests/codex/*.test.js`: 32/32 verdi (19 esistenti + 13 nuovi).
- CLI su `data/codex` reale (post-#3087): `errors=0` -- passa oggi.
- CLI sullo stato reale pre-#3087 (estratto da `cb16f7bf^`): exit 1, 10 errori (2 per voce x 5).
- Prettier clean; ASCII-first sui file nuovi.
- Nessuna voce live del codex e' stata rigenerata o modificata a mano.

## Changelog

- feat(codex): guard di coerenza codex<->species sul `resistance_archetype` (regression PR #3087).

## Rollback (03A)

Reversibile. `git revert c3413067` rimuove sia il guard sia il test; nessuna migrazione,
nessun cambio schema/contract, nessun dato live toccato. Il guard e' additivo (solo lettura
di dati esistenti) -> revert = ripristino stato pre-PR senza effetti collaterali.

## Note merge

Diff = +108 righe fuori `apps/backend/` (`tools/js/`) -> viola il gate-6 auto-merge L3
(regola 50-righe): **merge manuale master-dd**, non auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
