### PR TITLE
feat(coop): wire 3 recon-clean imprint cells (7/8, flag-OFF PROPOSED)

### DIFF
--- a/apps/backend/services/identity/brancoTraitProducer.js
+++ b/apps/backend/services/identity/brancoTraitProducer.js
@@ -48,14 +48,54 @@ function resolveImprintWeight(env = process.env) {
   return Number.isFinite(raw) && raw >= 0 ? raw : PROPOSED_IMPRINT_WEIGHT;
 }
 
+// Deterministic string hash over the WHOLE imprint tuple (all mapped axes' poles). Drives the
+// tuple-determined axis selection so the COMBINATION decides the trait (verdict D-2).
+function _tupleHash(tuple, axes) {
+  let h = 0;
+  for (const axis of axes) {
+    const v = tuple[axis] == null ? '' : String(tuple[axis]).toUpperCase();
+    for (let i = 0; i < v.length; i++) h = (Math.imul(h, 31) + v.charCodeAt(i)) >>> 0;
+  }
+  return h;
+}
+
+/**
+ * TUPLE-DETERMINED imprint-axis selection (verdict D-2; replaces the first-axis tie-break that
+ * left only locomotion reachable -- Codex P2 #3115). The imprint is a single shared 4-tuple of
+ * EQUAL-magnitude binary axes, so "which axis grants" cannot come from an argmax among them;
+ * instead the WHOLE tuple deterministically selects one of the wired-pole axes. Pure, no-mutate,
+ * never throws; same tuple -> same axis (reconnect/snapshot-stable). All wired cells are reachable
+ * across the tuple space. PROPOSED mechanism (the hash-mod is arbitrary-but-deterministic; master-dd
+ * may swap to a curated tuple->axis table at the N=40 ratify).
+ *
+ * @param {{ locomotion?, offense?, defense?, senses? }} tuple
+ * @param {object} mapping  imprint axis x pole -> trait_id
+ * @returns {{ axis, pole, trait_id } | null}
+ */
+function selectImprintAxis(tuple, mapping) {
+  if (!tuple || typeof tuple !== 'object' || !mapping || typeof mapping !== 'object') return null;
+  const axes = Object.keys(mapping);
+  const candidates = [];
+  for (const axis of axes) {
+    const raw = tuple[axis];
+    if (raw == null) continue;
+    const pole = String(raw).toUpperCase();
+    const trait_id = mapping[axis] && mapping[axis][pole];
+    if (trait_id) candidates.push({ axis, pole, trait_id }); // only wired poles are selectable
+  }
+  if (!candidates.length) return null;
+  const idx = _tupleHash(tuple, axes) % candidates.length;
+  return candidates[idx];
+}
+
 /**
  * Pure: fill the single branco-trait slot from the Form-Pulse aggregate and (when combined)
- * the imprint tuple. No-mutate, deterministic tie-break, never throws.
+ * the imprint tuple. No-mutate, deterministic, never throws.
  *
- * Tie-break: among ALL form candidates only the global argmax can win, so emergeBrancoTrait's
- * own first-max-wins result IS the form representative. It is compared against the imprint
- * candidates with a STRICT `>` so (a) Form-Pulse wins an exact tie with the imprint weight
- * (Form-Pulse precedence), and (b) among imprint axes the first in mapping order wins.
+ * Form side: emergeBrancoTrait's own first-max-wins result IS the form representative (only the
+ * global argmax can win). Imprint side: ONE tuple-determined candidate (selectImprintAxis). The
+ * two compete with a STRICT `>` so Form-Pulse wins an exact tie with the imprint weight w
+ * (Form-Pulse precedence).
  *
  * @param {object}  args.aggregate      Form-Pulse branco aggregate { creatureAxis: avg in [-1,1] }
  * @param {object}  [args.imprintTuple] { locomotion, offense, defense, senses } pole strings | null
@@ -85,8 +125,8 @@ function produceBrancoTrait(args = {}) {
   // Returned bare (no `source`) so the shape == emergeBrancoTrait exactly.
   if (!combined) return fromForm;
 
-  // ON: the imprint binary axes also compete for the single slot, each at magnitude w. The
-  // winner is tagged with which channel supplied it (observability; #3083 carried `source`).
+  // ON: the imprint contributes ONE tuple-determined candidate at magnitude w. The winner is
+  // tagged with which channel supplied it (observability; #3083 carried `source`).
   let best = fromForm ? { ...fromForm, source: 'formpulse' } : null;
   const wMag = Number.isFinite(w) ? w : 0;
   const effThreshold = Number.isFinite(threshold) ? threshold : 0;
@@ -94,15 +134,9 @@ function produceBrancoTrait(args = {}) {
   // control sweep) disables the imprint contribution -- otherwise an empty Form-Pulse aggregate
   // would still grant a magnitude-0 imprint trait, corrupting a zero-weight calibration run.
   if (imprintTuple && typeof imprintTuple === 'object' && wMag > 0 && wMag >= effThreshold) {
-    for (const axis of Object.keys(imprintMapping)) {
-      const raw = imprintTuple[axis];
-      if (raw == null) continue;
-      const pole = String(raw).toUpperCase();
-      const trait_id = imprintMapping[axis] && imprintMapping[axis][pole];
-      if (!trait_id) continue; // unmapped pole (e.g. a TODO balance-pick cell) -> no candidate
-      if (!best || wMag > best.magnitude) {
-        best = { trait_id, axis, pole, magnitude: wMag, source: 'imprint' };
-      }
+    const imp = selectImprintAxis(imprintTuple, imprintMapping);
+    if (imp && (!best || wMag > best.magnitude)) {
+      best = { ...imp, magnitude: wMag, source: 'imprint' };
     }
   }
   return best || null;
@@ -112,5 +146,6 @@ module.exports = {
   IMPRINT_WEIGHT_FLAG,
   PROPOSED_IMPRINT_WEIGHT,
   resolveImprintWeight,
+  selectImprintAxis,
   produceBrancoTrait,
 };

--- a/apps/backend/services/imprint/imprintTraitGrant.js
+++ b/apps/backend/services/imprint/imprintTraitGrant.js
@@ -55,20 +55,23 @@ const DESIGNATED_AXIS = 'locomotion';
 // fires, NOT a draft inert no-op (lesson #3083: inert picks pass N=40 falsely as ~0 delta).
 // Pole = the imprint VALUE (VELOCE/SILENZIOSA, ...), not a +/- sign.
 //
-// Audit 2026-06-30 (real registry, the isEngineLiveReliable predicate): all 6 cells below are
-// engine-LIVE (action_type:attack + a wired effect kind, no posizione_sopraelevata near-inert).
-//   - locomotion VELOCE     coda_stabilizzatrice_vortex  attack/extra_damage (melee + min_mos:5)
-//   - locomotion SILENZIOSA cartilagini_flessoacustiche  attack/damage_reduction (no gate) CLEAN
-//   - offense    PROFONDA   ferocia                      attack/apply_status on_kill     CLEAN
-//   - defense    DURA       pelle_elastomera             attack/damage_reduction (no gate) CLEAN
-//   - senses     LONTANO    sensori_geomagnetici         attack/extra_damage (min_mos:5)
-//   - senses     ACUTO      sensori_sismici              attack/extra_damage (melee + min_mos:5)
-// The min_mos/melee cells are situational-LIVE (same bar as the already-shipped VELOCE pick),
-// flagged as the weakest -> the primary N=40 re-pick candidates (master-dd may swap them).
+// Audit 2026-06-30 (real registry, isEngineLiveReliable) + weak-cell recon (#3114, verify-gated
+// scout + main-session re-audit, docs/planning/2026-06-30-form-pulse-trait-v2-imprint-weak-cell-recon.md).
+// 7/8 cells wired engine-LIVE; only offense/RAPIDA stays unwired (no clean LIVE pick exists).
+//   - locomotion VELOCE     coda_stabilizzatrice_vortex   attack/extra_damage (melee + min_mos:5)
+//   - locomotion SILENZIOSA cartilagini_flessoacustiche   attack/damage_reduction (no gate) CLEAN
+//   - offense    PROFONDA   ferocia                       attack/apply_status on_kill     CLEAN
+//   - defense    DURA       pelle_elastomera              attack/damage_reduction (no gate) CLEAN
+//   - defense    FLESSIBILE risposta_di_fuga              attack/damage_reduction (no gate) CLEAN  [recon: evasion-gap RESOLVED]
+//   - senses     LONTANO    sensori_geomagnetici          attack/extra_damage (min_mos:5)          [kept: senso_magnetico no-gate alt is self-labeled 'Stub data-only' -> rejected]
+//   - senses     ACUTO      occhi_analizzatori_di_tensione attack/extra_damage (no gate) CLEAN     [recon: swapped from double-gated sensori_sismici]
+// The min_mos/melee cells (VELOCE, LONTANO) are situational-LIVE (same bar as the shipped picks),
+// flagged as the weakest -> primary N=40 re-pick candidates (master-dd may swap). All wired ids
+// re-audited LIVE + disjoint from branco/minor pools. Mapping stays PROPOSED (ratify via N=40).
 //
-// TWO cells stay UNWIRED = master-dd / N=40 balance pick (do NOT auto-assign, draft sec.4):
-//   - offense RAPIDA   (draft candidate artiglio_cinetico_a_urto = melee+min_mos:5, situational)
-//   - defense FLESSIBILE (no clean evasion/dodge trait in the catalog today)
+// ONE cell stays UNWIRED = master-dd / N=40 balance pick (do NOT auto-assign, recon found no
+// clean fit): offense/RAPIDA (best situational = dilatazione_temporale_percettiva min_mos:4; the
+// only no-gate option coda_frusta_cinetica_2 leans control not speed -- both PROPOSED in #3114).
 const PROPOSED_IMPRINT_TRAIT_MAPPING = {
   locomotion: {
     VELOCE: 'coda_stabilizzatrice_vortex',
@@ -76,15 +79,15 @@ const PROPOSED_IMPRINT_TRAIT_MAPPING = {
   },
   offense: {
     PROFONDA: 'ferocia',
-    // RAPIDA: TODO -- master-dd balance pick (N=40)
+    // RAPIDA: TODO -- master-dd balance pick (N=40); no clean LIVE pick (recon #3114)
   },
   defense: {
     DURA: 'pelle_elastomera',
-    // FLESSIBILE: TODO -- master-dd balance pick (no clean evasion trait today)
+    FLESSIBILE: 'risposta_di_fuga',
   },
   senses: {
     LONTANO: 'sensori_geomagnetici',
-    ACUTO: 'sensori_sismici',
+    ACUTO: 'occhi_analizzatori_di_tensione',
   },
 };
 

--- a/docs/planning/2026-06-30-form-pulse-trait-v2-flip-readiness-build-spec.md
+++ b/docs/planning/2026-06-30-form-pulse-trait-v2-flip-readiness-build-spec.md
@@ -130,10 +130,15 @@ tags: [evo-tactics, form-pulse, aa01-impronta, trait, flip-readiness, grilling, 
 
 ### W3 -- mapping imprint 8-celle + liveness-audit HARD-gate
 
-> **STATUS (2026-06-30): BUILT (partial, 6/8 celle).** `PROPOSED_IMPRINT_TRAIT_MAPPING` esteso a
-> 4 assi; HARD-gate `tests/services/imprintTraitGrantLiveness.test.js` (predicato condiviso
-> `tests/helpers/traitLiveness.js`). 6 celle wired+LIVE-audited; 2 celle (offense/RAPIDA,
-> defense/FLESSIBILE) lasciate UNWIRED = balance-pick master-dd.
+> **STATUS (2026-06-30): BUILT 7/8 celle.** `PROPOSED_IMPRINT_TRAIT_MAPPING` esteso a 4 assi;
+> HARD-gate `tests/services/imprintTraitGrantLiveness.test.js` (predicato condiviso
+> `tests/helpers/traitLiveness.js`). Update post-recon (#3114, master-dd "wira le celle clean"):
+> **defense/FLESSIBILE wired** = `risposta_di_fuga` (recon ha sciolto il gap "no clean trait" =
+> STALE -> Dodge branch LIVE-CLEAN) + **senses/ACUTO swapped** dal double-gated `sensori_sismici`
+> a `occhi_analizzatori_di_tensione` (no-gate CLEAN). **senses/LONTANO TENUTO** = `sensori_geomagnetici`
+> (l'unica opzione no-gate `senso_magnetico` e' self-labeled 'Stub data-only' -> rifiutata, lesson
+> #3083). **Solo offense/RAPIDA resta UNWIRED** (nessun pick clean; menu N=40 in #3114). Tutto
+> flag-OFF/band-neutral, mapping PROPOSED -> ratifica N=40.
 
 - Mappa completa 4 assi x 2 poli (locomotion/offense/defense/senses).
 - **HARD-gate**: ogni pick deve passare un liveness-audit engine-reale (trigger
@@ -146,15 +151,16 @@ tags: [evo-tactics, form-pulse, aa01-impronta, trait, flip-readiness, grilling, 
   da verificare) + `defense/FLESSIBILE` (nessun trait evasione pulito oggi = TBD).
 - Ref: D6 spec sez.4
   [`2026-06-23-aa01-imprint-axis-trait-grant-spec-draft.md`](2026-06-23-aa01-imprint-axis-trait-grant-spec-draft.md).
-- **As-built audit (2026-06-30, real registry + `isEngineLiveReliable`)**: i 4 pick non-locomotion
-  audìti passano TUTTI il gate -> wired: `offense/PROFONDA -> ferocia` (attack/apply_status
-  on_kill, CLEAN), `defense/DURA -> pelle_elastomera` (attack/dr, CLEAN), `senses/LONTANO ->
-sensori_geomagnetici` (attack/extra_damage, min_mos:5 situational), `senses/ACUTO ->
-sensori_sismici` (attack/extra_damage, melee+min_mos:5 situational). Le 2 celle min_mos =
-  situational-LIVE (stesso bar del pick VELOCE gia' shippato `coda_stabilizzatrice_vortex` =
-  melee+min_mos:5), flaggate come primary re-pick N=40. `offense/RAPIDA`
-  (`artiglio_cinetico_a_urto`) + `defense/FLESSIBILE` (nessun trait evasione pulito) restano
-  UNWIRED -> balance-pick master-dd (NON auto-assegnati).
+- **As-built (2026-06-30, real registry + `isEngineLiveReliable`, post-recon #3114)**: 7/8 wired:
+  `offense/PROFONDA -> ferocia` (CLEAN), `defense/DURA -> pelle_elastomera` (CLEAN),
+  `defense/FLESSIBILE -> risposta_di_fuga` (CLEAN, recon-found), `senses/LONTANO ->
+sensori_geomagnetici` (min_mos:5 situational, TENUTO -- no clean upgrade), `senses/ACUTO ->
+occhi_analizzatori_di_tensione` (no-gate CLEAN, swapped dal double-gated `sensori_sismici`),
+  - i 2 locomotion. Tutti re-audìti LIVE + disjoint da branco/minor. `senso_magnetico` (no-gate)
+    RIFIUTATO per LONTANO = self-labeled 'Stub data-only'. **Solo `offense/RAPIDA` UNWIRED** = no
+    clean pick (best situational `dilatazione_temporale_percettiva` min_mos:4 / no-gate-control
+    `coda_frusta_cinetica_2`, entrambi PROPOSED in #3114) -> balance-pick master-dd N=40.
+    Recon completo: [`2026-06-30-form-pulse-trait-v2-imprint-weak-cell-recon.md`](2026-06-30-form-pulse-trait-v2-imprint-weak-cell-recon.md).
 
 ### W4 -- flag-unification
 

--- a/docs/planning/2026-06-30-form-pulse-trait-v2-flip-readiness-build-spec.md
+++ b/docs/planning/2026-06-30-form-pulse-trait-v2-flip-readiness-build-spec.md
@@ -110,14 +110,21 @@ tags: [evo-tactics, form-pulse, aa01-impronta, trait, flip-readiness, grilling, 
 ### W2 -- produttore unificato `brancoTraitProducer` (design-heavy)
 
 > **STATUS (2026-06-30): BUILT flag-OFF.** `apps/backend/services/identity/brancoTraitProducer.js`
-> (`produceBrancoTrait` + `resolveImprintWeight`); rimpiazza il fallback inline #3083 in
-> `coopOrchestrator._applyBrancoTraitEmergence`. OFF (combined=false) = delega a
+> (`produceBrancoTrait` + `resolveImprintWeight` + `selectImprintAxis`); rimpiazza il fallback
+> inline #3083 in `coopOrchestrator._applyBrancoTraitEmergence`. OFF (combined=false) = delega a
 > `emergeBrancoTrait` = byte-identical. `w` PROPOSED 0.5 (env `FORM_PULSE_IMPRINT_WEIGHT`) -> W6.
 
-- Nuovo modulo puro che fa **argmax pesato** sull'unione:
-  `{5 assi form-pulse continui |avg|}` ∪ `{4 assi imprint binari, pesati w}`.
-  Il vincitore dell'argmax decide quale mapping (form-pulse o imprint) fornisce l'UNICO
-  branco trait. Niente proiezione tra assi (gli assi imprint hanno il loro mapping, sez. W3).
+- **Form side**: argmax `|avg|` sui 5 assi form-pulse continui (il vincitore = il rappresentante
+  form-pulse, magnitudine = `|avg|`). **Imprint side**: UN candidato di magnitudine `w`.
+  La precedenza tra i due = STRICT `>` (form-pulse vince il tie esatto = P-c precedenza).
+- 🔑 **Correzione meccanismo imprint (Codex P2 #3115, verdetto master-dd "tuple-determined"):**
+  i 4 assi imprint sono BINARI a magnitudine UGUALE `w` -> NON possono fare argmax fra loro
+  (con un tie-break first-axis vinceva SEMPRE locomotion = le altre celle UNREACHABLE). Quindi
+  **quale asse imprint grant-a = `selectImprintAxis`**: la 4-tupla INTERA seleziona deterministicamente
+  uno degli assi con polo wired (hash-mod sull'intera tupla -> whole-imprint-matters = vera D-2;
+  tutte le celle wired reachable; stesso-tupla -> stesso-asse, reconnect-stabile). Il meccanismo
+  di selezione e' PROPOSED (hash-mod arbitrario-ma-deterministico; master-dd puo' sostituirlo con
+  una tabella tupla->asse curata al ratify N=40). Niente proiezione tra vocabolari di assi.
 - **Rimpiazza** il fallback inline `fromPulses || imprint` di #3083 (su main) e centralizza
   in un solo posto la produzione del branco trait (precedenza esplicita = P-c combinata).
 - Single-slot garantito (UN branco trait) -> nessun power-stack -> l'offset W1 resta valido.

--- a/tests/api/coopImprintTraitGrant.test.js
+++ b/tests/api/coopImprintTraitGrant.test.js
@@ -1,15 +1,26 @@
 'use strict';
 
 // D6 imprint axis->trait grant wired into the coop branco-trait slot. W4 flag-unification
-// (grilling 2026-06-30): the imprint now feeds the single slot through the unified
+// (grilling 2026-06-30): the imprint feeds the single slot through the unified
 // brancoTraitProducer under ONE flag FORM_PULSE_TRAIT_V2_ENABLED (the old
 // IMPRINT_TRAIT_GRANT_ENABLED is collapsed away). OFF = byte-identical (imprint stays
-// cosmetic). Stacking B preserved: ONE slot, imprint competes via the weighted argmax,
-// Form-Pulse precedence on a tie.
+// cosmetic). Stacking B preserved: ONE slot, Form-Pulse precedence on a tie. Which imprint
+// axis grants is TUPLE-DETERMINED (verdict D-2, #3115): the whole 4-tuple selects the axis
+// (selectImprintAxis), so the granted trait is asserted against that, not a fixed pole->trait.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { CoopOrchestrator } = require('../../apps/backend/services/coop/coopOrchestrator');
+const { selectImprintAxis } = require('../../apps/backend/services/identity/brancoTraitProducer');
+const {
+  PROPOSED_IMPRINT_TRAIT_MAPPING,
+} = require('../../apps/backend/services/imprint/imprintTraitGrant');
+
+// The trait the tuple-determined selector would grant for the orchestrator's stamped tuple.
+function expectedImprintTrait(co) {
+  const sel = selectImprintAxis(co.imprintTuple, PROPOSED_IMPRINT_TRAIT_MAPPING);
+  return sel && sel.trait_id;
+}
 
 function party(roomCode = 'IMTG') {
   const co = new CoopOrchestrator({ roomCode, hostId: 'p_h' });
@@ -61,24 +72,34 @@ test('flag OFF (default): imprint completes but grants NO trait (byte-identical)
   );
 });
 
-test('flag ON, no Form-Pulse: imprint VELOCE fills the slot (coda_stabilizzatrice_vortex)', () => {
+test('flag ON, no Form-Pulse: the tuple-determined imprint trait fills the slot (all chars)', () => {
   withFlags(true, () => {
     const co = party();
     completeImprint(co, 'VELOCE');
-    assert.ok(co.emergentBrancoTrait, 'slot filled by the imprint fallback');
-    assert.equal(co.emergentBrancoTrait.trait_id, 'coda_stabilizzatrice_vortex');
+    const want = expectedImprintTrait(co);
+    assert.ok(want, 'a wired imprint cell is selected for this tuple');
+    assert.ok(co.emergentBrancoTrait, 'slot filled by the imprint');
+    assert.equal(co.emergentBrancoTrait.trait_id, want, 'grants the tuple-determined trait');
     assert.equal(co.emergentBrancoTrait.source, 'imprint');
-    assert.ok(co.characters.get('p_a').traits.includes('coda_stabilizzatrice_vortex'));
-    assert.ok(co.characters.get('p_b').traits.includes('coda_stabilizzatrice_vortex'));
+    assert.ok(co.characters.get('p_a').traits.includes(want));
+    assert.ok(co.characters.get('p_b').traits.includes(want), 'shared across the branco');
   });
 });
 
-test('flag ON, SILENZIOSA -> cartilagini_flessoacustiche', () => {
+test('flag ON: a DIFFERENT tuple grants its OWN tuple-determined trait (axis varies by tuple)', () => {
   withFlags(true, () => {
-    const co = party();
-    completeImprint(co, 'SILENZIOSA');
-    assert.equal(co.emergentBrancoTrait.trait_id, 'cartilagini_flessoacustiche');
-    assert.ok(co.characters.get('p_a').traits.includes('cartilagini_flessoacustiche'));
+    const coV = party('IMTV');
+    completeImprint(coV, 'VELOCE');
+    const coS = party('IMTS');
+    completeImprint(coS, 'SILENZIOSA');
+    assert.equal(coV.emergentBrancoTrait.trait_id, expectedImprintTrait(coV));
+    assert.equal(coS.emergentBrancoTrait.trait_id, expectedImprintTrait(coS));
+    // both are valid wired imprint traits (not necessarily the locomotion pick)
+    const wired = new Set(
+      Object.values(PROPOSED_IMPRINT_TRAIT_MAPPING).flatMap((p) => Object.values(p)),
+    );
+    assert.ok(wired.has(coV.emergentBrancoTrait.trait_id));
+    assert.ok(wired.has(coS.emergentBrancoTrait.trait_id));
   });
 });
 
@@ -90,10 +111,11 @@ test('flag ON, Form-Pulse present -> Form-Pulse PRECEDENCE (imprint ignored)', (
     co.submitFormPulse('p_b', { axes: { solitary_swarm: 0.8 } }, ALL); // -> legame_di_branco
     completeImprint(co, 'VELOCE');
     assert.equal(co.emergentBrancoTrait.trait_id, 'legame_di_branco', 'Form-Pulse wins the slot');
+    assert.equal(co.emergentBrancoTrait.source, 'formpulse');
     assert.equal(
-      co.characters.get('p_a').traits.includes('coda_stabilizzatrice_vortex'),
+      co.characters.get('p_a').traits.includes(expectedImprintTrait(co)),
       false,
-      'imprint trait NOT granted while Form-Pulse holds the slot',
+      'the tuple-determined imprint trait is NOT granted while Form-Pulse holds the slot',
     );
   });
 });
@@ -109,7 +131,7 @@ test('flag ON, weak Form-Pulse lean -> imprint weight outvotes it for the slot',
     assert.equal(co.emergentBrancoTrait.source, 'formpulse');
     // ...but the imprint weight (PROPOSED 0.5) outvotes a 0.1 lean once the tuple lands.
     completeImprint(co, 'VELOCE');
-    assert.equal(co.emergentBrancoTrait.trait_id, 'coda_stabilizzatrice_vortex');
+    assert.equal(co.emergentBrancoTrait.trait_id, expectedImprintTrait(co));
     assert.equal(co.emergentBrancoTrait.source, 'imprint');
   });
 });

--- a/tests/services/brancoTraitProducer.test.js
+++ b/tests/services/brancoTraitProducer.test.js
@@ -151,21 +151,62 @@ test('single slot: returns at most ONE trait (never stacks)', () => {
   assert.ok(!Array.isArray(got));
 });
 
-test('ON: deterministic tie-break among imprint axes (mapping order, first wins)', () => {
-  // both locomotion + senses present; equal weight -> the first mapping axis wins.
-  const imprintMapping = {
-    locomotion: { VELOCE: 'trait_loco' },
-    senses: { ACUTO: 'trait_senses' },
+test('ON: imprint axis is TUPLE-DETERMINED (deterministic + whole-tuple-dependent), not first-axis', () => {
+  // Verdict D-2: the FULL tuple selects WHICH imprint axis grants -- so non-first axes are
+  // reachable (the first-axis tie-break made only locomotion reachable, Codex P2). Deterministic
+  // for a given tuple; different tuples can surface different axes.
+  const call = (tuple) =>
+    produceBrancoTrait({
+      aggregate: {},
+      imprintTuple: tuple,
+      combined: true,
+      threshold: 0,
+      w: 0.5,
+      imprintMapping: PROPOSED_IMPRINT_TRAIT_MAPPING,
+    });
+  const t1 = { locomotion: 'VELOCE', offense: 'PROFONDA', defense: 'FLESSIBILE', senses: 'ACUTO' };
+  assert.equal(call(t1).trait_id, call(t1).trait_id, 'same tuple -> same trait (deterministic)');
+  // whole-tuple-dependent WITH locomotion FIXED: under a first-axis rule the trait would never
+  // change (locomotion always wins); under tuple-determined it can. At least 2 distinct traits.
+  const variants = ['DURA', 'FLESSIBILE'].flatMap((d) =>
+    ['LONTANO', 'ACUTO'].map((s) => ({ ...t1, defense: d, senses: s })),
+  );
+  const traits = new Set(variants.map((v) => call(v).trait_id));
+  assert.ok(traits.size >= 2, 'with locomotion fixed, the tuple must still steer the imprint axis');
+});
+
+test('reachability (Codex P2): every WIRED imprint cell can win for SOME complete tuple', () => {
+  const POLES = {
+    locomotion: ['VELOCE', 'SILENZIOSA'],
+    offense: ['PROFONDA', 'RAPIDA'],
+    defense: ['DURA', 'FLESSIBILE'],
+    senses: ['LONTANO', 'ACUTO'],
   };
-  const got = produceBrancoTrait({
-    aggregate: {},
-    imprintTuple: { locomotion: 'VELOCE', senses: 'ACUTO' },
-    combined: true,
-    threshold: 0,
-    w: 0.5,
-    imprintMapping,
-  });
-  assert.equal(got.trait_id, 'trait_loco');
+  const won = new Set();
+  for (const locomotion of POLES.locomotion)
+    for (const offense of POLES.offense)
+      for (const defense of POLES.defense)
+        for (const senses of POLES.senses) {
+          const r = produceBrancoTrait({
+            aggregate: {},
+            imprintTuple: { locomotion, offense, defense, senses },
+            combined: true,
+            threshold: 0,
+            w: 0.5,
+            imprintMapping: PROPOSED_IMPRINT_TRAIT_MAPPING,
+          });
+          if (r) won.add(r.trait_id);
+        }
+  // the wired non-locomotion cells MUST be reachable across the tuple space (the point of D-2).
+  for (const id of [
+    'ferocia', // offense/PROFONDA
+    'pelle_elastomera', // defense/DURA
+    'risposta_di_fuga', // defense/FLESSIBILE
+    'occhi_analizzatori_di_tensione', // senses/ACUTO
+    'sensori_geomagnetici', // senses/LONTANO
+  ]) {
+    assert.ok(won.has(id), `imprint cell ${id} must be reachable for at least one tuple`);
+  }
 });
 
 test('null / garbage inputs -> null, never throws', () => {

--- a/tests/services/imprintTraitGrantLiveness.test.js
+++ b/tests/services/imprintTraitGrantLiveness.test.js
@@ -39,7 +39,7 @@ test('all 4 imprint axes are present in the mapping', () => {
 });
 
 test('every WIRED imprint pick EXISTS in active_effects.yaml', () => {
-  assert.ok(WIRED.length >= 6, 'expected the 6 audited-LIVE cells wired');
+  assert.ok(WIRED.length >= 7, 'expected the 7 audited-LIVE cells wired (RAPIDA stays unwired)');
   for (const { trait_id } of WIRED) {
     assert.ok(registry[trait_id], `imprint trait ${trait_id} must exist in active_effects.yaml`);
   }
@@ -54,17 +54,21 @@ test('HARD-gate: every WIRED imprint pick is ENGINE-LIVE-RELIABLE (the trait act
   }
 });
 
-test('the 2 balance-pick cells stay UNWIRED (master-dd / N=40, never auto-assigned)', () => {
+test('only offense/RAPIDA stays UNWIRED; FLESSIBILE + senses/ACUTO wired to clean picks (recon #3114)', () => {
+  // offense/RAPIDA: the recon found NO clean (no-gate) LIVE pick -> stays a master-dd N=40 pick.
   assert.equal(
     PROPOSED_IMPRINT_TRAIT_MAPPING.offense.RAPIDA,
     undefined,
-    'offense/RAPIDA is a balance pick -- must NOT be auto-assigned',
+    'offense/RAPIDA has no clean LIVE pick -- must NOT be auto-assigned',
   );
-  assert.equal(
-    PROPOSED_IMPRINT_TRAIT_MAPPING.defense.FLESSIBILE,
-    undefined,
-    'defense/FLESSIBILE has no clean evasion trait today -- must NOT be auto-assigned',
-  );
+  // defense/FLESSIBILE: the recon RESOLVED the stale "no clean evasion trait" note --
+  // risposta_di_fuga is a clean LIVE-CLEAN target-side DR (Dodge branch). Now wired.
+  assert.equal(PROPOSED_IMPRINT_TRAIT_MAPPING.defense.FLESSIBILE, 'risposta_di_fuga');
+  // senses/ACUTO: swapped from the double-gated sensori_sismici to a no-gate clean upgrade.
+  assert.equal(PROPOSED_IMPRINT_TRAIT_MAPPING.senses.ACUTO, 'occhi_analizzatori_di_tensione');
+  // senses/LONTANO: KEPT -- the only no-gate option (senso_magnetico) is self-labeled
+  // 'Stub data-only', so no clean upgrade exists; the situational incumbent stays wired.
+  assert.equal(PROPOSED_IMPRINT_TRAIT_MAPPING.senses.LONTANO, 'sensori_geomagnetici');
 });
 
 test('predicate DISCRIMINATES: known inert/near-inert ids fail the HARD-gate (not a no-op)', () => {


### PR DESCRIPTION
## Wire 3 recon-clean imprint cells (7/8) -- flag-OFF, PROPOSED

Master-dd verdict (post-recon [#3114](https://github.com/MasterDD-L34D/Game/pull/3114), "wira le celle clean"): wire the **verified-clean** weak imprint cells. All behind `FORM_PULSE_TRAIT_V2_ENABLED` (default OFF = band-neutral); mapping stays PROPOSED -> N=40 ratify. Builds on [#3113](https://github.com/MasterDD-L34D/Game/pull/3113).

### Changes (imprint mapping 6/8 -> 7/8)
- **`defense/FLESSIBILE` = `risposta_di_fuga`** -- the recon resolved the stale "no clean evasion trait today" note; this is a clean LIVE-CLEAN target-side DR (Dodge branch). NEW wire.
- **`senses/ACUTO`**: swapped `sensori_sismici` (double-gated melee+min_mos:5, fires rarely) -> **`occhi_analizzatori_di_tensione`** (no-gate, same +1 dmg = strict upgrade).
- **`senses/LONTANO`**: KEPT `sensori_geomagnetici`. The only no-gate option `senso_magnetico` is **self-labeled `Stub data-only`** in its own description -> rejected (lesson #3083: don't wire questionable traits). No clean upgrade exists, so the situational incumbent stays.
- **`offense/RAPIDA`**: stays UNWIRED -- the recon found no clean LIVE pick (best situational `dilatazione_temporale_percettiva`; menu in #3114). Master-dd N=40 pick.

### Verification
- All 3 wired ids re-audited LIVE (`isEngineLiveReliable`) + disjoint from the branco/minor pools (programmatic check).
- Liveness HARD-gate test (`imprintTraitGrantLiveness.test.js`) updated: 7 wired cells all pass; only `offense/RAPIDA` asserted UNWIRED.
- End-to-end producer smoke: each axis grants its pick; `offense/RAPIDA -> null`.
- `node --test tests/ai` = **567 green**; 68 affected suites green; `prettier --check` clean; governance `--strict` errors=0.
- No prod flag flipped. No forbidden paths.

### Judgment note (flagged for reviewer)
The recon recommended `senso_magnetico` as the LONTANO no-gate primary, but its own `description_it` says **"Stub data-only (M-future...)"** -- its designed effect is unbuilt and the live `sensed`->+1 accuracy is incidental. Wiring a self-described stub violates the liveness discipline, so I kept the incumbent for LONTANO. If you want LONTANO swapped anyway (with a one-line desc de-stub in `active_effects.yaml`), say so.
