### PR TITLE
feat(sim): W5 inc-1 -- graded calibration metrics + focus-fire scaffold

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -505,6 +505,45 @@
       "track": "active"
     },
     {
+      "path": "docs/superpowers/plans/2026-07-01-w5-sim-ai-player-upgrade.md",
+      "title": "W5 -- sim AI-player upgrade (objective-aware/positioning long-pole) implementation plan",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-07-01",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "active"
+    },
+    {
+      "path": "docs/research/2026-07-01-w5-ai-player-recon.md",
+      "title": "W5 sim AI-player recon -- objective-aware / positioning long-pole (corrected premise)",
+      "doc_status": "review_needed",
+      "doc_owner": "claude-code",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-07-01",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "active"
+    },
+    {
+      "path": "docs/playtest/2026-07-01-w5-focus-fire-ab-evidence.md",
+      "title": "W5 inc-1 -- focus-fire A/B evidence (band-neutral: survival lever, not speed lever)",
+      "doc_status": "review_needed",
+      "doc_owner": "claude-code",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-07-01",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "active"
+    },
+    {
       "path": "docs/superpowers/plans/2026-06-23-move-terrain-cost-substrate-plan.md",
       "title": "Move terrain-cost substrate -- implementation plan (volo grades + radici anchor)",
       "doc_status": "active",

--- a/docs/planning/2026-07-01-session-handoff-grilling-value-picks-drained.md
+++ b/docs/planning/2026-07-01-session-handoff-grilling-value-picks-drained.md
@@ -22,13 +22,13 @@ form-pulse W6 + a rigorous re-ratify of the D6/D8/ER6 provisional bands + G6.
 
 ## Done this session
 
-| item      | what                                                                                     | PR / state                   |
-| --------- | ---------------------------------------------------------------------------------------- | ---------------------------- |
-| 1 HA1     | ratify `aliena_enforcement strength 0.5` = **GUARDRAIL-LATENT** (not enabled)            | #3117 **MERGED** (doc)       |
-| 2 STAMINA | keep **carrier-independent** (player-only switch rejected); flip staged-latent           | #3117 **MERGED** (doc)       |
-| 3 ER6     | **BUILD carry-over** (unspent overrun -> next round), flag OFF + N=40 band-SAFE          | #3119 **OPEN** (OWNER-merge) |
-| 4 D6      | wire `offense/RAPIDA = dilatazione_temporale_percettiva` (8/8), liveness-gated, flag OFF | #3120 **OPEN** (OWNER-merge) |
-| 5 D8      | caps **3/2** (maxDepth 3) + footprint sweep, flag OFF; **flip DEFERRED** (master-dd)     | #3121 **OPEN** (OWNER-merge) |
+| item      | what                                                                                     | PR / state                  |
+| --------- | ---------------------------------------------------------------------------------------- | --------------------------- |
+| 1 HA1     | ratify `aliena_enforcement strength 0.5` = **GUARDRAIL-LATENT** (not enabled)            | #3117 **MERGED** (doc)      |
+| 2 STAMINA | keep **carrier-independent** (player-only switch rejected); flip staged-latent           | #3117 **MERGED** (doc)      |
+| 3 ER6     | **BUILD carry-over** (unspent overrun -> next round), flag OFF + N=40 band-SAFE          | #3119 **MERGED** `623860f5` |
+| 4 D6      | wire `offense/RAPIDA = dilatazione_temporale_percettiva` (8/8), liveness-gated, flag OFF | #3120 **MERGED** `516ad425` |
+| 5 D8      | caps **3/2** (maxDepth 3) + footprint sweep, flag OFF; **flip DEFERRED** (master-dd)     | #3121 **MERGED** `6b49023c` |
 
 - All bands **PROVISIONAL** (W5 not built; passive-AI harness). Flags ALL stay OFF.
 - **D8 flip verdict = DEFER** (master-dd 2026-07-01 AskUserQuestion): non-band-neutral +
@@ -57,6 +57,7 @@ that wins only elimination). See close-out plan **X1** + register **W5** row. It
 of its own (weeks); surface it as the next focus.
 
 Other open (OWNER): N3 ER7 flag-ON / N5 A2 re-tune / N7 interoception re-tune / N8 DR2 ratify /
