### PR TITLE
feat(tools): check_missing_traits 2-tier existence gate (TKT-P6 17 non-combat orphan)

### DIFF
--- a/tests/lint/test_check_missing_traits.py
+++ b/tests/lint/test_check_missing_traits.py
@@ -53,6 +53,19 @@ def test_combat_strict_escalates_to_fail(tmp_path):
     assert r.returncode == 1, r.stderr
 
 
+def test_combat_strict_rejects_json_reference(tmp_path):
+    # Codex P2 (#3124): --combat-strict + index JSON nasconderebbe i non-combat
+    # (taxonomy contiene i 15/17) -> audit falso-verde. Deve rifiutare (exit 2).
+    idx = tmp_path / "index.json"
+    idx.write_text(json.dumps({"traits": {"t_glossary_only": {}}}))
+    fx = _fixtures(tmp_path, ["t_glossary_only"])
+    # sostituisci il --trait-reference YAML con l'index JSON
+    fx[fx.index("--trait-reference") + 1] = str(idx)
+    r = _run([*fx, "--combat-strict", "--strict"])
+    assert r.returncode == 2, r.stderr
+    assert "combat-strict" in (r.stderr + r.stdout)
+
+
 def test_real_catalog_strict_is_clean(tmp_path):
     # Il vero gate: tutti i trait_refs del catalog esistono in glossary OR
     # active_effects -> default --strict deve uscire 0 (i 17 non-combat = WARN).

--- a/tests/lint/test_check_missing_traits.py
+++ b/tests/lint/test_check_missing_traits.py
@@ -66,6 +66,25 @@ def test_combat_strict_rejects_json_reference(tmp_path):
     assert "combat-strict" in (r.stderr + r.stdout)
 
 
+def test_yaml_reference_case_insensitive(tmp_path):
+    # P3 (pre-merge review): un --trait-reference .YAML deve essere parsato come
+    # YAML (loader case-insensitive), coerente col guard combat-strict che usa
+    # .lower(). Altrimenti load_trait_reference cade nel branch JSON -> crash.
+    active = tmp_path / "active.YAML"
+    active.write_text("traits:\n  t_combat:\n    tier: T1\n")
+    glossary = tmp_path / "glossary.json"
+    glossary.write_text(json.dumps({"traits": {"t_combat": {}, "t_glossary_only": {}}}))
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text(json.dumps({"catalog": [{"species_id": "s1", "trait_refs": ["t_glossary_only"]}]}))
+    r = _run([
+        "--species", str(catalog), "--trait-reference", str(active),
+        "--glossary", str(glossary), "--combat-strict", "--strict",
+    ])
+    # audit gira: t_glossary_only non in active -> combat_unauthored -> FAIL exit 1 (NON un traceback).
+    assert r.returncode == 1, r.stderr
+    assert "Traceback" not in r.stderr
+
+
 def test_real_catalog_strict_is_clean(tmp_path):
     # Il vero gate: tutti i trait_refs del catalog esistono in glossary OR
     # active_effects -> default --strict deve uscire 0 (i 17 non-combat = WARN).

