### PR TITLE
feat(skiv): durable crossbreed cooldown via persisted campaign_id (I3, FORBIDDEN-PATH)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -371,6 +371,10 @@ Da evidence `docs/reports/2026-06-11-spec-i-er6-overrun-n40-evidence.md` (ratifi
 - **TKT-ER6-CARRYOVER** (design fork, non bloccante): semantica carry-over del bonus overrun (persiste fino al primo tick spawnabile O spawn-tick immediato al crossing) -> knob significativo in TUTTI i biomi stresswave invece che solo abisso. Richiede nuova N=40 + verdetto master-dd (la ratifica corrente copre l'as-built consume-once).
 - **TKT-SIM-PROBE-ENTROPY** (harness reliability): gamba atollo ISO = floor +0.33 tra armi byte-identiche in processi separati (abisso -0.03 pulito) -- entropia process-level non-seedata in un path biome-specifico travolge il paired design. Investigare rng non-seedato (candidati: foodweb/eco path), fixare o documentare. Finche' aperto: ogni N=40 famiglia spec-i-gates-probe riporta il floor della propria gamba e scarta gambe anomale.
 
+### 🟢 P3 OPEN — SPEC-F crossbreed cooldown FIFO edge (I3, 2026-06-30)
+
+- **TKT-SKIV-COOLDOWN-FIFO** (low-impact correctness edge, cavecrew P1 on PR #3101 -> downgraded P3 con motivazione): la durable cooldown 1/campagna (I3) deriva da `crossbreed_history`, che e' FIFO-capped a 10 (product cap). Una lineage crossbred in >10 campagne distinte evince il record piu' vecchio -> ri-crossbreed di quella campagna evinta torna permesso. Impatto basso: feature flavor + rate-limit 10/h, serve 11+ campagne distinte sulla STESSA lineage, payoff = 1 offspring extra. Edge PINNED da un test (`tests/routes/skivCustode.test.js`) + commentato a `companion.js`. **Fix FIFO-immune** = campo separato uncapped `crossbred_campaign_ids` MA esporrebbe l'intera lista campaign-id nella card condivisa (leak peggiore del singolo id per-evento) -> trade-off owner-gated (forbidden-path packages/contracts). Riaprire solo se >10-campaign-su-una-lineage diventa realistico.
+
 ### ✅ SHIPPED — Canonical AI-driven playtest (paradigma flip 2026-05-29)
 
 SoT: `docs/process/CANONICAL-AI-PLAYTEST.md` + `docs/playtest/canonical-suite.yaml`. Flip: AI-driven multi-policy (N=40) = gate/oracolo riproducibile; playtest umano = conferma opzionale, mai bloccante. Tooling esistente `tools/py/calibrate_*.py` + `batch_calibrate_*.py`.

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -78,14 +78,11 @@ function createCompanionRouter({
     return false;
   }
 
-  // Cooldown 1 crossbreed per campaign per lineage (ADR-04-27). Tracked IN-MEMORY
-  // (per-router), NOT on the crossbreed_history item: the ratified
-  // skiv_companion schema (packages/contracts, additionalProperties:false) does
-  // not model a campaign_id on the event, and that schema is a forbidden-path
-  // change. In-memory matches the rate-limit's durability (per-process / per-run);
-  // a durable cross-restart cooldown needs a contracts schema field = master-dd.
-  const _crossbreedCampaigns = new Set(); // `${campaignId}::${lineageId}`
-  const cooldownKey = (campaignId, lineageId) => `${campaignId}::${lineageId}`;
+  // Cooldown 1 crossbreed per campaign per lineage (ADR-04-27). DURABLE (I3,
+  // 2026-06-30): derived from the persisted crossbreed_history -- each event carries
+  // its `campaign_id` (schema field added in packages/contracts), so the gate now
+  // survives a backend restart. (The ex in-memory Set was per-process and reset on
+  // every restart.) The IP rate-limit above stays in-memory by design.
 
   /**
    * POST /api/companion/pick
@@ -361,8 +358,10 @@ function createCompanionRouter({
     if (!local.species_id || !partner.species_id) {
       return res.status(422).json({ error: 'crossbreed_requires_biological' });
     }
-    // Cooldown 1/campaign (ADR-04-27): this campaign already crossbred this lineage.
-    if (_crossbreedCampaigns.has(cooldownKey(campaignId, lineageId))) {
+    // Cooldown 1/campaign (ADR-04-27): durable -- this campaign already crossbred
+    // this lineage iff a persisted history event carries its campaign_id.
+    const priorHistory = store.getCrossbreedHistory(lineageId) || [];
+    if (priorHistory.some((e) => e && e.campaign_id === campaignId)) {
       return res.status(409).json({ error: 'crossbreed_cooldown_active' });
     }
     // Roll with the preview seed (or a fresh one) so confirm == the previewed offspring.
@@ -392,8 +391,8 @@ function createCompanionRouter({
     // Persist the crossbreed event into the lineage Nido record (FIFO 10).
     // Schema-compliant fields ONLY (skiv_companion crossbreed_history item is
     // additionalProperties:false): role / with_lineage_id / offspring_lineage_id /
-    // tier / biome_at_crossbreed. campaign_id + seed are NOT persisted here (not
-    // schema fields) -- the cooldown is tracked in-memory above.
+    // tier / biome_at_crossbreed / campaign_id. `campaign_id` is the DURABLE cooldown
+    // key (I3, 2026-06-30); `seed` stays unpersisted (not a schema field).
     try {
       store.addCrossbreedEvent(lineageId, {
         role: 'parent_a',
@@ -401,14 +400,15 @@ function createCompanionRouter({
         offspring_lineage_id: (result.offspring && result.offspring.lineage_id) || null,
         tier: result.tier,
         biome_at_crossbreed: biomeId,
+        campaign_id: campaignId,
       });
     } catch (err) {
       return res
         .status(500)
         .json({ error: 'companion_crossbreed_failed', message: String(err.message || err) });
     }
-    // Mark this campaign+lineage as having crossbred (cooldown 1/campaign).
-    _crossbreedCampaigns.add(cooldownKey(campaignId, lineageId));
+    // Cooldown is now durable via the persisted campaign_id on the event above --
+    // no separate in-memory marker needed.
     return res.json({
       confirmed: true,
       offspring: result.offspring,

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -360,6 +360,14 @@ function createCompanionRouter({
     }
     // Cooldown 1/campaign (ADR-04-27): durable -- this campaign already crossbred
     // this lineage iff a persisted history event carries its campaign_id.
+    // KNOWN LIMITATION (P3, TKT-SKIV-COOLDOWN-FIFO): crossbreed_history is FIFO-capped
+    // at 10 (product cap), so a lineage crossbred in >10 distinct campaigns evicts the
+    // oldest cooldown record -> re-crossbreeding that evicted campaign is allowed again.
+    // Low-impact: rate-limited flavor feature, needs 11+ distinct-campaign crossbreeds
+    // on ONE lineage, payoff = 1 extra offspring. A FIFO-immune fix (a separate uncapped
+    // campaign-id field) is deferred: it would expose the full campaign-id LIST in the
+    // shared card (a worse share-leak than this single per-event id). master-dd weighs
+    // that trade-off at the forbidden-path merge.
     const priorHistory = store.getCrossbreedHistory(lineageId) || [];
     if (priorHistory.some((e) => e && e.campaign_id === campaignId)) {
       return res.status(409).json({ error: 'crossbreed_cooldown_active' });

--- a/packages/contracts/schemas/skiv_companion.schema.json
+++ b/packages/contracts/schemas/skiv_companion.schema.json
@@ -124,6 +124,10 @@
             "anyOf": [{ "type": "null" }, { "type": "string", "pattern": "^[a-f0-9]{64}$" }]
           },
           "offspring_lineage_id": { "type": ["string", "null"] },
+          "campaign_id": {
+            "type": ["string", "null"],
+            "description": "Opaque campaign id that performed this crossbreed. Durable key for the 1-per-campaign cooldown (replaces the ex in-memory Set so the gate survives a backend restart). Same id-class as the lineage ids already in this item; not PII/session."
+          },
           "biome_at_crossbreed": { "type": ["string", "null"] },
           "biome_environmental_mutation": { "type": ["string", "null"] },
           "tier": {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -383,14 +383,13 @@ test('POST /skiv/crossbreed/confirm valid → 200 confirmed + PERSISTS to histor
   // engine got a seeded rng (preview-integrity) + a numeric crossbreed_seed echoed.
   assert.equal(typeof captured.context.rng, 'function');
   assert.equal(typeof r.body.crossbreed_seed, 'number');
-  // PERSISTED: schema-compliant event (skiv_companion item is
-  // additionalProperties:false -> with_lineage_id, NOT campaign_id/partner_lineage_id).
-  // Cooldown campaign_id is tracked in-memory, never on the history item.
+  // PERSISTED: schema-compliant event. campaign_id IS now persisted (I3, 2026-06-30)
+  // as the DURABLE cooldown key (schema field added in packages/contracts).
   const hist = store.getCrossbreedHistory(LINEAGE);
   assert.equal(hist.length, 1);
   assert.equal(hist[0].with_lineage_id, 'partner-lineage-9999');
   assert.equal(hist[0].offspring_lineage_id, 'offspring-confirmed');
-  assert.equal(hist[0].campaign_id, undefined); // NOT persisted (schema-forbidden)
+  assert.equal(hist[0].campaign_id, 'camp-A'); // durable cooldown key (I3)
 });
 
 test('POST /skiv/crossbreed/confirm seed echo: a passed crossbreed_seed is reused (preview-match)', async () => {
@@ -431,6 +430,39 @@ test('POST /skiv/crossbreed/confirm different campaigns are allowed (cooldown is
   });
   assert.equal((await postJson(app, '/api/skiv/crossbreed/confirm', mk('c1'))).status, 200);
   assert.equal((await postJson(app, '/api/skiv/crossbreed/confirm', mk('c2'))).status, 200);
+});
+
+test('POST /skiv/crossbreed/confirm persists campaign_id on the event (durable cooldown key, I3)', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const app = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  await postJson(app, '/api/skiv/crossbreed/confirm', {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+    campaign_id: 'camp-persist',
+  });
+  const hist = store.getCrossbreedHistory(LINEAGE);
+  assert.ok(
+    hist.some((e) => e.campaign_id === 'camp-persist'),
+    'crossbreed event carries the campaign_id (durable cooldown key)',
+  );
+});
+
+test('POST /skiv/crossbreed/confirm cooldown is DURABLE: survives a fresh router (ex in-memory Set would not)', async () => {
+  // Durability: the cooldown is now derived from the persisted history, not a
+  // per-router in-memory Set. A brand-new app/router (= a backend restart) over the
+  // SAME store must still see the prior crossbreed and refuse the 2nd in-campaign.
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const body = {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+    campaign_id: 'camp-restart',
+  };
+  const app1 = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  assert.equal((await postJson(app1, '/api/skiv/crossbreed/confirm', body)).status, 200);
+  const app2 = buildApp({ store, rollMatingOffspring: rollStubOk() }); // simulated restart
+  const r = await postJson(app2, '/api/skiv/crossbreed/confirm', body);
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'crossbreed_cooldown_active');
 });
 
 test('POST /skiv/crossbreed/confirm missing campaign_id → 400', async () => {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -465,6 +465,29 @@ test('POST /skiv/crossbreed/confirm cooldown is DURABLE: survives a fresh router
   assert.equal(r.body.error, 'crossbreed_cooldown_active');
 });
 
+test('POST /skiv/crossbreed/confirm KNOWN LIMITATION: FIFO cap (10) evicts the oldest cooldown record (TKT-SKIV-COOLDOWN-FIFO)', async () => {
+  // crossbreed_history is FIFO-capped at 10 (product cap). A lineage crossbred in
+  // >10 distinct campaigns evicts the oldest event, so re-crossbreeding that evicted
+  // campaign is allowed again. This test PINS that documented edge (P3, low-impact:
+  // rate-limited, 11+ distinct campaigns, payoff = 1 offspring). Multiple apps share
+  // the SAME store to dodge the per-router 10/window IP rate-limit.
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const mk = (cid) => ({
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+    campaign_id: cid,
+  });
+  const app1 = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  for (let i = 1; i <= 10; i += 1) {
+    assert.equal((await postJson(app1, '/api/skiv/crossbreed/confirm', mk(`c${i}`))).status, 200);
+  }
+  // History now holds c1..c10. An 11th distinct campaign evicts c1 (FIFO).
+  const app2 = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  assert.equal((await postJson(app2, '/api/skiv/crossbreed/confirm', mk('c11'))).status, 200);
+  // c1's cooldown record was evicted -> re-crossbreeding c1 is (knowingly) allowed.
+  assert.equal((await postJson(app2, '/api/skiv/crossbreed/confirm', mk('c1'))).status, 200);
+});
+
 test('POST /skiv/crossbreed/confirm missing campaign_id → 400', async () => {
   const store = makeStoreStub({ [LINEAGE]: makeShareState() });
   const app = buildApp({ store, rollMatingOffspring: rollStubOk() });


### PR DESCRIPTION
## What (I3 -- close-out infra, agent-prepares / master-dd-merges)
Makes the SPEC-F **1-per-campaign crossbreed cooldown DURABLE**. Today it lives in a per-router in-memory `Set`, so it **resets on every backend restart** -> a player can re-crossbreed the same lineage in the same campaign after a restart. Fix = persist the cooldown key on the crossbreed event.

## ⚠️ FORBIDDEN-PATH -- master-dd merge required
Touches `packages/contracts/schemas/skiv_companion.schema.json` (shared schema). **Do NOT auto-merge** -- this is your manual merge per the close-out permissions. I will not self-merge it.

## Changes
- **packages/contracts** (forbidden): add optional `campaign_id` (`["string","null"]`) to the `crossbreed_history` item. The item is `additionalProperties:false`, so persisting the cooldown key required the schema field. Additive + optional = backward-compatible (old events, `required:["ts"]`, still validate).
- **apps/backend/routes/companion.js**: persist `campaign_id` on the event; derive the cooldown from the persisted history (`some(e => e.campaign_id === campaignId)`); delete the in-memory `_crossbreedCampaigns` Set + `cooldownKey`. IP rate-limit stays in-memory by design (ADR-04-27).
- **tests**: existing cooldown tests pass unchanged; +2 (campaign_id persisted; cooldown survives a fresh router = simulated restart, which the old in-memory Set would NOT).

## 🔎 Share-safety call for you (the reason this is your merge)
`crossbreed_history` is in the share whitelist, so `campaign_id` will ship in the shared companion card. It is an **opaque internal id** -- same id-class as the `with_lineage_id` / `offspring_lineage_id` already in the item -- NOT PII/session. If you consider campaign-linkage in a shared card a leak, reject and I will move the cooldown key to a **non-shared persisted slot** instead (slightly larger change). Flagging it so the decision is yours.

## Verification
- `node --test tests/routes/skivCustode.test.js` -> 24/24
- `node --test tests/services/skivCompanionState.test.js` -> 22/22
- schema JSON parses; `require('./packages/contracts')` loads; prettier clean

## Rollback (03A)
Revert the commit; the schema field is additive/optional so no data migration. Cooldown falls back to in-memory (prior behavior).

Coding-Agent: claude-code
Trace-Id: 3cce14bf-b702-4940-8923-eebc69c36b03
