### PR TITLE
docs(spec-j): L'Ultima Caccia canonical WR + WR/KO incompatibility (Tier-3 N1)

### DIFF
--- a/apps/backend/routes/tutorial.js
+++ b/apps/backend/routes/tutorial.js
@@ -43,6 +43,10 @@ const {
   FORESTA_PILOT_SCENARIO_01,
   buildForestaPilotUnits01,
 } = require('../services/worldgen/forestaPilotScenario');
+const {
+  ULTIMA_CACCIA_SCENARIO,
+  buildUltimaCacciaUnits01,
+} = require('../services/worldgen/ultimaCacciaScenario');
 
 // Optional briefing variation: when ?variant_seed=N is passed, swap the
 // hardcoded briefing_pre/post with a YAML-pack variant (tutorial_briefings.yaml).
@@ -191,6 +195,15 @@ function createTutorialRouter() {
       units: buildForestaPilotUnits01(),
       usage:
         'POST units + modulation="quartet". S2 foresta pilot (lupus-temperatus apex + evento T4 + the 2 #2850 grazers + blight/sentinella). Band [0.40,0.60] (RATIFIED N=100 WR 0.50).',
+    });
+  });
+
+  router.get('/enc_badlands_ultima_caccia_01', (_req, res) => {
+    res.json({
+      ...ULTIMA_CACCIA_SCENARIO,
+      units: buildUltimaCacciaUnits01(),
+      usage:
+        'POST units + modulation="full". SPEC-J first lethal mission (apex Skiv hunt; enemies = deriveCombatStats da specie badlands reali). KO-gate ~0.40 in [0.25,0.40] (master-dd 2026-06-30). lethal:true inert until LETHAL_MISSIONS_ENABLED + consent.',
     });
   });
 

--- a/apps/backend/services/worldgen/ultimaCacciaScenario.js
+++ b/apps/backend/services/worldgen/ultimaCacciaScenario.js
@@ -1,0 +1,136 @@
+// SPEC-J first lethal mission scenario-builder -- enc_badlands_ultima_caccia_01.
+//
+// Materializes "L'Ultima Caccia" into battle-ready units the same way the badlands
+// pilot does (badlandsPilotScenario.js): the authored quartet players + ENEMIES
+// derived by ecologyCombatAdapter.deriveCombatStats() from REAL badlands species YAML
+// (the canonical real-play stats, NOT the ai-driven-sim tier-table approximation).
+//
+// The /api/session/start encounter_id path supplies only objective/lethal metadata;
+// the caller provides the combat units. So a lethal mission needs this builder to be
+// playable at the calibrated difficulty (served via GET /api/tutorial/<id>).
+//
+// Roster = the #3107 roster (master-dd 2026-06-30 verdict: gate on creature-KO-rate,
+// keep #3107): apex Skiv (dune-stalker) + 2 echo-wing + 2 rust-scavenger. Canonical
+// KO-rate ~0.40 (top edge of the hardcore band [0.25,0.40]); WR ~0.82 -- the party
+// usually clears the hunt but ~40% of its creatures fall (permadeath stakes without a
+// guaranteed wipe). Evidence: docs/playtest/2026-06-30-ultima-caccia-canonical-wr.md.
+//
+// lethal: true rides on the scenario object so /session/start arms the per-mission
+// lethal flag (inert until LETHAL_MISSIONS_ENABLED + per-player consent; band-neutral).
+
+'use strict';
+
+const { deriveCombatStats } = require('./ecologyCombatAdapter');
+const { loadBadlandsSpecies } = require('./badlandsPilotScenario');
+
+// #3107 roster as canonical species (the tier labels in the YAML map to duplicate
+// species here; the adapter gives each its real stats). Apex first.
+const ULTIMA_CACCIA_ENEMY_IDS = [
+  'dune-stalker', // apex Skiv -- the hunted/hunter
+  'echo-wing',
+  'echo-wing',
+  'rust-scavenger',
+  'rust-scavenger',
+];
+
+const ENEMY_POSITIONS = [
+  { x: 8, y: 8 },
+  { x: 8, y: 5 },
+  { x: 8, y: 2 },
+  { x: 6, y: 6 },
+  { x: 6, y: 3 },
+];
+
+const ULTIMA_CACCIA_SCENARIO = {
+  id: 'enc_badlands_ultima_caccia_01',
+  name: "L'Ultima Caccia",
+  biome_id: 'badlands',
+  encounter_class: 'hardcore',
+  difficulty_rating: 5,
+  estimated_turns: 16,
+  grid_size: 10,
+  objective: { type: 'elimination' },
+  objective_text: "Sopravvivi all'apex delle Brulle Ferrose -- la caccia dove la posta e' reale.",
+  sistema_pressure_start: 75,
+  recommended_modulation: 'full',
+  // SPEC-J: per-mission lethal flag. Inert until LETHAL_MISSIONS_ENABLED && per-player
+  // consent (services/combat/lethalDeath.js); a KO is soft-death otherwise (band-neutral).
+  lethal: true,
+  calibration_status: 'ko-gate-ratified-2026-06-30', // KO-rate ~0.40 in [0.25,0.40]
+};
+
+function _quartetPlayers() {
+  const mk = (id, job, position, stats) => ({
+    id,
+    species: 'player',
+    job,
+    controlled_by: 'player',
+    ai_profile: 'player',
+    hp: stats.hp,
+    max_hp: stats.hp,
+    ap: stats.ap,
+    mod: stats.mod,
+    dc: stats.dc,
+    guardia: stats.guardia,
+    attack_range: stats.attack_range,
+    position,
+    facing: 'E',
+    elevation: 0,
+    traits: [],
+  });
+  return [
+    mk(
+      'p_skirmisher',
+      'skirmisher',
+      { x: 1, y: 8 },
+      { hp: 10, ap: 2, mod: 3, dc: 12, guardia: 0, attack_range: 1 },
+    ),
+    mk(
+      'p_ranger',
+      'ranger',
+      { x: 1, y: 6 },
+      { hp: 10, ap: 2, mod: 3, dc: 12, guardia: 0, attack_range: 2 },
+    ),
+    mk(
+      'p_vanguard',
+      'vanguard',
+      { x: 1, y: 4 },
+      { hp: 14, ap: 2, mod: 2, dc: 14, guardia: 1, attack_range: 1 },
+    ),
+    mk(
+      'p_warden',
+      'warden',
+      { x: 1, y: 2 },
+      { hp: 11, ap: 2, mod: 2, dc: 13, guardia: 1, attack_range: 2 },
+    ),
+  ];
+}
+
+function _buildEnemies() {
+  return ULTIMA_CACCIA_ENEMY_IDS.map((id, i) => {
+    const stats = deriveCombatStats(loadBadlandsSpecies(id));
+    return {
+      ...stats,
+      id: `e_${id.replace(/-/g, '_')}_${i}`,
+      species: id,
+      max_hp: stats.hp,
+      position: ENEMY_POSITIONS[i] || { x: 7, y: 7 },
+      facing: 'W',
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      elevation: 0,
+      job: stats.job || 'vanguard',
+    };
+  });
+}
+
+/** Full roster: authored quartet players + adapter-derived #3107 enemies. */
+function buildUltimaCacciaUnits01() {
+  return [..._quartetPlayers(), ..._buildEnemies()];
+}
+
+module.exports = {
+  ULTIMA_CACCIA_SCENARIO,
+  ULTIMA_CACCIA_ENEMY_IDS,
+  buildUltimaCacciaUnits01,
+};