--- a/tests/lint/test_check_missing_traits.py
+++ b/tests/lint/test_check_missing_traits.py
@@ -1,0 +1,60 @@
+"""Test 2-tier existence gate -- tools/py/check_missing_traits.py.
+
+Tier-1 FAIL = phantom (trait in nessun registro). Tier-2 WARN = esiste in
+glossary ma non in active_effects (non-combat), o specie senza trait_refs.
+`--combat-strict` ri-promuove i Tier-2 a FAIL (audit combat legacy).
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools/py/check_missing_traits.py"
+
+
+def _run(args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def _fixtures(tmp_path, trait_refs):
+    """Catalog + active_effects (t_combat only) + glossary (t_combat + t_glossary_only)."""
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text(json.dumps({"catalog": [{"species_id": "s1", "trait_refs": trait_refs}]}))
+    active = tmp_path / "active_effects.yaml"
+    active.write_text("traits:\n  t_combat:\n    tier: T1\n")
+    glossary = tmp_path / "glossary.json"
+    glossary.write_text(json.dumps({"traits": {"t_combat": {}, "t_glossary_only": {}}}))
+    return ["--species", str(catalog), "--trait-reference", str(active), "--glossary", str(glossary)]
+
+
+def test_phantom_ref_fails_strict(tmp_path):
+    # Trait in nessun registro -> Tier-1 FAIL anche in default --strict.
+    r = _run([*_fixtures(tmp_path, ["t_phantom"]), "--strict"])
+    assert r.returncode == 1, r.stderr
+    assert "phantom" in (r.stderr + r.stdout)
+
+
+def test_glossary_only_warns_not_fails(tmp_path):
+    # Esiste in glossary, non in active_effects -> Tier-2 WARN, exit 0.
+    r = _run([*_fixtures(tmp_path, ["t_glossary_only"]), "--strict"])
+    assert r.returncode == 0, r.stderr
+    assert "WARN" in r.stderr and "t_glossary_only" in r.stderr
+
+
+def test_combat_strict_escalates_to_fail(tmp_path):
+    # --combat-strict ri-promuove il non-combat a FAIL (audit legacy).
+    r = _run([*_fixtures(tmp_path, ["t_glossary_only"]), "--combat-strict", "--strict"])
+    assert r.returncode == 1, r.stderr
+
+
+def test_real_catalog_strict_is_clean(tmp_path):
+    # Il vero gate: tutti i trait_refs del catalog esistono in glossary OR
+    # active_effects -> default --strict deve uscire 0 (i 17 non-combat = WARN).
+    r = _run(["--strict"])
+    assert r.returncode == 0, f"gate non pulito (phantom ref reale?):\n{r.stderr}"

--- a/tools/py/check_missing_traits.py
+++ b/tools/py/check_missing_traits.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
-"""Verifica che tutti i trait referenziati dalle specie esistano nel trait reference."""
+"""Verifica che ogni trait referenziato dalle specie ESISTA in canon (2-tier).
+
+Tier-1 (FAIL): un trait_ref che non e' in NESSUN registro canonico -- ne'
+active_effects (resolver combat) ne' glossary (label+lore). Quello e' un
+phantom reference = bug reale.
+
+Tier-2 (WARN, non-fallante): un trait che esiste in glossary/taxonomy ma NON
+in active_effects (non-combat o non ancora autorato come meccanica combat);
+oppure una specie senza trait_refs. Sono gap di content owner-gated, non
+reference rotte. `--combat-strict` li ri-promuove a FAIL (audit combat).
+
+Esistenza-faithful: allinea questo tool advisory al guard CI gia' enforced
+`tests/scripts/speciesTraitReferences.test.js`, che usa glossary come registro
+di esistenza. active_effects da solo era il reference outlier (combat-only).
+"""
 
 from __future__ import annotations
 
@@ -38,6 +52,20 @@ def load_trait_reference(path: Path) -> Set[str]:
   if isinstance(traits, dict):
     return {trait_id for trait_id in traits.keys()}
   return set()
+
+
+def load_glossary_ids(path: Path) -> Set[str]:
+  """Trait ids nel glossary canonico (registro di ESISTENZA, SOURCE).
+
+  Un trait con entry glossary (label_it/en + descrizione) ESISTE in canon
+  anche se non e' combat-resolvable. Mirrorato dal guard CI
+  `tests/scripts/speciesTraitReferences.test.js`. Assente -> set vuoto.
+  """
+  if not path.exists():
+    return set()
+  payload = json.loads(path.read_text(encoding="utf-8"))
+  traits = payload.get("traits") if isinstance(payload, dict) else None
+  return set(traits.keys()) if isinstance(traits, dict) else set()
 
 
 def _extract_traits_from_catalog(path: Path) -> tuple[Set[str], list[str]]:
@@ -104,8 +132,10 @@ def main(argv: Iterable[str]) -> int:
     # NOTE: catalog trait_refs use legacy IDs (artigli_sette_vie etc.), NOT
     # TR-NNNN format. Default --trait-reference adjusted accordingly per
     # Codex review 2026-05-15 (avoid false "missing TR-1101" errors).
-    default=[Path("data/core/species/species_catalog.json")],
-    help="File catalog JSON (canonical) o YAML legacy (deprecated). Può essere passato più volte.",
+    # default=None (not a list) so passing --species REPLACES the catalog
+    # instead of appending to it (argparse append-with-list-default footgun).
+    default=None,
+    help="File catalog JSON (canonical) o YAML legacy (deprecated). Puo' essere passato piu' volte; sostituisce il default se passato.",
   )
   parser.add_argument(
     "--trait-reference",
@@ -123,14 +153,30 @@ def main(argv: Iterable[str]) -> int:
     # (TR-NNNN from species_expansion slot_* incoming docx_2026-04-16). These
     # are REAL gaps (master-dd backlog) ma noise per CI. Default non-strict
     # exit 0 with warning. --strict per CI gate enforcement.
-    help="Exit 1 quando missing_traits OR missing_core_contexts (default: exit 0 + warning).",
+    help="Exit 1 quando un trait_ref e' phantom (in nessun registro). I gap non-combat / no-trait restano WARN salvo --combat-strict.",
+  )
+  parser.add_argument(
+    "--glossary",
+    type=Path,
+    default=Path("data/core/traits/glossary.json"),
+    help="Registro di esistenza canonico (label+lore). Un trait qui presente ESISTE anche senza def combat.",
+  )
+  parser.add_argument(
+    "--combat-strict",
+    action="store_true",
+    help="Ri-promuove a FAIL i trait in glossary-ma-non-active_effects + le specie senza trait_refs (audit combat-resolvability, comportamento legacy).",
   )
   args = parser.parse_args(list(argv))
+  if args.species is None:
+    args.species = [Path("data/core/species/species_catalog.json")]
 
-  reference = load_trait_reference(args.trait_reference)
-  if not reference:
+  combat_reference = load_trait_reference(args.trait_reference)
+  if not combat_reference:
     print(f"Trait reference vuoto o non valido: {args.trait_reference}", file=sys.stderr)
     return 1
+
+  glossary_ids = load_glossary_ids(args.glossary)
+  existence = combat_reference | glossary_ids
 
   used_traits: Set[str] = set()
   missing_core_contexts: list[str] = []
@@ -142,21 +188,31 @@ def main(argv: Iterable[str]) -> int:
     used_traits.update(used)
     missing_core_contexts.extend(missing_core)
 
-  missing_traits = sorted(trait for trait in used_traits if trait not in reference)
+  # Tier-1 (FAIL): phantom = referenziato ma in NESSUN registro.
+  truly_missing = sorted(t for t in used_traits if t not in existence)
+  # Tier-2 (WARN): esiste in glossary/taxonomy ma non e' combat-resolvable.
+  combat_unauthored = sorted(t for t in used_traits if t in existence and t not in combat_reference)
+  no_trait_species = sorted(set(missing_core_contexts))
 
-  errors: list[str] = []
-  if missing_traits:
-    trait_list = ", ".join(missing_traits)
-    errors.append(f"Trait mancanti nel reference: {trait_list}")
-  if missing_core_contexts:
-    contexts = ", ".join(sorted(set(missing_core_contexts)))
-    errors.append(f"Specie senza trait core definiti: {contexts}")
+  failures: list[str] = []
+  warnings: list[str] = []
 
-  if errors:
-    print("\n".join(errors), file=sys.stderr)
-    # ADR-2026-05-15 Phase 4c Codex follow-up: default non-strict per CI noise
-    # reduction. Catalog v0.4.x has placeholder TR-NNNN traits as master-dd
-    # backlog tracking, not blocking errors.
+  if truly_missing:
+    failures.append("Trait inesistenti (in nessun registro -- phantom ref): " + ", ".join(truly_missing))
+
+  if combat_unauthored:
+    msg = f"{len(combat_unauthored)} trait esistono in glossary ma non in active_effects (non-combat / non ancora autorati): " + ", ".join(combat_unauthored)
+    (failures if args.combat_strict else warnings).append(msg)
+
+  if no_trait_species:
+    msg = f"{len(no_trait_species)} specie senza trait_refs (content gap owner-gated): " + ", ".join(no_trait_species)
+    (failures if args.combat_strict else warnings).append(msg)
+
+  for w in warnings:
+    print(f"[check_missing_traits] WARN: {w}", file=sys.stderr)
+
+  if failures:
+    print("\n".join(failures), file=sys.stderr)
     if args.strict:
       return 1
     print("[check_missing_traits] non-strict mode: exit 0 (use --strict per CI gate).", file=sys.stderr)

--- a/tools/py/check_missing_traits.py
+++ b/tools/py/check_missing_traits.py
@@ -40,7 +40,7 @@ def load_trait_reference(path: Path) -> Set[str]:
   # - .json (data/traits/index.json) → TR-NNNN format
   # Catalog trait_refs use legacy ids, so YAML reference preferred when
   # validating catalog. JSON reference per Pack v2 species YAML legacy.
-  if path.suffix in (".yaml", ".yml"):
+  if path.suffix.lower() in (".yaml", ".yml"):
     import yaml as _yaml
     payload = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     traits = payload.get("traits") if isinstance(payload, dict) else None

--- a/tools/py/check_missing_traits.py
+++ b/tools/py/check_missing_traits.py
@@ -164,11 +164,23 @@ def main(argv: Iterable[str]) -> int:
   parser.add_argument(
     "--combat-strict",
     action="store_true",
-    help="Ri-promuove a FAIL i trait in glossary-ma-non-active_effects + le specie senza trait_refs (audit combat-resolvability, comportamento legacy).",
+    help="Ri-promuove a FAIL i trait in glossary-ma-non-active_effects + le specie senza trait_refs (audit combat-resolvability, comportamento legacy). Richiede --trait-reference YAML (active_effects).",
   )
   args = parser.parse_args(list(argv))
   if args.species is None:
     args.species = [Path("data/core/species/species_catalog.json")]
+
+  # L'audit combat-strict misura la combat-resolvability: la reference DEVE essere
+  # il resolver combat (active_effects YAML). Un index JSON (taxonomy) contiene i
+  # trait non-combat -> li nasconderebbe da combat_unauthored = audit falso-verde.
+  if args.combat_strict and args.trait_reference.suffix.lower() not in (".yaml", ".yml"):
+    print(
+      f"--combat-strict richiede un --trait-reference YAML (active_effects); "
+      f"l'index JSON ({args.trait_reference}) e' la taxonomy, non il resolver combat. "
+      f"Rimuovi --combat-strict oppure passa data/core/traits/active_effects.yaml.",
+      file=sys.stderr,
+    )
+    return 2
 
   combat_reference = load_trait_reference(args.trait_reference)
   if not combat_reference:


### PR DESCRIPTION
## Cosa
`check_missing_traits` ora valuta l'esistenza dei trait su **2 tier**, allineandosi al guard CI gia' enforced `tests/scripts/speciesTraitReferences.test.js` (che usa il **glossary** come registro di esistenza). `active_effects` da solo era il reference outlier (combat-only, 428 entry tutte con trigger+effect).

- **Tier-1 FAIL**: trait_ref in **nessun** registro (ne active_effects ne glossary) = phantom ref = bug reale.
- **Tier-2 WARN** (non-fallante): trait in glossary ma **non** combat-resolvable (i **17 orphan non-combat** TKT-P6), oppure specie senza trait_refs (i **29**, content gap owner-gated).
- `--combat-strict`: ri-promuove i Tier-2 a FAIL (audit combat-resolvability legacy).

`default --strict` ora esce **0** onestamente: tutti e 17 i trait esistono gia' nel glossary (label+lore IT/EN) -- sono non-combat **by design**. Forzare un active_effects entry = fabbricazione (gia' bocciata dal verify di #3118). Owner-gated alternative (species-ref cleanup su species_catalog DERIVED) e' BLOCCATA su dev checkout.

## Perche'
Design-call **ratificata master-dd** (AskUserQuestion -> 'Gate existence 2-tier'). Il docstring del tool dichiara di verificare l'**esistenza**; usare il solo resolver combat contraddiceva quello e produceva 17 falsi flag combat che oscuravano il segnale reale.

## Fix collaterale
`--species` (`action=append`) aveva `default=[lista]` -> passare `--species X` **appendeva** al catalog di default invece di sostituirlo (footgun argparse). Ora `default=None` + fill post-parse -> override sostituisce davvero.

## Scope / sicurezza
- Tool **advisory** (NON CI-wired; `grep` zero ref in workflow/package.json/Makefile; nessuno lo importa). Nessun cambio a resolver/catalog/active_effects/contracts. **Reversibile**, PROPOSED.
- Non-forbidden-path. ~119 righe nuove fuori `apps/backend/` (docstring + reporting 2-tier + test DoD) -> **>50-line guardrail -> merge manuale master-dd** (fuori L3 auto-merge gate #6).

## Test
- `tests/lint/test_check_missing_traits.py` (nuovo, 4 case): phantom->FAIL, glossary-only->WARN+exit0, --combat-strict->FAIL, real-catalog->exit0.
- `pytest tests/lint/` 13/13 green; `speciesTraitReferences.test.js` (CI guard correlato) 3/3 green.

## Rollback
Revert del commit; il tool torna single-reference. Nessun effetto runtime (advisory).