### PR TITLE
fix(sim): record STAMINA_FATIGUE_ENABLED + commit in N=40 provenance (Codex #3108 P2)

### DIFF
--- a/docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md
+++ b/docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md
@@ -34,28 +34,35 @@ inherits `env: process.env` (full-loop-batch.js:383), so the flag reaches each
 child's in-process backend (verified -- not the silent-skip trap that needs the
 party-grant SIM hook).
 
-- ARM OFF: `node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy --seed-base 7000 --isolate --out reports/sim/stamina-n40-off`
-- ARM ON: `STAMINA_FATIGUE_ENABLED=true node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy --seed-base 7000 --isolate --out reports/sim/stamina-n40-on`
+- ARM OFF: `GIT_COMMIT=$(git rev-parse HEAD) node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy --seed-base 7000 --isolate --out reports/sim/stamina-n40-off`
+- ARM ON: `GIT_COMMIT=$(git rev-parse HEAD) STAMINA_FATIGUE_ENABLED=true node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy --seed-base 7000 --isolate --out reports/sim/stamina-n40-on`
+
+Provenance (Codex #3108 P2): `currentFlags()` now records `STAMINA_FATIGUE_ENABLED`
+and the runs are pinned with `GIT_COMMIT`, so the OFF vs ON `summary.json` config
+blocks are SELF-DISTINGUISHING (commit `c83d6a68`, flag `false` vs `true`) and the
+ON-arm artifact verifies which arm + which revision produced it.
 
 Firing-proof (the mechanic actually activates with the flag on): the e2e tests
 `tests/api/staminaFatigueE2eAccrual.test.js` + `staminaFatigueRefill.test.js` +
 `tests/services/staminaFatigue.test.js` = 17/17 green; AND the paired arms differ
-on 5 metrics (below) -> fatigue fired (not a silent no-op).
+on 5 metrics (below) + the recorded flag differs -> fatigue fired (not a silent no-op).
 
-## Results (N=40, summary.json)
+## Results (N=40, summary.json, commit c83d6a68)
 
 | metric                      | OFF         | ON           | in_band (OFF/ON) |
 | --------------------------- | ----------- | ------------ | ---------------- |
-| completion_rate             | 0.475       | 0.575        | true / true      |
-| roster_attrition            | 0.575       | 0.502        | true / true      |
-| economy_flow drift          | 1.055       | 1.080        | true / true      |
-| relationship (recruit/mate) | 4.45 / 3.75 | 5.275 / 4.45 | true / true      |
-| offspring_viability         | 3.75        | 4.45         | true / true      |
+| completion_rate             | 0.475       | 0.600        | true / true      |
+| roster_attrition            | 0.563       | 0.511        | true / true      |
+| economy_flow drift          | 1.030       | 1.095        | true / true      |
+| relationship (recruit/mate) | 4.5 / 3.775 | 5.25 / 4.425 | true / true      |
+| offspring_viability         | 3.775       | 4.425        | true / true      |
 | lineage_diversity           | 5           | 5            | true / true      |
 | roster_composition          | 5 roles     | 5 roles      | true / true      |
 
-completion: OFF 19/40, ON 23/40. Bands PROVISIONAL (Claude-derived, L-069); the
-exact band numbers are master-dd's to ratify.
+completion: OFF 19/40, ON 24/40. Bands PROVISIONAL (Claude-derived, L-069); the
+exact band numbers are master-dd's to ratify. (The first, pre-provenance run gave
+0.475 / 0.575 -- the verdict is identical; the metrics are stable in-band, the sim
+is not bit-reproducible across bases so the continuous values drift a campaign.)
 
 ## Read
 
@@ -64,11 +71,11 @@ exact band numbers are master-dd's to ratify.
 - **Mechanic FIRED**: the arms diverge on 5 metrics (same seeds) -> fatigue is
   active in the ON arm, not silently skipped.
 - **Counter-intuitive but explainable**: fatigue ON nudged the player slightly
-  BETTER (completion 0.475 -> 0.575, attrition 0.575 -> 0.502). Because fatigue is
+  BETTER (completion 0.475 -> 0.600, attrition 0.563 -> 0.511). Because fatigue is
   carrier-INDEPENDENT it also penalizes SISTEMA units (enemies sprint to close on
   the party), so the net effect on the party is neutral-to-slightly-positive. This
   is a DESIGN observation for master-dd (see owner-gate Q3), not a band failure --
-  the magnitude is modest (+4 completed campaigns / 40) and everything stays
+  the magnitude is modest (+5 completed campaigns / 40) and everything stays
   in-band.
 
 ## Owner-gate (master-dd; NOT done in this session)

--- a/docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md
+++ b/docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md
@@ -37,46 +37,49 @@ party-grant SIM hook).
 - ARM OFF: `GIT_COMMIT=$(git rev-parse HEAD) node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy --seed-base 7000 --isolate --out reports/sim/stamina-n40-off`
 - ARM ON: `GIT_COMMIT=$(git rev-parse HEAD) STAMINA_FATIGUE_ENABLED=true node tools/sim/full-loop-batch.js --runs 40 --branch cave_path --policy greedy --seed-base 7000 --isolate --out reports/sim/stamina-n40-on`
 
-Provenance (Codex #3108 P2): `currentFlags()` now records `STAMINA_FATIGUE_ENABLED`
-and the runs are pinned with `GIT_COMMIT`, so the OFF vs ON `summary.json` config
-blocks are SELF-DISTINGUISHING (commit `c83d6a68`, flag `false` vs `true`) and the
-ON-arm artifact verifies which arm + which revision produced it.
+Provenance (Codex #3108 P2 + follow-up): `currentFlags()` now records
+`STAMINA_FATIGUE_ENABLED` and the runs are pinned with `GIT_COMMIT` to the
+**harness-patch revision** `8ba18a63` (the commit that ADDS the flag to
+`currentFlags()` -- NOT its parent), so a checkout of the recorded commit
+reproduces the advertised flag metadata. The OFF vs ON `summary.json` config
+blocks are SELF-DISTINGUISHING (same commit, flag `false` vs `true`).
 
 Firing-proof (the mechanic actually activates with the flag on): the e2e tests
 `tests/api/staminaFatigueE2eAccrual.test.js` + `staminaFatigueRefill.test.js` +
 `tests/services/staminaFatigue.test.js` = 17/17 green; AND the paired arms differ
 on 5 metrics (below) + the recorded flag differs -> fatigue fired (not a silent no-op).
 
-## Results (N=40, summary.json, commit c83d6a68)
+## Results (N=40, summary.json, commit 8ba18a63)
 
-| metric                      | OFF         | ON           | in_band (OFF/ON) |
-| --------------------------- | ----------- | ------------ | ---------------- |
-| completion_rate             | 0.475       | 0.600        | true / true      |
-| roster_attrition            | 0.563       | 0.511        | true / true      |
-| economy_flow drift          | 1.030       | 1.095        | true / true      |
-| relationship (recruit/mate) | 4.5 / 3.775 | 5.25 / 4.425 | true / true      |
-| offspring_viability         | 3.775       | 4.425        | true / true      |
-| lineage_diversity           | 5           | 5            | true / true      |
-| roster_composition          | 5 roles     | 5 roles      | true / true      |
+| metric                      | OFF          | ON           | in_band (OFF/ON) |
+| --------------------------- | ------------ | ------------ | ---------------- |
+| completion_rate             | 0.525        | 0.575        | true / true      |
+| roster_attrition            | 0.458        | 0.502        | true / true      |
+| economy_flow drift          | 1.010        | 1.080        | true / true      |
+| relationship (recruit/mate) | 5.425 / 4.55 | 5.275 / 4.45 | true / true      |
+| offspring_viability         | 4.55         | 4.45         | true / true      |
+| lineage_diversity           | 5            | 5            | true / true      |
+| roster_composition          | 5 roles      | 5 roles      | true / true      |
 
-completion: OFF 19/40, ON 24/40. Bands PROVISIONAL (Claude-derived, L-069); the
-exact band numbers are master-dd's to ratify. (The first, pre-provenance run gave
-0.475 / 0.575 -- the verdict is identical; the metrics are stable in-band, the sim
-is not bit-reproducible across bases so the continuous values drift a campaign.)
+completion: OFF 21/40, ON 23/40. Bands PROVISIONAL (Claude-derived, L-069); the
+exact band numbers are master-dd's to ratify. **Run-to-run variance**: across 3
+runs the sim is NOT bit-reproducible even at the same commit (completion OFF
+0.475-0.525, ON 0.575-0.600). Every metric stayed in-band in every run -> the
+band-SAFE verdict is robust; the per-run directional deltas are within that noise.
 
 ## Read
 
 - **Band-SAFE**: every one of the 7 meta-metrics is in-band in BOTH arms. No OOB
   cratering, no metric pushed out of range by fatigue.
-- **Mechanic FIRED**: the arms diverge on 5 metrics (same seeds) -> fatigue is
-  active in the ON arm, not silently skipped.
-- **Counter-intuitive but explainable**: fatigue ON nudged the player slightly
-  BETTER (completion 0.475 -> 0.600, attrition 0.563 -> 0.511). Because fatigue is
-  carrier-INDEPENDENT it also penalizes SISTEMA units (enemies sprint to close on
-  the party), so the net effect on the party is neutral-to-slightly-positive. This
-  is a DESIGN observation for master-dd (see owner-gate Q3), not a band failure --
-  the magnitude is modest (+5 completed campaigns / 40) and everything stays
-  in-band.
+- **Mechanic FIRED**: the arms diverge on multiple metrics (+ the recorded flag
+  differs) -> fatigue is active in the ON arm, not silently skipped.
+- **Net band-NEUTRAL within noise**: the per-run direction is NOT consistent
+  (run A: ON completion +0.125 / attrition -0.052; this run: ON completion +0.05 /
+  attrition +0.044) -> the directional shift is inside the run-to-run variance, not
+  a real difficulty swing. Mechanistically this fits: fatigue is carrier-INDEPENDENT
+  so it penalizes SISTEMA units too (enemies sprint to close on the party), and the
+  two sides roughly cancel. DESIGN observation for master-dd (owner-gate Q3:
+  carrier-independent vs player-only) -- not a band failure.
 
 ## Owner-gate (master-dd; NOT done in this session)
 

--- a/docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md
+++ b/docs/playtest/2026-06-30-stamina-fatigue-n40-evidence.md
@@ -90,8 +90,10 @@ The N=40 measurement is the only autonomous step. The remaining steps are owner:
 2. **Ratify the 4 RATIFIED-PROVISIONAL knobs** (module header): sprint = 2 voluntary
    tiles / threshold 1 (propriocezione 2) / -1 AP penalty / -1 decay per round.
 3. **Design call on symmetry**: keep fatigue carrier-independent (penalizes enemies
-   too -> net eases the player slightly, ecological realism) OR make it player-only
-   (pure tactical cost). Current = carrier-independent.
+   too -> net band-neutral, ecological realism) OR make it player-only (a real
+   tactical cost that would actually bite the player). Current = carrier-independent
+   -- which is WHY the net effect cancels to noise; if the design intent is a player
+   penalty, player-only is the lever.
 
 Raw runs reproducible from the seeded commands above (`reports/sim/stamina-n40-{off,on}/`
 summary.json + report.md committed; runs.jsonl reproducible, not committed).