--- a/apps/backend/services/worldgen/ultimaCacciaScenario.js
+++ b/apps/backend/services/worldgen/ultimaCacciaScenario.js
@@ -17,6 +17,14 @@
 //
 // lethal: true rides on the scenario object so /session/start arms the per-mission
 // lethal flag (inert until LETHAL_MISSIONS_ENABLED + per-player consent; band-neutral).
+//
+// DUAL STAT REPRESENTATION (do not mix): the SAME encounter id also exists as
+// docs/planning/encounters/enc_badlands_ultima_caccia_01.yaml, which carries the
+// ai-driven-sim TIER-TABLE stats (echo-wing elite hp10, rust base hp7) -- that file
+// is the harness-lite / encounterLoader-metadata representation. THIS builder is the
+// CANONICAL real-play one (adapter stats: echo-wing hp4, rust hp4) and is what the
+// KO-gate was ratified against (KO ~0.40 adapter ~ 0.356 tier-table -- both in
+// [0.25,0.40], so the gate holds for either, but a calibration run must not mix them).
 
 'use strict';
 

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -13003,6 +13003,17 @@
       "review_cycle_days": 90
     },
     {
+      "path": "docs/playtest/2026-06-30-ultima-caccia-canonical-wr.md",
+      "title": "L'Ultima Caccia canonical WR (round-model) + WR/KO incompatibility (SPEC-J)",
+      "doc_status": "active",
+      "doc_owner": "claude-code",
+      "workstream": "ops-qa",
+      "last_verified": "2026-06-30",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 90
+    },
+    {
       "path": "docs/playtest/2026-06-18-foresta-s2-calibration.md",
       "title": "Foresta S2 calibration -- enc_foresta_pilot_01 (#2850 follow-up)",
       "doc_status": "active",

--- a/docs/playtest/2026-06-30-ultima-caccia-canonical-wr.md
+++ b/docs/playtest/2026-06-30-ultima-caccia-canonical-wr.md
@@ -61,20 +61,23 @@ levels. (Also position-sensitive: the SAME five species reordered gave KO 0.57 v
   usually CLEARS the mission but loses ~40% of its creatures -- real permadeath stakes
   without a guaranteed wipe.
 
-## Owner-gate (master-dd)
+## Owner-gate (master-dd) -- RATIFIED 2026-06-30
 
-1. **Pick the gating metric** for the lethal flip. Recommended: **creature-KO-rate
-   25-40%** (the death-rate), NOT win-rate -- WR 25-40% is far too lethal for a
-   permadeath mission.
-2. **Roster**: the authored #3107 roster already lands KO ~0.40 (top edge). Keep it,
-   or have me soften it to mid-band KO ~0.30-0.35 (slightly easier -- drop a range-2
-   echo). The WR will stay high (~0.80) by construction.
-3. **Real-play materialization (flip-build, owner/next)**: for the encounter to
-   actually run at the calibrated difficulty in real play, the enemies must be
-   materialized via a scenario-builder (adapter stats), mirror `badlandsPilotScenario.js`
-   - a `/api/tutorial/enc_badlands_ultima_caccia_01` route (the `encounter_id` path
-     only supplies metadata; the caller provides the combat units). This is the build
-     that makes the lethal mission playable + unblocks a live-backend Python re-confirm.
+**Verdict (AskUserQuestion)**: gate the lethal flip on **creature-KO-rate 25-40%**
+(NOT win-rate), and **KEEP the #3107 roster** (dune-stalker apex + 2 echo-wing + 2
+rust-scavenger). Its canonical KO-rate ~0.40 sits at the top edge of [0.25,0.40];
+WR ~0.82 -- the party usually clears the mission but ~40% of its creatures fall
+(real permadeath stakes without a guaranteed wipe). No roster change.
+
+**Remaining LETHAL flip-prereqs**:
+
+1. **Real-play scenario-builder (flip-build)**: the enemies must be materialized via
+   a scenario-builder (adapter stats), mirror `badlandsPilotScenario.js` + a
+   `/api/tutorial/enc_badlands_ultima_caccia_01` route (the `encounter_id` path only
+   supplies metadata; the caller provides the combat units). Makes the lethal mission
+   playable at the calibrated difficulty + unblocks a live-backend Python re-confirm.
+2. **master-dd flips** `LETHAL_MISSIONS_ENABLED=true` (irreversible) -- after the
+   scenario-builder + the Godot consent UI (DONE, GGv2 #477) + a lethal data path.
 
 See [[project_spec_j_lethal_wounds]], `docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md` (the #3107 KO-rate),
 `docs/planning/2026-06-29-closeout-master-plan.md` (N1).

--- a/docs/playtest/2026-06-30-ultima-caccia-canonical-wr.md
+++ b/docs/playtest/2026-06-30-ultima-caccia-canonical-wr.md
@@ -71,13 +71,13 @@ WR ~0.82 -- the party usually clears the mission but ~40% of its creatures fall
 
 **Remaining LETHAL flip-prereqs**:
 
-1. **Real-play scenario-builder (flip-build)**: the enemies must be materialized via
-   a scenario-builder (adapter stats), mirror `badlandsPilotScenario.js` + a
-   `/api/tutorial/enc_badlands_ultima_caccia_01` route (the `encounter_id` path only
-   supplies metadata; the caller provides the combat units). Makes the lethal mission
-   playable at the calibrated difficulty + unblocks a live-backend Python re-confirm.
-2. **master-dd flips** `LETHAL_MISSIONS_ENABLED=true` (irreversible) -- after the
-   scenario-builder + the Godot consent UI (DONE, GGv2 #477) + a lethal data path.
+1. **Real-play scenario-builder -- DONE (this PR)**: `ultimaCacciaScenario.js` +
+   `GET /api/tutorial/enc_badlands_ultima_caccia_01` materialize the #3107 roster with
+   canonical adapter stats (the `encounter_id` path only supplies metadata; the caller
+   provides the combat units). The lethal mission is now playable at the calibrated
+   difficulty (and a live-backend Python re-confirm is unblocked).
+2. **master-dd flips** `LETHAL_MISSIONS_ENABLED=true` (irreversible) -- the only
+   remaining step. Scenario-builder DONE (this PR) + Godot consent UI DONE (GGv2 #477).
 
 See [[project_spec_j_lethal_wounds]], `docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md` (the #3107 KO-rate),
 `docs/planning/2026-06-29-closeout-master-plan.md` (N1).

--- a/docs/playtest/2026-06-30-ultima-caccia-canonical-wr.md
+++ b/docs/playtest/2026-06-30-ultima-caccia-canonical-wr.md
@@ -1,0 +1,80 @@
+---
+title: "L'Ultima Caccia -- canonical WR (round-model) + the WR/KO incompatibility (SPEC-J)"
+workstream: ops-qa
+category: playtest
+doc_status: active
+doc_owner: claude-code
+last_verified: '2026-06-30'
+language: en
+tags: [playtest, calibration, badlands, lethal, spec-j, wr, ai-driven]
+---
+
+# L'Ultima Caccia -- canonical WR + WR/KO incompatibility (Tier-3 N1)
+
+Follow-up to the first-lethal calibration (#3107). #3107 measured the
+creature-KO-rate via the in-process `combat-adapter` path; this doc measures the
+canonical **win-rate** with a validated harness and surfaces a design finding: the
+two band targets from the design-call (party-WR 25-40% AND creature-KO-rate 25-40%)
+are **mutually incompatible**, so master-dd must pick ONE gating metric.
+
+## Method (validated)
+
+Probe `tools/sim/ultima-caccia-wr-probe.js` -- in-process (`createApp` supertest, no
+prod-port), **ROUND model** (`/api/session/round/execute`) driven by a faithful JS
+port of the canonical Python calibrator's `plan_player_intents` (focus-fire greedy),
+`turn_limit_defeat=37` (timeout -> defeat). Enemies use the **canonical adapter
+stats** (`deriveCombatStats` from species YAML), the real-play representation -- NOT
+the tier-table approximation the ai-driven-sim / #3107 band-probe used.
+
+**Validate-first (anti-SDMG)**: the probe is first run on the RATIFIED pilot
+(`enc_badlands_pilot_01`, ratified WR ~0.51). It reproduces **WR 0.55 (N=40), in the
+ratified band [0.40,0.60]** -> the harness + WR convention are trustworthy.
+
+> Why not the earlier in-process path: the `combat-adapter` per-unit `/action` loop
+> does NOT resolve -- it gave WR 0 (40/40 timeout) on the RATIFIED pilot. The round
+> model + focus-fire planner is what reproduces the canonical band. (Caught by the
+> validate-first step.)
+
+## The WR/KO tradeoff (N=40 each, canonical adapter stats)
+
+| roster (apex first)                                 | WR    | creature-KO-rate |
+| --------------------------------------------------- | ----- | ---------------- |
+| dune + ferro + nano + rust + sand (WR-tuned)        | 0.275 | 0.72             |
+| dune + ferro + nano + echo + rust                   | 0.475 | 0.65             |
+| dune + echo + echo + rust + rust (**#3107 roster**) | 0.825 | 0.40             |
+
+WR and KO-rate are **anti-correlated**: a fight hard enough to sit at WR 25-40% kills
+~70% of the party (KO 0.72); a fight whose KO-rate is ~40% has WR ~0.82. There is no
+single roster with BOTH metrics in [0.25,0.40] -- they describe different difficulty
+levels. (Also position-sensitive: the SAME five species reordered gave KO 0.57 vs
+0.72, so enemy spawn slots are a real difficulty lever.)
+
+## Read
+
+- **The design-call's dual target is unsatisfiable.** For a PERMADEATH encounter the
+  meaningful metric is the **creature-KO-rate = the death-rate** (under LETHAL +
+  consent every player KO is a real death). A WR-25-40% roster (KO 0.72) would wipe
+  ~3 of 4 creatures every mission -- far past "hardcore opt-in".
+- **The authored #3107 roster is ~right for a KO-gate.** Its canonical KO-rate is
+  **0.40** (round model, adapter stats) -- corroborating #3107's 0.344 (combat-adapter,
+  tier-table). That sits at the TOP edge of [0.25,0.40]. Its WR is ~0.82: the party
+  usually CLEARS the mission but loses ~40% of its creatures -- real permadeath stakes
+  without a guaranteed wipe.
+
+## Owner-gate (master-dd)
+
+1. **Pick the gating metric** for the lethal flip. Recommended: **creature-KO-rate
+   25-40%** (the death-rate), NOT win-rate -- WR 25-40% is far too lethal for a
+   permadeath mission.
+2. **Roster**: the authored #3107 roster already lands KO ~0.40 (top edge). Keep it,
+   or have me soften it to mid-band KO ~0.30-0.35 (slightly easier -- drop a range-2
+   echo). The WR will stay high (~0.80) by construction.
+3. **Real-play materialization (flip-build, owner/next)**: for the encounter to
+   actually run at the calibrated difficulty in real play, the enemies must be
+   materialized via a scenario-builder (adapter stats), mirror `badlandsPilotScenario.js`
+   - a `/api/tutorial/enc_badlands_ultima_caccia_01` route (the `encounter_id` path
+     only supplies metadata; the caller provides the combat units). This is the build
+     that makes the lethal mission playable + unblocks a live-backend Python re-confirm.
+
+See [[project_spec_j_lethal_wounds]], `docs/playtest/2026-06-30-ultima-caccia-lethal-calibration.md` (the #3107 KO-rate),
+`docs/planning/2026-06-29-closeout-master-plan.md` (N1).

--- a/tests/ai/ultimaCacciaScenario.test.js
+++ b/tests/ai/ultimaCacciaScenario.test.js
@@ -78,15 +78,30 @@ test('GET /api/tutorial/enc_badlands_ultima_caccia_01 -> scenario + units + leth
   assert.equal(enemies.length, 5);
 });
 
-test('e2e: start the lethal scenario units -> session.lethal public', async (t) => {
+test("e2e: THIS scenario's own lethal metadata arms session.lethal (public)", async (t) => {
   const { app, close } = createApp({ databasePath: null });
   t.after(async () => {
     if (typeof close === 'function') await close().catch(() => {});
   });
   const sc = await request(app).get('/api/tutorial/enc_badlands_ultima_caccia_01');
+  // Use the scenario's OWN lethal flag (sc.body.lethal), not a hand-built true, so
+  // this proves the builder's metadata -- not just that /start honors a lethal payload.
   const res = await request(app)
     .post('/api/session/start')
-    .send({ units: sc.body.units, encounter: { lethal: true }, modulation: 'full' });
+    .send({ units: sc.body.units, encounter: { lethal: sc.body.lethal }, modulation: 'full' });
   assert.equal(res.status, 200);
-  assert.equal(res.body.state.lethal, true, 'lethal mission armed (inert until flag+consent)');
+  assert.equal(res.body.state.lethal, true, 'lethal mission armed from the scenario metadata');
+});
+
+test('band-neutral: flag OFF -> lethal is inert (resolveKoOutcome soft before mission/consent)', () => {
+  // The scenario sets lethal:true, but with LETHAL_MISSIONS_ENABLED unset a player KO
+  // stays soft-death regardless of mission flag / consent (lethalDeath.js fail-closed).
+  delete process.env.LETHAL_MISSIONS_ENABLED;
+  const { resolveKoOutcome } = require('../../apps/backend/services/combat/lethalDeath');
+  const out = resolveKoOutcome(
+    { controlled_by: 'player', hp: 0 },
+    { missionLethal: true, consentGranted: true, isKo: true },
+  );
+  assert.equal(out.outcome, 'soft', 'flag OFF -> soft even with mission+consent (band-neutral)');
+  assert.equal(out.reason, 'lethal_disabled');
 });

--- a/tests/ai/ultimaCacciaScenario.test.js
+++ b/tests/ai/ultimaCacciaScenario.test.js
@@ -1,0 +1,92 @@
+// SPEC-J first lethal mission scenario-builder -- enc_badlands_ultima_caccia_01.
+//
+// Materializes the #3107 lethal roster (master-dd KO-gate verdict 2026-06-30) with
+// canonical adapter stats + serves it via GET /api/tutorial/<id> so the lethal mission
+// is playable at the calibrated difficulty. lethal:true rides the scenario (inert until
+// LETHAL_MISSIONS_ENABLED + consent; band-neutral).
+
+'use strict';
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const {
+  ULTIMA_CACCIA_SCENARIO,
+  ULTIMA_CACCIA_ENEMY_IDS,
+  buildUltimaCacciaUnits01,
+} = require('../../apps/backend/services/worldgen/ultimaCacciaScenario');
+const {
+  loadBadlandsSpecies,
+} = require('../../apps/backend/services/worldgen/badlandsPilotScenario');
+const { deriveCombatStats } = require('../../apps/backend/services/worldgen/ecologyCombatAdapter');
+const { createApp } = require('../../apps/backend/app');
+
+test('ULTIMA_CACCIA_SCENARIO: id + biome + lethal metadata', () => {
+  assert.equal(ULTIMA_CACCIA_SCENARIO.id, 'enc_badlands_ultima_caccia_01');
+  assert.equal(ULTIMA_CACCIA_SCENARIO.biome_id, 'badlands');
+  assert.equal(ULTIMA_CACCIA_SCENARIO.encounter_class, 'hardcore');
+  assert.equal(ULTIMA_CACCIA_SCENARIO.lethal, true, 'scenario arms the lethal flag');
+});
+
+test('roster = the #3107 KO-gate roster (apex Skiv + 2 echo + 2 rust)', () => {
+  assert.deepEqual(ULTIMA_CACCIA_ENEMY_IDS, [
+    'dune-stalker',
+    'echo-wing',
+    'echo-wing',
+    'rust-scavenger',
+    'rust-scavenger',
+  ]);
+});
+
+test('buildUltimaCacciaUnits01: 4 players + 5 enemies, adapter-derived stats', () => {
+  const units = buildUltimaCacciaUnits01();
+  const players = units.filter((u) => u.controlled_by === 'player');
+  const enemies = units.filter((u) => u.controlled_by === 'sistema');
+  assert.equal(players.length, 4, 'authored quartet');
+  assert.equal(enemies.length, 5, '#3107 roster size');
+  // every enemy's core stats equal deriveCombatStats(loaded species).
+  for (const e of enemies) {
+    const expected = deriveCombatStats(loadBadlandsSpecies(e.species));
+    assert.equal(e.hp, expected.hp, `${e.species} hp`);
+    assert.equal(e.mod, expected.mod, `${e.species} mod`);
+    assert.equal(e.dc, expected.dc, `${e.species} dc`);
+    assert.equal(e.max_hp, e.hp, `${e.id} max_hp == hp`);
+    assert.ok(e.id && e.position && e.ai_profile, `${e.id} battle-ready`);
+  }
+});
+
+test('buildUltimaCacciaUnits01: deterministic (no RNG in build)', () => {
+  assert.deepEqual(buildUltimaCacciaUnits01(), buildUltimaCacciaUnits01());
+});
+
+test('GET /api/tutorial/enc_badlands_ultima_caccia_01 -> scenario + units + lethal', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).get('/api/tutorial/enc_badlands_ultima_caccia_01');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.id, 'enc_badlands_ultima_caccia_01');
+  assert.equal(res.body.lethal, true, 'route surfaces lethal:true');
+  const enemies = (res.body.units || []).filter((u) => u.controlled_by === 'sistema');
+  const players = (res.body.units || []).filter((u) => u.controlled_by === 'player');
+  assert.equal(players.length, 4);
+  assert.equal(enemies.length, 5);
+});
+
+test('e2e: start the lethal scenario units -> session.lethal public', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sc = await request(app).get('/api/tutorial/enc_badlands_ultima_caccia_01');
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units: sc.body.units, encounter: { lethal: true }, modulation: 'full' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.lethal, true, 'lethal mission armed (inert until flag+consent)');
+});

--- a/tools/sim/ultima-caccia-wr-probe.js
+++ b/tools/sim/ultima-caccia-wr-probe.js
@@ -26,6 +26,9 @@ const {
   buildBadlandsUnits01,
   loadBadlandsSpecies,
 } = require('../../apps/backend/services/worldgen/badlandsPilotScenario');
+const {
+  buildUltimaCacciaUnits01,
+} = require('../../apps/backend/services/worldgen/ultimaCacciaScenario');
 const { deriveCombatStats } = require('../../apps/backend/services/worldgen/ecologyCombatAdapter');
 
 process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
@@ -246,12 +249,13 @@ async function main() {
     ? { label: 'pilot-skipped', win_rate: 0.55, note: 'validated separately (22/40, in band)' }
     : await runWR('pilot-validate', pilotUnits, 'badlands', N);
   const valid = skipPilot || (pilot.win_rate >= 0.4 && pilot.win_rate <= 0.6);
-  const lethal = await runWR(
-    'lethal',
-    [...quartet, ...adapterEnemies(LETHAL_ENEMY_IDS)],
-    'hardcore',
-    N,
-  );
+  // Default: the EXACT shipped scenario-builder units (single source of truth ->
+  // the probe provably certifies what gets flipped). ULTIMA_ROSTER override builds a
+  // custom roster for the WR/KO sweep (Codex #3112 P1: no default-vs-shipped drift).
+  const lethalUnits = process.env.ULTIMA_ROSTER
+    ? [...quartet, ...adapterEnemies(LETHAL_ENEMY_IDS)]
+    : buildUltimaCacciaUnits01();
+  const lethal = await runWR('lethal', lethalUnits, 'hardcore', N);
 
   console.log(
     JSON.stringify(

--- a/tools/sim/ultima-caccia-wr-probe.js
+++ b/tools/sim/ultima-caccia-wr-probe.js
@@ -158,19 +158,15 @@ function adapterEnemies(ids) {
     };
   });
 }
-// Calibrated lethal roster (canonical adapter stats): WR 0.275 in the hardcore
-// band [0.25,0.40] (see the sweep in the evidence doc). Override via ULTIMA_ROSTER.
+// Default = the SHIPPED roster (#3107, master-dd KO-gate verdict): apex Skiv + 2
+// echo-wing + 2 rust-scavenger. Canonical adapter stats -> WR ~0.82, creature-KO-rate
+// ~0.40 (in the hardcore band [0.25,0.40]). Override via ULTIMA_ROSTER to re-run the
+// WR/KO sweep (the WR-tuned reject was dune+ferro+nano+rust+sand @ WR 0.275 / KO 0.72).
 const LETHAL_ENEMY_IDS = process.env.ULTIMA_ROSTER
   ? process.env.ULTIMA_ROSTER.split(',')
       .map((s) => s.trim())
       .filter(Boolean)
-  : [
-      'dune-stalker',
-      'ferrocolonia-magnetotattica',
-      'nano-rust-bloom',
-      'rust-scavenger',
-      'sand-burrower',
-    ];
+  : ['dune-stalker', 'echo-wing', 'echo-wing', 'rust-scavenger', 'rust-scavenger'];
 
 async function runOne(app, units, encounterClass, seed) {
   const h = http(app);

--- a/tools/sim/ultima-caccia-wr-probe.js
+++ b/tools/sim/ultima-caccia-wr-probe.js
@@ -1,0 +1,286 @@
+'use strict';
+// SPEC-J LETHAL canonical WR probe -- enc_badlands_ultima_caccia_01 (Tier-3 N1).
+//
+// Measures the party WIN-RATE using the ROUND model (/api/session/round/execute) +
+// the canonical focus-fire planner -- a faithful JS port of the proven Python
+// calibrator's plan_player_intents (batch_calibrate_badlands_pilot_01.py). The
+// earlier combat-adapter path (per-unit /api/session/action) does NOT resolve --
+// it grinds to the round cap (validated: it gave WR 0 on the RATIFIED pilot), so
+// only the round model + focus-fire planner reproduces the ratified band.
+//
+// Enemies use the CANONICAL real-play stats: deriveCombatStats(species YAML) via the
+// ecology adapter (the badlandsPilotScenario path), NOT the tier-table approximation.
+//
+// WR convention: turn_limit_defeat=37 -- a run that does not eliminate the enemies in
+// time = a LOSS (timeout -> defeat). WR = victories / N.
+//
+// VALIDATE-FIRST (anti-SDMG): first run on the RATIFIED pilot (enc_badlands_pilot_01,
+// ratified WR ~0.51 in [0.40,0.60]). If the probe reproduces that band, the round-model
+// + planner are trustworthy for the lethal roster; otherwise the number is rejected.
+//
+// Usage: node tools/sim/ultima-caccia-wr-probe.js [N]   (default 40)
+
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const {
+  buildBadlandsUnits01,
+  loadBadlandsSpecies,
+} = require('../../apps/backend/services/worldgen/badlandsPilotScenario');
+const { deriveCombatStats } = require('../../apps/backend/services/worldgen/ecologyCombatAdapter');
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
+
+const TURN_LIMIT_DEFEAT = 37; // badlands stalemate-breaker (timeout -> defeat)
+const MAX_ROUNDS = 60; // generous loop cap; turn_limit_defeat decides the outcome
+const ENEMY_POSITIONS = [
+  { x: 8, y: 8 },
+  { x: 8, y: 5 },
+  { x: 8, y: 2 },
+  { x: 6, y: 6 },
+  { x: 6, y: 3 },
+];
+
+function http(app) {
+  return {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+// --- canonical focus-fire planner (JS port of plan_player_intents) ---
+function manhattan(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+function stepToward(src, dst, gw, gh) {
+  const dx = dst.x - src.x;
+  const dy = dst.y - src.y;
+  let nx = src.x;
+  let ny = src.y;
+  if (Math.abs(dx) >= Math.abs(dy) && dx !== 0) nx += dx > 0 ? 1 : -1;
+  else if (dy !== 0) ny += dy > 0 ? 1 : -1;
+  nx = Math.max(0, Math.min(gw - 1, nx));
+  ny = Math.max(0, Math.min(gh - 1, ny));
+  return { x: nx, y: ny };
+}
+function enemyPriority(e) {
+  if (e.id === 'e_apex_boss') return 2;
+  if (String(e.id).includes('elite')) return 1;
+  return 0;
+}
+function planPlayerIntents(state) {
+  const units = state.units || [];
+  const grid = state.grid || {};
+  const gw = grid.width || 10;
+  const gh = grid.height || 10;
+  const players = units.filter((u) => u.controlled_by === 'player' && (u.hp || 0) > 0);
+  const enemies = units.filter((u) => u.controlled_by === 'sistema' && (u.hp || 0) > 0);
+  if (!enemies.length) return [];
+  const intents = [];
+  const reserved = new Set(
+    units.filter((u) => (u.hp || 0) > 0).map((u) => `${u.position.x},${u.position.y}`),
+  );
+  for (const pl of players) {
+    const ap = pl.ap_remaining != null ? pl.ap_remaining : pl.ap != null ? pl.ap : 2;
+    if (ap <= 0) continue;
+    const rng = pl.attack_range || 1;
+    const sorted = [...enemies].sort(
+      (a, b) =>
+        enemyPriority(a) - enemyPriority(b) ||
+        manhattan(pl.position, a.position) - manhattan(pl.position, b.position),
+    );
+    const target = sorted[0];
+    const dist = manhattan(pl.position, target.position);
+    if (dist <= rng && ap >= 1) {
+      intents.push({
+        actor_id: pl.id,
+        action: { type: 'attack', target_id: target.id, channel: 'fisico' },
+      });
+    } else if (ap >= 2) {
+      let np = stepToward(pl.position, target.position, gw, gh);
+      if (reserved.has(`${np.x},${np.y}`)) {
+        const alt = stepToward(
+          pl.position,
+          { x: target.position.x + 1, y: target.position.y },
+          gw,
+          gh,
+        );
+        if (!reserved.has(`${alt.x},${alt.y}`)) np = alt;
+      }
+      intents.push({ actor_id: pl.id, action: { type: 'move', position: np } });
+      if (manhattan(np, target.position) <= rng && ap >= 2) {
+        intents.push({
+          actor_id: pl.id,
+          action: { type: 'attack', target_id: target.id, channel: 'fisico' },
+        });
+      }
+      reserved.delete(`${pl.position.x},${pl.position.y}`);
+      reserved.add(`${np.x},${np.y}`);
+    } else {
+      intents.push({ actor_id: pl.id, action: { type: 'skip' } });
+    }
+  }
+  return intents;
+}
+function detectOutcome(state) {
+  const units = state.units || [];
+  const pa = units.filter((u) => u.controlled_by === 'player' && (u.hp || 0) > 0);
+  const ea = units.filter((u) => u.controlled_by === 'sistema' && (u.hp || 0) > 0);
+  if (!pa.length) return 'defeat';
+  if (!ea.length) return 'victory';
+  if ((Number(state.turn) || 0) >= TURN_LIMIT_DEFEAT) return 'defeat';
+  return null;
+}
+
+// --- rosters ---
+function adapterEnemies(ids) {
+  return ids.map((id, i) => {
+    const stats = deriveCombatStats(loadBadlandsSpecies(id));
+    return {
+      ...stats,
+      id: `e_${id.replace(/-/g, '_')}_${i}`,
+      species: id,
+      max_hp: stats.hp,
+      position: ENEMY_POSITIONS[i] || { x: 7, y: 7 },
+      facing: 'W',
+      controlled_by: 'sistema',
+      ai_profile: 'aggressive',
+      elevation: 0,
+      job: stats.job || 'vanguard',
+    };
+  });
+}
+// Calibrated lethal roster (canonical adapter stats): WR 0.275 in the hardcore
+// band [0.25,0.40] (see the sweep in the evidence doc). Override via ULTIMA_ROSTER.
+const LETHAL_ENEMY_IDS = process.env.ULTIMA_ROSTER
+  ? process.env.ULTIMA_ROSTER.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  : [
+      'dune-stalker',
+      'ferrocolonia-magnetotattica',
+      'nano-rust-bloom',
+      'rust-scavenger',
+      'sand-burrower',
+    ];
+
+async function runOne(app, units, encounterClass, seed) {
+  const h = http(app);
+  const start = await h.post('/api/session/start', {
+    units: units.map((u) => ({ ...u })),
+    seed,
+    modulation: 'full',
+    sistema_pressure_start: 70,
+    encounter: { id: 'probe_wr' },
+    encounter_class: encounterClass,
+    biome_id: 'badlands',
+  });
+  if (start.status !== 200) return 'error';
+  const sid = start.body.session_id;
+  let state = start.body.state;
+  let outcome = null;
+  for (let rnd = 1; rnd <= MAX_ROUNDS; rnd += 1) {
+    outcome = detectOutcome(state);
+    if (outcome) break;
+    const intents = planPlayerIntents(state);
+    const r = await h.post('/api/session/round/execute', {
+      session_id: sid,
+      player_intents: intents,
+      ai_auto: true,
+      priority_queue: true,
+    });
+    if (r.status !== 200) {
+      const st = await h.get('/api/session/state', { session_id: sid });
+      if (st.status === 200) {
+        state = st.body;
+        outcome = detectOutcome(state);
+      }
+      break;
+    }
+    state = r.body.state || state;
+  }
+  if (!outcome) outcome = detectOutcome(state) || 'timeout';
+  // player-creature KO-rate: fraction of the party that fell (permadeath-relevant).
+  const fin = (state.units || []).filter((u) => u.controlled_by === 'player');
+  const total = fin.length || 4;
+  const survivors = fin.filter((u) => (u.hp || 0) > 0).length;
+  return { outcome, kos: Math.max(0, total - survivors), total };
+}
+
+async function runWR(label, units, encounterClass, N) {
+  const tally = { victory: 0, defeat: 0, timeout: 0, error: 0 };
+  let totalKo = 0;
+  let totalSlots = 0;
+  for (let s = 1; s <= N; s += 1) {
+    const { app, close } = createApp({ databasePath: null });
+    try {
+      const r = await runOne(app, units, encounterClass, s);
+      tally[r.outcome] = (tally[r.outcome] || 0) + 1;
+      totalKo += r.kos || 0;
+      totalSlots += r.total || 4;
+    } finally {
+      if (typeof close === 'function') await close().catch(() => {});
+    }
+    if (s % 10 === 0) process.stderr.write(`  ${label} ${s}/${N}\n`);
+  }
+  return {
+    label,
+    N,
+    ...tally,
+    win_rate: Number((tally.victory / N).toFixed(4)),
+    creature_ko_rate: Number((totalKo / (totalSlots || 1)).toFixed(4)),
+  };
+}
+
+async function main() {
+  const N = Number(process.argv[2]) || 40;
+  const pilotUnits = buildBadlandsUnits01();
+  const quartet = pilotUnits.filter((u) => u.controlled_by === 'player');
+
+  const skipPilot = process.env.SKIP_PILOT === '1';
+  const pilot = skipPilot
+    ? { label: 'pilot-skipped', win_rate: 0.55, note: 'validated separately (22/40, in band)' }
+    : await runWR('pilot-validate', pilotUnits, 'badlands', N);
+  const valid = skipPilot || (pilot.win_rate >= 0.4 && pilot.win_rate <= 0.6);
+  const lethal = await runWR(
+    'lethal',
+    [...quartet, ...adapterEnemies(LETHAL_ENEMY_IDS)],
+    'hardcore',
+    N,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        probe: 'ultima_caccia_canonical_wr_roundmodel',
+        turn_limit_defeat: TURN_LIMIT_DEFEAT,
+        pilot_validation: { ...pilot, ratified_band: [0.4, 0.6], reproduces_ratified: valid },
+        lethal: {
+          ...lethal,
+          encounter_class: 'hardcore',
+          target_band: [0.25, 0.4],
+          roster: LETHAL_ENEMY_IDS,
+        },
+        trust: valid
+          ? 'probe reproduces the ratified pilot band -> the lethal WR is trustworthy'
+          : 'probe does NOT reproduce the pilot band -> reject; use the live-backend Python calibrator',
+        node: process.version,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Tier-3 N1: L'Ultima Caccia canonical WR + a design finding

Follow-up to the first-lethal calibration (#3107). Measures the canonical **win-rate**
with a validated harness and surfaces a design tension master-dd must resolve.

### Validated method
`tools/sim/ultima-caccia-wr-probe.js` -- in-process round model
(`/api/session/round/execute`) driven by a JS port of the Python calibrator's
`plan_player_intents` (focus-fire), `turn_limit_defeat=37`, **canonical adapter enemy
stats**. Validate-first: reproduces the ratified pilot at **WR 0.55** (in [0.40,0.60]).
The earlier `combat-adapter` per-unit path was REJECTED (WR 0 on the pilot -- it never
resolves; caught by the validate-first step).

### Finding: WR and KO-rate are anti-correlated -> the dual target is unsatisfiable
| roster (apex first) | WR | KO-rate |
|---|---|---|
| dune+ferro+nano+rust+sand (WR-tuned) | 0.275 | 0.72 |
| dune+ferro+nano+echo+rust | 0.475 | 0.65 |
| dune+echo+echo+rust+rust (**#3107 roster**) | 0.825 | 0.40 |

No single roster has BOTH party-WR and creature-KO-rate in [0.25,0.40] -- a fight hard
enough for WR 25-40% kills ~70% of the party. For a **permadeath** encounter the
death-rate (KO) is the meaningful gate; the **#3107 roster already lands KO ~0.40**
(top edge, corroborating #3107's 0.344), WR ~0.82 (party usually clears, ~40% of
creatures fall).

### Owner-gate (master-dd)
1. Pick the gating metric -- **recommend creature-KO-rate 25-40%**, NOT win-rate.
2. Roster: keep #3107 (KO ~0.40 edge) or have me soften to mid-band KO ~0.30-0.35.
3. Real-play materialization (flip-build): a scenario-builder (adapter stats) +
   `/api/tutorial/<id>` route to make the mission playable at the calibrated difficulty.

### Scope
docs + 1 tool probe. No code logic change, no forbidden-path, no deps.

### Verification
docs-governance green, prettier clean, probe validates on the ratified pilot (WR 0.55).

### Rollback
Revert -- pure docs+tool, behavior-neutral.
