### PR TITLE
fix(coop): empty branco-trait slot on scenario advance (no cross-scenario stack)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -913,6 +913,33 @@ class CoopOrchestrator {
   }
 
   /**
+   * Codex #3083 P2: empty the single branco-trait slot + per-player minor traits.
+   * The party PERSISTS across scenarios (advanceScenarioOrEnd keeps `characters`),
+   * so nulling `emergentBrancoTrait` / clearing `playerMinorTraits` alone left the
+   * granted trait id in each character's `traits` array. The next slot source
+   * (Form-Pulse OR the D6 imprint fallback) then ran with prevId=null and ADDED a
+   * second branco trait. Strip the tracked ids from characters first, then clear
+   * the trackers, so the slot is truly empty for the next scenario.
+   */
+  _clearEmergentTraits() {
+    const brancoId = this.emergentBrancoTrait && this.emergentBrancoTrait.trait_id;
+    for (const [pid, ch] of this.characters.entries()) {
+      if (!ch || !Array.isArray(ch.traits)) continue;
+      if (brancoId) {
+        const i = ch.traits.indexOf(brancoId);
+        if (i !== -1) ch.traits.splice(i, 1);
+      }
+      const minorId = this.playerMinorTraits.get(pid);
+      if (minorId) {
+        const j = ch.traits.indexOf(minorId);
+        if (j !== -1) ch.traits.splice(j, 1);
+      }
+    }
+    this.emergentBrancoTrait = null;
+    this.playerMinorTraits.clear();
+  }
+
+  /**
    * Form-Pulse trait v2 -- Piece 3. Roll random bars for any EXPECTED player who never
    * submitted (the timeout anti-deadlock), PERSIST them into formPulses (frozen roll ->
    * reconnect-safe), then re-run the branco emergence (+ minor traits). Returns the list of
@@ -1923,10 +1950,11 @@ class CoopOrchestrator {
     this.routeVotes.clear();
     this.routeCandidates = null;
     this.formPulses.clear();
-    this.playerMinorTraits.clear();
     this._clearFormPulseTimer();
     this.formPulseTimeoutWarning = false;
-    this.emergentBrancoTrait = null;
+    // Codex #3083 P2: strip the branco/minor traits from the persisting party
+    // BEFORE clearing the trackers (else the next slot source double-stacks).
+    this._clearEmergentTraits();
     this.revealAcks.clear();
     // Codex #2794 P1: consent is per-scenario (a lethal mission = a scenario),
     // but the run keeps the same run.id == campaign_id across scenarios. Without

--- a/tests/api/coopBrancoTraitEmergence.test.js
+++ b/tests/api/coopBrancoTraitEmergence.test.js
@@ -63,3 +63,40 @@ test('re-submit changing dominant axis -> swap (old removed, new added)', () => 
   assert.ok(co.characters.get('p_a').traits.includes('ferocia'));
   assert.equal(co.characters.get('p_a').traits.includes('legame_di_branco'), false);
 });
+
+// Codex #3083 P2 -- the single branco slot must not stack across scenario advance.
+test('branco trait does NOT stack across scenario advance (slot emptied on advance)', () => {
+  const co = new CoopOrchestrator({ roomCode: 'BSCN', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_a', 'enc_b'] });
+  co._setPhase('character_creation');
+  const mk = (n) => ({ name: n, form_id: 'f', species_id: 's', job_id: 'guerriero' });
+  co.submitCharacter('p_a', mk('A'), ALL);
+  co.submitCharacter('p_b', mk('B'), ALL);
+
+  // Scenario 1: solitary_swarm+ -> legame_di_branco granted to the party.
+  co.submitFormPulse('p_a', { axes: { solitary_swarm: 0.8 } }, ALL);
+  co.submitFormPulse('p_b', { axes: { solitary_swarm: 0.8 } }, ALL);
+  assert.ok(co.characters.get('p_a').traits.includes('legame_di_branco'));
+
+  // Advance to scenario 2 -- the party PERSISTS, the slot must be emptied.
+  const adv = co.advanceScenarioOrEnd();
+  assert.equal(adv.action, 'next_scenario');
+  assert.equal(co.emergentBrancoTrait, null);
+  assert.equal(
+    co.characters.get('p_a').traits.includes('legame_di_branco'),
+    false,
+    'old branco trait stripped from the persisting party on advance',
+  );
+
+  // Scenario 2: a DIFFERENT dominant axis -> ferocia, and ONLY ferocia.
+  co._setPhase('character_creation');
+  co.submitFormPulse('p_a', { axes: { symbiosis_predation: 0.9 } }, ALL);
+  co.submitFormPulse('p_b', { axes: { symbiosis_predation: 0.9 } }, ALL);
+  const traits = co.characters.get('p_a').traits;
+  assert.ok(traits.includes('ferocia'));
+  assert.equal(
+    traits.filter((t) => t === 'ferocia' || t === 'legame_di_branco').length,
+    1,
+    'exactly one branco trait occupies the slot (no cross-scenario stacking)',
+  );
+});


### PR DESCRIPTION
Resolves Codex **P2** on #3083. `advanceScenarioOrEnd()` keeps the persisting party but only nulled `emergentBrancoTrait` / cleared `playerMinorTraits` -- it never stripped the granted trait id from `characters.traits[]`. The next slot population (Form-Pulse OR the D6 imprint fallback) ran with prevId=null and ADDED a second branco trait, breaking stacking-B / Form-Pulse precedence. New `_clearEmergentTraits()` strips the tracked branco + minor ids from characters before clearing the trackers. Pre-existing latent bug (Form-Pulse leaked too); D6 made it a contract violation. +regression test; 11/11; format clean. Non-forbidden (apps/backend + tests).