### PR TITLE
feat(spec-j): author first lethal encounter L'Ultima Caccia + schema lethal field

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12970,6 +12970,17 @@
       "review_cycle_days": 90
     },
     {
+      "path": "docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md",
+      "title": "L'Ultima Caccia -- first lethal-mission calibration (SPEC-J)",
+      "doc_status": "active",
+      "doc_owner": "claude-code",
+      "workstream": "ops-qa",
+      "last_verified": "2026-06-30",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 90
+    },
+    {
       "path": "docs/playtest/2026-06-18-foresta-s2-calibration.md",
       "title": "Foresta S2 calibration -- enc_foresta_pilot_01 (#2850 follow-up)",
       "doc_status": "active",

--- a/docs/planning/encounters/enc_badlands_ultima_caccia_01.yaml
+++ b/docs/planning/encounters/enc_badlands_ultima_caccia_01.yaml
@@ -52,15 +52,22 @@ player_spawn:
 
 # Wave unica e decisiva (turn 0). Apex Skiv + branco di supporto. La difficolta'
 # vive tutta qui: l'AI-sim calibration legge solo questa wave.
+#
+# Spawn a META-CAMPO (x~5-6), come il pilot canonico badlands
+# (enc_badlands_pilot_01 spawna a x=5): l'agguato si chiude in fretta e il
+# combattimento risolve entro la mission-clock. spawn_points mappa 1:1 sui
+# probe positions (Codex #3107 P2 parity: la banda calibrata = la missione reale).
+# Ordine = espansione harness (apex -> sp[0]; echo x2 -> sp[1],sp[2]; rust x2 ->
+# sp[3],sp[4]).
 waves:
   - wave_id: 1
     turn_trigger: 0
     spawn_points:
-      - [9, 4]
-      - [9, 5]
-      - [9, 6]
-      - [8, 4]
-      - [8, 6]
+      - [5, 5]
+      - [5, 4]
+      - [5, 6]
+      - [6, 4]
+      - [6, 6]
     units:
       - species: dune-stalker
         count: 1

--- a/docs/planning/encounters/enc_badlands_ultima_caccia_01.yaml
+++ b/docs/planning/encounters/enc_badlands_ultima_caccia_01.yaml
@@ -1,0 +1,94 @@
+# =============================================================================
+# Encounter: "L'Ultima Caccia" -- First Lethal Mission (SPEC-J permadeath)
+# Difficulty: 5/5 - Grid: 10x10 - Bioma: badlands
+# Objective: elimination. Single decisive wave (no reinforcement) so the AI-sim
+#   calibration band (ai-driven-sim reads wave 1 only) equals the real-play band.
+#
+# SCOPO: il PRIMO encounter `lethal: true` della suite SPEC-J (lethal-wounds +
+#   consent). Permadeath e' OPT-IN per-missione (point-9) e resta inerte finche'
+#   LETHAL_MISSIONS_ENABLED!=='true' AND il consenso per-player non e' concesso
+#   (services/combat/lethalDeath.js). Autorare questo encounter NON flippa nulla:
+#   il flag globale resta OFF -> band-neutral by construction.
+#
+# DESIGN-CALL (master-dd 2026-06-30, AskUserQuestion): veicolo = nuovo dedicato;
+#   banda = hardcore opt-in (target party-WR 25-40%, creature-KO-rate 25-40%).
+#   Narrativa: la party affronta l'apex Skiv (dune-stalker) nel suo territorio
+#   ferroso -- la caccia dove la posta e' reale. Lega permadeath <-> attaccamento
+#   (creature dossier #2856): una creatura puo' cadere per sempre.
+#
+# CALIBRAZIONE: la difficolta' misurata dall'harness vive nella WAVE 1 (l'AI-sim
+#   espande solo la wave a turn_trigger minimo + deriva stat da tier:
+#   base hp7/mod1, elite hp10/mod2, apex hp14/mod4). Niente reinforcement_pool
+#   ne' wave-2 -> banda-harness == banda-reale. Evidenza N=40 ->
+#   docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md.
+#
+# Schema: schemas/evo/encounter.schema.json (campo `lethal` additivo 2026-06-30)
+# Spec: docs/design/evo-tactics-lethal-wounds-rituals.md (SPEC-J)
+# =============================================================================
+
+encounter_id: enc_badlands_ultima_caccia_01
+name: "L'Ultima Caccia"
+biome_id: badlands
+grid_size: [10, 10]
+difficulty_rating: 5
+pressure_tier_floor: 4
+estimated_turns: 16
+encounter_class: hardcore
+
+# SPEC-J: per-mission lethal flag (point-9). Letto da routes/session.js /start
+# come encounterPayload.lethal -> session.lethal. Inerte finche'
+# LETHAL_MISSIONS_ENABLED && consenso per-player (PR2); markCreatureFallen non
+# scatta mai altrimenti (band-neutral).
+lethal: true
+
+objective:
+  type: elimination
+
+player_spawn:
+  - [0, 4]
+  - [0, 5]
+  - [0, 6]
+  - [1, 5]
+
+# Wave unica e decisiva (turn 0). Apex Skiv + branco di supporto. La difficolta'
+# vive tutta qui: l'AI-sim calibration legge solo questa wave.
+waves:
+  - wave_id: 1
+    turn_trigger: 0
+    spawn_points:
+      - [9, 4]
+      - [9, 5]
+      - [9, 6]
+      - [8, 4]
+      - [8, 6]
+    units:
+      - species: dune-stalker
+        count: 1
+        tier: apex
+        ai_profile: flanking
+      - species: echo-wing
+        count: 2
+        tier: elite
+        ai_profile: aggressive
+      - species: rust-scavenger
+        count: 2
+        tier: base
+        ai_profile: aggressive
+
+conditions: []
+
+tags: [boss]
+
+didactic_focus:
+  - lethal_stakes
+  - focus_fire
+  - positioning
+
+narrative: {}
+
+# Art direction metadata (docs/core/41-ART-DIRECTION.md)
+visual_mood:
+  mood_tag: pericolo_calore
+  lighting: alta_calda_dall_alto
+  particle_effect: polvere_secca
+  accent_override: '#c2542f'

--- a/docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md
+++ b/docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md
@@ -44,13 +44,24 @@ NO prod backend, node 22, seeds 1..N), elimination, grid 10x10, maxRounds 40.
 Roster variants: `pilot` = apex + 2 elite (the pilot wave-1, [0.40,0.60] reference);
 `minus_base` = + 1 base; `full` = + 2 base (the authored wave 1).
 
