### PR TITLE
feat(imprint): wire D7 branco-tendency prose (form-B per-biome, O5)

### DIFF
--- a/apps/backend/services/imprint/imprintBiomeWeights.js
+++ b/apps/backend/services/imprint/imprintBiomeWeights.js
@@ -146,12 +146,13 @@ function computeImprintBiomeWeights(teamTuples, opts = {}) {
 
 /**
  * D7 (aa01 L'Impronta, 2026-06-30): the diegetic "il tuo branco tende verso X"
- * tendency descriptor. SCAFFOLD ONLY -- the structure (i18n key + interpolation
- * var) lives here; the player-facing PROSE is master-dd HITL (codex-lore boundary),
- * authored in the client i18n table under `i18n_key`. The backend ships NO Italian
- * sentence -- `placeholder` is a neutral marker so the field is never empty and the
- * client knows to localize `i18n_key`. Additive to the existing cosmetic hint (rides
- * the IMPRINT_BEAT_ENABLED gate; band-neutral, no own flag). null for an empty lean.
+ * tendency descriptor. The structure (a PER-BIOME i18n key) lives here; the
+ * player-facing PROSE is master-dd HITL (codex-lore boundary), authored in the client
+ * i18n table under `imprint.branco_tendency.<biome>` (form-B per-biome flavor, ratified
+ * master-dd 2026-06-30 close-out Tier-2). The backend ships NO Italian sentence --
+ * `placeholder` stays a neutral never-empty fallback marker; the client localizes the
+ * per-biome `i18n_key`. Additive to the existing cosmetic hint (rides the
+ * IMPRINT_BEAT_ENABLED gate; band-neutral, no own flag). null for an empty lean.
  *
  * @param {string} leansToward the top biome from the cosmetic affinity hint
  * @returns {{ leans_toward, i18n_key, vars: { biome }, placeholder } | null}
@@ -160,8 +161,8 @@ function brancoTendencyHint(leansToward) {
   if (!leansToward || typeof leansToward !== 'string') return null;
   return {
     leans_toward: leansToward,
-    i18n_key: 'imprint.branco_tendency', // client resolves the diegetic prose (HITL master-dd)
-    vars: { biome: leansToward }, // "il tuo branco tende verso {biome}"
+    i18n_key: `imprint.branco_tendency.${leansToward}`, // per-biome diegetic prose key (HITL master-dd, form-B)
+    vars: { biome: leansToward }, // retained for fallback/telemetry; the per-biome key carries the prose
     placeholder: 'TODO_IMPRINT_TENDENCY_PROSE',
   };
 }

--- a/data/i18n/en/common.json
+++ b/data/i18n/en/common.json
@@ -139,6 +139,17 @@
     "label": "Wounded biome",
     "tooltip": "it bears the scars of a failed expedition; the ecosystem reacts more harshly"
   },
+  "imprint": {
+    "branco_tendency": {
+      "savana": "Your pack leans toward the open savannas: long runs and wide horizons.",
+      "badlands": "Your pack leans toward the badlands: hard ground, fast strikes.",
+      "caverna_risonante": "Your pack leans toward the resonant caverns: silence and sharp hearing.",
+      "rovine_planari": "Your pack leans toward the planar ruins: ambushes in the dark.",
+      "palude_tossica": "Your pack leans toward the toxic marshes: patience and resilience.",
+      "canopia_ionica": "Your pack leans toward the ionic canopy: agility and discharges among the fronds.",
+      "reef_luminescente": "Your pack leans toward the luminescent reefs: gliding silent through the current."
+    }
+  },
   "overcharge_hint": {
     "label": "The System reacts to your stolen tempo"
   },

--- a/data/i18n/it/common.json
+++ b/data/i18n/it/common.json
@@ -139,6 +139,17 @@
     "label": "Bioma ferito",
     "tooltip": "porta le cicatrici di una spedizione fallita; l'ecosistema reagisce con più durezza"
   },
+  "imprint": {
+    "branco_tendency": {
+      "savana": "Il tuo branco tende verso le savane aperte: corsa lunga e orizzonti larghi.",
+      "badlands": "Il tuo branco tende verso i calanchi: terra dura, colpi rapidi.",
+      "caverna_risonante": "Il tuo branco tende verso le caverne risonanti: silenzio e udito acuto.",
+      "rovine_planari": "Il tuo branco tende verso le rovine planari: agguati nel buio.",
+      "palude_tossica": "Il tuo branco tende verso le paludi tossiche: pazienza e resistenza.",
+      "canopia_ionica": "Il tuo branco tende verso la canopia ionica: agilita e scariche fra le fronde.",
+      "reef_luminescente": "Il tuo branco tende verso le scogliere luminescenti: scivola silenzioso nella corrente."
+    }
+  },
   "overcharge_hint": {
     "label": "Il Sistema reagisce al tuo tempo rubato"
   },

--- a/tests/api/coopImprintBeat.test.js
+++ b/tests/api/coopImprintBeat.test.js
@@ -105,10 +105,10 @@ test('all 4 axes marked (4 players) -> cosmetic hint stamped, beat closes', () =
   assert.deepEqual(t.branco_biome_hint, {
     leans_toward: 'savana',
     weights: { savana: 1 },
-    // D7: additive diegetic tendency descriptor (structure only; prose = client HITL).
+    // D7: additive diegetic tendency descriptor (per-biome key; prose = client HITL form-B).
     tendency: {
       leans_toward: 'savana',
-      i18n_key: 'imprint.branco_tendency',
+      i18n_key: 'imprint.branco_tendency.savana',
       vars: { biome: 'savana' },
       placeholder: 'TODO_IMPRINT_TENDENCY_PROSE',
     },

--- a/tests/services/imprintBiomeWeights.test.js
+++ b/tests/services/imprintBiomeWeights.test.js
@@ -166,25 +166,26 @@ test('isImprintEnabled: OFF by default, ON only when env flag === "true"', () =>
   assert.equal(isImprintEnabled(null), false);
 });
 
-// D7 -- diegetic tendency descriptor scaffold (structure only; prose = client HITL).
+// D7 -- diegetic tendency descriptor (per-biome i18n key; prose = client HITL form-B).
 test('brancoTendencyHint: structured descriptor for a non-empty lean', () => {
   assert.deepEqual(brancoTendencyHint('palude'), {
     leans_toward: 'palude',
-    i18n_key: 'imprint.branco_tendency',
+    i18n_key: 'imprint.branco_tendency.palude',
     vars: { biome: 'palude' },
     placeholder: 'TODO_IMPRINT_TENDENCY_PROSE',
   });
 });
 
-test('brancoTendencyHint: the var tracks the lean (different biome)', () => {
+test('brancoTendencyHint: the key + var track the lean (different biome)', () => {
   const t = brancoTendencyHint('reef');
   assert.equal(t.vars.biome, 'reef');
   assert.equal(t.leans_toward, 'reef');
-  assert.equal(t.i18n_key, 'imprint.branco_tendency');
+  assert.equal(t.i18n_key, 'imprint.branco_tendency.reef');
 });
 
 test('brancoTendencyHint: ships NO player-facing prose (boundary)', () => {
-  // The backend must never embed the Italian sentence; only a neutral marker.
+  // The backend must never embed the Italian sentence; only a neutral marker + the
+  // per-biome i18n key the client localizes.
   assert.equal(brancoTendencyHint('savana').placeholder, 'TODO_IMPRINT_TENDENCY_PROSE');
 });
 


### PR DESCRIPTION
## What
Lands the master-dd-approved **form-B per-biome** branco-tendency prose (O5, close-out Tier-2). The D7 scaffold (#3084) shipped a flat i18n_key + TODO placeholder; this wires the actual diegetic copy.

## Changes
- **backend** `imprintBiomeWeights.js`: `brancoTendencyHint` now emits a **per-biome** key `imprint.branco_tendency.<biome>` (the 7 sentences are distinct, not one template). `vars.biome` + `placeholder` retained -- the backend still ships **no** Italian sentence (HITL boundary preserved; prose lives in i18n).
- **i18n** `data/i18n/{it,en}/common.json`: add `imprint.branco_tendency.<biome>` for the 7 `base_lookup` biomes. Keys match the `leansToward` slugs the cosmetic affinity producer resolves (verified vs `biome_resolution.yaml` VALUES -- NOT the short test strings).
- **tests**: 4 assertions updated to the per-biome key.

## Why
O5 was the last truly-open piece of the aa01 D7 item: scaffold built, only the player-facing prose (master-dd HITL) was missing. He approved form-B.

## Surface / impact
No web consumer exists (`imprint_hint` surface is Godot-only, cross-repo) -> this is **copy-readiness**. Flag `IMPRINT_BEAT_ENABLED` stays **OFF** -> zero player/band impact today.

## Verification
- `node --test tests/services/imprintBiomeWeights.test.js` -> 17/17
- `node --test tests/api/coopImprintBeat.test.js` -> 14/14
- `node --test tests/i18n/parity.test.js` -> 4/4 (it==en key parity enforced)
- prettier clean

## Rollback (03A)
Revert the commit; flag is OFF and there is no live consumer, so no runtime effect either way.

Coding-Agent: claude-code
Trace-Id: 65b0fbb3-bdc2-4900-a80e-0b5803393911
