### PR TITLE
docs(spec-h): HA1 aliena_enforcement strength evidence + flip-safety (Tier-3 N2)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -12992,6 +12992,17 @@
       "review_cycle_days": 90
     },
     {
+      "path": "docs/playtest/2026-06-30-ha1-aliena-enforcement-evidence.md",
+      "title": "HA1 aliena_enforcement strength evidence + flip-safety (SPEC-H, Tier-3 N2)",
+      "doc_status": "active",
+      "doc_owner": "claude-code",
+      "workstream": "ops-qa",
+      "last_verified": "2026-06-30",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 90
+    },
+    {
       "path": "docs/playtest/2026-06-18-foresta-s2-calibration.md",
       "title": "Foresta S2 calibration -- enc_foresta_pilot_01 (#2850 follow-up)",
       "doc_status": "active",

--- a/docs/playtest/2026-06-30-ha1-aliena-enforcement-evidence.md
+++ b/docs/playtest/2026-06-30-ha1-aliena-enforcement-evidence.md
@@ -1,0 +1,90 @@
+---
+title: 'HA1 aliena_enforcement strength evidence + flip-safety (SPEC-H, Tier-3 N2)'
+workstream: ops-qa
+category: playtest
+doc_status: active
+doc_owner: claude-code
+last_verified: '2026-06-30'
+language: en
+tags: [playtest, spec-h, aliena, enforcement, guardrail, n40]
+---
+
+# HA1 aliena_enforcement -- strength evidence + flip-safety (Tier-3 lane N2)
+
+SPEC-H HA1 = the ALIENA soft-enforcement flip. When
+`policy.aliena_enforcement = {enabled:true, strength>0}`, reinforcement spawn
+weights are modulated by each pool entry's ALIENA coherence aggregate:
+`factor = max(0.0001, 1 - strength*(1 - aggregate))`
+(`apps/backend/services/combat/biomeSpawnBias.js:261`). `strength` is a continuous
+knob [0,1], default 0 (off). Machinery + surface COMPLETE (#2828-#2835); this is
+the flip-gate evidence. Probe: `tools/sim/aliena-enforcement-probe.js`.
+
+## Verify-first finding -- HA1 is a GUARDRAIL, not a balance lever
+
+A naive combat N=40 on `enc_badlands_pilot_01` would have been an **I3-style
+illusory result**. Computing the real coherence aggregates of the authored
+badlands reinforcement pool (real `scoreAlienaCoherence` on real pool data):
+
+| pool entry                                                                              | aggregate           |
+| --------------------------------------------------------------------------------------- | ------------------- |
+| sand-burrower / rust-scavenger / echo-wing / ferrocolonia-magnetotattica / dune-stalker | 0.5 (ALL identical) |
+
+Every entry scores the **same** aggregate (bare pool entries -> identical
+plausibilita/coerenza_eco/ancoraggio sub-scores). A uniform aggregate means a
+**uniform factor** -> all spawn weights scale by the same number -> the relative
+weighted-random distribution is **unchanged at any strength** -> enforcement is
+**INERT on the real pool**. A combat N=40 would read "band-neutral" for the WRONG
+reason (no differential effect), masking the no-op.
+
+**Consequence**: enforcement only does anything on a pool whose entries have
+VARYING coherence (a procedurally-generated pool, or an authoring mistake that
+drops an off-biome species into a pool). On today's well-authored, coherence-
+uniform pools it is inert. So **flipping `aliena_enforcement` ON is band-safe by
+construction for current content** -- it is a future-facing guardrail, not a
+balance change.
+
+## Mechanism demonstration (synthetic coherence-varied pool)
+
+To show the re-weighting DOES work when coherence varies, a synthetic 2-entry pool:
+`coherent_native` (in canonical pool + narrative-anchored -> aggregate 0.6) vs
+`incoherent_alien` (not canonical + no narrative -> aggregate 0.1), equal base
+weight (so strength 0 = 1:1 baseline; divergence at strength>0 is purely the
+aliena factor):
+
+| strength | coherent w | incoherent w | incoherent share | suppression |
+| -------- | ---------- | ------------ | ---------------- | ----------- |
+| 0.00     | 1.00       | 1.00         | 50.0%            | 0%          |
+| 0.25     | 0.90       | 0.775        | 46.3%            | 13.9%       |
+| 0.50     | 0.80       | 0.550        | 40.7%            | 31.3%       |
+| 0.75     | 0.70       | 0.325        | 31.7%            | 53.6%       |
+| 1.00     | 0.60       | 0.100        | 14.3%            | 83.3%       |
+
+Monotone in strength, bounded (floored at 0.0001 -> an incoherent entry is never
+fully excluded; weighted-random anti-determinism is preserved, per the design doc).
+
+## Recommendation
+
+- **Flip**: `aliena_enforcement` is safe to enable -- inert on current content
+  (proven above), active only as a guardrail on future coherence-varied pools.
+- **Strength = 0.5** (recommended default): a moderate guardrail -- ~31%
+  suppression of a fully-incoherent entry, which still spawns ~41% of the time vs
+  a coherent peer. Picks: 0.25 = light nudge, 0.5 = moderate, 0.75 = strong,
+  1.0 = near-exclusion (still 14% share). This is a feel/policy choice -- the curve
+  is the input, master-dd ratifies the value (L-069 lock = data; here the "data" is
+  the deterministic re-weighting curve, since combat is unaffected on real pools).
+
+## Owner-gate (master-dd)
+
+1. **Ratify strength** (recommended 0.5) -- guardrail aggressiveness, reversible.
+2. **Flip** `policy.aliena_enforcement.enabled` (per-encounter) or a global default
+   -- band-safe (inert on current pools). Reversible.
+
+NOTE: because enforcement is inert on the only authored pools, there is no combat
+N=40 band to ratify here -- the gate is the re-weighting curve + the flip-safety
+proof, not a win-rate band. An optional belt-and-suspenders combat N=40 (inject
+`aliena_enforcement` into a varied pool + run) would confirm combat-neutrality but
+adds no new signal (the weighting math is exercised directly above).
+
+See [[project_spec_h_codex_surface]],
+`docs/design/evo-tactics-aliena-enforcement-lore.md`,
+`docs/planning/2026-06-29-closeout-master-plan.md` (N2).

--- a/tools/sim/aliena-enforcement-probe.js
+++ b/tools/sim/aliena-enforcement-probe.js
@@ -1,0 +1,114 @@
+'use strict';
+// SPEC-H HA1 aliena_enforcement strength probe (Tier-3 N=40 lane, N2).
+//
+// HA1 = the soft-enforcement flip: when policy.aliena_enforcement = {enabled,
+// strength>0}, reinforcement spawn weights are modulated by each pool entry's
+// ALIENA coherence aggregate -- factor = max(0.0001, 1 - strength*(1 - aggregate))
+// (biomeSpawnBias.js:261). strength is a continuous knob [0,1], default 0 (off).
+//
+// VERIFY-FIRST FINDING (the reason this is NOT a combat-band sweep):
+// On a REAL well-authored pool every entry scores the SAME coherence aggregate
+// (bare reinforcement_pool entries: no affixes/tags/narrative -> identical p/e/n),
+// so the factor is UNIFORM and the relative spawn weights are UNCHANGED at any
+// strength -> enforcement is INERT on current content -> the flip is band-safe by
+// construction (it changes nothing in real play). A naive combat N=40 on the
+// badlands pilot would read "band-neutral" for the WRONG reason (no differential
+// effect), masking the no-op (an I3-style illusory result). So this probe instead
+// (1) PROVES the real-pool no-op deterministically and (2) demonstrates the
+// re-weighting on a synthetic coherence-VARIED pool so master-dd can pick the
+// guardrail strength.
+//
+// Usage: node tools/sim/aliena-enforcement-probe.js
+
+const fs = require('fs');
+const yaml = require('js-yaml');
+const { applyBiomeBias } = require('../../apps/backend/services/combat/biomeSpawnBias');
+const { scoreAlienaCoherence } = require('../../apps/backend/services/authorial/alienaCoherence');
+
+const STRENGTHS = [0, 0.25, 0.5, 0.75, 1.0];
+
+function loadBadlands() {
+  const biomes = yaml.load(fs.readFileSync('data/core/biomes.yaml', 'utf8'));
+  const b = biomes.biomes || biomes;
+  return b.badlands || (Array.isArray(b) ? b.find((x) => x.id === 'badlands') : null);
+}
+
+function weightsAt(pool, biome, canonicalPool, strength) {
+  const out = applyBiomeBias(pool, biome, {
+    canonicalPool,
+    alienaEnforcement: strength > 0 ? { enabled: true, strength } : null,
+  });
+  return out.map((e) => ({ id: e.id || e.unit_id, weight: Number(e.weight.toFixed(4)) }));
+}
+
+function main() {
+  const badlands = loadBadlands();
+  if (!badlands) throw new Error('badlands biomeConfig not found');
+
+  // --- (1) Real pool no-op proof: the authored badlands pilot reinforcement pool.
+  const enc = yaml.load(
+    fs.readFileSync('docs/planning/encounters/enc_badlands_foodweb_pilot_01.yaml', 'utf8'),
+  );
+  const realPool = (enc.reinforcement_pool || []).map((e) => ({
+    id: e.unit_id,
+    weight: e.weight || 1,
+  }));
+  const realCanon = realPool.map((e) => ({ id: e.id }));
+  const realAggs = realPool.map(
+    (e) => scoreAlienaCoherence({ ...e }, badlands, { canonicalPool: realCanon }).aggregate,
+  );
+  const realUniform = new Set(realAggs).size === 1;
+
+  // --- (2) Synthetic coherence-VARIED pool. HIGH = in canonicalPool + narrative
+  // anchored; LOW = not in canonical + no narrative. Same base weight so strength=0
+  // is the 1:1 baseline; the divergence at strength>0 is purely the aliena factor.
+  const variedPool = [
+    { id: 'coherent_native', weight: 1, narrative_hooks: ['endemic to the ferrous flats'] },
+    { id: 'incoherent_alien', weight: 1 },
+  ];
+  const variedCanon = [{ id: 'coherent_native' }];
+  const aggH = scoreAlienaCoherence(variedPool[0], badlands, {
+    canonicalPool: variedCanon,
+  }).aggregate;
+  const aggL = scoreAlienaCoherence(variedPool[1], badlands, {
+    canonicalPool: variedCanon,
+  }).aggregate;
+
+  const rows = STRENGTHS.map((s) => {
+    const w = weightsAt(variedPool, badlands, variedCanon, s);
+    const wH = w.find((x) => x.id === 'coherent_native').weight;
+    const wL = w.find((x) => x.id === 'incoherent_alien').weight;
+    return {
+      strength: s,
+      coherent_weight: wH,
+      incoherent_weight: wL,
+      incoherent_share: Number((wL / (wH + wL)).toFixed(4)),
+      suppression_pct: Number(((1 - wL / wH) * 100 || 0).toFixed(1)),
+    };
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        probe: 'aliena_enforcement_strength',
+        real_pool: {
+          scenario: 'enc_badlands_foodweb_pilot_01',
+          aggregates: realAggs,
+          uniform: realUniform,
+          verdict: realUniform
+            ? 'INERT on real pool (uniform coherence) -> flip band-safe by construction'
+            : 'real pool has varied coherence -> enforcement would re-weight',
+        },
+        synthetic_varied_pool: {
+          coherent_aggregate: aggH,
+          incoherent_aggregate: aggL,
+          sweep: rows,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main();


### PR DESCRIPTION
## Tier-3 N=40 lane (N2): SPEC-H HA1 aliena_enforcement -- strength evidence + flip-safety

HA1 = the ALIENA soft-enforcement flip (`policy.aliena_enforcement.strength` modulates
reinforcement spawn weights by each entry's coherence aggregate). Machinery+surface
COMPLETE (#2828-#2835); this PR is the flip-gate evidence (probe + doc). **Nothing
flipped** -- strength + flip are master-dd's call.

### Verify-first finding -- HA1 is a GUARDRAIL, not a balance N=40
The authored badlands pilot reinforcement pool scores a **uniform** coherence
aggregate (all 5 entries = 0.5 -- bare entries, identical sub-scores). Uniform
aggregate -> uniform factor -> relative spawn weights **unchanged at any strength**
-> enforcement is **INERT on real content**. A naive combat N=40 would read
"band-neutral" for the WRONG reason (a no-op) -- an I3-style illusory result. So the
flip is **band-safe by construction on current pools**; enforcement only acts on
coherence-VARIED (procedural/future) pools. The probe exercises the REAL
`applyBiomeBias` + `scoreAlienaCoherence` on real biome/pool data (not a stub).

### Mechanism demonstration (synthetic varied pool)
coherent (agg 0.6) vs incoherent (agg 0.1), equal base weight:

| strength | incoherent share | suppression |
|---|---|---|
| 0.00 | 50.0% | 0% |
| 0.50 | 40.7% | 31.3% |
| 0.75 | 31.7% | 53.6% |
| 1.00 | 14.3% | 83.3% |

Monotone, bounded (never zeroed -- weighted-random preserved).

### Recommendation
- **Flip safe** -- inert on current content; a future-facing guardrail.
- **Strength 0.5** (recommended): moderate guardrail. 0.25 light / 0.75 strong /
  1.0 near-exclusion. Feel/policy pick -- master-dd ratifies.

### Owner-gate
1. Ratify strength (recommended 0.5). 2. Flip `aliena_enforcement` (band-safe).
No combat win-rate band to ratify (inert on real pools) -- the gate is the
re-weighting curve + the flip-safety proof.

### Scope
docs + 1 tool probe (tools/sim). No code logic change, no forbidden-path, no deps.

### Verification
docs-governance green (errors=0 warnings=0), prettier clean, probe runs (real
weighting code).

### Rollback
Revert -- pure docs+tool, behavior-neutral.
