### PR TITLE
docs(od-024): STAMINA_FATIGUE paired N=40 band-safety evidence (Tier-3 N4)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12981,6 +12981,17 @@
       "review_cycle_days": 90
     },
     {
+      "path": "docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md",
+      "title": "STAMINA_FATIGUE paired N=40 band-safety evidence (OD-024 engine #2)",
+      "doc_status": "active",
+      "doc_owner": "claude-code",
+      "workstream": "ops-qa",
+      "last_verified": "2026-06-30",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 90
+    },
+    {
       "path": "docs/playtest/2026-06-18-foresta-s2-calibration.md",
       "title": "Foresta S2 calibration -- enc_foresta_pilot_01 (#2850 follow-up)",
       "doc_status": "active",

--- a/docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md
+++ b/docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md
@@ -1,0 +1,90 @@
+---
+title: 'STAMINA_FATIGUE paired N=40 band-safety evidence (OD-024 engine #2)'
+workstream: ops-qa
+category: playtest
+doc_status: active
+doc_owner: claude-code
+last_verified: '2026-06-30'
+language: en
+tags: [playtest, calibration, od-024, stamina, fatigue, n40, ai-driven]
+---
+
+# STAMINA_FATIGUE paired N=40 -- band-safety evidence (Tier-3 N=40 lane)
+
+Tier-3 N=40 lane item N4 (OD-024 engine #2, sprint stamina/fatica). The mechanic
+is BUILT + wired flag-gated OFF (`STAMINA_FATIGUE_ENABLED`, PR #2937); this is the
+paired band-safety N=40 the flip is gated on. The flag is NOT flipped here -- the
+flip + the 4 provisional-knob ratifications are master-dd's call (below).
+
+## Mechanic (verified vs code)
+
+`apps/backend/services/combat/staminaFatigue.js`, carrier-INDEPENDENT (fires on any
+unit, player or sistema -- not gated on a trait carrier). A unit that ENDS a round
+with `ap_remaining==0` AND moved `>=2` voluntary tiles = "sprint" -> `+1 fatica`;
+`fatica >= threshold` (1, or 2 for `propriocezione` bearers) -> `-1 AP` next round,
+floored at 1; `-1 fatica` decay per non-sprint round. AP floor 1 = a sprint never
+costs a whole turn.
+
+## Method
+
+Paired A/B, same `--seed-base 7000`, `tools/sim/full-loop-batch.js` (in-process
+`createApp` + supertest, NO prod-port, node 22, `--isolate` child-per-seed). The
+ONLY difference between arms is `STAMINA_FATIGUE_ENABLED`. The `--isolate` child
+inherits `env: process.env` (full-loop-batch.js:383), so the flag reaches each
+child's in-process backend (verified -- not the silent-skip trap that needs the
+party-grant SIM hook).
+
+- ARM OFF: `node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy --seed-base 7000 --isolate --out reports/sim/stamina-n40-off`
+- ARM ON: `STAMINA_FATIGUE_ENABLED=true node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy --seed-base 7000 --isolate --out reports/sim/stamina-n40-on`
+
+Firing-proof (the mechanic actually activates with the flag on): the e2e tests
+`tests/api/staminaFatigueE2eAccrual.test.js` + `staminaFatigueRefill.test.js` +
+`tests/services/staminaFatigue.test.js` = 17/17 green; AND the paired arms differ
+on 5 metrics (below) -> fatigue fired (not a silent no-op).
+
+## Results (N=40, summary.json)
+
+| metric                      | OFF         | ON           | in_band (OFF/ON) |
+| --------------------------- | ----------- | ------------ | ---------------- |
+| completion_rate             | 0.475       | 0.575        | true / true      |
+| roster_attrition            | 0.575       | 0.502        | true / true      |
+| economy_flow drift          | 1.055       | 1.080        | true / true      |
+| relationship (recruit/mate) | 4.45 / 3.75 | 5.275 / 4.45 | true / true      |
+| offspring_viability         | 3.75        | 4.45         | true / true      |
+| lineage_diversity           | 5           | 5            | true / true      |
+| roster_composition          | 5 roles     | 5 roles      | true / true      |
+
+completion: OFF 19/40, ON 23/40. Bands PROVISIONAL (Claude-derived, L-069); the
+exact band numbers are master-dd's to ratify.
+
+## Read
+
+- **Band-SAFE**: every one of the 7 meta-metrics is in-band in BOTH arms. No OOB
+  cratering, no metric pushed out of range by fatigue.
+- **Mechanic FIRED**: the arms diverge on 5 metrics (same seeds) -> fatigue is
+  active in the ON arm, not silently skipped.
+- **Counter-intuitive but explainable**: fatigue ON nudged the player slightly
+  BETTER (completion 0.475 -> 0.575, attrition 0.575 -> 0.502). Because fatigue is
+  carrier-INDEPENDENT it also penalizes SISTEMA units (enemies sprint to close on
+  the party), so the net effect on the party is neutral-to-slightly-positive. This
+  is a DESIGN observation for master-dd (see owner-gate Q3), not a band failure --
+  the magnitude is modest (+4 completed campaigns / 40) and everything stays
+  in-band.
+
+## Owner-gate (master-dd; NOT done in this session)
+
+The N=40 measurement is the only autonomous step. The remaining steps are owner:
+
+1. **Flip** (reversible): set `STAMINA_FATIGUE_ENABLED=true` in keys.env + restart
+   (I8 prod-flips bundle). Band-safe per above.
+2. **Ratify the 4 RATIFIED-PROVISIONAL knobs** (module header): sprint = 2 voluntary
+   tiles / threshold 1 (propriocezione 2) / -1 AP penalty / -1 decay per round.
+3. **Design call on symmetry**: keep fatigue carrier-independent (penalizes enemies
+   too -> net eases the player slightly, ecological realism) OR make it player-only
+   (pure tactical cost). Current = carrier-independent.
+
+Raw runs reproducible from the seeded commands above (`reports/sim/stamina-n40-{off,on}/`
+summary.json + report.md committed; runs.jsonl reproducible, not committed).
+
+See [[project_sentience_interoception_producer]],
+`docs/planning/2026-06-29-closeout-master-plan.md` (N4).

--- a/reports/sim/stamina-n40-off/report.md
+++ b/reports/sim/stamina-n40-off/report.md
@@ -1,0 +1,37 @@
+# Full-loop meta band-metrics
+
+Runs: **40** | Completed: **19/40** | Policy: `greedy` | Branch: `cave_path`
+
+> **RATIFIED (master-dd, L-069)** -- RATIFIED 2026-06-03 by master-dd (L-069): the working bands. Reversible (two-way door) -- revise when evidence warrants. Keep the design space healthy (Quality-Diversity); do not optimize to a single best run. GRAPH-MODE RE-RATIFIED 2026-06-04 by master-dd (#2603): with the real draft rosters + the cm3/hp2/dcAdd1 overlay, graph-mode completion lands ~0.66 (N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60), inside this 0.4-0.7 band -- the fallback-era wider 0.4-0.85 is superseded; completion_rate [0.4, 0.7] holds for both static and graph mode.
+
+| Metric | Value | Band | In band |
+|---|---|---|:---:|
+| completion_rate | 0.475 | 0.4 - 0.7 | ✅ |
+| roster_attrition | 0.575 | 0 - 1 | ✅ |
+| economy_flow | drift 1.055 (pe 39.4, bp 144.6) | 0.5 - 2 | ✅ |
+| relationship_progress | recruit 4.45, aff 1, mate 3.75 | composite | ✅ |
+| offspring_viability | offspring 3.75 | >= 1 | ✅ |
+| lineage_diversity | 5 crosses, dominant dune-stalker x nano-rust-bloom | >= 3 | ✅ |
+| roster_composition | dominant APEX/HAZARD, 5 roles | >= 3 | ✅ |
+
+> Note (economy_flow): PE earned + build-power drift; PI sink exercised (378 attempts)
+
+## Personality axes (Opt 3 OUTPUT) -- N-sample evidence
+
+2012 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
+
+| axis | n | mean | sd | min | max | neutral_rate |
+| --- | --- | --- | --- | --- | --- | --- |
+| symbiosis_predation | 2012 | 0.990 | 0.044 | 0.688 | 1.000 | 0.000 |
+| explore_caution | 2012 | 0.630 | 0.207 | 0.500 | 1.000 | 0.713 |
+| solitary_swarm | 2012 | 0.577 | 0.204 | 0.250 | 1.000 | 0.775 |
+| memory_instinct | 2012 | 0.505 | 0.050 | 0.442 | 0.875 | 0.885 |
+| agile_robust | 2012 | 0.479 | 0.075 | 0.140 | 0.735 | 0.670 |
+
+Degenerate (all-5 neutral) rate: 0.000.
+Dominant-axis histogram: symbiosis_predation 1823, solitary_swarm 189.
+Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.90.
+Faction player (664): symbiosis_predation 1.00, explore_caution 0.63, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
+Faction sistema (1348): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
+
+Per-run records: `runs.jsonl`. Aggregate: `summary.json`.

--- a/reports/sim/stamina-n40-off/summary.json
+++ b/reports/sim/stamina-n40-off/summary.json
@@ -1,0 +1,342 @@
+{
+  "config": {
+    "runs": 40,
+    "branch": "cave_path",
+    "policy": "greedy",
+    "commit": "unknown",
+    "flags": {
+      "META_NETWORK_ROUTING": "false",
+      "IDEA_ENGINE_STUB_ORCHESTRATOR": "1",
+      "IDEA_ENGINE_DISABLE_STATUS_REFRESH": "1",
+      "A13_WOUND_READ_DISABLED": "0",
+      "SENTIENCE_INTEROCEPTION_GRANT_ENABLED": "false",
+      "SIM_GRANT_PARTY_INTEROCEPTION": "0"
+    },
+    "enemyScaling": {
+      "countMult": 5,
+      "countAdd": 0,
+      "hpMult": 1,
+      "hpAdd": 3,
+      "modAdd": 1,
+      "dcAdd": 1
+    },
+    "peEarned": 8,
+    "a13": false,
+    "a13MaxRetries": 1
+  },
+  "n": 40,
+  "provisional": false,
+  "metrics": {
+    "completion_rate": {
+      "value": 0.475,
+      "range": [
+        0.4,
+        0.7
+      ],
+      "in_band": true,
+      "note": "completed campaigns / N"
+    },
+    "roster_attrition": {
+      "value": 0.575,
+      "range": [
+        0,
+        1
+      ],
+      "in_band": true,
+      "note": "survivors / units-that-fought (exclusive: real losses, no wipe)"
+    },
+    "economy_flow": {
+      "pe_earned_avg": 39.4,
+      "build_power_avg": 144.6,
+      "build_power_drift": 1.055,
+      "pi_sink_exercised": true,
+      "pi_pick_attempts": 378,
+      "pi_insufficient": 331,
+      "has_signal": true,
+      "range": [
+        0.5,
+        2
+      ],
+      "in_band": true,
+      "note": "PE earned + build-power drift; PI sink exercised (378 attempts)"
+    },
+    "relationship_progress": {
+      "recruit_rate": 4.45,
+      "affinity_proven_rate": 1,
+      "reached_step": 28,
+      "mating_rate": 3.75,
+      "range": null,
+      "in_band": true,
+      "note": "recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire"
+    },
+    "offspring_viability": {
+      "offspring_avg": 3.75,
+      "viable_rate": 1,
+      "range": [
+        1,
+        null
+      ],
+      "in_band": true,
+      "note": "mean offspring per run >= threshold (breeding exercised); lineage spread = the separate lineage_diversity metric"
+    },
+    "lineage_diversity": {
+      "value": 5,
+      "lineage_profile": {
+        "dune-stalker x nano-rust-bloom": 47,
+        "ferrocolonia-magnetotattica x nano-rust-bloom": 28,
+        "ferrocolonia-magnetotattica x sand-burrower": 28,
+        "rust-scavenger x sand-burrower": 28,
+        "dune-stalker x rust-scavenger": 19
+      },
+      "dominant_lineages": [
+        "dune-stalker x nano-rust-bloom"
+      ],
+      "unknown_lineage_count": 0,
+      "range": [
+        3,
+        null
+      ],
+      "in_band": true,
+      "note": "distinct parent-species crosses across the batch (>= 3 = healthy spread, no collapse); dominant cross is POLICY-SENSITIVE -> P4 in breeding; UNKNOWN/missing parents excluded, tracked as unknown_lineage_count"
+    },
+    "roster_composition": {
+      "role_profile": {
+        "APEX": 47,
+        "HAZARD": 47,
+        "PREDATOR": 28,
+        "PREY": 28,
+        "SUPPORT": 28
+      },
+      "distinct_roles": 5,
+      "dominant_roles": [
+        "APEX",
+        "HAZARD"
+      ],
+      "unknown_count": 0,
+      "range": [
+        3,
+        null
+      ],
+      "in_band": true,
+      "note": "role_class profile of the recruited roster (UNKNOWN excluded, tracked as unknown_count); dominant_roles diverge by policy -> P4 measurable (composition, not quantity)"
+    }
+  },
+  "completion": {
+    "completed": 19,
+    "total": 40
+  },
+  "personality": {
+    "n_samples": 2012,
+    "per_axis": {
+      "symbiosis_predation": {
+        "n": 2012,
+        "mean": 0.9904433408439862,
+        "sd": 0.04423161163420384,
+        "min": 0.6875,
+        "max": 1,
+        "neutral_rate": 0
+      },
+      "explore_caution": {
+        "n": 2012,
+        "mean": 0.6297707544099472,
+        "sd": 0.20703173488493437,
+        "min": 0.5,
+        "max": 1,
+        "neutral_rate": 0.7127236580516899
+      },
+      "solitary_swarm": {
+        "n": 2012,
+        "mean": 0.577162027833002,
+        "sd": 0.2036668028666504,
+        "min": 0.25,
+        "max": 1,
+        "neutral_rate": 0.7748508946322068
+      },
+      "memory_instinct": {
+        "n": 2012,
+        "mean": 0.505409959135305,
+        "sd": 0.05025345400138734,
+        "min": 0.4419642857142857,
+        "max": 0.875,
+        "neutral_rate": 0.8846918489065606
+      },
+      "agile_robust": {
+        "n": 2012,
+        "mean": 0.4790141503917709,
+        "sd": 0.07486453023998312,
+        "min": 0.13999999999999996,
+        "max": 0.7352941176470588,
+        "neutral_rate": 0.6699801192842942
+      }
+    },
+    "degenerate_rate": 0,
+    "dominant_hist": {
+      "solitary_swarm": 189,
+      "symbiosis_predation": 1823
+    },
+    "correlations": [
+      {
+        "pair": [
+          "symbiosis_predation",
+          "explore_caution"
+        ],
+        "r": -0.2471191491325013
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "solitary_swarm"
+        ],
+        "r": -0.4485667399292049
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "memory_instinct"
+        ],
+        "r": -0.9011917430705041
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "agile_robust"
+        ],
+        "r": -0.040835777165656575
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "solitary_swarm"
+        ],
+        "r": 0.27841599718777227
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "memory_instinct"
+        ],
+        "r": 0.12677816283519125
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "agile_robust"
+        ],
+        "r": 0.015271445813140293
+      },
+      {
+        "pair": [
+          "solitary_swarm",
+          "memory_instinct"
+        ],
+        "r": 0.22350220041032612
+      },
+      {
+        "pair": [
+          "solitary_swarm",
+          "agile_robust"
+        ],
+        "r": -0.05615881020109161
+      },
+      {
+        "pair": [
+          "memory_instinct",
+          "agile_robust"
+        ],
+        "r": 0.04605528803933993
+      }
+    ],
+    "by_faction": {
+      "player": {
+        "n_samples": 664,
+        "per_axis": {
+          "symbiosis_predation": {
+            "n": 664,
+            "mean": 0.9967006086732675,
+            "sd": 0.010097311335783789,
+            "min": 0.9547368421052631,
+            "max": 1,
+            "neutral_rate": 0
+          },
+          "explore_caution": {
+            "n": 664,
+            "mean": 0.6331553498740863,
+            "sd": 0.21094480532121496,
+            "min": 0.5,
+            "max": 1,
+            "neutral_rate": 0.7123493975903614
+          },
+          "solitary_swarm": {
+            "n": 664,
+            "mean": 0.6212349397590361,
+            "sd": 0.25957735385552333,
+            "min": 0.25,
+            "max": 1,
+            "neutral_rate": 0.5858433734939759
+          },
+          "memory_instinct": {
+            "n": 664,
+            "mean": 0.49698317809267556,
+            "sd": 0.012380297118434391,
+            "min": 0.4490254872563718,
+            "max": 0.5267857142857143,
+            "neutral_rate": 0.8689759036144579
+          },
+          "agile_robust": {
+            "n": 664,
+            "mean": 0.4364103472714367,
+            "sd": 0.11947279531453815,
+            "min": 0.13999999999999996,
+            "max": 0.7352941176470588,
+            "neutral_rate": 0
+          }
+        }
+      },
+      "sistema": {
+        "n_samples": 1348,
+        "per_axis": {
+          "symbiosis_predation": {
+            "n": 1348,
+            "mean": 0.9873611258301551,
+            "sd": 0.05330226815959447,
+            "min": 0.6875,
+            "max": 1,
+            "neutral_rate": 0
+          },
+          "explore_caution": {
+            "n": 1348,
+            "mean": 0.6281035649528339,
+            "sd": 0.20505624707973844,
+            "min": 0.5,
+            "max": 1,
+            "neutral_rate": 0.7129080118694362
+          },
+          "solitary_swarm": {
+            "n": 1348,
+            "mean": 0.5554525222551929,
+            "sd": 0.16520920996553445,
+            "min": 0.25,
+            "max": 1,
+            "neutral_rate": 0.8679525222551929
+          },
+          "memory_instinct": {
+            "n": 1348,
+            "mean": 0.5095608364441376,
+            "sd": 0.0603462741314609,
+            "min": 0.4419642857142857,
+            "max": 0.875,
+            "neutral_rate": 0.892433234421365
+          },
+          "agile_robust": {
+            "n": 1348,
+            "mean": 0.5,
+            "sd": 0,
+            "min": 0.5,
+            "max": 0.5,
+            "neutral_rate": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/reports/sim/stamina-n40-on/report.md
+++ b/reports/sim/stamina-n40-on/report.md
@@ -1,0 +1,37 @@
+# Full-loop meta band-metrics
+
+Runs: **40** | Completed: **23/40** | Policy: `greedy` | Branch: `cave_path`
+
+> **RATIFIED (master-dd, L-069)** -- RATIFIED 2026-06-03 by master-dd (L-069): the working bands. Reversible (two-way door) -- revise when evidence warrants. Keep the design space healthy (Quality-Diversity); do not optimize to a single best run. GRAPH-MODE RE-RATIFIED 2026-06-04 by master-dd (#2603): with the real draft rosters + the cm3/hp2/dcAdd1 overlay, graph-mode completion lands ~0.66 (N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60), inside this 0.4-0.7 band -- the fallback-era wider 0.4-0.85 is superseded; completion_rate [0.4, 0.7] holds for both static and graph mode.
+
+| Metric | Value | Band | In band |
+|---|---|---|:---:|
+| completion_rate | 0.575 | 0.4 - 0.7 | ✅ |
+| roster_attrition | 0.502 | 0 - 1 | ✅ |
+| economy_flow | drift 1.08 (pe 46.8, bp 171) | 0.5 - 2 | ✅ |
+| relationship_progress | recruit 5.275, aff 1, mate 4.45 | composite | ✅ |
+| offspring_viability | offspring 4.45 | >= 1 | ✅ |
+| lineage_diversity | 5 crosses, dominant dune-stalker x nano-rust-bloom | >= 3 | ✅ |
+| roster_composition | dominant APEX/HAZARD, 5 roles | >= 3 | ✅ |
+
+> Note (economy_flow): PE earned + build-power drift; PI sink exercised (445 attempts)
+
+## Personality axes (Opt 3 OUTPUT) -- N-sample evidence
+
+2296 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
+
+| axis | n | mean | sd | min | max | neutral_rate |
+| --- | --- | --- | --- | --- | --- | --- |
+| symbiosis_predation | 2296 | 0.990 | 0.044 | 0.688 | 1.000 | 0.000 |
+| explore_caution | 2296 | 0.626 | 0.204 | 0.500 | 1.000 | 0.721 |
+| solitary_swarm | 2296 | 0.578 | 0.206 | 0.250 | 1.000 | 0.769 |
+| memory_instinct | 2296 | 0.506 | 0.051 | 0.438 | 0.875 | 0.883 |
+| agile_robust | 2296 | 0.478 | 0.076 | 0.140 | 0.735 | 0.665 |
+
+Degenerate (all-5 neutral) rate: 0.000.
+Dominant-axis histogram: symbiosis_predation 2084, solitary_swarm 212.
+Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.90.
+Faction player (769): symbiosis_predation 1.00, explore_caution 0.63, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
+Faction sistema (1527): symbiosis_predation 0.99, explore_caution 0.62, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
+
+Per-run records: `runs.jsonl`. Aggregate: `summary.json`.

--- a/reports/sim/stamina-n40-on/summary.json
+++ b/reports/sim/stamina-n40-on/summary.json
@@ -1,0 +1,342 @@
+{
+  "config": {
+    "runs": 40,
+    "branch": "cave_path",
+    "policy": "greedy",
+    "commit": "unknown",
+    "flags": {
+      "META_NETWORK_ROUTING": "false",
+      "IDEA_ENGINE_STUB_ORCHESTRATOR": "1",
+      "IDEA_ENGINE_DISABLE_STATUS_REFRESH": "1",
+      "A13_WOUND_READ_DISABLED": "0",
+      "SENTIENCE_INTEROCEPTION_GRANT_ENABLED": "false",
+      "SIM_GRANT_PARTY_INTEROCEPTION": "0"
+    },
+    "enemyScaling": {
+      "countMult": 5,
+      "countAdd": 0,
+      "hpMult": 1,
+      "hpAdd": 3,
+      "modAdd": 1,
+      "dcAdd": 1
+    },
+    "peEarned": 8,
+    "a13": false,
+    "a13MaxRetries": 1
+  },
+  "n": 40,
+  "provisional": false,
+  "metrics": {
+    "completion_rate": {
+      "value": 0.575,
+      "range": [
+        0.4,
+        0.7
+      ],
+      "in_band": true,
+      "note": "completed campaigns / N"
+    },
+    "roster_attrition": {
+      "value": 0.502,
+      "range": [
+        0,
+        1
+      ],
+      "in_band": true,
+      "note": "survivors / units-that-fought (exclusive: real losses, no wipe)"
+    },
+    "economy_flow": {
+      "pe_earned_avg": 46.8,
+      "build_power_avg": 171,
+      "build_power_drift": 1.08,
+      "pi_sink_exercised": true,
+      "pi_pick_attempts": 445,
+      "pi_insufficient": 389,
+      "has_signal": true,
+      "range": [
+        0.5,
+        2
+      ],
+      "in_band": true,
+      "note": "PE earned + build-power drift; PI sink exercised (445 attempts)"
+    },
+    "relationship_progress": {
+      "recruit_rate": 5.275,
+      "affinity_proven_rate": 1,
+      "reached_step": 33,
+      "mating_rate": 4.45,
+      "range": null,
+      "in_band": true,
+      "note": "recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire"
+    },
+    "offspring_viability": {
+      "offspring_avg": 4.45,
+      "viable_rate": 1,
+      "range": [
+        1,
+        null
+      ],
+      "in_band": true,
+      "note": "mean offspring per run >= threshold (breeding exercised); lineage spread = the separate lineage_diversity metric"
+    },
+    "lineage_diversity": {
+      "value": 5,
+      "lineage_profile": {
+        "dune-stalker x nano-rust-bloom": 56,
+        "ferrocolonia-magnetotattica x nano-rust-bloom": 33,
+        "ferrocolonia-magnetotattica x sand-burrower": 33,
+        "rust-scavenger x sand-burrower": 33,
+        "dune-stalker x rust-scavenger": 23
+      },
+      "dominant_lineages": [
+        "dune-stalker x nano-rust-bloom"
+      ],
+      "unknown_lineage_count": 0,
+      "range": [
+        3,
+        null
+      ],
+      "in_band": true,
+      "note": "distinct parent-species crosses across the batch (>= 3 = healthy spread, no collapse); dominant cross is POLICY-SENSITIVE -> P4 in breeding; UNKNOWN/missing parents excluded, tracked as unknown_lineage_count"
+    },
+    "roster_composition": {
+      "role_profile": {
+        "APEX": 56,
+        "HAZARD": 56,
+        "PREDATOR": 33,
+        "PREY": 33,
+        "SUPPORT": 33
+      },
+      "distinct_roles": 5,
+      "dominant_roles": [
+        "APEX",
+        "HAZARD"
+      ],
+      "unknown_count": 0,
+      "range": [
+        3,
+        null
+      ],
+      "in_band": true,
+      "note": "role_class profile of the recruited roster (UNKNOWN excluded, tracked as unknown_count); dominant_roles diverge by policy -> P4 measurable (composition, not quantity)"
+    }
+  },
+  "completion": {
+    "completed": 23,
+    "total": 40
+  },
+  "personality": {
+    "n_samples": 2296,
+    "per_axis": {
+      "symbiosis_predation": {
+        "n": 2296,
+        "mean": 0.9904516294787299,
+        "sd": 0.04400924091807938,
+        "min": 0.6875,
+        "max": 1,
+        "neutral_rate": 0
+      },
+      "explore_caution": {
+        "n": 2296,
+        "mean": 0.6256171835670208,
+        "sd": 0.2044452836436191,
+        "min": 0.5,
+        "max": 1,
+        "neutral_rate": 0.7208188153310104
+      },
+      "solitary_swarm": {
+        "n": 2296,
+        "mean": 0.5780705574912892,
+        "sd": 0.20574644480830354,
+        "min": 0.25,
+        "max": 1,
+        "neutral_rate": 0.7687282229965157
+      },
+      "memory_instinct": {
+        "n": 2296,
+        "mean": 0.5055274010921711,
+        "sd": 0.05054026279666187,
+        "min": 0.43846153846153846,
+        "max": 0.875,
+        "neutral_rate": 0.8832752613240418
+      },
+      "agile_robust": {
+        "n": 2296,
+        "mean": 0.4784622873539709,
+        "sd": 0.076060160060366,
+        "min": 0.13999999999999996,
+        "max": 0.7352941176470588,
+        "neutral_rate": 0.6650696864111498
+      }
+    },
+    "degenerate_rate": 0,
+    "dominant_hist": {
+      "solitary_swarm": 212,
+      "symbiosis_predation": 2084
+    },
+    "correlations": [
+      {
+        "pair": [
+          "symbiosis_predation",
+          "explore_caution"
+        ],
+        "r": -0.2575920255398028
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "solitary_swarm"
+        ],
+        "r": -0.44493121719736994
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "memory_instinct"
+        ],
+        "r": -0.9026685440951846
+      },
+      {
+        "pair": [
+          "symbiosis_predation",
+          "agile_robust"
+        ],
+        "r": -0.04197874642288168
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "solitary_swarm"
+        ],
+        "r": 0.28618265574610885
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "memory_instinct"
+        ],
+        "r": 0.1344686180728351
+      },
+      {
+        "pair": [
+          "explore_caution",
+          "agile_robust"
+        ],
+        "r": 0.011666061765849637
+      },
+      {
+        "pair": [
+          "solitary_swarm",
+          "memory_instinct"
+        ],
+        "r": 0.2242802215451112
+      },
+      {
+        "pair": [
+          "solitary_swarm",
+          "agile_robust"
+        ],
+        "r": -0.04959628903206619
+      },
+      {
+        "pair": [
+          "memory_instinct",
+          "agile_robust"
+        ],
+        "r": 0.04528641222495755
+      }
+    ],
+    "by_faction": {
+      "player": {
+        "n_samples": 769,
+        "per_axis": {
+          "symbiosis_predation": {
+            "n": 769,
+            "mean": 0.9967589025293447,
+            "sd": 0.010207165025793429,
+            "min": 0.9398148148148148,
+            "max": 1,
+            "neutral_rate": 0
+          },
+          "explore_caution": {
+            "n": 769,
+            "mean": 0.6335202187001651,
+            "sd": 0.21165017238158015,
+            "min": 0.5,
+            "max": 1,
+            "neutral_rate": 0.7126137841352406
+          },
+          "solitary_swarm": {
+            "n": 769,
+            "mean": 0.618335500650195,
+            "sd": 0.2599926713002125,
+            "min": 0.25,
+            "max": 1,
+            "neutral_rate": 0.5838751625487646
+          },
+          "memory_instinct": {
+            "n": 769,
+            "mean": 0.49726122418920443,
+            "sd": 0.01213036422233031,
+            "min": 0.4519230769230769,
+            "max": 0.5267857142857143,
+            "neutral_rate": 0.8751625487646294
+          },
+          "agile_robust": {
+            "n": 769,
+            "mean": 0.4356949437772484,
+            "sd": 0.12050948083297235,
+            "min": 0.13999999999999996,
+            "max": 0.7352941176470588,
+            "neutral_rate": 0
+          }
+        }
+      },
+      "sistema": {
+        "n_samples": 1527,
+        "per_axis": {
+          "symbiosis_predation": {
+            "n": 1527,
+            "mean": 0.9872752752050409,
+            "sd": 0.053194024833876724,
+            "min": 0.6875,
+            "max": 1,
+            "neutral_rate": 0
+          },
+          "explore_caution": {
+            "n": 1527,
+            "mean": 0.6216372005824833,
+            "sd": 0.20060114916730246,
+            "min": 0.5,
+            "max": 1,
+            "neutral_rate": 0.724950884086444
+          },
+          "solitary_swarm": {
+            "n": 1527,
+            "mean": 0.5577930582842174,
+            "sd": 0.16846559466471359,
+            "min": 0.25,
+            "max": 1,
+            "neutral_rate": 0.8618205631958088
+          },
+          "memory_instinct": {
+            "n": 1527,
+            "mean": 0.5096902629378698,
+            "sd": 0.060949440036320655,
+            "min": 0.43846153846153846,
+            "max": 0.875,
+            "neutral_rate": 0.8873608382449247
+          },
+          "agile_robust": {
+            "n": 1527,
+            "mean": 0.5,
+            "sd": 0,
+            "min": 0.5,
+            "max": 0.5,
+            "neutral_rate": 1
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Tier-3 N=40 lane (N4): STAMINA_FATIGUE band-safety evidence

OD-024 engine #2 (sprint stamina/fatica) is BUILT + wired flag-gated OFF
(`STAMINA_FATIGUE_ENABLED`, PR #2937). This PR adds the **paired band-safety N=40**
the flip is gated on. **Nothing is flipped** -- the flip + the 4 provisional-knob
ratifications are master-dd's call.

### Method
Paired A/B, same `--seed-base 7000`, `tools/sim/full-loop-batch.js` (in-process,
NO prod-port, `--isolate`). Only difference between arms = the flag. `--isolate`
child inherits `env: process.env` (full-loop-batch.js:383) so the flag reaches each
child -- NOT the party-grant silent-skip trap.

**Firing-proof**: e2e tests 17/17 green AND the paired arms diverge on 5 metrics
(same seeds) -> fatigue actually fired (not a silent no-op).

### Result -- band-SAFE
All 7 meta-metrics in-band in BOTH arms:

| metric | OFF | ON |
|---|---|---|
| completion_rate | 0.475 | 0.575 |
| roster_attrition | 0.575 | 0.502 |
| economy_flow drift | 1.055 | 1.080 |
| offspring_viability | 3.75 | 4.45 |

completion 19/40 -> 23/40. Counter-intuitive net-positive: fatigue is
carrier-independent (penalizes sistema units too) -> slightly eases the player.
Modest, in-band -- a design note for master-dd, not a band failure.

### Owner-gate (NOT in this PR)
1. Flip `STAMINA_FATIGUE_ENABLED=true` (reversible) -- band-safe per above.
2. Ratify 4 provisional knobs (sprint=2 tiles / threshold 1 / -1 AP / -1 decay).
3. Symmetry design call: carrier-independent (current) vs player-only.

### Scope
Pure docs + reports (evidence doc + registry + summary.json/report.md both arms).
No code, no forbidden-path, no deps. runs.jsonl reproducible from the seeded
command, not committed.

### Verification
docs-governance green (errors=0 warnings=0), prettier clean, firing-proof 17/17.

### Rollback
Revert -- pure docs, behavior-neutral.