-O5 D7 prose (HITL) / O7 GAP2-next (deferred). The 3 code PRs above await master-dd merge.
+O5 D7 prose (HITL) / O7 GAP2-next (deferred). The 3 code PRs above are **MERGED** (#3119
+`623860f5` / #3120 `516ad425` / #3121 `6b49023c`); W5 is the next focus.
 
 See `docs/playtest/2026-06-30-{ha1-aliena-enforcement,stamina-fatigue-n40,er6-overrun-carryover-n40,d8-chain-lightning-cap-footprint}-*.md`.

--- a/docs/playtest/2026-07-01-w5-focus-fire-ab-evidence.md
+++ b/docs/playtest/2026-07-01-w5-focus-fire-ab-evidence.md
@@ -1,0 +1,93 @@
+---
+title: 'W5 inc-1 -- focus-fire A/B evidence (band-neutral: survival lever, not speed lever)'
+date: 2026-07-01
+sprint: closeout-w5-sim-harness
+doc_status: review_needed
+doc_owner: claude-code
+workstream: cross-cutting
+last_verified: '2026-07-01'
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+---
+
+# W5 inc-1 -- focus-fire A/B evidence
+
+> First W5 increment. Probe: `tools/sim/focus-fire-ab-probe.js` (paired-seed OFF vs ON,
+> in-process supertest, node 22, NO prod). Plan: `docs/superpowers/plans/2026-07-01-w5-sim-ai-player-upgrade.md`.
+> **Result: focus-fire is band-NEUTRAL on both tested setups.** Not a failure -- a scouting
+> result that falsifies focus-fire as the primary Gap-A lever and redirects inc-2 to positioning.
+
+## 1. What shipped (inc-1)
+
+- **Graded calibration metrics** (`combat-adapter.js`): `hp_remaining_pct` (mean survivor HP
+  fraction) + `units_lost`, additive to the run result. AI-independent. The Gap-C measurement
+  surface (master-dd Q2) -- a team-power delta that binary win/lose collapses (cakewalk vs
+  limped-in) is now readable. PROVEN live (populate in every probe run).
+- **F1 focus-fire** (`combat-policy.js selectPlayerAction`, `opts.focusFire`): among IN-RANGE
+  enemies, target the lowest-HP (finish-off) instead of the nearest. Default OFF = byte-identical.
+  First factor of the ratified utility-AI (Q1). Unit-tested (5 cases, RED-GREEN); 214/214 sim green.
+
+## 2. A/B results (paired seed, OFF vs ON)
+
+### 2a. Hardcore -- `enc_badlands_ultima_caccia_01` wave-1 (canonical badlands party)
+
+| Metric                | N=20 OFF | N=20 ON | N=40 OFF | N=40 ON |
+| --------------------- | -------- | ------- | -------- | ------- |
+| win_rate              | 0.000    | 0.000   | 0.025    | 0.025   |
+| creature_ko_rate      | 0.3625   | 0.3625  | 0.3563   | 0.3563  |
+| mean_hp_remaining_pct | 0.958    | 0.965   | 0.958    | 0.957   |
+| avg_rounds            | 40.0     | 40.0    | 39.83    | 39.83   |
+| timeouts              | 20/20    | 20/20   | 39/40    | 39/40   |
+
+**wr_delta = 0, ko_rate_delta = 0.** Timeout-bound (39-40/40 hit the round cap); survivors sit
+at ~96% HP. The party neither wins (can't finish 5 hardcore foes in 40 rounds) nor loses (barely
+takes damage). Focus-fire changes nothing.
+
+### 2b. Synthetic elimination cluster (4p vs 5 staggered-HP foes, no objective)
+
+| Metric                | N=20 OFF | N=20 ON |
+| --------------------- | -------- | ------- |
+| win_rate              | 1.000    | 1.000   |
+| avg_rounds            | 27.20    | 27.25   |
+| mean_hp_remaining_pct | 1.000    | 1.000   |
+
+Both arms win every run; avg_rounds identical (27.2 vs 27.25); players take 0 damage. Focus-fire
+changes nothing here either.
+
+## 3. Finding -- focus-fire is a SURVIVAL lever, not a speed lever
+
+Killing all N enemies requires the same TOTAL damage regardless of the order you kill them in ->
+focus-fire does NOT reduce time-to-eliminate-all. Its only benefit is removing an enemy's future
+INCOMING damage sooner (a dead foe stops hitting you). So it moves a metric ONLY when the player
+party is under sustained attrition. On BOTH tested setups the party was not being ground down
+(survivors 96-100% HP) -> kill-order was outcome-neutral.
+
+Corollary for W5: the Gap-A saturation on these encounters is **timeout / positioning-driven**
+(can't close + finish; or concentrated-burst deaths), **NOT target-selection-driven**. A smarter
+target picker is the wrong lever here.
+
+## 4. Redirect (drives inc-2)
+
+- **Elevate F3 positioning to the primary Gap-A/B lever** (was inc-2, now evidence-motivated):
+  terrain-cost-aware movement + threat-avoidance (don't end in a high-incoming-threat tile; close
+  distance efficiently). Test whether better positioning converts the hardcore timeouts into
+  decisions AND surfaces the volo/radici terrain power (Gap B -> G6).
+- **Revisit the timeout structure**: 40-round cap + the party's inability to finish is itself a
+  calibration artifact worth checking (is `maxRounds` too tight, or is player DPR too low for the
+  hardcore roster?). A follow-up probe should separate "can't win because timeout" from "can't
+  win because wiped".
+- **Keep focus-fire** as the utility-scorer scaffold (byte-identical OFF, correct, foundation for
+  F2/F3/F4). Do NOT flip its default; its value will materialize once the party is under real
+  attrition (a wipe-prone encounter) -- re-measure then.
+
+## 5. Reproduce
+
+```
+node tools/sim/focus-fire-ab-probe.js 40 hardcore     # 2a
+node tools/sim/focus-fire-ab-probe.js 20 synthetic    # 2b
+```
+
+Sim is NOT bit-repro cross node-version (calibrate + read on node 22; variance ~+-0.05). The
+shipped code is byte-identical with `focusFire` OFF (the default), so inc-1 is inherently
+band-safe for the existing harness + bands.

--- a/docs/research/2026-07-01-w5-ai-player-recon.md
+++ b/docs/research/2026-07-01-w5-ai-player-recon.md
@@ -1,0 +1,159 @@
+---
+title: 'W5 sim AI-player recon -- objective-aware / positioning long-pole (corrected premise)'
+date: 2026-07-01
+sprint: closeout-w5-sim-harness
+doc_status: review_needed
+doc_owner: claude-code
+workstream: cross-cutting
+last_verified: '2026-07-01'
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+---
+
+# W5 -- sim AI-player recon
+
+> Kick-off recon for W5 (the sim-harness long-pole). Maps the current AI-player + objective
+> system against git-truth, CORRECTS the "passive closest-attack / never wins non-elim"
+> premise the chip + register carried, and frames the design-call for master-dd.
+> **Nothing built here** -- recon + design-fork only. Bands stay PROVISIONAL until W5 lands.
+
+## 0. TL;DR (verify-first correction, anti-pattern #19)
+
+The premise "the sim AI-player is passive closest-attack and never wins capture/escort/escape/
+survival" is **PARTLY STALE**. Ground-truth (code + tests, not markers):
+
+- **Objective-awareness ALREADY EXISTS.** `tools/sim/combat-policy.js` has OA2/SPEC-O
+  zone-pursuit: for `capture_point / sabotage / escape / escort` it drives units toward the
+  objective `target_zone`, routes around occupied tiles, satisfies `min_units_in_zone > 1`,
+  and HOLDS in-zone (never chases a far foe out). `tests/sim/combatPolicy.test.js` = **13/13
+  pass**, incl. "two units from adjacent spawns BOTH reach the zone (min_units=2)".
+  `tools/sim/scenario-enemies.js` gives all 6 objective types their authored scaled roster so
+  "completion_rate is a meaningful band metric". The non-elim encounters (`enc_capture_01`
+  etc, in `docs/planning/encounters/`) ARE loadable by `encounter_id` (encounterLoader reads
+  that dir) and DO complete in the sim.
+- So W5 is **NOT** "teach the AI to reach the zone". That is done.
+
+The **real** W5 problem is **calibration SIGNAL**, not "winning". A team-power delta (the
+form-pulse +1.2, the D6/D8/ER6 mechanics, volo/radici) is only measurable when the AI plays
+the encounter in a power-DISCRIMINATING regime. Today it does not, for three distinct reasons
+(sec.2). This reframes W5 from one problem ("upgrade the AI") into three (sec.2) -- and one of
+them is arguably encounter/metric design, not AI at all.
+
+## 1. Current AI-player map (what exists)
+
+| Piece              | File                                                       | Role                                                                                                                                                                                            |
+| ------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Combat move policy | `tools/sim/combat-policy.js` `selectPlayerAction`          | closest-enemy attack-or-approach + OA2 zone-pursuit. **THE thing W5 upgrades.** 146 LOC.                                                                                                        |
+| Combat driver      | `tools/sim/combat-adapter.js` `runEncounter`               | boots a session (roster+enemies via /start), fetches objective ONCE, drives the round loop, polls objective completion for non-elim, returns outcome. In-process (supertest) or tunnel (fetch). |
+| Meta policy        | `tools/sim/greedy-policy.js`                               | recruit / route / courtship / mating (NOT combat moves -- easy to confuse).                                                                                                                     |
+| Personality policy | `tools/sim/mbti-policy.js`                                 | MBTI temperament overlay for full-loop batch.                                                                                                                                                   |
+| Objective logic    | `apps/backend/services/combat/objectiveEvaluator.js`       | 6 evaluators: elimination, capture_point, escort, sabotage, survival, escape. Pure fn of (session, encounter, objective) -> {completed, failed, outcome}.                                       |
+| Objective staging  | `tools/sim/scenario-enemies.js`                            | `SUPPORTED_OBJECTIVES` all 6; builds the authored wave-1 roster; clamps to on-grid.                                                                                                             |
+| Batch (full-loop)  | `tools/sim/full-loop-batch.js` + `meta-band-aggregator.js` | N-run band batch; metric `completion_rate` band [0.4,0.7]; `--isolate` per-seed process; `--gate` warn-only.                                                                                    |
+| Flip A/B           | `tools/sim/batch-ai-runner.js` + `fp-trait-ab-analyze.js`  | paired rounds-to-victory A/B (the form-pulse offset used this).                                                                                                                                 |
+
+Movement primitives (`stepToward`, `stepTowardZone`) are **pure Manhattan** -- one-tile greedy
+step, x-axis tie-break, occupancy-avoidance. No move-cost / terrain consult. No focus-fire.
+No ability/trait use (only a `combat-adapter` "greedy overcharge" hook). No retreat/kite.
+
+## 2. The real W5 gaps (each with git evidence)
+
+**Gap A -- tactical weakness -> saturation-LOW (measured).**
+On hardcore elimination the closest-attack AI is too weak to win: `enc_badlands_foodweb_pilot_01`
+(hardcore diff4) control scored **0/16 victories, 0 both-victory pairs -> no signal**
+(`docs/planning/2026-06-24-...-encounter-offset.md` sez.4). No both-win pairs = a power delta
+cannot be measured. Root: nearest-target attack, no kill-priority/focus-fire, no ability use,
+no threat weighting.
+
+**Gap B -- terrain-cost blindness (confirmed by code).**
+`combat-policy.js stepToward/stepTowardZone` never reference move-cost. A move-cost engine
+(`moveCost.js`, the move-terrain substrate merged 2026-06-29) exists and is enforced server-side,
+but the sim AI walks Manhattan straight through costly tiles. So the power-sensitivity of
+flight/burrow (terrain-cost-avoiding) traits is invisible in sim. This is the **G6 / X1 / #3053**
+link -- move-terrain Godot engine-AP enforcement needs a sim AI that actually values cheap tiles.
+
+**Gap C -- power-insensitive objectives -> saturation-HIGH (HYPOTHESIS, to verify in the plan).**
+OA2 makes non-elim encounters COMPLETE, but "walk-to-zone-and-hold" may complete at ~100%
+regardless of team combat power (you reach the zone and the fixed roster can't stop you) ->
+`completion_rate` saturates high -> a power buff is invisible. NOT yet empirically measured (the
+offset-doc cross-biome sweep stopped at "non-elim never wins", which is now stale). This may be
+an **encounter-design / metric** problem: the fix could be power-coupled objectives (holding
+requires winning contested fights) and/or a **graded power-proxy metric** (margin, HP-remaining,
+rounds-to-hold) instead of binary completion -- possibly cheaper than a smarter AI.
+
+**Gap D -- the flip A/B measures elimination only.**
+The form-pulse flip used `batch-ai-runner` + `fp-trait-ab-analyze` = paired rounds-to-victory,
+and "only `enc_savana_01` (standard + elimination + diff2) yields a clean rounds A/B"; badlands
+elim saturated, the 12 non-elim gave no rounds signal. So the flip lane's metric is
+elimination-shaped. Cross-biome / non-elim / terrain signal needs BOTH a stronger AI (A,B) AND a
+signal path for non-elim (C).
+
+## 3. Constraints that bound the design (load-bearing)
+
+1. **No cheap forward model.** The only way to advance/evaluate game state is a real,
+   side-effecting HTTP round-trip through the Express backend (in-process supertest). State
+   cannot be cheaply cloned/forked/rolled-back. => per-move deep search (MCTS/rollout) is
+   very expensive and arguably infeasible without a separate lightweight forward model.
+2. **Determinism / low variance.** N=40 bands need low run-to-run variance (today ~+-0.05,
+   sim is NOT bit-reproducible cross node-version -> calibrate + gate on node 22). A stochastic
+   planner would widen CI and need larger N.
+3. **Calibration fidelity, NOT superhuman play.** The AI's job is to make balance changes
+   MEASURABLE. Too strong -> wins everything -> masks balance holes; too weak -> loses
+   everything -> Gap A. The target is the discriminating middle. "How strong is enough" is
+   itself a fork.
+4. **Path discipline.** All work stays in `tools/sim/` (NOT forbidden-path). objectiveEvaluator
+   is `apps/backend/services/combat/` (backend, allowed but ripples tests).
+5. **Long-pole, incremental.** Weeks. Ship reviewable increments each validated by N=40 on an
+   encounter the current AI fails/saturates.
+
+## 4. Design-call for master-dd (the fork to decide BEFORE the big build)
+
+**Question 1 -- how much AI?** heuristic/behavior-tree vs **utility-AI (weighted action
+scoring)** vs MCTS/rollout.
+
+- Preliminary recommendation: **utility-AI, incremental on the existing OA2 heuristic.**
+  Rationale: MCTS needs a cheap forward model we do NOT have (constraint 1); it is also
+  stochastic (constraint 2). Utility-AI is deterministic, cheap (one scored decision per move,
+  no rollouts), a strict superset of the current closest-attack heuristic, and naturally
+  extends to terrain-cost (Gap B) as just another scored factor. Factors to score: kill-priority
+  / focus-fire, positioning (incl. terrain move-cost), ability/trait use, retreat/kite,
+  objective-zone value. **RATIFIED by master-dd 2026-07-01** (utility-AI; MCTS ruled out --
+  balance-illuminator brief: no forward model -> 100-1000x cost + nondeterministic, Hernandez
+  CoG 2020). Full plan: `docs/superpowers/plans/2026-07-01-w5-sim-ai-player-upgrade.md`.
+
+**Question 2 -- is Gap C an AI problem or an encounter/metric problem?** Options: (a) rely on a
+stronger AI to expose power on non-elim, (b) add power-coupled objective variants + a graded
+power-proxy metric (margin/HP/rounds), (c) both. Preliminary lean: **(c)** -- the metric side
+(graded proxy) may be the cheaper high-signal win and is worth a spike before over-investing in
+AI strength for non-elim.
+
+**Question 3 -- "how strong is enough" / masking risk.** Options: calibrate the AI to a target
+win-rate band on a reference set, OR run **multiple AI skill tiers as a sensitivity sweep** (weak
+/ mid / strong) so balance findings are reported across skill, not at one arbitrary point.
+Preliminary lean: **skill-tier sweep** -- it turns the masking risk into an explicit axis.
+
+## 5. What W5 unblocks (value -- name this when surfacing)
+
+- **form-pulse v2 W6 flip** (the real N=40 cross-biome, today PARKED) -- gated on a non-elim /
+  cross-biome power signal.
+- **G6** (move-terrain Godot engine-AP enforcement) -- needs a sim AI that values cheap tiles.
+- **Rigorous re-ratify of D6 / D8 / ER6 PROVISIONAL bands** (shipped flag-OFF 2026-07-01) --
+  their current bands are passive-AI provisional.
+- **Tier-3 N=40 on non-elimination scenarios** (the residual N3/N5/N7/N8 lane, all gated W5).
+
+## 6. Next step
+
+1. balance-illuminator research brief (running) -> fold into the fork above.
+2. **AskUserQuestion to master-dd** on Q1-Q3 (recommendation + reversibility) BEFORE big build.
+3. Per his verdict: write the detailed plan (`docs/superpowers/plans/`), then a first reviewable
+   increment (likely: utility-AI target-selection + a graded power-proxy metric spike) validated
+   by N=40 on an encounter the current AI saturates. Do NOT flip anything in W5.
+
+## Cross-reference
+
+- Register row: `docs/planning/2026-06-23-residual-gate-register.md` sez.1 (W5 row).
+- Close-out X1: `docs/planning/2026-06-29-closeout-master-plan.md` (X1 / nuance note sez.1).
+- Build-spec W5: `docs/planning/2026-06-30-form-pulse-trait-v2-flip-readiness-build-spec.md` sec.W5.
+- Stale premise source: `docs/planning/2026-06-24-aa01-form-pulse-trait-v2-encounter-offset.md` sez.4.
+- Entry handoff: `docs/planning/2026-07-01-session-handoff-grilling-value-picks-drained.md`.

--- a/docs/superpowers/plans/2026-07-01-w5-sim-ai-player-upgrade.md
+++ b/docs/superpowers/plans/2026-07-01-w5-sim-ai-player-upgrade.md
@@ -1,0 +1,130 @@
+---
+title: 'W5 -- sim AI-player upgrade (objective-aware/positioning long-pole) implementation plan'
+date: 2026-07-01
+doc_status: active
+doc_owner: master-dd
+workstream: cross-cutting
+last_verified: '2026-07-01'
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+tags:
+  [sim, ai-player, calibration, utility-ai, combat-policy, w5, n40, tdd, terrain-cost, form-pulse]
+---
+
+# W5 -- sim AI-player upgrade (implementation plan)
+
+> Long-pole (weeks, project of its own). Recon: `docs/research/2026-07-01-w5-ai-player-recon.md`.
+> Design decisions RATIFIED by master-dd 2026-07-01 (AskUserQuestion, research-backed by
+> balance-illuminator). This plan is the SoT for the arc; increments ship reviewable + N=40-validated.
+> **No prod flag flipped in W5.** All work in `tools/sim/` + the graded-metric read-side
+> (`combat-adapter.js`); objectiveEvaluator is backend but read-only here.
+
+## 0. Why (value it unblocks)
+
+The sim AI-player's tactical/positioning weakness makes team-power deltas UNMEASURABLE on
+hardcore + terrain + (hypothesised) non-elim scenarios. Fixing it unblocks:
+
+- **form-pulse v2 W6 flip** (real N=40 cross-biome, today PARKED).
+- **G6** (move-terrain Godot engine-AP enforcement -- needs a sim AI that values cheap tiles).
+- **Rigorous re-ratify of D6 / D8 / ER6 PROVISIONAL bands** (shipped flag-OFF 2026-07-01 on passive-AI).
+- **Tier-3 N=40 on non-elimination scenarios** (residual N3/N5/N7/N8 lane, all gated W5).
+
+## 1. Ratified decisions (master-dd 2026-07-01)
+
+1. **Approach = Utility-AI, incremental on the existing OA2 heuristic.** MCTS ruled OUT
+   (no forward model: every state-step is a real HTTP call, no clone/rollback -> 100-1000x
+   cost + nondeterministic; Hernandez CoG 2020). Utility-AI = deterministic, 1 HTTP/decision
+   (same cost as today), a strict superset of closest-attack.
+2. **Gap C (non-elim power-insensitivity) = graded metric FIRST.** Add
+   `hp_remaining_pct` / `rounds_to_complete` / `units_lost` alongside binary `completion_rate`
+   (combat-adapter already returns rounds + survivors). AI-independent, cheapest, high-signal.
+   Power-coupled encounter redesign only later IF the graded metric alone falls short.
+   A stronger AI would saturate C HARDER, not help -- the axes are orthogonal.
+3. **Calibration = tune-to-band + skill sweep.** Bayes-optimize the utility weights to a target
+   WR band (~0.3-0.7) per encounter-class (treat AI-strength as a knob like boss-HP), plus a
+   periodic 3-tier Restricted-Play sweep (weak / mid / strong) as a stale-band sensitivity net.
+   Reuses the existing BO + SPRT patterns.
+
+## 2. Architecture -- the utility scorer
+
+Replace the naive closest-enemy branch of `combat-policy.js selectPlayerAction` with a utility
+scorer over the enumerable candidate action set for the active unit. **OA2 zone-pursuit
+(capture/sabotage/escape/escort) is UNTOUCHED** -- it is a pathing problem, already solved +
+tested 13/13. The scorer targets the `elimination` / `survival` / in-zone branch.
+
+`utility(action) = sum_i (w_i * factor_i(action, actor, units, ctx))`, argmax with a fixed
+tie-break (stable sort by candidate key) -> deterministic. Weights `w_i` are a named,
+env/DI-overridable vector (so P1 Bayes-tuning has a clean surface; defaults are the v1 hand-set).
+
+Factors (ship incrementally, each additive + tested):
+
+| #   | Factor                                                                                                                | Closes                          | Increment |
+| --- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------- |
+| F1  | Target kill-priority / focus-fire (`expected_dmg / target_hp` + finish-off bonus + threat weight)                     | Gap A (saturation-low)          | inc-1     |
+| F2  | Retreat / threat-avoidance (negative utility ending in high incoming-threat tile when own HP low + no kill available) | Gap A (never disengages)        | inc-2     |
+| F3  | Positioning / terrain-cost (score candidate tile by `-moveCost` + flank bonus)                                        | Gap B (terrain blindness -> G6) | inc-2     |
+| F4  | Ability / trait use (score each ability by value-per-AP, replace the single greedy-overcharge hook)                   | tactical depth                  | inc-3     |
+
+Determinism guard: no `Math.random`; all factor math is pure over the fetched state; tie-break
+is total-ordered. Keep the sim node-22-pinned (not bit-repro cross node-version; existing caveat).
+
+## 3. Increments (each = reviewable PR, N=40-validated, master-dd merges)
+
+- **inc-1 -- graded metrics + focus-fire scaffold (THIS SESSION, DONE). PR-ready.**
+  - `combat-adapter.js`: return `hp_remaining_pct` (mean survivor HP fraction), `units_lost`, keep
+    `rounds` (graded metrics, AI-independent -- the Gap C measurement surface, master-dd Q2). PROVEN
+    live (populate correctly in the probe).
+  - `combat-policy.js`: F1 focus-fire (among IN-RANGE enemies target lowest-HP; opt `opts.focusFire`,
+    default OFF = byte-identical). First utility-scorer factor (Q1 foundation). OA2 branch untouched.
+  - Tests: `tests/sim/combatPolicy.test.js` (5 focus-fire cases, RED-GREEN) + `combatAdapter.test.js`
+    (graded metrics). 214/214 sim suite green.
+  - Evidence: `tools/sim/focus-fire-ab-probe.js` (paired-seed OFF vs ON, hardcore + synthetic modes).
+  - **FINDING (reshapes the plan): focus-fire is band-NEUTRAL on both tested setups** (N=20 hardcore
+    `enc_badlands_ultima_caccia_01`: WR/KO delta 0, timeout-bound, survivors ~96% HP; N=20 synthetic
+    elimination: avg_rounds 27.2 vs 27.25, players 0 damage). Root cause: **focus-fire is a
+    SURVIVAL/attrition lever, not a speed lever** -- killing all N foes needs the same total damage
+    regardless of order; it only helps by removing INCOMING damage sooner, so it moves a metric ONLY
+    when the party is under sustained attrition. On the tested encounters the party was not being
+    ground down -> kill-order was outcome-neutral. => the Gap-A saturation on these encounters is
+    TIMEOUT/POSITIONING-driven, NOT target-selection-driven.
+- **inc-2 -- terrain-cost positioning (F3). EVIDENCE-ELEVATED to the primary Gap-A/B lever.** The
+  inc-1 finding shows the AI's weakness is closing distance / not-getting-focused, not which target
+  it picks. Wire `moveCost.js` into candidate-tile scoring + a threat-avoidance term (don't end in a
+  high-incoming-threat tile). Validate on a terrain encounter (`enc_foresta_temperata_radici` /
+  hazard pilot) that volo/radici traits shift a metric AND on the hardcore timeout (does better
+  positioning convert timeouts to decisions?). Unblocks G6.
+- **inc-3 -- ability/trait use (F4).** Generic value-per-AP ability scoring. Validate no
+  regression on inc-1/2 bands.
+- **inc-4 -- P1 tune-to-band (BO).** Bayes-optimize `w_i` per encounter-class to the target WR
+  band. Emit a ratify-doc of the tuned weights (master-dd ratifies, SDMG).
+- **inc-5 -- P1 skill-tier sweep.** 3-tier Restricted-Play harness (degenerate / tuned / full-factor
+  utility-AI as the low/mid/high skill dial) as a periodic sensitivity net.
+- **inc-6 (conditional) -- Gap C power-coupled encounters.** ONLY if the graded metric alone
+  doesn't yield a non-elim power signal: author contested pressure (patrols / tight timers) into
+  objective encounters. Content call -> master-dd.
+
+## 4. Then (post-W5, gated on the above)
+
+- **W6** form-pulse: N=40 cross-biome on the graded/terrain-capable harness -> ratify offset/`w`/picks
+  -> flip (operator Ryzen). PARKED until inc-1..inc-2 land a cross-biome signal.
+- **Re-ratify D6 / D8 / ER6** provisional bands on the upgraded AI.
+- **Tier-3 N=40** non-elim lane (N3 ER7 / N5 A2 / N7 interoception / N8 DR2).
+
+## 5. Non-goals / out of scope (explicit)
+
+- **No prod flag flipped in W5** (form-pulse, D8 chain-lightning, terrain-cost stay as-is).
+- **No MCTS / RL / LLM-as-policy** (ruled out sec.1; LLM-as-critic stays a separate P2 qualitative
+  tool, not a decision-maker). MCTS revisit ONLY if an in-process forward model is ever built.
+- **No objectiveEvaluator behavior change** (read-only from the sim; changing it ripples backend tests).
+- **No forbidden-path** (`.github/workflows/`, `packages/contracts/`, `services/generation/`,
+  `migrations/`, `services/rules/`).
+
+## 6. References
+
+- Recon: `docs/research/2026-07-01-w5-ai-player-recon.md`.
+- Register W5 row: `docs/planning/2026-06-23-residual-gate-register.md` sez.1.
+- Close-out X1: `docs/planning/2026-06-29-closeout-master-plan.md`.
+- Build-spec W5: `docs/planning/2026-06-30-form-pulse-trait-v2-flip-readiness-build-spec.md` sec.W5.
+- Research (MCTS ruled out, utility-AI, graded metric, tune-to-band): balance-illuminator brief 2026-07-01
+  (Hernandez CoG 2020; Tactical Troops CoG 2021; EA/SEED CoG 2023; Sims/XCOM utility-AI patterns).

--- a/tests/sim/combatAdapter.test.js
+++ b/tests/sim/combatAdapter.test.js
@@ -124,6 +124,32 @@ test('combatAdapter.runEncounter: a fixed seed replays deterministically (Codex 
   assert.equal(a.rounds, b.rounds);
 });
 
+// W5 inc-1: graded calibration metrics (Q2 -- Gap C signal). runEncounter returns
+// hp_remaining_pct + units_lost alongside the binary outcome so a team-power delta that a
+// binary win/lose hides (cakewalk vs limped-in) becomes measurable. AI-independent.
+test('combatAdapter.runEncounter: returns graded metrics (hp_remaining_pct, units_lost)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = supertestHttp(app);
+  const res = await runEncounter(http, {
+    roster: roster(),
+    enemies: enemies(),
+    scenarioId: 'full_loop_test',
+    seed: 'graded-1',
+    maxRounds: 40,
+  });
+  assert.equal(res.outcome, 'victory');
+  // both roster units survive the weak enemy -> 0 lost, survivors carry HP.
+  assert.equal(res.units_lost, 0, `expected 0 lost, got ${res.units_lost}`);
+  assert.equal(typeof res.hp_remaining_pct, 'number');
+  assert.ok(
+    res.hp_remaining_pct > 0 && res.hp_remaining_pct <= 1,
+    `hp_remaining_pct in (0,1], got ${res.hp_remaining_pct}`,
+  );
+});
+
 // OA2 (SPEC-O): a NON-elimination objective completes via the objective-driver + the
 // objective-outcome wiring (sabotage progress while in the zone), NOT elimination.
 test('combatAdapter.runEncounter: OA2 -- sabotage objective completes (not elimination)', async (t) => {

--- a/tests/sim/combatPolicy.test.js
+++ b/tests/sim/combatPolicy.test.js
@@ -95,6 +95,34 @@ test('focusFire: none in range -> approaches nearest (unchanged)', () => {
   assert.deepEqual(r.target_position, { x: 1, y: 0 });
 });
 
+// Codex P2 #3127: focusFire must be honored in the OA2 in-zone attack path too (attacking
+// does not move the actor, so focusing a low-HP in-range foe keeps the hold intact).
+test('focusFire IN zone: attacks lowest-HP in-range foe, not nearest', () => {
+  const actor = { id: 'p', position: { x: 5, y: 5 }, attack_range: 2, ap_remaining: 1 };
+  const units = [
+    actor,
+    { id: 'hi', controlled_by: 'sistema', hp: 9, position: { x: 5, y: 6 } }, // adjacent, high HP
+    { id: 'lo', controlled_by: 'sistema', hp: 2, position: { x: 6, y: 6 } }, // dist 2, low HP
+  ];
+  const obj = { type: 'capture_point', config: { target_zone: [4, 4, 6, 6] } };
+  const r = selectPlayerAction(actor, units, obj, { focusFire: true });
+  assert.deepEqual(r, { action_type: 'attack', target_id: 'lo' });
+});
+
+test('in zone default (no focusFire): still attacks the nearest in-range (byte-identical)', () => {
+  const actor = { id: 'p', position: { x: 5, y: 5 }, attack_range: 2, ap_remaining: 1 };
+  const units = [
+    actor,
+    { id: 'hi', controlled_by: 'sistema', hp: 9, position: { x: 5, y: 6 } }, // nearest
+    { id: 'lo', controlled_by: 'sistema', hp: 2, position: { x: 6, y: 6 } },
+  ];
+  const obj = { type: 'capture_point', config: { target_zone: [4, 4, 6, 6] } };
+  assert.deepEqual(selectPlayerAction(actor, units, obj), {
+    action_type: 'attack',
+    target_id: 'hi',
+  });
+});
+
 // OA2 (SPEC-O): objective-aware zone-pursuit so non-elimination objectives complete in the sim.
 test('zone objective + actor outside zone -> moves toward the zone, NOT the enemy', () => {
   const actor = { id: 'p', position: { x: 5, y: 5 }, attack_range: 1, ap_remaining: 3 };

--- a/tests/sim/combatPolicy.test.js
+++ b/tests/sim/combatPolicy.test.js
@@ -31,6 +31,70 @@ test('selectPlayerAction: returns null when no alive enemy', () => {
   assert.equal(selectPlayerAction(actor, units), null);
 });
 
+// W5 inc-1: focus-fire (opt-in via opts.focusFire). Among IN-RANGE enemies, target the
+// lowest-HP (finish-off) to concentrate damage. Default OFF = byte-identical (nearest).
+test('focusFire: two enemies in range, different HP -> attacks the LOWEST-HP one', () => {
+  const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 3, ap_remaining: 1 };
+  const units = [
+    actor,
+    { id: 'hi', controlled_by: 'sistema', hp: 9, position: { x: 1, y: 0 } }, // nearer, high HP
+    { id: 'lo', controlled_by: 'sistema', hp: 2, position: { x: 3, y: 0 } }, // farther, low HP
+  ];
+  const a = selectPlayerAction(actor, units, { type: 'elimination' }, { focusFire: true });
+  assert.deepEqual(a, { action_type: 'attack', target_id: 'lo' });
+});
+
+test('focusFire OFF (default) -> attacks the NEAREST in-range (byte-identical)', () => {
+  const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 3, ap_remaining: 1 };
+  const units = [
+    actor,
+    { id: 'hi', controlled_by: 'sistema', hp: 9, position: { x: 1, y: 0 } },
+    { id: 'lo', controlled_by: 'sistema', hp: 2, position: { x: 3, y: 0 } },
+  ];
+  // no opts + explicit focusFire:false both keep the legacy nearest pick
+  assert.deepEqual(selectPlayerAction(actor, units, { type: 'elimination' }), {
+    action_type: 'attack',
+    target_id: 'hi',
+  });
+  assert.deepEqual(
+    selectPlayerAction(actor, units, { type: 'elimination' }, { focusFire: false }),
+    {
+      action_type: 'attack',
+      target_id: 'hi',
+    },
+  );
+});
+
+test('focusFire: equal HP in range -> deterministic nearest, then id tie-break', () => {
+  const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 3, ap_remaining: 1 };
+  const units = [
+    actor,
+    { id: 'b', controlled_by: 'sistema', hp: 5, position: { x: 2, y: 0 } },
+    { id: 'a', controlled_by: 'sistema', hp: 5, position: { x: 1, y: 0 } }, // nearer -> wins
+  ];
+  const r = selectPlayerAction(actor, units, { type: 'elimination' }, { focusFire: true });
+  assert.deepEqual(r, { action_type: 'attack', target_id: 'a' });
+});
+
+test('focusFire: low-HP enemy OUT of range, full-HP in range -> attacks in-range (no chase-out)', () => {
+  const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 1, ap_remaining: 1 };
+  const units = [
+    actor,
+    { id: 'near', controlled_by: 'sistema', hp: 9, position: { x: 1, y: 0 } }, // in range
+    { id: 'weak', controlled_by: 'sistema', hp: 1, position: { x: 5, y: 0 } }, // far, low HP
+  ];
+  const r = selectPlayerAction(actor, units, { type: 'elimination' }, { focusFire: true });
+  assert.deepEqual(r, { action_type: 'attack', target_id: 'near' });
+});
+
+test('focusFire: none in range -> approaches nearest (unchanged)', () => {
+  const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 1, ap_remaining: 3 };
+  const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 2, position: { x: 4, y: 0 } }];
+  const r = selectPlayerAction(actor, units, { type: 'elimination' }, { focusFire: true });
+  assert.equal(r.action_type, 'move');
+  assert.deepEqual(r.target_position, { x: 1, y: 0 });
+});
+
 // OA2 (SPEC-O): objective-aware zone-pursuit so non-elimination objectives complete in the sim.
 test('zone objective + actor outside zone -> moves toward the zone, NOT the enemy', () => {
   const actor = { id: 'p', position: { x: 5, y: 5 }, attack_range: 1, ap_remaining: 3 };

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -55,6 +55,10 @@ async function runEncounter(
     // -> byte-identical start body.
     terrainFeatures = null,
     gridSize = null,
+    // W5 inc-1: opt-in focus-fire player policy (combat-policy.js selectPlayerAction). Default
+    // false = byte-identical closest-attack. The N=40 A/B harness sets it to measure the AI
+    // upgrade against the same seeds.
+    focusFire = false,
   } = {},
 ) {
   if (Array.isArray(terrainFeatures) && terrainFeatures.length && scenarioId) {
@@ -205,7 +209,7 @@ async function runEncounter(
       });
       if (oc && oc.status >= 200 && oc.status < 300) overchargeUses += 1;
     }
-    const action = selectPlayerAction(active, units, objective);
+    const action = selectPlayerAction(active, units, objective, { focusFire });
     if (!action) {
       await http.post('/api/session/turn/end', { session_id: sessionId });
       continue;
@@ -232,9 +236,24 @@ async function runEncounter(
     }
   }
 
-  const survivorIds = lastUnits
-    .filter((u) => u.controlled_by === 'player' && (u.hp ?? 0) > 0)
-    .map((u) => u.id);
+  const survivors = lastUnits.filter((u) => u.controlled_by === 'player' && (u.hp ?? 0) > 0);
+  const survivorIds = survivors.map((u) => u.id);
+
+  // W5 inc-1: graded calibration metrics (Gap C signal, master-dd Q2). AI-independent read
+  // over the final board -- a team-power delta that the binary win/lose outcome collapses
+  // (cakewalk vs limped-in) shows up here. Scoped to the ROSTER (rosterIds) so a transient
+  // spawned minion (B5: player-controlled but NOT in the roster) can't mask a roster loss in
+  // units_lost nor dilute hp_remaining_pct. units_lost = roster units that fell;
+  // hp_remaining_pct = mean surviving-roster HP fraction (0 when the roster is wiped).
+  const rosterSet = new Set(rosterIds);
+  const rosterSurvivors = lastUnits.filter((u) => rosterSet.has(u.id) && (u.hp ?? 0) > 0);
+  const unitsLost = Math.max(0, rosterIds.length - rosterSurvivors.length);
+  const hpRemainingPct = rosterSurvivors.length
+    ? rosterSurvivors.reduce(
+        (s, u) => s + (u.hp ?? 0) / (Number(u.max_hp) || Number(u.hp) || 1),
+        0,
+      ) / rosterSurvivors.length
+    : 0;
 
   // SPEC-I event collector: one post-loop sweep so events emitted by the final
   // commit (after the last in-loop poll) still land in the tail window.
@@ -295,6 +314,8 @@ async function runEncounter(
     sessionId,
     rosterIds,
     survivorIds,
+    units_lost: unitsLost,
+    hp_remaining_pct: Number(hpRemainingPct.toFixed(4)),
     personalityUnits,
     biomeWounded,
     ended,

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -97,7 +97,7 @@ function stepTowardZone(actor, zone, units) {
   return null; // boxed in -> hold this tick
 }
 
-function selectPlayerAction(actor, units, objective) {
+function selectPlayerAction(actor, units, objective, opts = {}) {
   // OA2 zone-pursuit: a zone objective + actor outside the zone -> move toward it.
   const objType = objective && objective.type;
   // bug C (#2662-era OA2): GET /:id/objective + the evaluator carry `target_zone` at the TOP
@@ -133,14 +133,29 @@ function selectPlayerAction(actor, units, objective) {
   // Default / in-zone / elimination / survival: closest-enemy attack-or-approach.
   const enemies = units.filter((u) => u.controlled_by === 'sistema' && (u.hp ?? 0) > 0);
   if (enemies.length === 0) return null;
-  const target = enemies.sort(
-    (a, b) => dist(actor.position, a.position) - dist(actor.position, b.position),
-  )[0];
+  const nearest = enemies
+    .slice()
+    .sort((a, b) => dist(actor.position, a.position) - dist(actor.position, b.position))[0];
   const range = actor.attack_range || 1;
-  if (dist(actor.position, target.position) <= range && (actor.ap_remaining ?? 0) >= 1) {
-    return { action_type: 'attack', target_id: target.id };
+  if (dist(actor.position, nearest.position) <= range && (actor.ap_remaining ?? 0) >= 1) {
+    // W5 inc-1 focus-fire (opt-in via opts.focusFire): among IN-RANGE enemies target the
+    // lowest-HP (finish-off) to concentrate damage; tie-break nearest, then id (deterministic).
+    // Default OFF = byte-identical (attacks the nearest, as before). Only the target PICK
+    // changes -- an enemy is already in range, so we always attack (never chase a far low-HP
+    // foe out of position).
+    if (opts && opts.focusFire) {
+      const inRange = enemies.filter((e) => dist(actor.position, e.position) <= range);
+      const target = inRange.sort(
+        (a, b) =>
+          (a.hp ?? 0) - (b.hp ?? 0) ||
+          dist(actor.position, a.position) - dist(actor.position, b.position) ||
+          (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+      )[0];
+      return { action_type: 'attack', target_id: target.id };
+    }
+    return { action_type: 'attack', target_id: nearest.id };
   }
-  return stepToward(actor, target.position);
+  return stepToward(actor, nearest.position);
 }
 
 module.exports = { dist, inZone, selectPlayerAction, ZONE_PURSUIT_OBJECTIVES };

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -97,6 +97,24 @@ function stepTowardZone(actor, zone, units) {
   return null; // boxed in -> hold this tick
 }
 
+// Pick the attack target among IN-RANGE enemies. focusFire -> the lowest-HP (finish-off),
+// tie-break nearest then id (deterministic); else the nearest. Null if none in range. Shared by
+// the elimination/survival branch AND the OA2 in-zone hold branch so opts.focusFire is honored in
+// the non-elimination cases W5 measures (Codex P2 #3127) -- attacking never moves the actor, so
+// focusing a low-HP in-range foe keeps the zone hold intact. Default (focusFire off) = nearest
+// in-range, byte-identical to the prior closest-attack.
+function pickInRangeTarget(actor, enemies, focusFire) {
+  const range = actor.attack_range || 1;
+  const inRange = enemies.filter((e) => dist(actor.position, e.position) <= range);
+  if (!inRange.length) return null;
+  const byNearest = (a, b) => dist(actor.position, a.position) - dist(actor.position, b.position);
+  if (!focusFire) return inRange.sort(byNearest)[0];
+  return inRange.sort(
+    (a, b) =>
+      (a.hp ?? 0) - (b.hp ?? 0) || byNearest(a, b) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  )[0];
+}
+
 function selectPlayerAction(actor, units, objective, opts = {}) {
   // OA2 zone-pursuit: a zone objective + actor outside the zone -> move toward it.
   const objType = objective && objective.type;
@@ -114,47 +132,27 @@ function selectPlayerAction(actor, units, objective, opts = {}) {
       // centroid funneled every unit to one tile -> 2nd unit blocked outside).
       return stepTowardZone(actor, zone, units);
     }
-    // IN zone: HOLD. Attack only an already-in-range enemy; NEVER leave the zone to
-    // chase a far foe (that would break the hold and the objective would never tick).
+    // IN zone: HOLD. Attack an already-in-range enemy (focus-fire honored); NEVER leave the zone
+    // to chase a far foe (that would break the hold and the objective would never tick).
     const foes = units.filter((u) => u.controlled_by === 'sistema' && (u.hp ?? 0) > 0);
-    const tgt = foes.length
-      ? foes.sort((a, b) => dist(actor.position, a.position) - dist(actor.position, b.position))[0]
-      : null;
-    if (
-      tgt &&
-      dist(actor.position, tgt.position) <= (actor.attack_range || 1) &&
-      (actor.ap_remaining ?? 0) >= 1
-    ) {
+    const tgt = pickInRangeTarget(actor, foes, opts && opts.focusFire);
+    if (tgt && (actor.ap_remaining ?? 0) >= 1) {
       return { action_type: 'attack', target_id: tgt.id };
     }
     return null; // hold position -> the zone objective ticks
   }
 
-  // Default / in-zone / elimination / survival: closest-enemy attack-or-approach.
+  // Default / elimination / survival: closest-enemy attack-or-approach (focus-fire honored).
   const enemies = units.filter((u) => u.controlled_by === 'sistema' && (u.hp ?? 0) > 0);
   if (enemies.length === 0) return null;
+  const tgt = pickInRangeTarget(actor, enemies, opts && opts.focusFire);
+  if (tgt && (actor.ap_remaining ?? 0) >= 1) {
+    return { action_type: 'attack', target_id: tgt.id };
+  }
+  // None in range (or no AP): approach the nearest.
   const nearest = enemies
     .slice()
     .sort((a, b) => dist(actor.position, a.position) - dist(actor.position, b.position))[0];
-  const range = actor.attack_range || 1;
-  if (dist(actor.position, nearest.position) <= range && (actor.ap_remaining ?? 0) >= 1) {
-    // W5 inc-1 focus-fire (opt-in via opts.focusFire): among IN-RANGE enemies target the
-    // lowest-HP (finish-off) to concentrate damage; tie-break nearest, then id (deterministic).
-    // Default OFF = byte-identical (attacks the nearest, as before). Only the target PICK
-    // changes -- an enemy is already in range, so we always attack (never chase a far low-HP
-    // foe out of position).
-    if (opts && opts.focusFire) {
-      const inRange = enemies.filter((e) => dist(actor.position, e.position) <= range);
-      const target = inRange.sort(
-        (a, b) =>
-          (a.hp ?? 0) - (b.hp ?? 0) ||
-          dist(actor.position, a.position) - dist(actor.position, b.position) ||
-          (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
-      )[0];
-      return { action_type: 'attack', target_id: target.id };
-    }
-    return { action_type: 'attack', target_id: nearest.id };
-  }
   return stepToward(actor, nearest.position);
 }
 

--- a/tools/sim/focus-fire-ab-probe.js
+++ b/tools/sim/focus-fire-ab-probe.js
@@ -1,0 +1,225 @@
+'use strict';
+// W5 inc-1 focus-fire A/B probe -- paired-seed OFF vs ON on a hardcore badlands encounter.
+//
+// Purpose: prove the utility-AI focus-fire upgrade (combat-policy.js selectPlayerAction,
+// opts.focusFire) moves a tactically-weak AI OFF the saturation-low floor (Gap A) so team-power
+// deltas become measurable, WITHOUT saturating high. Reports win-rate, creature-KO-rate, and the
+// new graded metrics (hp_remaining_pct, units_lost) for each arm + the paired delta.
+//
+// In-process (supertest createApp, NO prod backend, node 22). Same seed feeds both arms so the
+// ONLY between-arm difference is the player policy. Sim is NOT bit-repro cross node-version ->
+// read bands as ranges (~+-0.05 variance). This is a DIRECTION probe at N<=20, a PROVISIONAL
+// band at N=40; owner ratifies exact numbers (SDMG).
+//
+// Roster/enemies mirror ultima-caccia-band-probe.js (canonical badlands party + wave-1 hardcore
+// roster, AI-sim tier table). Usage: node tools/sim/focus-fire-ab-probe.js [N]   (default 40)
+
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runEncounter } = require('./combat-adapter');
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
+
+function supertestHttp(app) {
+  return {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+const TIER_HP = { base: 7, elite: 10, apex: 14 };
+const TIER_MOD = { base: 1, elite: 2, apex: 4 };
+
+// Wave 1 of enc_badlands_ultima_caccia_01 (apex + 2 elite + 2 base), AI-sim tier table.
+function enemies() {
+  return [
+    ['dune-stalker', 'apex', { x: 5, y: 5 }, 'flanking'],
+    ['echo-wing', 'elite', { x: 5, y: 4 }, 'aggressive'],
+    ['echo-wing', 'elite', { x: 5, y: 6 }, 'aggressive'],
+    ['rust-scavenger', 'base', { x: 6, y: 4 }, 'aggressive'],
+    ['rust-scavenger', 'base', { x: 6, y: 6 }, 'aggressive'],
+  ].map(([species, tier, position, aiProfile], i) => ({
+    id: `sis_${i + 1}`,
+    species,
+    species_id: species,
+    hp: TIER_HP[tier],
+    max_hp: TIER_HP[tier],
+    ap: 2,
+    ap_max: 2,
+    mod: TIER_MOD[tier],
+    dc: tier === 'apex' ? 14 : tier === 'elite' ? 12 : 11,
+    attack_range: 1,
+    damage: { min: 1, max: 3 },
+    initiative: tier === 'apex' ? 14 : 10,
+    position,
+    ai_profile: aiProfile,
+    controlled_by: 'sistema',
+    status: {},
+  }));
+}
+
+// Synthetic elimination cluster: 4 players vs 5 enemies packed within attack range with
+// STAGGERED HP, no objective (alive-count). This isolates the focus-fire mechanism -- with
+// several enemies simultaneously in range, concentrating damage on the lowest-HP target kills
+// foes sooner, removing their future damage. NOT a calibration band; a mechanism sanity check.
+function syntheticRoster() {
+  return [
+    ['sp1', { x: 2, y: 2 }],
+    ['sp2', { x: 2, y: 3 }],
+    ['sp3', { x: 3, y: 2 }],
+    ['sp4', { x: 3, y: 3 }],
+  ].map(([id, position]) => ({
+    id,
+    species: 'velox',
+    hp: 14,
+    max_hp: 14,
+    ap: 2,
+    ap_max: 2,
+    mod: 14,
+    attack_range: 3,
+    initiative: 15,
+    position,
+    damage: { min: 1, max: 3 },
+    controlled_by: 'player',
+    status: {},
+  }));
+}
+function syntheticEnemies() {
+  return [
+    ['se1', { x: 4, y: 2 }, 4],
+    ['se2', { x: 4, y: 3 }, 7],
+    ['se3', { x: 5, y: 2 }, 10],
+    ['se4', { x: 5, y: 3 }, 13],
+    ['se5', { x: 5, y: 4 }, 16],
+  ].map(([id, position, hp]) => ({
+    id,
+    species: 'velox',
+    hp,
+    max_hp: hp,
+    ap: 2,
+    ap_max: 2,
+    mod: 6,
+    dc: 11,
+    attack_range: 1,
+    damage: { min: 1, max: 3 },
+    initiative: 8,
+    position,
+    ai_profile: 'aggressive',
+    controlled_by: 'sistema',
+    status: {},
+  }));
+}
+
+const CANON_PARTY_SCENARIO = 'enc_badlands_pilot_01';
+let _party = null;
+async function fetchCanonicalParty() {
+  if (_party) return _party;
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const r = await request(app).get(`/api/tutorial/${CANON_PARTY_SCENARIO}`);
+    if (r.status !== 200) throw new Error(`canon party fetch ${r.status}`);
+    _party = (r.body.units || []).filter((u) => u.controlled_by === 'player');
+    if (!_party.length) throw new Error('canon party empty');
+    return _party;
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+function roster(party) {
+  return party.map((u) => ({ ...u, hp: u.max_hp ?? u.hp, status: {} }));
+}
+
+async function runOne(party, seed, focusFire, mode) {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const http = supertestHttp(app);
+    const synthetic = mode === 'synthetic';
+    const r = await runEncounter(http, {
+      roster: synthetic ? syntheticRoster() : roster(party),
+      enemies: synthetic ? syntheticEnemies() : enemies(),
+      seed,
+      maxRounds: 40,
+      gridSize: synthetic ? 8 : 10,
+      focusFire,
+    });
+    const rosterN = (r.rosterIds || []).length || 4;
+    const kos = Math.max(0, rosterN - (r.survivorIds || []).length);
+    return {
+      outcome: r.outcome,
+      rounds: r.rounds,
+      kos,
+      rosterN,
+      hp_remaining_pct: r.hp_remaining_pct,
+      units_lost: r.units_lost,
+    };
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+function summarize(arr) {
+  const wins = arr.filter((r) => r.outcome === 'victory').length;
+  const totalKo = arr.reduce((s, r) => s + r.kos, 0);
+  const totalSlots = arr.reduce((s, r) => s + r.rosterN, 0);
+  return {
+    N: arr.length,
+    wins,
+    defeats: arr.filter((r) => r.outcome === 'defeat').length,
+    timeouts: arr.filter((r) => r.outcome === 'timeout').length,
+    win_rate: Number((wins / arr.length).toFixed(4)),
+    creature_ko_rate: Number((totalKo / (totalSlots || 1)).toFixed(4)),
+    mean_hp_remaining_pct: Number(
+      (arr.reduce((s, r) => s + (r.hp_remaining_pct || 0), 0) / arr.length).toFixed(4),
+    ),
+    avg_rounds: Number((arr.reduce((s, r) => s + (r.rounds || 0), 0) / arr.length).toFixed(2)),
+  };
+}
+
+async function main() {
+  const N = Number(process.argv[2]) || 40;
+  const mode = process.argv[3] === 'synthetic' ? 'synthetic' : 'hardcore';
+  const party = mode === 'synthetic' ? null : await fetchCanonicalParty();
+  const off = [];
+  const on = [];
+  for (let s = 1; s <= N; s += 1) {
+    off.push(await runOne(party, s, false, mode));
+    on.push(await runOne(party, s, true, mode));
+    if (s % 10 === 0) process.stderr.write(`  ${s}/${N}\n`);
+  }
+  const sOff = summarize(off);
+  const sOn = summarize(on);
+  console.log(
+    JSON.stringify(
+      {
+        scenario:
+          mode === 'synthetic'
+            ? 'synthetic elimination cluster (4p vs 5 staggered-HP foes)'
+            : 'enc_badlands_ultima_caccia_01 (wave-1 hardcore)',
+        mode,
+        party_source: mode === 'synthetic' ? 'synthetic' : CANON_PARTY_SCENARIO,
+        focus_fire_off: sOff,
+        focus_fire_on: sOn,
+        wr_delta: Number((sOn.win_rate - sOff.win_rate).toFixed(4)),
+        ko_rate_delta: Number((sOn.creature_ko_rate - sOff.creature_ko_rate).toFixed(4)),
+        node: process.version,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tools/sim/focus-fire-ab-probe.js
+++ b/tools/sim/focus-fire-ab-probe.js
@@ -153,7 +153,12 @@ async function runOne(party, seed, focusFire, mode) {
       focusFire,
     });
     const rosterN = (r.rosterIds || []).length || 4;
-    const kos = Math.max(0, rosterN - (r.survivorIds || []).length);
+    // Prefer the adapter's roster-scoped units_lost (a spawned minion is player-controlled but
+    // NOT in the roster, so recomputing from survivorIds would undercount roster KOs). Fallback
+    // to the survivor delta only if the field is absent (older adapter). (cavecrew W5 inc-1)
+    const kos = Number.isFinite(r.units_lost)
+      ? r.units_lost
+      : Math.max(0, rosterN - (r.survivorIds || []).length);
     return {
       outcome: r.outcome,
       rounds: r.rounds,


### PR DESCRIPTION
## W5 inc-1 -- graded calibration metrics + focus-fire utility scaffold

First increment of **W5** (the sim-harness long-pole surfaced after the Tier-3 grilling value-picks drained). Recon-first; design ratified by master-dd (AskUserQuestion 2026-07-01, research-backed).

### Why (unblocks)
The sim AI-player's tactical/positioning weakness makes team-power deltas unmeasurable on hardcore / terrain / non-elim scenarios -> the D6/D8/ER6 bands + the form-pulse W6 flip all run on a passive AI = PROVISIONAL. W5 upgrades the AI-player. This increment lands the measurement surface + the first utility factor + a scouting result that redirects the arc.

### Ratified design (master-dd 2026-07-01)
- Approach = **utility-AI incremental** (MCTS ruled out: no forward model -> 100-1000x cost + nondeterministic; balance-illuminator research, Hernandez CoG 2020).
- Gap C = **graded metric first** (AI-independent, cheapest).
- Calibration = **tune-to-band + skill sweep**.
- Recon (corrected the stale "AI never wins non-elim" premise -- OA2 zone-pursuit already exists, 13/13) + full plan in the added docs.

### What this ships
- `combat-adapter.js`: return `hp_remaining_pct` + `units_lost` (graded metrics, ROSTER-scoped, AI-independent -- the Gap-C measurement surface).
- `combat-policy.js`: F1 focus-fire (among in-range enemies target lowest-HP; `opts.focusFire`, **default OFF = byte-identical**). First utility-scorer factor.
- `focus-fire-ab-probe.js`: paired-seed OFF-vs-ON A/B (hardcore + synthetic modes).
- Docs: recon + plan + evidence (registered, governance clean).

### Finding (the increment's real value)
Focus-fire is **band-NEUTRAL** on both tested setups (N=40 hardcore + N=20 synthetic, exactly 0 WR/KO delta). Root cause: it is a **survival/attrition lever, not a speed lever** -- killing all N foes needs the same total damage regardless of order; it only helps by removing INCOMING damage sooner. On the tested encounters the party wasn't ground down -> kill-order was outcome-neutral, and the Gap-A saturation is timeout/positioning-driven. => inc-2 elevated to **F3 positioning** with evidence, not assumption.

### Verification
- 214/214 sim suite green (`node --test tests/sim/*.test.js`).
- `prettier --check` clean; `check_docs_governance.py --strict` errors=0, warnings=0.
- Adversarial review (3-lens): false-null verified SOUND (focus-fire fires + diverges at unit level, 3 ways); regression CLEAN (survivorIds byte-identical, additive return fields, all runEncounter/selectPlayerAction consumers checked); correctness -- minion-masking edge caught + fixed (graded metrics now roster-scoped) + cavecrew pass.

### Rollback (03A)
Pure revert. All changes are additive and `focusFire` defaults OFF (byte-identical to the existing harness + bands). No prod flag, no schema, no migration. `git revert <sha>` is a clean no-op for existing behavior.

### Scope
`tools/sim/` + `combat-adapter.js` read-side only. No forbidden-path. **No prod flag flipped.**

Coding-Agent: claude-code