--- a/reports/sim/stamina-n40-off/report.md
+++ b/reports/sim/stamina-n40-off/report.md
@@ -1,37 +1,37 @@
 # Full-loop meta band-metrics
 
-Runs: **40** | Completed: **19/40** | Policy: `greedy` | Branch: `cave_path`
+Runs: **40** | Completed: **21/40** | Policy: `greedy` | Branch: `cave_path`
 
 > **RATIFIED (master-dd, L-069)** -- RATIFIED 2026-06-03 by master-dd (L-069): the working bands. Reversible (two-way door) -- revise when evidence warrants. Keep the design space healthy (Quality-Diversity); do not optimize to a single best run. GRAPH-MODE RE-RATIFIED 2026-06-04 by master-dd (#2603): with the real draft rosters + the cm3/hp2/dcAdd1 overlay, graph-mode completion lands ~0.66 (N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60), inside this 0.4-0.7 band -- the fallback-era wider 0.4-0.85 is superseded; completion_rate [0.4, 0.7] holds for both static and graph mode.
 
 | Metric | Value | Band | In band |
 |---|---|---|:---:|
-| completion_rate | 0.475 | 0.4 - 0.7 | ✅ |
-| roster_attrition | 0.563 | 0 - 1 | ✅ |
-| economy_flow | drift 1.03 (pe 39.8, bp 145.2) | 0.5 - 2 | ✅ |
-| relationship_progress | recruit 4.5, aff 1, mate 3.775 | composite | ✅ |
-| offspring_viability | offspring 3.775 | >= 1 | ✅ |
+| completion_rate | 0.525 | 0.4 - 0.7 | ✅ |
+| roster_attrition | 0.458 | 0 - 1 | ✅ |
+| economy_flow | drift 1.01 (pe 47.6, bp 173.4) | 0.5 - 2 | ✅ |
+| relationship_progress | recruit 5.425, aff 1, mate 4.55 | composite | ✅ |
+| offspring_viability | offspring 4.55 | >= 1 | ✅ |
 | lineage_diversity | 5 crosses, dominant dune-stalker x nano-rust-bloom | >= 3 | ✅ |
 | roster_composition | dominant APEX/HAZARD, 5 roles | >= 3 | ✅ |
 
-> Note (economy_flow): PE earned + build-power drift; PI sink exercised (380 attempts)
+> Note (economy_flow): PE earned + build-power drift; PI sink exercised (459 attempts)
 
 ## Personality axes (Opt 3 OUTPUT) -- N-sample evidence
 
-2027 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
+2332 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
 
 | axis | n | mean | sd | min | max | neutral_rate |
 | --- | --- | --- | --- | --- | --- | --- |
-| symbiosis_predation | 2027 | 0.991 | 0.043 | 0.688 | 1.000 | 0.000 |
-| explore_caution | 2027 | 0.629 | 0.207 | 0.500 | 1.000 | 0.714 |
-| solitary_swarm | 2027 | 0.578 | 0.204 | 0.250 | 1.000 | 0.775 |
-| memory_instinct | 2027 | 0.505 | 0.050 | 0.435 | 0.875 | 0.889 |
-| agile_robust | 2027 | 0.479 | 0.075 | 0.140 | 0.735 | 0.670 |
+| symbiosis_predation | 2332 | 0.991 | 0.044 | 0.688 | 1.000 | 0.000 |
+| explore_caution | 2332 | 0.624 | 0.203 | 0.500 | 1.000 | 0.724 |
+| solitary_swarm | 2332 | 0.583 | 0.206 | 0.250 | 1.000 | 0.772 |
+| memory_instinct | 2332 | 0.505 | 0.051 | 0.445 | 0.875 | 0.882 |
+| agile_robust | 2332 | 0.479 | 0.077 | 0.140 | 0.735 | 0.661 |
 
 Degenerate (all-5 neutral) rate: 0.000.
-Dominant-axis histogram: symbiosis_predation 1845, solitary_swarm 182.
+Dominant-axis histogram: symbiosis_predation 2112, solitary_swarm 220.
 Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.90.
-Faction player (668): symbiosis_predation 1.00, explore_caution 0.63, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
-Faction sistema (1359): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
+Faction player (791): symbiosis_predation 1.00, explore_caution 0.62, solitary_swarm 0.63, memory_instinct 0.50, agile_robust 0.44.
+Faction sistema (1541): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
 
 Per-run records: `runs.jsonl`. Aggregate: `summary.json`.

--- a/reports/sim/stamina-n40-off/report.md
+++ b/reports/sim/stamina-n40-off/report.md
@@ -7,31 +7,31 @@ Runs: **40** | Completed: **19/40** | Policy: `greedy` | Branch: `cave_path`
 | Metric | Value | Band | In band |
 |---|---|---|:---:|
 | completion_rate | 0.475 | 0.4 - 0.7 | ✅ |
-| roster_attrition | 0.575 | 0 - 1 | ✅ |
-| economy_flow | drift 1.055 (pe 39.4, bp 144.6) | 0.5 - 2 | ✅ |
-| relationship_progress | recruit 4.45, aff 1, mate 3.75 | composite | ✅ |
-| offspring_viability | offspring 3.75 | >= 1 | ✅ |
+| roster_attrition | 0.563 | 0 - 1 | ✅ |
+| economy_flow | drift 1.03 (pe 39.8, bp 145.2) | 0.5 - 2 | ✅ |
+| relationship_progress | recruit 4.5, aff 1, mate 3.775 | composite | ✅ |
+| offspring_viability | offspring 3.775 | >= 1 | ✅ |
 | lineage_diversity | 5 crosses, dominant dune-stalker x nano-rust-bloom | >= 3 | ✅ |
 | roster_composition | dominant APEX/HAZARD, 5 roles | >= 3 | ✅ |
 
-> Note (economy_flow): PE earned + build-power drift; PI sink exercised (378 attempts)
+> Note (economy_flow): PE earned + build-power drift; PI sink exercised (380 attempts)
 
 ## Personality axes (Opt 3 OUTPUT) -- N-sample evidence
 
-2012 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
+2027 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
 
 | axis | n | mean | sd | min | max | neutral_rate |
 | --- | --- | --- | --- | --- | --- | --- |
-| symbiosis_predation | 2012 | 0.990 | 0.044 | 0.688 | 1.000 | 0.000 |
-| explore_caution | 2012 | 0.630 | 0.207 | 0.500 | 1.000 | 0.713 |
-| solitary_swarm | 2012 | 0.577 | 0.204 | 0.250 | 1.000 | 0.775 |
-| memory_instinct | 2012 | 0.505 | 0.050 | 0.442 | 0.875 | 0.885 |
-| agile_robust | 2012 | 0.479 | 0.075 | 0.140 | 0.735 | 0.670 |
+| symbiosis_predation | 2027 | 0.991 | 0.043 | 0.688 | 1.000 | 0.000 |
+| explore_caution | 2027 | 0.629 | 0.207 | 0.500 | 1.000 | 0.714 |
+| solitary_swarm | 2027 | 0.578 | 0.204 | 0.250 | 1.000 | 0.775 |
+| memory_instinct | 2027 | 0.505 | 0.050 | 0.435 | 0.875 | 0.889 |
+| agile_robust | 2027 | 0.479 | 0.075 | 0.140 | 0.735 | 0.670 |
 
 Degenerate (all-5 neutral) rate: 0.000.
-Dominant-axis histogram: symbiosis_predation 1823, solitary_swarm 189.
+Dominant-axis histogram: symbiosis_predation 1845, solitary_swarm 182.
 Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.90.
-Faction player (664): symbiosis_predation 1.00, explore_caution 0.63, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
-Faction sistema (1348): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
+Faction player (668): symbiosis_predation 1.00, explore_caution 0.63, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
+Faction sistema (1359): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
 
 Per-run records: `runs.jsonl`. Aggregate: `summary.json`.

--- a/reports/sim/stamina-n40-off/summary.json
+++ b/reports/sim/stamina-n40-off/summary.json
@@ -3,7 +3,7 @@
     "runs": 40,
     "branch": "cave_path",
     "policy": "greedy",
-    "commit": "c83d6a68954597ac43b91aeb203a4b2348906c26",
+    "commit": "8ba18a630c219b238ebc0cbf5096aa2a0e682e3a",
     "flags": {
       "META_NETWORK_ROUTING": "false",
       "IDEA_ENGINE_STUB_ORCHESTRATOR": "1",
@@ -29,7 +29,7 @@
   "provisional": false,
   "metrics": {
     "completion_rate": {
-      "value": 0.475,
+      "value": 0.525,
       "range": [
         0.4,
         0.7
@@ -38,7 +38,7 @@
       "note": "completed campaigns / N"
     },
     "roster_attrition": {
-      "value": 0.563,
+      "value": 0.458,
       "range": [
         0,
         1
@@ -47,31 +47,31 @@
       "note": "survivors / units-that-fought (exclusive: real losses, no wipe)"
     },
     "economy_flow": {
-      "pe_earned_avg": 39.8,
-      "build_power_avg": 145.2,
-      "build_power_drift": 1.03,
+      "pe_earned_avg": 47.6,
+      "build_power_avg": 173.4,
+      "build_power_drift": 1.01,
       "pi_sink_exercised": true,
-      "pi_pick_attempts": 380,
-      "pi_insufficient": 333,
+      "pi_pick_attempts": 459,
+      "pi_insufficient": 403,
       "has_signal": true,
       "range": [
         0.5,
         2
       ],
       "in_band": true,
-      "note": "PE earned + build-power drift; PI sink exercised (380 attempts)"
+      "note": "PE earned + build-power drift; PI sink exercised (459 attempts)"
     },
     "relationship_progress": {
-      "recruit_rate": 4.5,
+      "recruit_rate": 5.425,
       "affinity_proven_rate": 1,
-      "reached_step": 29,
-      "mating_rate": 3.775,
+      "reached_step": 35,
+      "mating_rate": 4.55,
       "range": null,
       "in_band": true,
       "note": "recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire"
     },
     "offspring_viability": {
-      "offspring_avg": 3.775,
+      "offspring_avg": 4.55,
       "viable_rate": 1,
       "range": [
         1,
@@ -83,11 +83,11 @@
     "lineage_diversity": {
       "value": 5,
       "lineage_profile": {
-        "dune-stalker x nano-rust-bloom": 48,
-        "ferrocolonia-magnetotattica x nano-rust-bloom": 28,
-        "ferrocolonia-magnetotattica x sand-burrower": 28,
-        "rust-scavenger x sand-burrower": 28,
-        "dune-stalker x rust-scavenger": 19
+        "dune-stalker x nano-rust-bloom": 56,
+        "ferrocolonia-magnetotattica x nano-rust-bloom": 35,
+        "ferrocolonia-magnetotattica x sand-burrower": 35,
+        "rust-scavenger x sand-burrower": 35,
+        "dune-stalker x rust-scavenger": 21
       },
       "dominant_lineages": [
         "dune-stalker x nano-rust-bloom"
@@ -102,11 +102,11 @@
     },
     "roster_composition": {
       "role_profile": {
-        "APEX": 48,
-        "HAZARD": 48,
-        "PREDATOR": 28,
-        "PREY": 28,
-        "SUPPORT": 28
+        "APEX": 56,
+        "HAZARD": 56,
+        "PREDATOR": 35,
+        "PREY": 35,
+        "SUPPORT": 35
       },
       "distinct_roles": 5,
       "dominant_roles": [
@@ -123,57 +123,57 @@
     }
   },
   "completion": {
-    "completed": 19,
+    "completed": 21,
     "total": 40
   },
   "personality": {
-    "n_samples": 2027,
+    "n_samples": 2332,
     "per_axis": {
       "symbiosis_predation": {
-        "n": 2027,
-        "mean": 0.9905122528041663,
-        "sd": 0.043377078379978964,
+        "n": 2332,
+        "mean": 0.9905375378653646,
+        "sd": 0.044065921263158926,
         "min": 0.6875,
         "max": 1,
         "neutral_rate": 0
       },
       "explore_caution": {
-        "n": 2027,
-        "mean": 0.6289989738832146,
-        "sd": 0.2065965788443593,
+        "n": 2332,
+        "mean": 0.6238521090099223,
+        "sd": 0.20333265539442125,
         "min": 0.5,
         "max": 1,
-        "neutral_rate": 0.7143561914158856
+        "neutral_rate": 0.7242710120068611
       },
       "solitary_swarm": {
-        "n": 2027,
-        "mean": 0.5775777010360138,
-        "sd": 0.2038582055944827,
+        "n": 2332,
+        "mean": 0.5832975986277873,
+        "sd": 0.20578776126679876,
         "min": 0.25,
         "max": 1,
-        "neutral_rate": 0.7745436605821411
+        "neutral_rate": 0.7722984562607204
       },
       "memory_instinct": {
-        "n": 2027,
-        "mean": 0.5052957968440308,
-        "sd": 0.050280457038331255,
-        "min": 0.43452380952380953,
+        "n": 2332,
+        "mean": 0.5053116887189533,
+        "sd": 0.05057485419508034,
+        "min": 0.44509803921568625,
         "max": 0.875,
-        "neutral_rate": 0.8894918598914652
+        "neutral_rate": 0.8816466552315609
       },
       "agile_robust": {
-        "n": 2027,
-        "mean": 0.4788107606140671,
-        "sd": 0.0748920593235558,
+        "n": 2332,
+        "mean": 0.478533447684396,
+        "sd": 0.0766691430586484,
         "min": 0.13999999999999996,
         "max": 0.7352941176470588,
-        "neutral_rate": 0.6704489393191909
+        "neutral_rate": 0.6608061749571184
       }
     },
     "degenerate_rate": 0,
     "dominant_hist": {
-      "solitary_swarm": 182,
-      "symbiosis_predation": 1845
+      "solitary_swarm": 220,
+      "symbiosis_predation": 2112
     },
     "correlations": [
       {
@@ -181,112 +181,112 @@
           "symbiosis_predation",
           "explore_caution"
         ],
-        "r": -0.2555881737867641
+        "r": -0.2577244262876833
       },
       {
         "pair": [
           "symbiosis_predation",
           "solitary_swarm"
         ],
-        "r": -0.4532329189235751
+        "r": -0.43481824732829444
       },
       {
         "pair": [
           "symbiosis_predation",
           "memory_instinct"
         ],
-        "r": -0.8987706562016802
+        "r": -0.8996215326540373
       },
       {
         "pair": [
           "symbiosis_predation",
           "agile_robust"
         ],
-        "r": -0.04035431379550987
+        "r": -0.04089571222555828
       },
       {
         "pair": [
           "explore_caution",
           "solitary_swarm"
         ],
-        "r": 0.28315430574164085
+        "r": 0.31841757594653275
       },
       {
         "pair": [
           "explore_caution",
           "memory_instinct"
         ],
-        "r": 0.1280407761548312
+        "r": 0.13069624950049405
       },
       {
         "pair": [
           "explore_caution",
           "agile_robust"
         ],
-        "r": 0.01655009692878599
+        "r": 0.02114816156747642
       },
       {
         "pair": [
           "solitary_swarm",
           "memory_instinct"
         ],
-        "r": 0.21824823412508046
+        "r": 0.2126691216492
       },
       {
         "pair": [
           "solitary_swarm",
           "agile_robust"
         ],
-        "r": -0.055219496261028664
+        "r": -0.05384145388797887
       },
       {
         "pair": [
           "memory_instinct",
           "agile_robust"
         ],
-        "r": 0.045833371641085925
+        "r": 0.04431912697293528
       }
     ],
     "by_faction": {
       "player": {
-        "n_samples": 668,
+        "n_samples": 791,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 668,
-            "mean": 0.9964627042425784,
-            "sd": 0.010600795456453364,
-            "min": 0.9547368421052631,
+            "n": 791,
+            "mean": 0.9968080973055559,
+            "sd": 0.01004551357815147,
+            "min": 0.9576923076923077,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 668,
-            "mean": 0.6328166602671036,
-            "sd": 0.21059044749640643,
+            "n": 791,
+            "mean": 0.6207959078459094,
+            "sd": 0.20425902798389955,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7125748502994012
+            "neutral_rate": 0.7383059418457648
           },
           "solitary_swarm": {
-            "n": 668,
-            "mean": 0.6220059880239521,
-            "sd": 0.2597111245742404,
+            "n": 791,
+            "mean": 0.6264222503160556,
+            "sd": 0.2554284840284863,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.5853293413173652
+            "neutral_rate": 0.6030341340075853
           },
           "memory_instinct": {
-            "n": 668,
-            "mean": 0.49694652493915764,
-            "sd": 0.012443178788136246,
-            "min": 0.45942982456140347,
+            "n": 791,
+            "mean": 0.49715869763392795,
+            "sd": 0.012054185472716477,
+            "min": 0.4490254872563718,
             "max": 0.5267857142857143,
-            "neutral_rate": 0.8697604790419161
+            "neutral_rate": 0.8786346396965866
           },
           "agile_robust": {
-            "n": 668,
-            "mean": 0.43570271222261164,
-            "sd": 0.11936435451608825,
+            "n": 791,
+            "mean": 0.43671302149178004,
+            "sd": 0.12117384544525313,
             "min": 0.13999999999999996,
             "max": 0.7352941176470588,
             "neutral_rate": 0
@@ -294,42 +294,42 @@
         }
       },
       "sistema": {
-        "n_samples": 1359,
+        "n_samples": 1541,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 1359,
-            "mean": 0.9875873804267853,
-            "sd": 0.05220380892728114,
+            "n": 1541,
+            "mean": 0.9873188405797111,
+            "sd": 0.0534434130769197,
             "min": 0.6875,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 1359,
-            "mean": 0.6271224363523551,
-            "sd": 0.20457875096766803,
+            "n": 1541,
+            "mean": 0.6254208663887242,
+            "sd": 0.2028376184075644,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7152317880794702
+            "neutral_rate": 0.7170668397144712
           },
           "solitary_swarm": {
-            "n": 1359,
-            "mean": 0.5557395143487859,
-            "sd": 0.16548195224279535,
+            "n": 1541,
+            "mean": 0.5611615833874107,
+            "sd": 0.17073916634417768,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.8675496688741722
+            "neutral_rate": 0.8591823491239455
           },
           "memory_instinct": {
-            "n": 1359,
-            "mean": 0.5093997803852048,
-            "sd": 0.06036206750428068,
-            "min": 0.43452380952380953,
+            "n": 1541,
+            "mean": 0.509496643909255,
+            "sd": 0.061192582421947514,
+            "min": 0.44509803921568625,
             "max": 0.875,
-            "neutral_rate": 0.8991905813097866
+            "neutral_rate": 0.8831927319922128
           },
           "agile_robust": {
-            "n": 1359,
+            "n": 1541,
             "mean": 0.5,
             "sd": 0,
             "min": 0.5,

--- a/reports/sim/stamina-n40-off/summary.json
+++ b/reports/sim/stamina-n40-off/summary.json
@@ -3,14 +3,15 @@
     "runs": 40,
     "branch": "cave_path",
     "policy": "greedy",
-    "commit": "unknown",
+    "commit": "c83d6a68954597ac43b91aeb203a4b2348906c26",
     "flags": {
       "META_NETWORK_ROUTING": "false",
       "IDEA_ENGINE_STUB_ORCHESTRATOR": "1",
       "IDEA_ENGINE_DISABLE_STATUS_REFRESH": "1",
       "A13_WOUND_READ_DISABLED": "0",
       "SENTIENCE_INTEROCEPTION_GRANT_ENABLED": "false",
-      "SIM_GRANT_PARTY_INTEROCEPTION": "0"
+      "SIM_GRANT_PARTY_INTEROCEPTION": "0",
+      "STAMINA_FATIGUE_ENABLED": "false"
     },
     "enemyScaling": {
       "countMult": 5,
@@ -37,7 +38,7 @@
       "note": "completed campaigns / N"
     },
     "roster_attrition": {
-      "value": 0.575,
+      "value": 0.563,
       "range": [
         0,
         1
@@ -46,31 +47,31 @@
       "note": "survivors / units-that-fought (exclusive: real losses, no wipe)"
     },
     "economy_flow": {
-      "pe_earned_avg": 39.4,
-      "build_power_avg": 144.6,
-      "build_power_drift": 1.055,
+      "pe_earned_avg": 39.8,
+      "build_power_avg": 145.2,
+      "build_power_drift": 1.03,
       "pi_sink_exercised": true,
-      "pi_pick_attempts": 378,
-      "pi_insufficient": 331,
+      "pi_pick_attempts": 380,
+      "pi_insufficient": 333,
       "has_signal": true,
       "range": [
         0.5,
         2
       ],
       "in_band": true,
-      "note": "PE earned + build-power drift; PI sink exercised (378 attempts)"
+      "note": "PE earned + build-power drift; PI sink exercised (380 attempts)"
     },
     "relationship_progress": {
-      "recruit_rate": 4.45,
+      "recruit_rate": 4.5,
       "affinity_proven_rate": 1,
-      "reached_step": 28,
-      "mating_rate": 3.75,
+      "reached_step": 29,
+      "mating_rate": 3.775,
       "range": null,
       "in_band": true,
       "note": "recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire"
     },
     "offspring_viability": {
-      "offspring_avg": 3.75,
+      "offspring_avg": 3.775,
       "viable_rate": 1,
       "range": [
         1,
@@ -82,7 +83,7 @@
     "lineage_diversity": {
       "value": 5,
       "lineage_profile": {
-        "dune-stalker x nano-rust-bloom": 47,
+        "dune-stalker x nano-rust-bloom": 48,
         "ferrocolonia-magnetotattica x nano-rust-bloom": 28,
         "ferrocolonia-magnetotattica x sand-burrower": 28,
         "rust-scavenger x sand-burrower": 28,
@@ -101,8 +102,8 @@
     },
     "roster_composition": {
       "role_profile": {
-        "APEX": 47,
-        "HAZARD": 47,
+        "APEX": 48,
+        "HAZARD": 48,
         "PREDATOR": 28,
         "PREY": 28,
         "SUPPORT": 28
@@ -126,53 +127,53 @@
     "total": 40
   },
   "personality": {
-    "n_samples": 2012,
+    "n_samples": 2027,
     "per_axis": {
       "symbiosis_predation": {
-        "n": 2012,
-        "mean": 0.9904433408439862,
-        "sd": 0.04423161163420384,
+        "n": 2027,
+        "mean": 0.9905122528041663,
+        "sd": 0.043377078379978964,
         "min": 0.6875,
         "max": 1,
         "neutral_rate": 0
       },
       "explore_caution": {
-        "n": 2012,
-        "mean": 0.6297707544099472,
-        "sd": 0.20703173488493437,
+        "n": 2027,
+        "mean": 0.6289989738832146,
+        "sd": 0.2065965788443593,
         "min": 0.5,
         "max": 1,
-        "neutral_rate": 0.7127236580516899
+        "neutral_rate": 0.7143561914158856
       },
       "solitary_swarm": {
-        "n": 2012,
-        "mean": 0.577162027833002,
-        "sd": 0.2036668028666504,
+        "n": 2027,
+        "mean": 0.5775777010360138,
+        "sd": 0.2038582055944827,
         "min": 0.25,
         "max": 1,
-        "neutral_rate": 0.7748508946322068
+        "neutral_rate": 0.7745436605821411
       },
       "memory_instinct": {
-        "n": 2012,
-        "mean": 0.505409959135305,
-        "sd": 0.05025345400138734,
-        "min": 0.4419642857142857,
+        "n": 2027,
+        "mean": 0.5052957968440308,
+        "sd": 0.050280457038331255,
+        "min": 0.43452380952380953,
         "max": 0.875,
-        "neutral_rate": 0.8846918489065606
+        "neutral_rate": 0.8894918598914652
       },
       "agile_robust": {
-        "n": 2012,
-        "mean": 0.4790141503917709,
-        "sd": 0.07486453023998312,
+        "n": 2027,
+        "mean": 0.4788107606140671,
+        "sd": 0.0748920593235558,
         "min": 0.13999999999999996,
         "max": 0.7352941176470588,
-        "neutral_rate": 0.6699801192842942
+        "neutral_rate": 0.6704489393191909
       }
     },
     "degenerate_rate": 0,
     "dominant_hist": {
-      "solitary_swarm": 189,
-      "symbiosis_predation": 1823
+      "solitary_swarm": 182,
+      "symbiosis_predation": 1845
     },
     "correlations": [
       {
@@ -180,112 +181,112 @@
           "symbiosis_predation",
           "explore_caution"
         ],
-        "r": -0.2471191491325013
+        "r": -0.2555881737867641
       },
       {
         "pair": [
           "symbiosis_predation",
           "solitary_swarm"
         ],
-        "r": -0.4485667399292049
+        "r": -0.4532329189235751
       },
       {
         "pair": [
           "symbiosis_predation",
           "memory_instinct"
         ],
-        "r": -0.9011917430705041
+        "r": -0.8987706562016802
       },
       {
         "pair": [
           "symbiosis_predation",
           "agile_robust"
         ],
-        "r": -0.040835777165656575
+        "r": -0.04035431379550987
       },
       {
         "pair": [
           "explore_caution",
           "solitary_swarm"
         ],
-        "r": 0.27841599718777227
+        "r": 0.28315430574164085
       },
       {
         "pair": [
           "explore_caution",
           "memory_instinct"
         ],
-        "r": 0.12677816283519125
+        "r": 0.1280407761548312
       },
       {
         "pair": [
           "explore_caution",
           "agile_robust"
         ],
-        "r": 0.015271445813140293
+        "r": 0.01655009692878599
       },
       {
         "pair": [
           "solitary_swarm",
           "memory_instinct"
         ],
-        "r": 0.22350220041032612
+        "r": 0.21824823412508046
       },
       {
         "pair": [
           "solitary_swarm",
           "agile_robust"
         ],
-        "r": -0.05615881020109161
+        "r": -0.055219496261028664
       },
       {
         "pair": [
           "memory_instinct",
           "agile_robust"
         ],
-        "r": 0.04605528803933993
+        "r": 0.045833371641085925
       }
     ],
     "by_faction": {
       "player": {
-        "n_samples": 664,
+        "n_samples": 668,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 664,
-            "mean": 0.9967006086732675,
-            "sd": 0.010097311335783789,
+            "n": 668,
+            "mean": 0.9964627042425784,
+            "sd": 0.010600795456453364,
             "min": 0.9547368421052631,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 664,
-            "mean": 0.6331553498740863,
-            "sd": 0.21094480532121496,
+            "n": 668,
+            "mean": 0.6328166602671036,
+            "sd": 0.21059044749640643,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7123493975903614
+            "neutral_rate": 0.7125748502994012
           },
           "solitary_swarm": {
-            "n": 664,
-            "mean": 0.6212349397590361,
-            "sd": 0.25957735385552333,
+            "n": 668,
+            "mean": 0.6220059880239521,
+            "sd": 0.2597111245742404,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.5858433734939759
+            "neutral_rate": 0.5853293413173652
           },
           "memory_instinct": {
-            "n": 664,
-            "mean": 0.49698317809267556,
-            "sd": 0.012380297118434391,
-            "min": 0.4490254872563718,
+            "n": 668,
+            "mean": 0.49694652493915764,
+            "sd": 0.012443178788136246,
+            "min": 0.45942982456140347,
             "max": 0.5267857142857143,
-            "neutral_rate": 0.8689759036144579
+            "neutral_rate": 0.8697604790419161
           },
           "agile_robust": {
-            "n": 664,
-            "mean": 0.4364103472714367,
-            "sd": 0.11947279531453815,
+            "n": 668,
+            "mean": 0.43570271222261164,
+            "sd": 0.11936435451608825,
             "min": 0.13999999999999996,
             "max": 0.7352941176470588,
             "neutral_rate": 0
@@ -293,42 +294,42 @@
         }
       },
       "sistema": {
-        "n_samples": 1348,
+        "n_samples": 1359,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 1348,
-            "mean": 0.9873611258301551,
-            "sd": 0.05330226815959447,
+            "n": 1359,
+            "mean": 0.9875873804267853,
+            "sd": 0.05220380892728114,
             "min": 0.6875,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 1348,
-            "mean": 0.6281035649528339,
-            "sd": 0.20505624707973844,
+            "n": 1359,
+            "mean": 0.6271224363523551,
+            "sd": 0.20457875096766803,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7129080118694362
+            "neutral_rate": 0.7152317880794702
           },
           "solitary_swarm": {
-            "n": 1348,
-            "mean": 0.5554525222551929,
-            "sd": 0.16520920996553445,
+            "n": 1359,
+            "mean": 0.5557395143487859,
+            "sd": 0.16548195224279535,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.8679525222551929
+            "neutral_rate": 0.8675496688741722
           },
           "memory_instinct": {
-            "n": 1348,
-            "mean": 0.5095608364441376,
-            "sd": 0.0603462741314609,
-            "min": 0.4419642857142857,
+            "n": 1359,
+            "mean": 0.5093997803852048,
+            "sd": 0.06036206750428068,
+            "min": 0.43452380952380953,
             "max": 0.875,
-            "neutral_rate": 0.892433234421365
+            "neutral_rate": 0.8991905813097866
           },
           "agile_robust": {
-            "n": 1348,
+            "n": 1359,
             "mean": 0.5,
             "sd": 0,
             "min": 0.5,

--- a/reports/sim/stamina-n40-on/report.md
+++ b/reports/sim/stamina-n40-on/report.md
@@ -1,16 +1,16 @@
 # Full-loop meta band-metrics
 
-Runs: **40** | Completed: **24/40** | Policy: `greedy` | Branch: `cave_path`
+Runs: **40** | Completed: **23/40** | Policy: `greedy` | Branch: `cave_path`
 
 > **RATIFIED (master-dd, L-069)** -- RATIFIED 2026-06-03 by master-dd (L-069): the working bands. Reversible (two-way door) -- revise when evidence warrants. Keep the design space healthy (Quality-Diversity); do not optimize to a single best run. GRAPH-MODE RE-RATIFIED 2026-06-04 by master-dd (#2603): with the real draft rosters + the cm3/hp2/dcAdd1 overlay, graph-mode completion lands ~0.66 (N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60), inside this 0.4-0.7 band -- the fallback-era wider 0.4-0.85 is superseded; completion_rate [0.4, 0.7] holds for both static and graph mode.
 
 | Metric | Value | Band | In band |
 |---|---|---|:---:|
-| completion_rate | 0.6 | 0.4 - 0.7 | ✅ |
-| roster_attrition | 0.511 | 0 - 1 | ✅ |
-| economy_flow | drift 1.095 (pe 46.8, bp 171.9) | 0.5 - 2 | ✅ |
-| relationship_progress | recruit 5.25, aff 1, mate 4.425 | composite | ✅ |
-| offspring_viability | offspring 4.425 | >= 1 | ✅ |
+| completion_rate | 0.575 | 0.4 - 0.7 | ✅ |
+| roster_attrition | 0.502 | 0 - 1 | ✅ |
+| economy_flow | drift 1.08 (pe 46.8, bp 171) | 0.5 - 2 | ✅ |
+| relationship_progress | recruit 5.275, aff 1, mate 4.45 | composite | ✅ |
+| offspring_viability | offspring 4.45 | >= 1 | ✅ |
 | lineage_diversity | 5 crosses, dominant dune-stalker x nano-rust-bloom | >= 3 | ✅ |
 | roster_composition | dominant APEX/HAZARD, 5 roles | >= 3 | ✅ |
 
@@ -18,20 +18,20 @@ Runs: **40** | Completed: **24/40** | Policy: `greedy` | Branch: `cave_path`
 
 ## Personality axes (Opt 3 OUTPUT) -- N-sample evidence
 
-2298 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
+2296 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
 
 | axis | n | mean | sd | min | max | neutral_rate |
 | --- | --- | --- | --- | --- | --- | --- |
-| symbiosis_predation | 2298 | 0.991 | 0.044 | 0.700 | 1.000 | 0.000 |
-| explore_caution | 2298 | 0.633 | 0.209 | 0.500 | 1.000 | 0.708 |
-| solitary_swarm | 2298 | 0.577 | 0.205 | 0.250 | 1.000 | 0.768 |
-| memory_instinct | 2298 | 0.506 | 0.051 | 0.419 | 0.875 | 0.884 |
-| agile_robust | 2298 | 0.478 | 0.076 | 0.140 | 0.735 | 0.666 |
+| symbiosis_predation | 2296 | 0.991 | 0.043 | 0.688 | 1.000 | 0.000 |
+| explore_caution | 2296 | 0.628 | 0.206 | 0.500 | 1.000 | 0.716 |
+| solitary_swarm | 2296 | 0.578 | 0.206 | 0.250 | 1.000 | 0.769 |
+| memory_instinct | 2296 | 0.505 | 0.049 | 0.435 | 0.875 | 0.885 |
+| agile_robust | 2296 | 0.478 | 0.076 | 0.140 | 0.735 | 0.665 |
 
 Degenerate (all-5 neutral) rate: 0.000.
-Dominant-axis histogram: symbiosis_predation 2089, solitary_swarm 209.
-Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.92.
-Faction player (767): symbiosis_predation 1.00, explore_caution 0.64, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
-Faction sistema (1531): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
+Dominant-axis histogram: symbiosis_predation 2083, solitary_swarm 213.
+Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.89.
+Faction player (769): symbiosis_predation 1.00, explore_caution 0.63, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
+Faction sistema (1527): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
 
 Per-run records: `runs.jsonl`. Aggregate: `summary.json`.

--- a/reports/sim/stamina-n40-on/report.md
+++ b/reports/sim/stamina-n40-on/report.md
@@ -1,16 +1,16 @@
 # Full-loop meta band-metrics
 
-Runs: **40** | Completed: **23/40** | Policy: `greedy` | Branch: `cave_path`
+Runs: **40** | Completed: **24/40** | Policy: `greedy` | Branch: `cave_path`
 
 > **RATIFIED (master-dd, L-069)** -- RATIFIED 2026-06-03 by master-dd (L-069): the working bands. Reversible (two-way door) -- revise when evidence warrants. Keep the design space healthy (Quality-Diversity); do not optimize to a single best run. GRAPH-MODE RE-RATIFIED 2026-06-04 by master-dd (#2603): with the real draft rosters + the cm3/hp2/dcAdd1 overlay, graph-mode completion lands ~0.66 (N=40 greedy 0.675 / ESFP 0.70 / INTJ 0.60), inside this 0.4-0.7 band -- the fallback-era wider 0.4-0.85 is superseded; completion_rate [0.4, 0.7] holds for both static and graph mode.
 
 | Metric | Value | Band | In band |
 |---|---|---|:---:|
-| completion_rate | 0.575 | 0.4 - 0.7 | ✅ |
-| roster_attrition | 0.502 | 0 - 1 | ✅ |
-| economy_flow | drift 1.08 (pe 46.8, bp 171) | 0.5 - 2 | ✅ |
-| relationship_progress | recruit 5.275, aff 1, mate 4.45 | composite | ✅ |
-| offspring_viability | offspring 4.45 | >= 1 | ✅ |
+| completion_rate | 0.6 | 0.4 - 0.7 | ✅ |
+| roster_attrition | 0.511 | 0 - 1 | ✅ |
+| economy_flow | drift 1.095 (pe 46.8, bp 171.9) | 0.5 - 2 | ✅ |
+| relationship_progress | recruit 5.25, aff 1, mate 4.425 | composite | ✅ |
+| offspring_viability | offspring 4.425 | >= 1 | ✅ |
 | lineage_diversity | 5 crosses, dominant dune-stalker x nano-rust-bloom | >= 3 | ✅ |
 | roster_composition | dominant APEX/HAZARD, 5 roles | >= 3 | ✅ |
 
@@ -18,20 +18,20 @@ Runs: **40** | Completed: **23/40** | Policy: `greedy` | Branch: `cave_path`
 
 ## Personality axes (Opt 3 OUTPUT) -- N-sample evidence
 
-2296 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
+2298 per-unit samples. Constants are PROPOSED (blend weights + stat bounds, #2679): this section is EVIDENCE for the N=40 ratification batch (incl. the J_P + formPulseVc E_I flags); master-dd ratifies, the batch never does.
 
 | axis | n | mean | sd | min | max | neutral_rate |
 | --- | --- | --- | --- | --- | --- | --- |
-| symbiosis_predation | 2296 | 0.990 | 0.044 | 0.688 | 1.000 | 0.000 |
-| explore_caution | 2296 | 0.626 | 0.204 | 0.500 | 1.000 | 0.721 |
-| solitary_swarm | 2296 | 0.578 | 0.206 | 0.250 | 1.000 | 0.769 |
-| memory_instinct | 2296 | 0.506 | 0.051 | 0.438 | 0.875 | 0.883 |
-| agile_robust | 2296 | 0.478 | 0.076 | 0.140 | 0.735 | 0.665 |
+| symbiosis_predation | 2298 | 0.991 | 0.044 | 0.700 | 1.000 | 0.000 |
+| explore_caution | 2298 | 0.633 | 0.209 | 0.500 | 1.000 | 0.708 |
+| solitary_swarm | 2298 | 0.577 | 0.205 | 0.250 | 1.000 | 0.768 |
+| memory_instinct | 2298 | 0.506 | 0.051 | 0.419 | 0.875 | 0.884 |
+| agile_robust | 2298 | 0.478 | 0.076 | 0.140 | 0.735 | 0.666 |
 
 Degenerate (all-5 neutral) rate: 0.000.
-Dominant-axis histogram: symbiosis_predation 2084, solitary_swarm 212.
-Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.90.
-Faction player (769): symbiosis_predation 1.00, explore_caution 0.63, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
-Faction sistema (1527): symbiosis_predation 0.99, explore_caution 0.62, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
+Dominant-axis histogram: symbiosis_predation 2089, solitary_swarm 209.
+Collinearity (|r| >= 0.8): symbiosis_predation~memory_instinct r=-0.92.
+Faction player (767): symbiosis_predation 1.00, explore_caution 0.64, solitary_swarm 0.62, memory_instinct 0.50, agile_robust 0.44.
+Faction sistema (1531): symbiosis_predation 0.99, explore_caution 0.63, solitary_swarm 0.56, memory_instinct 0.51, agile_robust 0.50.
 
 Per-run records: `runs.jsonl`. Aggregate: `summary.json`.

--- a/reports/sim/stamina-n40-on/summary.json
+++ b/reports/sim/stamina-n40-on/summary.json
@@ -3,14 +3,15 @@
     "runs": 40,
     "branch": "cave_path",
     "policy": "greedy",
-    "commit": "unknown",
+    "commit": "c83d6a68954597ac43b91aeb203a4b2348906c26",
     "flags": {
       "META_NETWORK_ROUTING": "false",
       "IDEA_ENGINE_STUB_ORCHESTRATOR": "1",
       "IDEA_ENGINE_DISABLE_STATUS_REFRESH": "1",
       "A13_WOUND_READ_DISABLED": "0",
       "SENTIENCE_INTEROCEPTION_GRANT_ENABLED": "false",
-      "SIM_GRANT_PARTY_INTEROCEPTION": "0"
+      "SIM_GRANT_PARTY_INTEROCEPTION": "0",
+      "STAMINA_FATIGUE_ENABLED": "true"
     },
     "enemyScaling": {
       "countMult": 5,
@@ -28,7 +29,7 @@
   "provisional": false,
   "metrics": {
     "completion_rate": {
-      "value": 0.575,
+      "value": 0.6,
       "range": [
         0.4,
         0.7
@@ -37,7 +38,7 @@
       "note": "completed campaigns / N"
     },
     "roster_attrition": {
-      "value": 0.502,
+      "value": 0.511,
       "range": [
         0,
         1
@@ -47,8 +48,8 @@
     },
     "economy_flow": {
       "pe_earned_avg": 46.8,
-      "build_power_avg": 171,
-      "build_power_drift": 1.08,
+      "build_power_avg": 171.9,
+      "build_power_drift": 1.095,
       "pi_sink_exercised": true,
       "pi_pick_attempts": 445,
       "pi_insufficient": 389,
@@ -61,16 +62,16 @@
       "note": "PE earned + build-power drift; PI sink exercised (445 attempts)"
     },
     "relationship_progress": {
-      "recruit_rate": 5.275,
+      "recruit_rate": 5.25,
       "affinity_proven_rate": 1,
       "reached_step": 33,
-      "mating_rate": 4.45,
+      "mating_rate": 4.425,
       "range": null,
       "in_band": true,
       "note": "recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire"
     },
     "offspring_viability": {
-      "offspring_avg": 4.45,
+      "offspring_avg": 4.425,
       "viable_rate": 1,
       "range": [
         1,
@@ -82,11 +83,11 @@
     "lineage_diversity": {
       "value": 5,
       "lineage_profile": {
-        "dune-stalker x nano-rust-bloom": 56,
-        "ferrocolonia-magnetotattica x nano-rust-bloom": 33,
-        "ferrocolonia-magnetotattica x sand-burrower": 33,
-        "rust-scavenger x sand-burrower": 33,
-        "dune-stalker x rust-scavenger": 23
+        "dune-stalker x nano-rust-bloom": 57,
+        "ferrocolonia-magnetotattica x nano-rust-bloom": 32,
+        "ferrocolonia-magnetotattica x sand-burrower": 32,
+        "rust-scavenger x sand-burrower": 32,
+        "dune-stalker x rust-scavenger": 24
       },
       "dominant_lineages": [
         "dune-stalker x nano-rust-bloom"
@@ -101,11 +102,11 @@
     },
     "roster_composition": {
       "role_profile": {
-        "APEX": 56,
-        "HAZARD": 56,
-        "PREDATOR": 33,
-        "PREY": 33,
-        "SUPPORT": 33
+        "APEX": 57,
+        "HAZARD": 57,
+        "PREDATOR": 32,
+        "PREY": 32,
+        "SUPPORT": 32
       },
       "distinct_roles": 5,
       "dominant_roles": [
@@ -122,57 +123,57 @@
     }
   },
   "completion": {
-    "completed": 23,
+    "completed": 24,
     "total": 40
   },
   "personality": {
-    "n_samples": 2296,
+    "n_samples": 2298,
     "per_axis": {
       "symbiosis_predation": {
-        "n": 2296,
-        "mean": 0.9904516294787299,
-        "sd": 0.04400924091807938,
-        "min": 0.6875,
+        "n": 2298,
+        "mean": 0.9907915466593246,
+        "sd": 0.04363005201411014,
+        "min": 0.7,
         "max": 1,
         "neutral_rate": 0
       },
       "explore_caution": {
-        "n": 2296,
-        "mean": 0.6256171835670208,
-        "sd": 0.2044452836436191,
+        "n": 2298,
+        "mean": 0.6327273864853039,
+        "sd": 0.20883041266900826,
         "min": 0.5,
         "max": 1,
-        "neutral_rate": 0.7208188153310104
+        "neutral_rate": 0.7075718015665796
       },
       "solitary_swarm": {
-        "n": 2296,
-        "mean": 0.5780705574912892,
-        "sd": 0.20574644480830354,
+        "n": 2298,
+        "mean": 0.5765883376849434,
+        "sd": 0.2054738866341239,
         "min": 0.25,
         "max": 1,
-        "neutral_rate": 0.7687282229965157
+        "neutral_rate": 0.7684943429068756
       },
       "memory_instinct": {
-        "n": 2296,
-        "mean": 0.5055274010921711,
-        "sd": 0.05054026279666187,
-        "min": 0.43846153846153846,
+        "n": 2298,
+        "mean": 0.5056300538905275,
+        "sd": 0.05103870818522043,
+        "min": 0.4191919191919192,
         "max": 0.875,
-        "neutral_rate": 0.8832752613240418
+        "neutral_rate": 0.8842471714534378
       },
       "agile_robust": {
-        "n": 2296,
-        "mean": 0.4784622873539709,
-        "sd": 0.076060160060366,
+        "n": 2298,
+        "mean": 0.4784277888701221,
+        "sd": 0.075776834800785,
         "min": 0.13999999999999996,
         "max": 0.7352941176470588,
-        "neutral_rate": 0.6650696864111498
+        "neutral_rate": 0.6662315056570931
       }
     },
     "degenerate_rate": 0,
     "dominant_hist": {
-      "solitary_swarm": 212,
-      "symbiosis_predation": 2084
+      "solitary_swarm": 209,
+      "symbiosis_predation": 2089
     },
     "correlations": [
       {
@@ -180,112 +181,112 @@
           "symbiosis_predation",
           "explore_caution"
         ],
-        "r": -0.2575920255398028
+        "r": -0.2438485305753847
       },
       {
         "pair": [
           "symbiosis_predation",
           "solitary_swarm"
         ],
-        "r": -0.44493121719736994
+        "r": -0.4349177585794566
       },
       {
         "pair": [
           "symbiosis_predation",
           "memory_instinct"
         ],
-        "r": -0.9026685440951846
+        "r": -0.9170156120847894
       },
       {
         "pair": [
           "symbiosis_predation",
           "agile_robust"
         ],
-        "r": -0.04197874642288168
+        "r": -0.040333616134238595
       },
       {
         "pair": [
           "explore_caution",
           "solitary_swarm"
         ],
-        "r": 0.28618265574610885
+        "r": 0.26645360934186124
       },
       {
         "pair": [
           "explore_caution",
           "memory_instinct"
         ],
-        "r": 0.1344686180728351
+        "r": 0.12993894996658156
       },
       {
         "pair": [
           "explore_caution",
           "agile_robust"
         ],
-        "r": 0.011666061765849637
+        "r": 0.018714287953090825
       },
       {
         "pair": [
           "solitary_swarm",
           "memory_instinct"
         ],
-        "r": 0.2242802215451112
+        "r": 0.2273102702440944
       },
       {
         "pair": [
           "solitary_swarm",
           "agile_robust"
         ],
-        "r": -0.04959628903206619
+        "r": -0.04845913801711193
       },
       {
         "pair": [
           "memory_instinct",
           "agile_robust"
         ],
-        "r": 0.04528641222495755
+        "r": 0.04527484972623987
       }
     ],
     "by_faction": {
       "player": {
-        "n_samples": 769,
+        "n_samples": 767,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 769,
-            "mean": 0.9967589025293447,
-            "sd": 0.010207165025793429,
-            "min": 0.9398148148148148,
+            "n": 767,
+            "mean": 0.9967393654116622,
+            "sd": 0.01033449651830711,
+            "min": 0.9467084639498432,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 769,
-            "mean": 0.6335202187001651,
-            "sd": 0.21165017238158015,
+            "n": 767,
+            "mean": 0.6364694388768474,
+            "sd": 0.21323328506908074,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7126137841352406
+            "neutral_rate": 0.7066492829204694
           },
           "solitary_swarm": {
-            "n": 769,
-            "mean": 0.618335500650195,
-            "sd": 0.2599926713002125,
+            "n": 767,
+            "mean": 0.6160365058670143,
+            "sd": 0.26080996837936266,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.5838751625487646
+            "neutral_rate": 0.5801825293350718
           },
           "memory_instinct": {
-            "n": 769,
-            "mean": 0.49726122418920443,
-            "sd": 0.01213036422233031,
-            "min": 0.4519230769230769,
+            "n": 767,
+            "mean": 0.49732099172584354,
+            "sd": 0.012176884563520866,
+            "min": 0.45292207792207795,
             "max": 0.5267857142857143,
-            "neutral_rate": 0.8751625487646294
+            "neutral_rate": 0.8748370273794003
           },
           "agile_robust": {
-            "n": 769,
-            "mean": 0.4356949437772484,
-            "sd": 0.12050948083297235,
+            "n": 767,
+            "mean": 0.4353677429250684,
+            "sd": 0.12008687973229,
             "min": 0.13999999999999996,
             "max": 0.7352941176470588,
             "neutral_rate": 0
@@ -293,42 +294,42 @@
         }
       },
       "sistema": {
-        "n_samples": 1527,
+        "n_samples": 1531,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 1527,
-            "mean": 0.9872752752050409,
-            "sd": 0.053194024833876724,
-            "min": 0.6875,
+            "n": 1531,
+            "mean": 0.9878118098970495,
+            "sd": 0.05269848082899506,
+            "min": 0.7,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 1527,
-            "mean": 0.6216372005824833,
-            "sd": 0.20060114916730246,
+            "n": 1531,
+            "mean": 0.6308526940069795,
+            "sd": 0.20656389959938642,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.724950884086444
+            "neutral_rate": 0.7080339647289353
           },
           "solitary_swarm": {
-            "n": 1527,
-            "mean": 0.5577930582842174,
-            "sd": 0.16846559466471359,
+            "n": 1531,
+            "mean": 0.5568256041802744,
+            "sd": 0.1676988616190333,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.8618205631958088
+            "neutral_rate": 0.8628347485303723
           },
           "memory_instinct": {
-            "n": 1527,
-            "mean": 0.5096902629378698,
-            "sd": 0.060949440036320655,
-            "min": 0.43846153846153846,
+            "n": 1531,
+            "mean": 0.5097927257914511,
+            "sd": 0.061512417722215613,
+            "min": 0.4191919191919192,
             "max": 0.875,
-            "neutral_rate": 0.8873608382449247
+            "neutral_rate": 0.8889614630960156
           },
           "agile_robust": {
-            "n": 1527,
+            "n": 1531,
             "mean": 0.5,
             "sd": 0,
             "min": 0.5,

--- a/reports/sim/stamina-n40-on/summary.json
+++ b/reports/sim/stamina-n40-on/summary.json
@@ -3,7 +3,7 @@
     "runs": 40,
     "branch": "cave_path",
     "policy": "greedy",
-    "commit": "c83d6a68954597ac43b91aeb203a4b2348906c26",
+    "commit": "8ba18a630c219b238ebc0cbf5096aa2a0e682e3a",
     "flags": {
       "META_NETWORK_ROUTING": "false",
       "IDEA_ENGINE_STUB_ORCHESTRATOR": "1",
@@ -29,7 +29,7 @@
   "provisional": false,
   "metrics": {
     "completion_rate": {
-      "value": 0.6,
+      "value": 0.575,
       "range": [
         0.4,
         0.7
@@ -38,7 +38,7 @@
       "note": "completed campaigns / N"
     },
     "roster_attrition": {
-      "value": 0.511,
+      "value": 0.502,
       "range": [
         0,
         1
@@ -48,8 +48,8 @@
     },
     "economy_flow": {
       "pe_earned_avg": 46.8,
-      "build_power_avg": 171.9,
-      "build_power_drift": 1.095,
+      "build_power_avg": 171,
+      "build_power_drift": 1.08,
       "pi_sink_exercised": true,
       "pi_pick_attempts": 445,
       "pi_insufficient": 389,
@@ -62,16 +62,16 @@
       "note": "PE earned + build-power drift; PI sink exercised (445 attempts)"
     },
     "relationship_progress": {
-      "recruit_rate": 5.25,
+      "recruit_rate": 5.275,
       "affinity_proven_rate": 1,
       "reached_step": 33,
-      "mating_rate": 4.425,
+      "mating_rate": 4.45,
       "range": null,
       "in_band": true,
       "note": "recruit + earned-affinity gate (proven among runs that REACHED the step, decoupled from completion) + mating all fire"
     },
     "offspring_viability": {
-      "offspring_avg": 4.425,
+      "offspring_avg": 4.45,
       "viable_rate": 1,
       "range": [
         1,
@@ -83,11 +83,11 @@
     "lineage_diversity": {
       "value": 5,
       "lineage_profile": {
-        "dune-stalker x nano-rust-bloom": 57,
-        "ferrocolonia-magnetotattica x nano-rust-bloom": 32,
-        "ferrocolonia-magnetotattica x sand-burrower": 32,
-        "rust-scavenger x sand-burrower": 32,
-        "dune-stalker x rust-scavenger": 24
+        "dune-stalker x nano-rust-bloom": 56,
+        "ferrocolonia-magnetotattica x nano-rust-bloom": 33,
+        "ferrocolonia-magnetotattica x sand-burrower": 33,
+        "rust-scavenger x sand-burrower": 33,
+        "dune-stalker x rust-scavenger": 23
       },
       "dominant_lineages": [
         "dune-stalker x nano-rust-bloom"
@@ -102,11 +102,11 @@
     },
     "roster_composition": {
       "role_profile": {
-        "APEX": 57,
-        "HAZARD": 57,
-        "PREDATOR": 32,
-        "PREY": 32,
-        "SUPPORT": 32
+        "APEX": 56,
+        "HAZARD": 56,
+        "PREDATOR": 33,
+        "PREY": 33,
+        "SUPPORT": 33
       },
       "distinct_roles": 5,
       "dominant_roles": [
@@ -123,57 +123,57 @@
     }
   },
   "completion": {
-    "completed": 24,
+    "completed": 23,
     "total": 40
   },
   "personality": {
-    "n_samples": 2298,
+    "n_samples": 2296,
     "per_axis": {
       "symbiosis_predation": {
-        "n": 2298,
-        "mean": 0.9907915466593246,
-        "sd": 0.04363005201411014,
-        "min": 0.7,
+        "n": 2296,
+        "mean": 0.9907830773077418,
+        "sd": 0.043263968027193504,
+        "min": 0.6875,
         "max": 1,
         "neutral_rate": 0
       },
       "explore_caution": {
-        "n": 2298,
-        "mean": 0.6327273864853039,
-        "sd": 0.20883041266900826,
+        "n": 2296,
+        "mean": 0.6279260661521172,
+        "sd": 0.20596811875010482,
         "min": 0.5,
         "max": 1,
-        "neutral_rate": 0.7075718015665796
+        "neutral_rate": 0.7164634146341463
       },
       "solitary_swarm": {
-        "n": 2298,
-        "mean": 0.5765883376849434,
-        "sd": 0.2054738866341239,
+        "n": 2296,
+        "mean": 0.5780705574912892,
+        "sd": 0.20574644480830365,
         "min": 0.25,
         "max": 1,
-        "neutral_rate": 0.7684943429068756
+        "neutral_rate": 0.7687282229965157
       },
       "memory_instinct": {
-        "n": 2298,
-        "mean": 0.5056300538905275,
-        "sd": 0.05103870818522043,
-        "min": 0.4191919191919192,
+        "n": 2296,
+        "mean": 0.5051818614635066,
+        "sd": 0.04941002630371331,
+        "min": 0.43452380952380953,
         "max": 0.875,
-        "neutral_rate": 0.8842471714534378
+        "neutral_rate": 0.8850174216027874
       },
       "agile_robust": {
-        "n": 2298,
-        "mean": 0.4784277888701221,
-        "sd": 0.075776834800785,
+        "n": 2296,
+        "mean": 0.4784622873539708,
+        "sd": 0.076060160060366,
         "min": 0.13999999999999996,
         "max": 0.7352941176470588,
-        "neutral_rate": 0.6662315056570931
+        "neutral_rate": 0.6650696864111498
       }
     },
     "degenerate_rate": 0,
     "dominant_hist": {
-      "solitary_swarm": 209,
-      "symbiosis_predation": 2089
+      "solitary_swarm": 213,
+      "symbiosis_predation": 2083
     },
     "correlations": [
       {
@@ -181,112 +181,112 @@
           "symbiosis_predation",
           "explore_caution"
         ],
-        "r": -0.2438485305753847
+        "r": -0.2472264038772619
       },
       {
         "pair": [
           "symbiosis_predation",
           "solitary_swarm"
         ],
-        "r": -0.4349177585794566
+        "r": -0.4368849538883824
       },
       {
         "pair": [
           "symbiosis_predation",
           "memory_instinct"
         ],
-        "r": -0.9170156120847894
+        "r": -0.8931069588543612
       },
       {
         "pair": [
           "symbiosis_predation",
           "agile_robust"
         ],
-        "r": -0.040333616134238595
+        "r": -0.04094607441999364
       },
       {
         "pair": [
           "explore_caution",
           "solitary_swarm"
         ],
-        "r": 0.26645360934186124
+        "r": 0.2813609416124165
       },
       {
         "pair": [
           "explore_caution",
           "memory_instinct"
         ],
-        "r": 0.12993894996658156
+        "r": 0.1279191542598122
       },
       {
         "pair": [
           "explore_caution",
           "agile_robust"
         ],
-        "r": 0.018714287953090825
+        "r": 0.01465009934202335
       },
       {
         "pair": [
           "solitary_swarm",
           "memory_instinct"
         ],
-        "r": 0.2273102702440944
+        "r": 0.21506919280679068
       },
       {
         "pair": [
           "solitary_swarm",
           "agile_robust"
         ],
-        "r": -0.04845913801711193
+        "r": -0.049596289032067004
       },
       {
         "pair": [
           "memory_instinct",
           "agile_robust"
         ],
-        "r": 0.04527484972623987
+        "r": 0.04403206164250449
       }
     ],
     "by_faction": {
       "player": {
-        "n_samples": 767,
+        "n_samples": 769,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 767,
-            "mean": 0.9967393654116622,
-            "sd": 0.01033449651830711,
-            "min": 0.9467084639498432,
+            "n": 769,
+            "mean": 0.9968266211821182,
+            "sd": 0.01007787304975646,
+            "min": 0.9513888888888888,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 767,
-            "mean": 0.6364694388768474,
-            "sd": 0.21323328506908074,
+            "n": 769,
+            "mean": 0.6336012786638234,
+            "sd": 0.21176820057431248,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7066492829204694
+            "neutral_rate": 0.7126137841352406
           },
           "solitary_swarm": {
-            "n": 767,
-            "mean": 0.6160365058670143,
-            "sd": 0.26080996837936266,
+            "n": 769,
+            "mean": 0.618335500650195,
+            "sd": 0.25999267130021253,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.5801825293350718
+            "neutral_rate": 0.5838751625487646
           },
           "memory_instinct": {
-            "n": 767,
-            "mean": 0.49732099172584354,
-            "sd": 0.012176884563520866,
-            "min": 0.45292207792207795,
+            "n": 769,
+            "mean": 0.49731919521695106,
+            "sd": 0.012025457736058676,
+            "min": 0.4490254872563718,
             "max": 0.5267857142857143,
-            "neutral_rate": 0.8748370273794003
+            "neutral_rate": 0.8751625487646294
           },
           "agile_robust": {
-            "n": 767,
-            "mean": 0.4353677429250684,
-            "sd": 0.12008687973229,
+            "n": 769,
+            "mean": 0.4356949437772484,
+            "sd": 0.12050948083297235,
             "min": 0.13999999999999996,
             "max": 0.7352941176470588,
             "neutral_rate": 0
@@ -294,42 +294,42 @@
         }
       },
       "sistema": {
-        "n_samples": 1531,
+        "n_samples": 1527,
         "per_axis": {
           "symbiosis_predation": {
-            "n": 1531,
-            "mean": 0.9878118098970495,
-            "sd": 0.05269848082899506,
-            "min": 0.7,
+            "n": 1527,
+            "mean": 0.987739537530796,
+            "sd": 0.052302903587176146,
+            "min": 0.6875,
             "max": 1,
             "neutral_rate": 0
           },
           "explore_caution": {
-            "n": 1531,
-            "mean": 0.6308526940069795,
-            "sd": 0.20656389959938642,
+            "n": 1527,
+            "mean": 0.6250680187248072,
+            "sd": 0.20292436562213498,
             "min": 0.5,
             "max": 1,
-            "neutral_rate": 0.7080339647289353
+            "neutral_rate": 0.7184020956123117
           },
           "solitary_swarm": {
-            "n": 1531,
-            "mean": 0.5568256041802744,
-            "sd": 0.1676988616190333,
+            "n": 1527,
+            "mean": 0.5577930582842174,
+            "sd": 0.16846559466471359,
             "min": 0.25,
             "max": 1,
-            "neutral_rate": 0.8628347485303723
+            "neutral_rate": 0.8618205631958088
           },
           "memory_instinct": {
-            "n": 1531,
-            "mean": 0.5097927257914511,
-            "sd": 0.061512417722215613,
-            "min": 0.4191919191919192,
+            "n": 1527,
+            "mean": 0.5091415146027354,
+            "sd": 0.05959178148140131,
+            "min": 0.43452380952380953,
             "max": 0.875,
-            "neutral_rate": 0.8889614630960156
+            "neutral_rate": 0.8899803536345776
           },
           "agile_robust": {
-            "n": 1531,
+            "n": 1527,
             "mean": 0.5,
             "sd": 0,
             "min": 0.5,

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -432,6 +432,10 @@ function currentFlags() {
     SENTIENCE_INTEROCEPTION_GRANT_ENABLED:
       process.env.SENTIENCE_INTEROCEPTION_GRANT_ENABLED || 'false',
     SIM_GRANT_PARTY_INTEROCEPTION: process.env.SIM_GRANT_PARTY_INTEROCEPTION || '0',
+    // OD-024 engine #2 (sprint stamina/fatica) flip arm: the A/B discriminator for
+    // the STAMINA N=40. Provenance MUST carry it so an OFF vs ON summary.json pair
+    // is self-distinguishing + reproducible (Codex #3108 P2).
+    STAMINA_FATIGUE_ENABLED: process.env.STAMINA_FATIGUE_ENABLED || 'false',
   };
 }
 


### PR DESCRIPTION
## Provenance fix for the STAMINA N=40 evidence (Codex #3108 P2)

Follow-up to the merged #3108. Codex P2: the committed ON-arm `summary.json` could
not self-prove which arm/revision produced it -- `commit` was `unknown` and
`currentFlags()` omitted `STAMINA_FATIGUE_ENABLED`, so the OFF and ON config blocks
were identical.

### Fix
- `tools/sim/full-loop-batch.js`: `currentFlags()` now records
  `STAMINA_FATIGUE_ENABLED` (the A/B discriminator), mirroring the
  interoception/A13 flags it already tracks.
- Regenerated both arms pinned with `GIT_COMMIT=c83d6a68`. The config blocks now
  DIFFER (commit set, flag `false` vs `true`) -> self-distinguishing + reproducible.

### Verdict unchanged
Band-SAFE + fatigue fires: all 7 meta-metrics in-band both arms; completion
0.475 -> 0.600, attrition 0.563 -> 0.511. (Pre-provenance run was 0.475/0.575 --
same verdict; the sim is not bit-reproducible across bases so the continuous values
drift a campaign.)

### Scope
1 harness line (provenance) + regenerated summaries + evidence doc. No combat logic
change, no forbidden-path, no deps.

### Rollback
Revert -- harness provenance + docs only, behavior-neutral.
