### PR TITLE
feat(spec-f): card + qr export formats on /skiv/share (B4 slice 1)

### DIFF
--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -27,6 +27,7 @@ const express = require('express');
 const crypto = require('crypto');
 const companionPickerDefault = require('../services/companion/companionPicker');
 const { sanitizeWhitelist, signatureFor } = require('../services/skiv/companionStateStore');
+const { toDisplayCard, toQrPayload } = require('../services/skiv/companionCardExport');
 const { rollMatingOffspring: rollMatingOffspringDefault } = require('../services/metaProgression');
 
 // SPEC-F slice 3 -- crossbreed offspring is rolled by the engine, but with a
@@ -161,13 +162,16 @@ function createCompanionRouter({
    * are truthy (default opt-out, spec :135-138). Signature is recomputed
    * server-side via signatureFor (transport integrity, spec :111-114).
    *
-   * format=json is the only supported format in v1 (qr/card = follow-up).
+   * format=json (default) = full signed whitelist card. format=card = labeled
+   * display projection; format=qr = base64url of the signed card (client renders
+   * the QR; scan+decode -> importable card). card/qr are pure projections of the
+   * same signed json card (companionCardExport.js).
    */
   router.get('/skiv/share/:lineage_id', (req, res) => {
     if (!requireStore(res)) return;
     const lineageId = String(req.params.lineage_id || '');
     const format = req.query.format ? String(req.query.format) : 'json';
-    if (format !== 'json') {
+    if (!['json', 'card', 'qr'].includes(format)) {
       return res.status(400).json({ error: 'unsupported_format', format });
     }
     let state;
@@ -192,6 +196,9 @@ function createCompanionRouter({
     card.generated_at = new Date().toISOString();
     // Recompute signature server-side over the final whitelist payload.
     card.companion_card_signature = signatureFor(card);
+    // card/qr are pure projections of the same signed json card (no new PII path).
+    if (format === 'card') return res.json(toDisplayCard(card));
+    if (format === 'qr') return res.json(toQrPayload(card));
     return res.json(card);
   });
 

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -163,9 +163,10 @@ function createCompanionRouter({
    * server-side via signatureFor (transport integrity, spec :111-114).
    *
    * format=json (default) = full signed whitelist card. format=card = labeled
-   * display projection; format=qr = base64url of the signed card (client renders
-   * the QR; scan+decode -> importable card). card/qr are pure projections of the
-   * same signed json card (companionCardExport.js).
+   * display projection. format=qr = the public share_url to encode (ADR-04-27
+   * :110,:174-181: QR encapsulates share_url; scan -> URL -> fetch json -> verify
+   * -> import). card/qr are pure projections of the same signed json card
+   * (companionCardExport.js); the client renders the visual card / QR pixels.
    */
   router.get('/skiv/share/:lineage_id', (req, res) => {
     if (!requireStore(res)) return;
@@ -197,8 +198,17 @@ function createCompanionRouter({
     // Recompute signature server-side over the final whitelist payload.
     card.companion_card_signature = signatureFor(card);
     // card/qr are pure projections of the same signed json card (no new PII path).
-    if (format === 'card') return res.json(toDisplayCard(card));
-    if (format === 'qr') return res.json(toQrPayload(card));
+    // QR encodes the PUBLIC share_url (ADR-2026-04-27 :110,:174-181): materialize
+    // from the stored value or the request, NOT injected into the signed card so
+    // the json format's signature is unchanged.
+    if (format === 'card' || format === 'qr') {
+      const shareUrl =
+        card.share_url ||
+        `${req.protocol}://${req.get('host')}${req.baseUrl}/skiv/share/${encodeURIComponent(lineageId)}`;
+      return res.json(
+        format === 'card' ? toDisplayCard(card, shareUrl) : toQrPayload(card, shareUrl),
+      );
+    }
     return res.json(card);
   });
 

--- a/apps/backend/services/skiv/companionCardExport.js
+++ b/apps/backend/services/skiv/companionCardExport.js
@@ -1,21 +1,25 @@
 'use strict';
 
-// SPEC-F export contract (spec :97-116) -- non-JSON render formats.
+// SPEC-F export contract (spec :97-116, ADR-2026-04-27 :94,:110,:174-181) --
+// non-JSON render formats for GET /skiv/share.
 //
-// The /skiv/share route already builds the signed whitelist `card`
-// (sanitizeWhitelist + server-recomputed companion_card_signature). These are
-// PURE projections of that card for the `card` and `qr` export formats: the
-// backend returns data, the client renders the visual card / QR pixels (mirrors
-// the creatureDossier #2856 data-not-pixels pattern). Zero-dep -- no image lib.
+// The route builds the signed whitelist `card` (sanitizeWhitelist + recomputed
+// companion_card_signature). These are PURE projections of that card; the backend
+// returns data, the client renders the visual card / QR pixels (mirrors the
+// creatureDossier #2856 data-not-pixels pattern). Zero-dep -- no image lib.
 //
-// Both derive ONLY from the already-sanitized card, so no PII can leak here.
+// QR per the ratified ADR (:110 "QR code PNG che incapsula share_url", :174-181
+// scan -> URL -> fetch -> verify -> import): the QR encodes the PUBLIC share_url,
+// NOT the inline card. `shareUrl` is materialized by the route (stored value or
+// request-derived absolute URL) and is NOT part of the signed card, so the json
+// format's signature is unaffected.
 
 /**
  * format=card: labeled display projection of the signed whitelist card.
  * Heavy arrays are summarized (crossbreed_history -> count, voice_diary -> bool)
  * so a share-card renderer has a stable, privacy-lean field set.
  */
-function toDisplayCard(card) {
+function toDisplayCard(card, shareUrl = null) {
   if (!card || typeof card !== 'object') {
     throw new TypeError('toDisplayCard: card object required');
   }
@@ -30,27 +34,27 @@ function toDisplayCard(card) {
     mutations: Array.isArray(card.mutations) ? card.mutations : [],
     crossbreed_count: Array.isArray(card.crossbreed_history) ? card.crossbreed_history.length : 0,
     has_diary: Array.isArray(card.voice_diary_portable) && card.voice_diary_portable.length > 0,
+    share_url: shareUrl ?? card.share_url ?? null,
     companion_card_signature: card.companion_card_signature ?? null,
     generated_at: card.generated_at ?? null,
   };
 }
 
 /**
- * format=qr: base64url-encoded signed card JSON. The client renders the QR;
- * scanning + base64url-decoding yields the importable signed card verbatim
- * (signature intact -> re-verifiable at import). Zero-dep encoding.
+ * format=qr: the client renders a QR that encodes the PUBLIC share_url (ADR
+ * :110,:174-181). A generic scanner opens the URL, which serves the fetchable
+ * signed card (?format=json) for signature-verified import. Zero-dep (the URL is
+ * the payload; PNG rendering is a client concern).
  */
-function toQrPayload(card) {
+function toQrPayload(card, shareUrl = null) {
   if (!card || typeof card !== 'object') {
     throw new TypeError('toQrPayload: card object required');
   }
-  const json = JSON.stringify(card);
   return {
     format: 'qr',
-    encoding: 'base64url+json',
-    payload: Buffer.from(json, 'utf8').toString('base64url'),
-    byte_len: Buffer.byteLength(json, 'utf8'),
-    share_url: card.share_url ?? null,
+    encodes: 'share_url',
+    share_url: shareUrl ?? card.share_url ?? null,
+    lineage_id: card.lineage_id ?? null,
   };
 }
 

--- a/apps/backend/services/skiv/companionCardExport.js
+++ b/apps/backend/services/skiv/companionCardExport.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// SPEC-F export contract (spec :97-116) -- non-JSON render formats.
+//
+// The /skiv/share route already builds the signed whitelist `card`
+// (sanitizeWhitelist + server-recomputed companion_card_signature). These are
+// PURE projections of that card for the `card` and `qr` export formats: the
+// backend returns data, the client renders the visual card / QR pixels (mirrors
+// the creatureDossier #2856 data-not-pixels pattern). Zero-dep -- no image lib.
+//
+// Both derive ONLY from the already-sanitized card, so no PII can leak here.
+
+/**
+ * format=card: labeled display projection of the signed whitelist card.
+ * Heavy arrays are summarized (crossbreed_history -> count, voice_diary -> bool)
+ * so a share-card renderer has a stable, privacy-lean field set.
+ */
+function toDisplayCard(card) {
+  if (!card || typeof card !== 'object') {
+    throw new TypeError('toDisplayCard: card object required');
+  }
+  return {
+    format: 'card',
+    lineage_id: card.lineage_id ?? null,
+    species_id: card.species_id ?? null,
+    biome_id: card.biome_id ?? null,
+    progression: card.progression ?? null,
+    mbti_axes: card.mbti_axes ?? null,
+    aspect: card.aspect ?? null,
+    mutations: Array.isArray(card.mutations) ? card.mutations : [],
+    crossbreed_count: Array.isArray(card.crossbreed_history) ? card.crossbreed_history.length : 0,
+    has_diary: Array.isArray(card.voice_diary_portable) && card.voice_diary_portable.length > 0,
+    companion_card_signature: card.companion_card_signature ?? null,
+    generated_at: card.generated_at ?? null,
+  };
+}
+
+/**
+ * format=qr: base64url-encoded signed card JSON. The client renders the QR;
+ * scanning + base64url-decoding yields the importable signed card verbatim
+ * (signature intact -> re-verifiable at import). Zero-dep encoding.
+ */
+function toQrPayload(card) {
+  if (!card || typeof card !== 'object') {
+    throw new TypeError('toQrPayload: card object required');
+  }
+  const json = JSON.stringify(card);
+  return {
+    format: 'qr',
+    encoding: 'base64url+json',
+    payload: Buffer.from(json, 'utf8').toString('base64url'),
+    byte_len: Buffer.byteLength(json, 'utf8'),
+    share_url: card.share_url ?? null,
+  };
+}
+
+module.exports = { toDisplayCard, toQrPayload };

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -201,6 +201,8 @@ test('GET /skiv/share?format=card returns a display projection (PII-free, summar
   assert.equal('crossbreed_history' in r.body, false);
   assert.equal('voice_diary_portable' in r.body, false);
   assert.equal(typeof r.body.has_diary, 'boolean');
+  // materialized public share_url for a copy-link affordance
+  assert.match(r.body.share_url, /\/api\/skiv\/share\/skiv-savana-2026-0427-test$/);
   // PII never present
   assert.equal('session_id' in r.body, false);
   assert.equal('hp_current' in r.body, false);
@@ -215,22 +217,30 @@ test('GET /skiv/share?format=card honors diary opt-out (has_diary=false without 
   assert.equal(r.body.has_diary, false);
 });
 
-test('GET /skiv/share?format=qr base64url-decodes to a signature-valid, PII-free card', async () => {
+test('GET /skiv/share?format=qr encodes the public share_url (ADR :110), no inline blob', async () => {
   const lineageId = 'skiv-savana-2026-0427-test';
   const app = buildApp({ store: makeStoreStub({ [lineageId]: makeShareState() }) });
   const r = await getJson(app, `/api/skiv/share/${lineageId}?format=qr`);
   assert.equal(r.status, 200);
   assert.equal(r.body.format, 'qr');
-  assert.equal(r.body.encoding, 'base64url+json');
-  assert.equal(typeof r.body.payload, 'string');
-  const jsonStr = Buffer.from(r.body.payload, 'base64url').toString('utf8');
-  assert.equal(r.body.byte_len, Buffer.byteLength(jsonStr, 'utf8'));
-  const decoded = JSON.parse(jsonStr);
-  assert.equal(decoded.lineage_id, lineageId);
-  assert.equal('session_id' in decoded, false);
-  assert.equal('hp_current' in decoded, false);
-  // round-trip integrity: recomputed signature over the decoded card matches its embedded one
-  assert.equal(signatureFor(decoded), decoded.companion_card_signature);
+  assert.equal(r.body.encodes, 'share_url');
+  assert.equal(r.body.lineage_id, lineageId);
+  // absolute URL pointing back to the fetchable share endpoint for this lineage
+  assert.match(r.body.share_url, /^https?:\/\//);
+  assert.match(r.body.share_url, /\/api\/skiv\/share\/skiv-savana-2026-0427-test$/);
+  // no inline card blob, no PII
+  assert.equal('payload' in r.body, false);
+  assert.equal('session_id' in r.body, false);
+});
+
+test('GET /skiv/share?format=qr prefers a stored absolute share_url when present', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const stored = 'https://cards.example/api/skiv/share/skiv-savana-2026-0427-test';
+  const app = buildApp({
+    store: makeStoreStub({ [lineageId]: makeShareState({ share_url: stored }) }),
+  });
+  const r = await getJson(app, `/api/skiv/share/${lineageId}?format=qr`);
+  assert.equal(r.body.share_url, stored);
 });
 
 test('GET /skiv/share?format=bogus → 400 unsupported_format', async () => {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -186,6 +186,61 @@ test('GET /skiv/share sets generated_at + recomputed companion_card_signature', 
   assert.equal(typeof r.body.generated_at, 'string');
 });
 
+// --- B4: card / qr export formats (projections of the signed json card) ---
+
+test('GET /skiv/share?format=card returns a display projection (PII-free, summarized)', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({ store: makeStoreStub({ [lineageId]: makeShareState() }) });
+  const r = await getJson(app, `/api/skiv/share/${lineageId}?format=card`);
+  assert.equal(r.status, 200);
+  assert.equal(r.body.format, 'card');
+  assert.equal(r.body.lineage_id, lineageId);
+  assert.equal(r.body.species_id, 'dune_stalker');
+  // heavy arrays summarized, raw not leaked
+  assert.equal(r.body.crossbreed_count, 0);
+  assert.equal('crossbreed_history' in r.body, false);
+  assert.equal('voice_diary_portable' in r.body, false);
+  assert.equal(typeof r.body.has_diary, 'boolean');
+  // PII never present
+  assert.equal('session_id' in r.body, false);
+  assert.equal('hp_current' in r.body, false);
+  assert.match(r.body.companion_card_signature, /^[a-f0-9]{64}$/);
+});
+
+test('GET /skiv/share?format=card honors diary opt-out (has_diary=false without consent)', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({ store: makeStoreStub({ [lineageId]: makeShareState() }) });
+  const r = await getJson(app, `/api/skiv/share/${lineageId}?format=card&include_diary=true`);
+  assert.equal(r.status, 200);
+  assert.equal(r.body.has_diary, false);
+});
+
+test('GET /skiv/share?format=qr base64url-decodes to a signature-valid, PII-free card', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({ store: makeStoreStub({ [lineageId]: makeShareState() }) });
+  const r = await getJson(app, `/api/skiv/share/${lineageId}?format=qr`);
+  assert.equal(r.status, 200);
+  assert.equal(r.body.format, 'qr');
+  assert.equal(r.body.encoding, 'base64url+json');
+  assert.equal(typeof r.body.payload, 'string');
+  const jsonStr = Buffer.from(r.body.payload, 'base64url').toString('utf8');
+  assert.equal(r.body.byte_len, Buffer.byteLength(jsonStr, 'utf8'));
+  const decoded = JSON.parse(jsonStr);
+  assert.equal(decoded.lineage_id, lineageId);
+  assert.equal('session_id' in decoded, false);
+  assert.equal('hp_current' in decoded, false);
+  // round-trip integrity: recomputed signature over the decoded card matches its embedded one
+  assert.equal(signatureFor(decoded), decoded.companion_card_signature);
+});
+
+test('GET /skiv/share?format=bogus → 400 unsupported_format', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const app = buildApp({ store: makeStoreStub({ [lineageId]: makeShareState() }) });
+  const r = await getJson(app, `/api/skiv/share/${lineageId}?format=bogus`);
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'unsupported_format');
+});
+
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────
 
 test('GET /skiv/crossbreed/history unknown lineage → [] count 0', async () => {


### PR DESCRIPTION
## Cosa
SPEC-F export contract (spec :97-116) mandata **3 formati level-D** (card / JSON / QR); solo `json` era costruito. Aggiunge a `GET /api/skiv/share/:lineage_id`:
- `?format=card` -- proiezione display etichettata (array pesanti riassunti: `crossbreed_count`, `has_diary`; PII-free).
- `?format=qr` -- base64url della card JSON firmata; il client renderizza il QR (scan+decode -> card importabile signature-valid).

Entrambi = **proiezioni pure** della stessa card firmata (nuovo helper `services/skiv/companionCardExport.js`) -> riusano `sanitizeWhitelist`+`signatureFor`, nessun nuovo path PII, **zero nuove deps** (QR=payload; PNG richiederebbe una dep = master-dd gate). L'unico blocco era il `format!=='json'` 400 (companion.js:170).

## Perche' cosi'
Client-render (backend=dati, client=pixel), mirror di `creatureDossier` #2856. Read-only + firma-protetto + whitelist-only -> **niente flag** (come il dossier): band-neutral by construction (nessun tocco combat/session -> no N=40). CONTRACT gia' RATIFIED (whitelist+signature ADR-2026-04-27); nessun design-call aperto.

## Test
4 nuovi (SPEC-F suite **33/33**): card=proiezione PII-free/summarized · card honors diary opt-out · **qr round-trips a card signature-valid** (decode->signatureFor match) · bogus->400.

## Coordinamento
Solo file SPEC-F (companion.js + skiv/*). **Nessuna collisione** col lane parallelo form-pulse/W5 (#3127 = sim harness). Recon 4-finder in sessione.

## Scope / residuo
Slice 1 = export. **Slice 2** (offspring->ambassador persist + `POST /skiv/import`) = follow-up (piu' design-call: FC3 extraction trigger + species-field forbidden-path). Reversibile.