+Codex #3107 P2 corrections (applied): the probe now (1) emits the authored
+`ai_profile` per enemy (flanking apex + aggressive pack) and (2) spawns enemies at
+the encounter's authored `spawn_points` -- which were aligned to midfield (x~5-6,
+the canonical badlands engagement) so probe and shipped mission are identical.
+
 ## Results
+
+Authoritative (corrected probe -- ai_profile emitted + spawn == encounter):
+
+| variant  | N   | creature_KO_rate | win_rate | timeouts | avg_rounds |
+| -------- | --- | ---------------- | -------- | -------- | ---------- |
+| full (5) | 40  | **0.356**        | 0.025    | 39/40    | 39.8       |
+
+Pre-correction sweep (midfield spawn, ai_profile dropped) -- for direction only:
 
 | variant       | N   | creature_KO_rate | win_rate | timeouts | avg_rounds |
 | ------------- | --- | ---------------- | -------- | -------- | ---------- |
 | pilot (3)     | 12  | 0.396            | 0.083    | 11/12    | 39.6       |
-| minus_base(4) | 12  | 0.354            | 0.250    | 9/12     | 39.0       |
-| full (5)      | 12  | 0.417            | 0.000    | 12/12    | 40.0       |
 | minus_base(4) | 24  | 0.302            | 0.125    | 21/24    | 39.5       |
 | full (5)      | 24  | 0.344            | 0.000    | 24/24    | 40.0       |
 | full (5)      | 40  | 0.344            | 0.000    | 40/40    | 40.0       |
