### PR TITLE
fix(codex): normalize hyphen species ids in coherence guard + align sentinella

### DIFF
--- a/data/codex/sentinella_radice.yaml
+++ b/data/codex/sentinella_radice.yaml
@@ -19,7 +19,7 @@ codex_entry:
     biome_name: Foresta Temperata Umida
     biome_trait: Boschi piovosi con canopy densa, nebbie calde e radure bioenergetiche
     lineage: forme a morfologia Organismo radicante sessile
-    archetype: adattivo
+    archetype: bioelettrico
     morphotype: Organismo radicante sessile
     job: ''
     role: ingegneri ecosistema
@@ -53,7 +53,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: adattivo'
+      - 'resistance_archetype: bioelettrico'
       - 'role_trofico: ingegneri_ecosistema; sentient: True'
       - 'trait_refs: focus_frazionato, pathfinder, pianificatore, random, empatia_coordinativa'
       cross_ref:
@@ -63,11 +63,11 @@ codex_entry:
       - trait:pianificatore
       - trait:random
       - trait:empatia_coordinativa
-      game_impact: Archetipo adattivo.
+      game_impact: Archetipo bioelettrico.
       content: 'Il sentinella radice evolve lungo le fasi cucciolo, giovane, maturo, apex,
         eredita''. I suoi tratti -- focus frazionato, pathfinder, pianificatore, random, empatia
         coordinativa -- non sono ornamenti ma risposte: ognuno racconta una pressione superata,
-        in archetipo adattivo.'
+        in archetipo bioelettrico.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/tests/codex/archetypeCoherence.test.js
+++ b/tests/codex/archetypeCoherence.test.js
@@ -17,6 +17,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const {
+  normSpeciesId,
   parseKeyFactArchetype,
   checkArchetypeCoherence,
   loadSpeciesArchetypes,
@@ -123,11 +124,24 @@ test('checkArchetypeCoherence: skips when neither spot is authored', () => {
 
 // --- loadSpeciesArchetypes --------------------------------------------------
 
+test('normSpeciesId aliases hyphens to underscores (pack ids are inconsistent)', () => {
+  assert.equal(normSpeciesId('sentinella-radice'), 'sentinella_radice');
+  assert.equal(normSpeciesId('lithoconstructus_inhibens'), 'lithoconstructus_inhibens');
+  assert.equal(normSpeciesId(null), '');
+});
+
 test('loadSpeciesArchetypes resolves a known species id by its id field', () => {
   // Filenames hyphenate (lithoconstructus-inhibens.yaml) but ids underscore;
   // resolution must key on the in-file `id`, not the filename.
   const m = loadSpeciesArchetypes(REPO_ROOT);
   assert.equal(m.get('lithoconstructus_inhibens'), 'adattivo');
+});
+
+test('loadSpeciesArchetypes resolves a HYPHEN-id species (Codex P1 #3090 gap)', () => {
+  // sentinella-radice.yaml has id: sentinella-radice (hyphen) -> the raw-key map
+  // missed the underscore codex id sentinella_radice and the gate silently skipped.
+  const m = loadSpeciesArchetypes(REPO_ROOT);
+  assert.equal(m.get('sentinella_radice'), 'bioelettrico');
 });
 
 // --- CLI end-to-end ---------------------------------------------------------

--- a/tools/js/validate_codex_aliena.js
+++ b/tools/js/validate_codex_aliena.js
@@ -169,6 +169,15 @@ function collectInPlaySpecies(repoRoot) {
 // in-file `id`, not the filename.
 const SPECIES_PACK_REL = 'packs/evo_tactics_pack/data/species';
 
+// Pack species ids are inconsistent: some underscore (lithoconstructus_inhibens),
+// some hyphen (sentinella-radice), while codex entry ids are always underscore.
+// Normalize hyphens -> underscores on BOTH the map key and the lookup so the
+// coherence gate covers hyphen-id species (Codex P1, PR #3090 follow-up) instead
+// of silently skipping them.
+function normSpeciesId(id) {
+  return String(id == null ? '' : id).replace(/-/g, '_');
+}
+
 // Build a Map<id, resistance_archetype> from the pack species specs. Best-effort:
 // a species file that fails to parse degrades to skip, not a crash. Returns an
 // empty Map if the pack dir is absent (coherence then has nothing to check).
@@ -198,7 +207,7 @@ function loadSpeciesArchetypes(repoRoot) {
         }
         if (parsed && typeof parsed === 'object' && parsed.id) {
           const arch = parsed.resistance_archetype;
-          map.set(String(parsed.id), arch == null ? null : String(arch));
+          map.set(normSpeciesId(parsed.id), arch == null ? null : String(arch));
         }
       }
     }
@@ -319,7 +328,7 @@ function validateEntry(file, parsed, errors, warnings, universe = null, speciesA
   // HARD (PR #3087 guard): codex<->species archetype coherence. Only when the
   // type:species id resolves to a species with a defined resistance_archetype.
   if (speciesArchetypes && entry.type === 'species' && entry.id) {
-    const speciesArch = speciesArchetypes.get(String(entry.id));
+    const speciesArch = speciesArchetypes.get(normSpeciesId(entry.id));
     if (speciesArch != null && String(speciesArch).trim() !== '') {
       for (const e of checkArchetypeCoherence(entry, String(speciesArch))) errors.push(e);
     }
@@ -401,6 +410,7 @@ module.exports = {
   CONTENT_MAX,
   parseArgs,
   collectInPlaySpecies,
+  normSpeciesId,
   loadSpeciesArchetypes,
   parseKeyFactArchetype,
   checkArchetypeCoherence,


### PR DESCRIPTION
Resolves Codex **P1** on #3090. `loadSpeciesArchetypes` keyed on raw pack ids, but pack ids are inconsistent (underscore vs hyphen) while codex ids are always underscore -> hyphen-id species silently skipped the HARD gate. `normSpeciesId()` aliases hyphens->underscores on map-build + lookup. Surfaced + fixed a real desync the gate was missing: `sentinella_radice` codex `adattivo` (stale) vs species `bioelettrico` -> aligned codex to species canon (#3087 pattern). dune_stalker has no archetype fields -> correctly skipped. +2 tests; validator errors=0; 15/15 + 15/15; format clean. Non-forbidden (tools/js + tests + data/codex).