### PR TITLE
feat(scar): ratify SCAR_TRAIT_MAP + map testa (O1)

### DIFF
--- a/apps/backend/services/combat/nidoRitual.js
+++ b/apps/backend/services/combat/nidoRitual.js
@@ -31,18 +31,20 @@
 
 const SEVERITY_GRAVE = 'grave';
 
-// PROPOSED scar->trait map (verdetto master-dd 2026-06-23). Failure-as-lore: the
-// wound at a location hardens into a thematic trait. Keyed by woundSystem location
-// (LOCATION_STAT: torso=defense, arti_anteriori=attack, arti_posteriori=mobility,
-// testa=accuracy). `testa` is intentionally UNMAPPED -> fail-closed until master-dd
-// maps it. Values are real active_effects ids but RATIFIED-PROVISIONAL: master-dd
-// confirms/replaces each mapping + runs N=40 before SCAR_TRANSFORM_TRAIT_GRANT_ENABLED
-// is flipped on. Always validated at grant time against the injected SoT id set
-// (never trusts the map alone).
+// scar->trait map (RATIFIED-PROVISIONAL master-dd 2026-06-30, close-out Tier-2; was
+// PROPOSED 2026-06-23). Failure-as-lore: the wound at a location hardens into a thematic
+// trait. Keyed by woundSystem location (LOCATION_STAT: torso=defense,
+// arti_anteriori=attack, arti_posteriori=mobility, testa=accuracy/senses). All 4
+// locations mapped (master-dd verdict: map `testa`); an UNKNOWN location still
+// fail-closes (deriveScarTrait + injected SoT id set). Values are real active_effects
+// ids, all LIVE (trigger.action_type=attack), RATIFIED-PROVISIONAL: master-dd runs N=40
+// before SCAR_TRANSFORM_TRAIT_GRANT_ENABLED is flipped on. Always validated at grant
+// time against the injected SoT id set (never trusts the map alone).
 const SCAR_TRAIT_MAP = Object.freeze({
-  torso: 'pelle_elastomera', // defense scar -> resilient skin
-  arti_anteriori: 'martello_osseo', // attack scar -> bone hammer
-  arti_posteriori: 'zampe_a_molla', // mobility scar -> spring legs
+  torso: 'pelle_elastomera', // defense scar -> resilient skin (-1 dmg taken on hit)
+  arti_anteriori: 'martello_osseo', // attack scar -> bone hammer (fracture on crit MoS>=8)
+  arti_posteriori: 'zampe_a_molla', // mobility scar -> spring legs (+1 dmg from elevation)
+  testa: 'occhi_cristallo_modulare', // accuracy/senses scar -> crystalline focus optics (+2 dmg on MoS>=8 hit)
 });
 
 /**

--- a/docs/design/evo-tactics-lethal-wounds-rituals.md
+++ b/docs/design/evo-tactics-lethal-wounds-rituals.md
@@ -5,7 +5,7 @@ type: design-spec
 doc_status: active
 doc_owner: master-dd
 workstream: flow
-last_verified: '2026-06-08'
+last_verified: '2026-06-30'
 source_of_truth: false
 review_cycle_days: 30
 language: it
@@ -123,6 +123,11 @@ missione flaggata lethal (public: tutti sanno che e' a rischio)
   validato vs `active_effects` SoT (mai fidarsi della map sola); il wire `/nido/ritual` lo persiste su
   `campaign.acquiredTraitsByCreature` (MA1). RESIDUO owner-gated: ratifica/estensione `SCAR_TRAIT_MAP` +
   N=40 + flip; il costo (E6) resta SPEC-E. Tracking: `docs/planning/2026-06-23-residual-gate-register.md`.
+- **Update 2026-06-30 (verdetto master-dd, close-out Tier-2 -- O1):** `SCAR_TRAIT_MAP` **RATIFIED-PROVISIONAL**
+  - `testa` ora **mappato** -> `occhi_cristallo_modulare` (cicatrice accuracy/senses -> ottica cristallina,
+    +2 dmg su colpo MoS>=8). Tutte e 4 le location mappate; una location SCONOSCIUTA fa ancora fail-close.
+    Tutti i 4 target trait sono LIVE (`trigger.action_type=attack`, verificato vs `passesBasicTriggers`).
+    RESIDUO ristretto a: **N=40** (flag ON) + **flip**; il costo (E6) resta SPEC-E. 33/33 test nido verdi.
 
 ## 7. Succession + failure-as-lore
 

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -9313,7 +9313,7 @@
       "doc_status": "active",
       "doc_owner": "master-dd",
       "workstream": "flow",
-      "last_verified": "2026-06-08",
+      "last_verified": "2026-06-30",
       "source_of_truth": false,
       "language": "it",
       "review_cycle_days": 90,

--- a/tests/api/nidoRitualWire.test.js
+++ b/tests/api/nidoRitualWire.test.js
@@ -139,7 +139,7 @@ test('nido/ritual transform: flag ON -> grants the PROPOSED scar trait (SPEC-E)'
   assert.ok(res.body.ritual.mark, 'narrative mark still present alongside the grant');
 });
 
-test('nido/ritual transform: flag ON but UNMAPPED location (testa) -> no grant (gate)', async (t) => {
+test('nido/ritual transform: flag ON + testa (now mapped 2026-06-30) -> grants occhi_cristallo_modulare', async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {
     delete process.env.SCAR_TRANSFORM_TRAIT_GRANT_ENABLED;
@@ -151,7 +151,23 @@ test('nido/ritual transform: flag ON but UNMAPPED location (testa) -> no grant (
     .post(`/api/session/${sid}/nido/ritual`)
     .send({ unit_id: pgId, location: 'testa', kind: 'transform' });
   assert.equal(res.status, 200);
-  assert.equal(res.body.ritual.granted_trait, null, 'testa is unmapped -> master-dd gate');
+  // testa (accuracy/senses scar) -> occhi_cristallo_modulare per SCAR_TRAIT_MAP, validated vs SoT.
+  assert.equal(res.body.ritual.granted_trait, 'occhi_cristallo_modulare');
+});
+
+test('nido/ritual transform: flag ON but UNKNOWN location -> no grant (fail-closed gate)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    delete process.env.SCAR_TRANSFORM_TRAIT_GRANT_ENABLED;
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const { sid, pgId } = await startWithScar(app, 'coda');
+  process.env.SCAR_TRANSFORM_TRAIT_GRANT_ENABLED = 'true';
+  const res = await request(app)
+    .post(`/api/session/${sid}/nido/ritual`)
+    .send({ unit_id: pgId, location: 'coda', kind: 'transform' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.ritual.granted_trait, null, 'unknown location stays unmapped -> gate');
 });
 
 test('nido/ritual: invalid kind -> 400; unknown unit -> 404', async (t) => {

--- a/tests/services/combat/nidoRitualScarTrait.test.js
+++ b/tests/services/combat/nidoRitualScarTrait.test.js
@@ -24,14 +24,21 @@ function scarredUnit(location, stat) {
   return { id: 'u1', status: { wounds: [graveScar(location, stat)] } };
 }
 
-// The 3 PROPOSED real trait ids (validated against active_effects in the map).
-const VALID = new Set(['pelle_elastomera', 'martello_osseo', 'zampe_a_molla', 'whatever']);
+// The 4 real trait ids (validated against active_effects in the map) + a filler.
+const VALID = new Set([
+  'pelle_elastomera',
+  'martello_osseo',
+  'zampe_a_molla',
+  'occhi_cristallo_modulare',
+  'whatever',
+]);
 
-test('SCAR_TRAIT_MAP maps the 3 stat-scar locations to real proposed traits, leaves testa unmapped', () => {
+test('SCAR_TRAIT_MAP maps all 4 scar locations to real LIVE traits (testa added 2026-06-30)', () => {
   assert.equal(SCAR_TRAIT_MAP.torso, 'pelle_elastomera');
   assert.equal(SCAR_TRAIT_MAP.arti_anteriori, 'martello_osseo');
   assert.equal(SCAR_TRAIT_MAP.arti_posteriori, 'zampe_a_molla');
-  assert.ok(!('testa' in SCAR_TRAIT_MAP), 'testa is intentionally unmapped (master-dd gate)');
+  assert.equal(SCAR_TRAIT_MAP.testa, 'occhi_cristallo_modulare');
+  assert.ok(!('coda' in SCAR_TRAIT_MAP), 'an unknown location stays unmapped -> fail-closed');
 });
 
 test('deriveScarTrait returns the mapped trait when it is a valid id', () => {
@@ -39,8 +46,15 @@ test('deriveScarTrait returns the mapped trait when it is a valid id', () => {
   assert.equal(t, 'pelle_elastomera');
 });
 
-test('deriveScarTrait fail-closes on an unmapped location (testa)', () => {
-  assert.equal(deriveScarTrait(graveScar('testa', 'accuracy'), SCAR_TRAIT_MAP, VALID), null);
+test('deriveScarTrait returns the mapped trait for testa (now mapped 2026-06-30)', () => {
+  assert.equal(
+    deriveScarTrait(graveScar('testa', 'accuracy'), SCAR_TRAIT_MAP, VALID),
+    'occhi_cristallo_modulare',
+  );
+});
+
+test('deriveScarTrait fail-closes on an unknown/unmapped location', () => {
+  assert.equal(deriveScarTrait(graveScar('coda'), SCAR_TRAIT_MAP, VALID), null);
 });
 
 test('deriveScarTrait fail-closes when the mapped id is not in the valid-id set (SoT)', () => {
@@ -73,9 +87,19 @@ test('transformScar WITH map+validIds returns granted_trait for a mapped scar', 
   assert.equal(r.granted_trait, 'zampe_a_molla');
 });
 
-test('transformScar WITH map but unmapped scar (testa) = no granted_trait, still transforms', () => {
+test('transformScar WITH map grants the testa scar its trait (occhi_cristallo_modulare)', () => {
   const u = scarredUnit('testa', 'accuracy');
   const r = transformScar(u, 'testa', {
+    scarTraitMap: SCAR_TRAIT_MAP,
+    validTraitIds: VALID,
+  });
+  assert.equal(r.transformed, true);
+  assert.equal(r.granted_trait, 'occhi_cristallo_modulare');
+});
+
+test('transformScar WITH map but unknown scar location = no granted_trait, still transforms', () => {
+  const u = scarredUnit('coda');
+  const r = transformScar(u, 'coda', {
     scarTraitMap: SCAR_TRAIT_MAP,
     validTraitIds: VALID,
   });


### PR DESCRIPTION
## What
master-dd verdict (close-out Tier-2, O1): **ratify** the SPEC-J scar->transform map AND **map the previously-gated `testa`** location. The map (built flag-OFF in #2994) is now **RATIFIED-PROVISIONAL**; all 4 scar locations grant a real LIVE trait.

## Changes
- `nidoRitual.js`: `SCAR_TRAIT_MAP` adds `testa -> occhi_cristallo_modulare` (crystalline focus optics, +2 dmg on a MoS>=8 hit). Comment flipped PROPOSED -> RATIFIED-PROVISIONAL.
- **Liveness verified**: `occhi_cristallo_modulare` carries `trigger.action_type=attack` -> passes `passesBasicTriggers` (LIVE, not inert). Thematic: head scar -> enhanced predatory optics (failure-as-lore).
- **Gate unchanged**: an UNKNOWN location still fail-closes (`deriveScarTrait` + injected `active_effects` SoT id set). Only `testa` moved from unmapped to mapped.
- tests: added testa-grants + unknown-location fail-close at BOTH unit (`nidoRitualScarTrait`) and wire (`nidoRitualWire`) level.
- spec doc (`evo-tactics-lethal-wounds-rituals.md`) + registry: ratification recorded.

## Why
O1 was an owner design/balance call: which trait each scar grants + whether `testa` stays gated. master-dd chose ratify + map testa. The build/flag/fail-close/liveness were already done; this lands the value decision.

## Impact
Flag `SCAR_TRANSFORM_TRAIT_GRANT_ENABLED` stays **OFF** -> band-neutral. Residue narrowed to **N=40 + flip** (cost E6 = SPEC-E). Known item-3 caveat (campaign->next-encounter trait re-attach is Godot/scenario-payload-owned) is unchanged and tracked separately.

## Verification
`node --test tests/services/combat/nidoRitualScarTrait.test.js tests/services/combat/nidoRitual.test.js tests/api/nidoRitualWire.test.js` -> **33/33**. governance strict errors=0. prettier clean.

## Rollback (03A)
Revert the commit; flag is OFF so no runtime effect either way.

Coding-Agent: claude-code
Trace-Id: 97c076ed-7fa9-4aeb-acd0-7f177704d6bf