@@ -59,10 +70,11 @@ Roster variants: `pilot` = apex + 2 elite (the pilot wave-1, [0.40,0.60] referen
 
 **Primary metric = creature-KO-rate** (the permadeath-relevant one: under
 LETHAL+consent every player KO becomes a real death, so the KO-rate IS the
-death-rate). The authored **full** roster lands at **0.344 (N=24 AND N=40, identical)** --
-squarely inside the hardcore target band [0.25, 0.40], and very stable across
-sample sizes. (The N=12 0.42 was small-sample noise; N=24/40 tightened it.) The
-roster is in the right ballpark for hardcore opt-in.
+death-rate). The authored **full** roster lands at **0.356 (N=40, corrected probe)** --
+squarely inside the hardcore target band [0.25, 0.40]. (Pre-correction it was 0.344
+at N=24/40; emitting the authored flanking/aggressive profiles nudged it up slightly
+-- the enemies are marginally more lethal with their real behavior, as expected.)
+The roster is in the right ballpark for hardcore opt-in.
 
 **Win-rate is NOT reliably measurable in this in-process probe.** The
 `combat-adapter` player policy grinds to the 40-round cap (avg_rounds ~40,

--- a/docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md
+++ b/docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md
@@ -1,0 +1,94 @@
+---
+title: "L'Ultima Caccia -- first lethal-mission calibration (SPEC-J)"
+workstream: ops-qa
+category: playtest
+doc_status: active
+doc_owner: claude-code
+last_verified: '2026-06-30'
+language: en
+tags: [playtest, calibration, badlands, lethal, spec-j, ai-driven]
+---
+
+# L'Ultima Caccia -- first lethal-mission band probe (SPEC-J)
+
+Direction-probe evidence for `enc_badlands_ultima_caccia_01`, the FIRST
+`lethal: true` encounter of the SPEC-J lethal-wounds suite. The encounter ships
+flag-OFF (`LETHAL_MISSIONS_ENABLED` unset + no consent producer) -- this probe
+measures the combat band the lethal mission would run at, it never produces
+permadeath.
+
+## Design-call (master-dd 2026-06-30, AskUserQuestion)
+
+- **Vehicle**: a NEW dedicated lethal encounter (not flagging an existing one) --
+  clean "opt-in dangerous mission" framing, does not retro-change a played scenario.
+- **Band target**: hardcore opt-in -- party win-rate 25-40%, creature-KO-rate
+  25-40%.
+- **Fiction**: the party confronts the apex Skiv (dune-stalker) in its ferrous
+  badlands -- the hunt where the stakes are real. Ties permadeath to attachment
+  (creature dossier #2856): a creature can fall for good.
+
+## Method
+
+In-process probe `tools/sim/ultima-caccia-band-probe.js` (`createApp` supertest,
+NO prod backend, node 22, seeds 1..N), elimination, grid 10x10, maxRounds 40.
+
+- **Enemies** = the encounter WAVE 1, expanded with the SAME tier->stat table the
+  canonical AI-sim harness uses (`tests/smoke/ai-driven-sim.js buildEnemiesFromYaml`:
+  base hp7/mod1, elite hp10/mod2, apex hp14/mod4, damage {1,3}, ap 2, range 1).
+  Midfield spawn (x~5-6) mirrors the badlands-pilot engagement distance.
+- **Party** = the CANONICAL badlands tier party, fetched from
+  `GET /api/tutorial/enc_badlands_pilot_01` (the same source the canonical Python
+  harness uses -- `batch_calibrate_badlands_pilot_01.py:run_one`). NOT hand-built,
+  so the only difference vs the badlands-pilot calibration is the enemy roster.
+
+Roster variants: `pilot` = apex + 2 elite (the pilot wave-1, [0.40,0.60] reference);
+`minus_base` = + 1 base; `full` = + 2 base (the authored wave 1).
+
+## Results
+
+| variant       | N   | creature_KO_rate | win_rate | timeouts | avg_rounds |
+| ------------- | --- | ---------------- | -------- | -------- | ---------- |
+| pilot (3)     | 12  | 0.396            | 0.083    | 11/12    | 39.6       |
+| minus_base(4) | 12  | 0.354            | 0.250    | 9/12     | 39.0       |
+| full (5)      | 12  | 0.417            | 0.000    | 12/12    | 40.0       |
+| minus_base(4) | 24  | 0.302            | 0.125    | 21/24    | 39.5       |
+| full (5)      | 24  | 0.344            | 0.000    | 24/24    | 40.0       |
+| full (5)      | 40  | 0.344            | 0.000    | 40/40    | 40.0       |
+
+## Read
+
+**Primary metric = creature-KO-rate** (the permadeath-relevant one: under
+LETHAL+consent every player KO becomes a real death, so the KO-rate IS the
+death-rate). The authored **full** roster lands at **0.344 (N=24 AND N=40, identical)** --
+squarely inside the hardcore target band [0.25, 0.40], and very stable across
+sample sizes. (The N=12 0.42 was small-sample noise; N=24/40 tightened it.) The
+roster is in the right ballpark for hardcore opt-in.
+
+**Win-rate is NOT reliably measurable in this in-process probe.** The
+`combat-adapter` player policy grinds to the 40-round cap (avg_rounds ~40,
+~90% timeouts) where the canonical Python harness (`plan_player_intents`
+focus-fire + `turn_limit_defeat` semantics) resolves the fight. So the WR column
+here is timeout-dominated and is NOT the band signal -- only the KO-rate is.
+
+## Decision
+
+- **Keep the authored 5-enemy wave-1** (apex dune-stalker + 2 echo-wing elite +
+  2 rust-scavenger base). Its creature-KO-rate centers the hardcore band.
+- The encounter ships **flag-OFF** -- band-neutral by construction.
+
+## Owner-gated next (NOT this session)
+
+The absolute **win-rate band ratification + the permadeath flip** are owner-gated
+(N-sample discipline: N=24/40 here = direction, ratify = owner; SDMG: even a
+canonical-party in-process probe is a hypothesis, the specialist harness decides):
+
+1. Run the canonical N=40 WR-band via the G2 / Python harness. This needs either
+   (a) a scenario-builder + `/api/tutorial/enc_badlands_ultima_caccia_01` wiring
+   (mirror `badlandsPilotScenario.js`) so the harness materializes party+enemies,
+   OR (b) a live backend + a `batch_calibrate_ultima_caccia_01.py` driver (clone
+   `batch_calibrate_badlands_pilot_01.py`, retarget SCENARIO_ID + encounter_class
+   hardcore).
+2. If in band -> master-dd flips `LETHAL_MISSIONS_ENABLED=true` (the irreversible
+   step) once the Godot consent UI (DONE, GGv2 #477) + a lethal data path are live.
+
+See [[project_spec_j_lethal_wounds]], `docs/design/evo-tactics-lethal-wounds-rituals.md`.

--- a/schemas/evo/encounter.schema.json
+++ b/schemas/evo/encounter.schema.json
@@ -223,6 +223,11 @@
       "maximum": 5,
       "description": "1-5 star difficulty"
     },
+    "lethal": {
+      "type": "boolean",
+      "default": false,
+      "description": "SPEC-J per-mission lethal flag (point-9): when true the mission can produce permadeath. Read by routes/session.js /start as session.lethal. Inert unless LETHAL_MISSIONS_ENABLED==='true' AND per-player consent is granted (services/combat/lethalDeath.js); a KO is soft-death otherwise (band-neutral by construction). Default false = soft-death mission."
+    },
     "pressure_tier_floor": {
       "type": "integer",
       "minimum": 0,

--- a/tests/api/lethalMissionFlag.test.js
+++ b/tests/api/lethalMissionFlag.test.js
@@ -15,6 +15,10 @@ const assert = require('node:assert/strict');
 const request = require('supertest');
 
 const { createApp } = require('../../apps/backend/app');
+const { loadEncounter } = require('../../apps/backend/services/combat/encounterLoader');
+const { isMissionLethal } = require('../../apps/backend/services/combat/lethalDeath');
+
+const AUTHORED_LETHAL_ID = 'enc_badlands_ultima_caccia_01';
 
 async function startScenario(app, extra = {}) {
   const scenario = await request(app).get('/api/tutorial/enc_tutorial_01');
@@ -52,4 +56,30 @@ test('lethal flag does NOT coerce from a truthy string in the body', async (t) =
   const res = await startScenario(app, { lethal: 'true' });
   assert.equal(res.status, 200);
   assert.equal(res.body.state.lethal, false, 'string "true" must not arm a lethal mission');
+});
+
+// SPEC-J first lethal mission: the authored encounter must carry the strict
+// boolean lethal flag and that data alone must arm the per-mission gate.
+test('authored encounter enc_badlands_ultima_caccia_01 carries lethal:true', () => {
+  const enc = loadEncounter(AUTHORED_LETHAL_ID);
+  assert.ok(enc, `${AUTHORED_LETHAL_ID} should load from docs/planning/encounters`);
+  assert.equal(enc.lethal, true, 'authored encounter is flagged lethal (point-9)');
+  assert.equal(
+    isMissionLethal({ lethal: enc.lethal }),
+    true,
+    'the authored lethal flag arms isMissionLethal',
+  );
+});
+
+// e2e: the authored encounter payload flows lethal:true -> session.lethal ->
+// public state (SPEC-J sez.8), the same chain req.body.lethal proves above.
+test('start with authored lethal encounter payload -> public state lethal:true', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const enc = loadEncounter(AUTHORED_LETHAL_ID);
+  const res = await startScenario(app, { encounter: enc });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.lethal, true, 'authored encounter arms the lethal mission flag');
 });

--- a/tools/sim/ultima-caccia-band-probe.js
+++ b/tools/sim/ultima-caccia-band-probe.js
@@ -59,8 +59,9 @@ const TIER_MOD = { base: 1, elite: 2, apex: 4 };
 
 // Enemy roster variant (env ULTIMA_ROSTER): 'full' = wave-1 as authored
 // (apex+2elite+2base), 'minus_base' = drop 1 base, 'pilot' = apex+2elite (the
-// badlands-pilot wave-1, [0.40,0.60] reference). Midfield spawn (x~5-6) mirrors
-// the pilot engagement distance so the fight resolves inside maxRounds.
+// badlands-pilot wave-1, [0.40,0.60] reference). Spawn positions match the
+// authored encounter spawn_points 1:1 (Codex #3107 P2: midfield x~5-6, the
+// canonical badlands engagement distance, so the probe band == the real mission).
 const ROSTER_VARIANT = process.env.ULTIMA_ROSTER || 'full';
 
 function enemies() {
@@ -73,7 +74,7 @@ function enemies() {
   ];
   if (ROSTER_VARIANT === 'minus_base') defs = defs.slice(0, 4);
   else if (ROSTER_VARIANT === 'pilot') defs = defs.slice(0, 3);
-  return defs.map(([species, tier, position], i) => ({
+  return defs.map(([species, tier, position, aiProfile], i) => ({
     id: `sis_${i + 1}`,
     species,
     species_id: species,
@@ -87,6 +88,9 @@ function enemies() {
     damage: { min: 1, max: 3 },
     initiative: tier === 'apex' ? 14 : 10,
     position,
+    // Codex #3107 P2: emit the authored ai_profile so /session/start selects the
+    // utility-brain behavior (flanking/aggressive), not the default policy.
+    ai_profile: aiProfile,
     controlled_by: 'sistema',
     status: {},
   }));

--- a/tools/sim/ultima-caccia-band-probe.js
+++ b/tools/sim/ultima-caccia-band-probe.js
@@ -1,0 +1,178 @@
+'use strict';
+// SPEC-J first-lethal band probe -- enc_badlands_ultima_caccia_01.
+//
+// In-process (supertest createApp, NO prod backend, node 22), single-arm
+// elimination. Measures the win-rate band + the player-creature KO-rate (the
+// permadeath-relevant metric: under LETHAL+consent every player KO becomes a
+// real death, so the KO-rate IS the death-rate). The flag stays OFF here -- this
+// probe never produces permadeath, it measures the combat band the lethal
+// mission would run at.
+//
+// METHODOLOGY:
+// - Enemies are the encounter's WAVE 1 expanded with the SAME tier->stat table
+//   the canonical AI-sim harness uses (tests/smoke/ai-driven-sim.js
+//   buildEnemiesFromYaml: base hp7/mod1, elite hp10/mod2, apex hp14/mod4,
+//   damage {1,3}, ap 2, range 1). So this in-process band is comparable to a
+//   live-harness run of the same scenario.
+// - The player party is the CANONICAL badlands tier party, fetched from
+//   GET /api/tutorial/enc_badlands_pilot_01 (same source the canonical Python
+//   harness uses -- batch_calibrate_badlands_pilot_01.py:run_one). NOT hand-built,
+//   so the only difference vs the badlands pilot calibration is the enemy roster:
+//   our wave 1 (apex + 2 elite + 2 base) is harder than the pilot's wave 1
+//   (apex + 2 elite), so the band should sit below the pilot's [0.40,0.60].
+// - This is still a DIRECTION probe (N=10) / provisional band (N=40), NOT the
+//   owner ratification: the absolute-band ratification + the permadeath flip are
+//   owner-gated via the G2 Python calibration harness + master-dd (N-sample
+//   discipline: N=10 = direction, N=40 = ratify; SDMG: even a canonical-party
+//   in-process probe is a hypothesis, the specialist harness is the decider).
+//
+// DESIGN target (master-dd 2026-06-30): hardcore opt-in, party-WR 25-40%,
+//   creature-KO-rate 25-40%.
+//
+// Usage: node tools/sim/ultima-caccia-band-probe.js [N]   (default N=40)
+
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runEncounter } = require('./combat-adapter');
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
+
+function supertestHttp(app) {
+  return {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+// Wave 1 of enc_badlands_ultima_caccia_01, expanded with the AI-sim tier table.
+const TIER_HP = { base: 7, elite: 10, apex: 14 };
+const TIER_MOD = { base: 1, elite: 2, apex: 4 };
+
+// Enemy roster variant (env ULTIMA_ROSTER): 'full' = wave-1 as authored
+// (apex+2elite+2base), 'minus_base' = drop 1 base, 'pilot' = apex+2elite (the
+// badlands-pilot wave-1, [0.40,0.60] reference). Midfield spawn (x~5-6) mirrors
+// the pilot engagement distance so the fight resolves inside maxRounds.
+const ROSTER_VARIANT = process.env.ULTIMA_ROSTER || 'full';
+
+function enemies() {
+  let defs = [
+    ['dune-stalker', 'apex', { x: 5, y: 5 }, 'flanking'],
+    ['echo-wing', 'elite', { x: 5, y: 4 }, 'aggressive'],
+    ['echo-wing', 'elite', { x: 5, y: 6 }, 'aggressive'],
+    ['rust-scavenger', 'base', { x: 6, y: 4 }, 'aggressive'],
+    ['rust-scavenger', 'base', { x: 6, y: 6 }, 'aggressive'],
+  ];
+  if (ROSTER_VARIANT === 'minus_base') defs = defs.slice(0, 4);
+  else if (ROSTER_VARIANT === 'pilot') defs = defs.slice(0, 3);
+  return defs.map(([species, tier, position], i) => ({
+    id: `sis_${i + 1}`,
+    species,
+    species_id: species,
+    hp: TIER_HP[tier],
+    max_hp: TIER_HP[tier],
+    ap: 2,
+    ap_max: 2,
+    mod: TIER_MOD[tier],
+    dc: tier === 'apex' ? 14 : tier === 'elite' ? 12 : 11,
+    attack_range: 1,
+    damage: { min: 1, max: 3 },
+    initiative: tier === 'apex' ? 14 : 10,
+    position,
+    controlled_by: 'sistema',
+    status: {},
+  }));
+}
+
+// Canonical badlands tier party (player units only), fetched once from the
+// tutorial scenario the badlands pilot calibration also uses.
+const CANON_PARTY_SCENARIO = 'enc_badlands_pilot_01';
+let _party = null;
+async function fetchCanonicalParty() {
+  if (_party) return _party;
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const r = await request(app).get(`/api/tutorial/${CANON_PARTY_SCENARIO}`);
+    if (r.status !== 200) throw new Error(`canon party fetch ${r.status}`);
+    _party = (r.body.units || []).filter((u) => u.controlled_by === 'player');
+    if (!_party.length) throw new Error('canon party empty');
+    return _party;
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+function roster(party) {
+  // Deep-clone so each run starts from full HP (runEncounter mutates units).
+  return party.map((u) => ({ ...u, hp: u.max_hp ?? u.hp, status: {} }));
+}
+
+async function runOne(party, seed) {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const http = supertestHttp(app);
+    const r = await runEncounter(http, {
+      roster: roster(party),
+      enemies: enemies(),
+      seed,
+      maxRounds: 40,
+      gridSize: 10,
+    });
+    const rosterN = (r.rosterIds || []).length || 4;
+    const survivors = (r.survivorIds || []).length;
+    const kos = Math.max(0, rosterN - survivors);
+    return { outcome: r.outcome, rounds: r.rounds, kos, rosterN };
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+function summarize(arr) {
+  const wins = arr.filter((r) => r.outcome === 'victory').length;
+  const defeats = arr.filter((r) => r.outcome === 'defeat').length;
+  const timeouts = arr.filter((r) => r.outcome === 'timeout').length;
+  const totalKo = arr.reduce((s, r) => s + r.kos, 0);
+  const totalSlots = arr.reduce((s, r) => s + r.rosterN, 0);
+  const avgRounds = arr.reduce((s, r) => s + (r.rounds || 0), 0) / (arr.length || 1);
+  return {
+    N: arr.length,
+    wins,
+    defeats,
+    timeouts,
+    win_rate: Number((wins / arr.length).toFixed(4)),
+    creature_ko_rate: Number((totalKo / (totalSlots || 1)).toFixed(4)),
+    avg_rounds: Number(avgRounds.toFixed(2)),
+  };
+}
+
+async function main() {
+  const N = Number(process.argv[2]) || 40;
+  const party = await fetchCanonicalParty();
+  const runs = [];
+  for (let s = 1; s <= N; s += 1) {
+    runs.push(await runOne(party, s));
+    if (s % 10 === 0) process.stderr.write(`  ${s}/${N}\n`);
+  }
+  const out = {
+    scenario: 'enc_badlands_ultima_caccia_01',
+    roster_variant: ROSTER_VARIANT,
+    party_source: CANON_PARTY_SCENARIO,
+    target_band: { win_rate: [0.25, 0.4], creature_ko_rate: [0.25, 0.4] },
+    ...summarize(runs),
+    node: process.version,
+  };
+  console.log(JSON.stringify(out, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## SPEC-J flip-prereq #1: author the first lethal encounter

First step of the **Tier-3 SPEC-J LETHAL arc** (close-out program). SPEC-J backend
(death/consent/ritual/bridge/auto-timer) + Godot consent UI (GGv2 #477) are already
DONE. The flip `LETHAL_MISSIONS_ENABLED=true` is gated on three prereqs; this PR
delivers **prereq #1: author >=1 `lethal:true` encounter**.

### Design-call (master-dd 2026-06-30, AskUserQuestion)
- **Vehicle**: a NEW dedicated lethal encounter (not flagging an existing one).
- **Band**: hardcore opt-in -- party-WR 25-40%, creature-KO-rate 25-40%.
- **Fiction**: "L'Ultima Caccia" -- the party hunts the apex Skiv (dune-stalker) in
  the ferrous badlands. Ties permadeath to attachment (creature dossier #2856).

### Changes
- `docs/planning/encounters/enc_badlands_ultima_caccia_01.yaml` -- new badlands
  encounter, single decisive wave-1 elimination, `lethal: true`.
- `schemas/evo/encounter.schema.json` -- **add optional boolean `lethal`** (default
  false). The schema is `additionalProperties:false` and `encounterSchema.test.js`
  gates every encounter, so the field must be declared. Additive, no ripple beyond
  the already-built `lethalDeath.js` reader.
- `tests/api/lethalMissionFlag.test.js` -- +2 cases (loader carries `lethal:true`;
  e2e authored payload -> `session.lethal` public).
- `tools/sim/ultima-caccia-band-probe.js` -- in-process band probe (canonical
  badlands party from `/api/tutorial` + wave-1 tier-stat enemies).
- `docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md` (+registry).

### Band-neutral by construction
`LETHAL_MISSIONS_ENABLED` unset + no consent producer => every KO stays soft-death.
The `lethal:true` flag is inert until the owner flips. No new sim path reached.

### Calibration evidence (N=40)
Creature-KO-rate (the permadeath death-rate) = **0.344, stable across N=24 and N=40**
-- squarely inside the hardcore band [0.25, 0.40]. WR is NOT reliably measurable
in-process (the combat-adapter policy grinds to the round cap); the **WR-band
ratification + the permadeath flip stay owner-gated** (canonical G2/Python harness
+ master-dd). See the evidence doc.

### Verification
- lethalMissionFlag 5/5 - encounterSchema 19/19 - lethalDeath 20/20 -
  sessionEncounterWiring 7/7 - AI 560/560 - schema:lint + docs-governance green -
  A2 difficulty guard delta 0 - prettier clean.

### :warning: Merge note (NOT auto-merge)
Touches `schemas/evo/` (schema change). Per the close-out program rules this is a
**master-dd manual merge**, not auto-merge L3. Surface is green; awaiting master-dd.

### Rollback
Revert the commit. The encounter + schema field are inert (flag OFF), so revert is
behavior-neutral; no migration, no data backfill.
