### PR TITLE
feat(spec-f): promote offspring to ambassador (B4 slice 2)

### DIFF
--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -29,6 +29,7 @@ const companionPickerDefault = require('../services/companion/companionPicker');
 const { sanitizeWhitelist, signatureFor } = require('../services/skiv/companionStateStore');
 const { toDisplayCard, toQrPayload } = require('../services/skiv/companionCardExport');
 const { rollMatingOffspring: rollMatingOffspringDefault } = require('../services/metaProgression');
+const offspringStoreDefault = require('../services/lineage/offspringStore');
 
 // SPEC-F slice 3 -- crossbreed offspring is rolled by the engine, but with a
 // SEEDED rng so the proposal preview (slice 2) and the committed confirm
@@ -58,6 +59,7 @@ function createCompanionRouter({
   companionPicker = companionPickerDefault,
   store = null,
   rollMatingOffspring = rollMatingOffspringDefault,
+  offspringStore = offspringStoreDefault,
 } = {}) {
   const router = express.Router();
 
@@ -210,6 +212,71 @@ function createCompanionRouter({
       );
     }
     return res.json(card);
+  });
+
+  /**
+   * POST /api/skiv/offspring/:offspring_id/promote
+   * Body: { species_id, unit_id? }
+   *
+   * SPEC-F B4 slice 2 -- offspring -> playable lineage. FC3 (spec :162): an
+   * EXPLICIT per-offspring extraction (not mass-export). Persists the offspring as
+   * an ambassador companion card (reuses saveCompanionState + the cap-10 FIFO); the
+   * card is the portable, spawnable genome (species + mutations + lineage) AND a
+   * crossbreed-able ambassador. Also returns a thin `spawn_descriptor` = the genome
+   * a session/Godot needs to spawn the offspring as a playable unit; combat-stat
+   * derivation + live-run roster injection are DOWNSTREAM (session lane), not wired
+   * here. Species is resolved at promote-time from the body (the offspring record
+   * carries no species field; adding one = forbidden-path packages/contracts).
+   *
+   * Response: 201 { ambassador, spawn_descriptor } | 400 species_required
+   *           404 offspring_not_found | 422 promote_failed
+   */
+  router.post('/skiv/offspring/:offspring_id/promote', async (req, res) => {
+    if (!requireStore(res)) return;
+    const offspringId = String(req.params.offspring_id || '');
+    const body = req.body || {};
+    const speciesId = body.species_id ? String(body.species_id) : '';
+    if (!speciesId) {
+      return res.status(400).json({
+        error: 'species_required',
+        hint: 'the offspring record carries no species; pass species_id in the body',
+      });
+    }
+    let offspring;
+    try {
+      offspring = await offspringStore.getById(offspringId);
+    } catch (err) {
+      return res
+        .status(500)
+        .json({ error: 'offspring_lookup_failed', message: String(err.message || err) });
+    }
+    if (!offspring) {
+      return res.status(404).json({ error: 'offspring_not_found' });
+    }
+    // Ambassador companion card (saveCompanionState applies cap-10 FIFO + signs).
+    // Only offspring-derived fields are set -- no fabricated mbti/aspect/progression.
+    const ambassadorState = {
+      schema_version: '0.2.0',
+      unit_id: body.unit_id ? String(body.unit_id) : `offspring-${offspring.lineage_id}`,
+      species_id: speciesId,
+      biome_id: offspring.biome_origin || null,
+      lineage_id: offspring.lineage_id,
+      mutations: Array.isArray(offspring.mutations) ? offspring.mutations : [],
+    };
+    let ambassador;
+    try {
+      ambassador = store.saveCompanionState(ambassadorState);
+    } catch (err) {
+      return res.status(422).json({ error: 'promote_failed', message: String(err.message || err) });
+    }
+    const spawnDescriptor = {
+      lineage_id: offspring.lineage_id,
+      species_id: speciesId,
+      applied_mutations: Array.isArray(offspring.mutations) ? offspring.mutations : [],
+      trait_ids: Array.isArray(offspring.trait_inherited) ? offspring.trait_inherited : [],
+      biome_origin: offspring.biome_origin || null,
+    };
+    return res.status(201).json({ ambassador, spawn_descriptor: spawnDescriptor });
   });
 
   /**

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -90,6 +90,25 @@ function createCompanionRouter({
   const _crossbreedCampaigns = new Set(); // `${campaignId}::${lineageId}`
   const cooldownKey = (campaignId, lineageId) => `${campaignId}::${lineageId}`;
 
+  // Promote (offspring->ambassador) is the other write that grows the capped
+  // ambassador registry, so it gets the same 10/h-per-IP posture as the crossbreed
+  // write (partial mitigation of cap-10 FIFO eviction grief; full per-Nido
+  // isolation = SPEC-F-wide auth, see header). Independent budget so a griefer
+  // cannot also exhaust the crossbreed quota.
+  const _promoteHits = new Map();
+  function promoteRateLimited(ip) {
+    const now = Date.now();
+    const key = ip || 'unknown';
+    const recent = (_promoteHits.get(key) || []).filter((t) => now - t < CROSSBREED_RATE_WINDOW_MS);
+    if (recent.length >= CROSSBREED_RATE_LIMIT) {
+      _promoteHits.set(key, recent);
+      return true;
+    }
+    recent.push(now);
+    _promoteHits.set(key, recent);
+    return false;
+  }
+
   /**
    * POST /api/companion/pick
    * Body: { biome_id, form_axes?, run_seed?, trainer_canonical? }
@@ -229,10 +248,14 @@ function createCompanionRouter({
    * carries no species field; adding one = forbidden-path packages/contracts).
    *
    * Response: 201 { ambassador, spawn_descriptor } | 400 species_required
-   *           404 offspring_not_found | 422 promote_failed
+   *           404 offspring_not_found | 422 promote_failed | 429 rate_limited
    */
   router.post('/skiv/offspring/:offspring_id/promote', async (req, res) => {
     if (!requireStore(res)) return;
+    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    if (promoteRateLimited(ip)) {
+      return res.status(429).json({ error: 'rate_limited' });
+    }
     const offspringId = String(req.params.offspring_id || '');
     const body = req.body || {};
     const speciesId = body.species_id ? String(body.species_id) : '';

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -247,6 +247,14 @@ function createCompanionRouter({
    * here. Species is resolved at promote-time from the body (the offspring record
    * carries no species field; adding one = forbidden-path packages/contracts).
    *
+   * SCOPE: operates on a PERSISTED offspring lineage record (offspringStore, i.e.
+   * the /api/lineage/offspring-ritual path). Crossbreed-confirm offspring
+   * (rollMatingOffspring result) are NOT persisted to offspringStore and use a
+   * different shape (gene_slots/tier_bonus_traits/biome_id_at_mating), and confirm
+   * is campaign-scoped while offspringStore requires a session_id -> wiring
+   * confirm -> offspringStore.create (to make crossbreed offspring promotable) is a
+   * follow-up with a scoping decision, not this slice. Unknown id -> 404.
+   *
    * Response: 201 { ambassador, spawn_descriptor } | 400 species_required
    *           404 offspring_not_found | 422 promote_failed | 429 rate_limited
    */

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -335,6 +335,20 @@ test('POST promote then GET /skiv/share returns the persisted ambassador', async
   assert.equal(r.body.lineage_id, off.lineage_id);
 });
 
+test('POST promote rate-limits after 10/h per IP → 429 (parity w/ crossbreed write)', async () => {
+  const off = makeOffspring();
+  const app = buildApp({
+    store: createCompanionStateStore(),
+    offspringStore: makeOffspringStoreStub({ 'off-1': off }),
+  });
+  let last;
+  for (let i = 0; i < 11; i++) {
+    last = await postJson(app, '/api/skiv/offspring/off-1/promote', { species_id: 'dune_stalker' });
+  }
+  assert.equal(last.status, 429);
+  assert.equal(last.body.error, 'rate_limited');
+});
+
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────
 
 test('GET /skiv/crossbreed/history unknown lineage → [] count 0', async () => {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -19,7 +19,10 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const express = require('express');
 const { createCompanionRouter } = require('../../apps/backend/routes/companion');
-const { signatureFor } = require('../../apps/backend/services/skiv/companionStateStore');
+const {
+  signatureFor,
+  createCompanionStateStore,
+} = require('../../apps/backend/services/skiv/companionStateStore');
 
 // A whitelist-shaped Custode state mirroring makeValidState from
 // tests/services/skivCompanionState.test.js, plus non-whitelist PII so we can
@@ -79,11 +82,37 @@ function makeStoreStub(seed = {}) {
   };
 }
 
-function buildApp({ store, rollMatingOffspring } = {}) {
+function buildApp({ store, rollMatingOffspring, offspringStore } = {}) {
   const app = express();
   app.use(express.json());
-  app.use('/api', createCompanionRouter({ store, rollMatingOffspring }));
+  app.use('/api', createCompanionRouter({ store, rollMatingOffspring, offspringStore }));
   return app;
+}
+
+// Minimal offspringStore stub -- only getById is called by the promote route.
+function makeOffspringStoreStub(seed = {}) {
+  const rows = new Map(Object.entries(seed));
+  return {
+    async getById(id) {
+      const r = rows.get(String(id));
+      return r ? { ...r } : null;
+    },
+  };
+}
+
+function makeOffspring(overrides = {}) {
+  return {
+    id: 'off-1',
+    lineage_id: 'skiv-savana-2026-0427-offspring',
+    session_id: 'sess-1',
+    parent_a_id: 'skiv',
+    parent_b_id: 'partner',
+    mutations: ['glow'],
+    trait_inherited: ['ambush', 'burrow'],
+    biome_origin: 'savana',
+    born_at: '2026-06-08T00:00:00Z',
+    ...overrides,
+  };
 }
 
 async function getJson(app, path) {
@@ -249,6 +278,61 @@ test('GET /skiv/share?format=bogus → 400 unsupported_format', async () => {
   const r = await getJson(app, `/api/skiv/share/${lineageId}?format=bogus`);
   assert.equal(r.status, 400);
   assert.equal(r.body.error, 'unsupported_format');
+});
+
+// --- B4 slice 2: POST /skiv/offspring/:id/promote (offspring -> ambassador) ---
+
+test('POST promote unknown offspring → 404 offspring_not_found', async () => {
+  const app = buildApp({
+    store: createCompanionStateStore(),
+    offspringStore: makeOffspringStoreStub(),
+  });
+  const r = await postJson(app, '/api/skiv/offspring/nope/promote', { species_id: 'dune_stalker' });
+  assert.equal(r.status, 404);
+  assert.equal(r.body.error, 'offspring_not_found');
+});
+
+test('POST promote without species_id → 400 species_required', async () => {
+  const app = buildApp({
+    store: createCompanionStateStore(),
+    offspringStore: makeOffspringStoreStub({ 'off-1': makeOffspring() }),
+  });
+  const r = await postJson(app, '/api/skiv/offspring/off-1/promote', {});
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'species_required');
+});
+
+test('POST promote persists ambassador + returns spawn_descriptor', async () => {
+  const off = makeOffspring();
+  const app = buildApp({
+    store: createCompanionStateStore(),
+    offspringStore: makeOffspringStoreStub({ 'off-1': off }),
+  });
+  const r = await postJson(app, '/api/skiv/offspring/off-1/promote', {
+    species_id: 'dune_stalker',
+  });
+  assert.equal(r.status, 201);
+  // ambassador companion card (species resolved from body, offspring-derived fields)
+  assert.equal(r.body.ambassador.lineage_id, off.lineage_id);
+  assert.equal(r.body.ambassador.species_id, 'dune_stalker');
+  assert.deepEqual(r.body.ambassador.mutations, ['glow']);
+  assert.match(r.body.ambassador.companion_card_signature, /^[a-f0-9]{64}$/);
+  // spawn descriptor = the unit-half genome (combat stats derived downstream)
+  assert.equal(r.body.spawn_descriptor.species_id, 'dune_stalker');
+  assert.deepEqual(r.body.spawn_descriptor.trait_ids, ['ambush', 'burrow']);
+  assert.deepEqual(r.body.spawn_descriptor.applied_mutations, ['glow']);
+  assert.equal(r.body.spawn_descriptor.biome_origin, 'savana');
+});
+
+test('POST promote then GET /skiv/share returns the persisted ambassador', async () => {
+  const off = makeOffspring();
+  const store = createCompanionStateStore();
+  const app = buildApp({ store, offspringStore: makeOffspringStoreStub({ 'off-1': off }) });
+  await postJson(app, '/api/skiv/offspring/off-1/promote', { species_id: 'dune_stalker' });
+  const r = await getJson(app, `/api/skiv/share/${off.lineage_id}`);
+  assert.equal(r.status, 200);
+  assert.equal(r.body.species_id, 'dune_stalker');
+  assert.equal(r.body.lineage_id, off.lineage_id);
 });
 
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────


### PR DESCRIPTION
## Cosa
SPEC-F B4 slice 2 (offspring->playable lineage). Nuova **POST /api/skiv/offspring/:id/promote**.

Verdetti master-dd (AskUserQuestion): shape=**entrambi** (ambassador + unit) - trigger=**promote esplicito** (FC3 :162, no mass-export) - species=**risolta al promote-time dal body** (l'offspring record non ha campo species; aggiungerlo = forbidden-path packages/contracts).

- Persiste l'offspring come **ambassador companion card** via il `saveCompanionState` esistente (riusa cap-10 FIFO + firma) -- la card e' il genoma portabile/spawnable + un ambassador crossbreedabile.
- Restituisce un **`spawn_descriptor`** sottile (lineage_id/species_id/applied_mutations/trait_ids/biome_origin) = il genoma che un session/Godot serve per spawnare l'offspring come unita'. La derivazione combat-stat + injection nella roster live sono **DOWNSTREAM** (session lane) -- NON wirate qui.

## Coordinamento
La injection live-run tocca `session.js`/`coopOrchestrator` = **lane form-pulse/W5 attivo** -> deliberatamente NON toccata (lo spawn_descriptor e' il bridge; la meta' unit resta contract-level). Zero collisione (solo companion store + offspring read).

## Sicurezza / scope
Band-neutral (companion store, no combat/balance), FC3-respecting (esplicito/per-offspring). Ship live come le slice crossbreed. Solo campi offspring-derived (no mbti/aspect fabbricati). 400 species_required / 404 offspring_not_found / 422 promote_failed.

## Test
4 nuovi + round-trip (promote -> GET /share ritorna la card persistita); SPEC-F suite **38/38**.

## Residuo
Live-run unit injection (session.js roster) = coordinare col lane W5. Import di una card esterna (POST /skiv/import) = slice separata.
