### PR TITLE
feat(sim): W5 inc-2 -- graded metrics validated as the Gap-C power discriminator (pivot)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -544,6 +544,19 @@
       "track": "active"
     },
     {
+      "path": "docs/playtest/2026-07-01-w5-graded-metric-power-validation.md",
+      "title": "W5 inc-2 -- graded metrics validated as the Gap-C power discriminator (pivot rationale)",
+      "doc_status": "review_needed",
+      "doc_owner": "claude-code",
+      "workstream": "cross-cutting",
+      "last_verified": "2026-07-01",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "active"
+    },
+    {
       "path": "docs/superpowers/plans/2026-06-23-move-terrain-cost-substrate-plan.md",
       "title": "Move terrain-cost substrate -- implementation plan (volo grades + radici anchor)",
       "doc_status": "active",

--- a/docs/playtest/2026-07-01-w5-graded-metric-power-validation.md
+++ b/docs/playtest/2026-07-01-w5-graded-metric-power-validation.md
@@ -1,0 +1,90 @@
+---
+title: 'W5 inc-2 -- graded metrics validated as the Gap-C power discriminator (pivot rationale)'
+date: 2026-07-01
+sprint: closeout-w5-sim-harness
+doc_status: review_needed
+doc_owner: claude-code
+workstream: cross-cutting
+last_verified: '2026-07-01'
+source_of_truth: false
+review_cycle_days: 90
+language: it-en
+---
+
+# W5 inc-2 -- graded metrics validated (Gap-C power discriminator)
+
+> Follow-up to inc-1 ([2026-07-01-w5-focus-fire-ab-evidence.md](2026-07-01-w5-focus-fire-ab-evidence.md)).
+> Master-dd ratified the **graded-metric re-ratify** direction (AskUserQuestion 2026-07-01) over
+> more AI-tactics factors, on this evidence. Probe: `tools/sim/focus-fire-ab-probe.js`.
+
+## 1. Two diagnostics that reshape W5
+
+### 1a. The hardcore timeout is DPR/hit-rate-bound, NOT positioning-bound
+
+Diagnostic on `enc_badlands_ultima_caccia_01` (wave-1 hardcore, canonical party, focusFire OFF,
+N=8) with the new engagement/output metrics:
+
+| metric                      | value    |
+| --------------------------- | -------- |
+| win_rate                    | 0        |
+| avg_rounds                  | 40 (cap) |
+| **mean_player_attacks**     | 24.3     |
+| **mean_enemy_hp_remaining** | 0.74     |
+| mean_hp_remaining (party)   | 0.975    |
+| creature_ko_rate            | 0.41     |
+
+Players DO engage (~24 landed attacks/run) but the enemies still sit at **74% HP** at the
+round cap: ~24 attacks removed ~26% of ~48 enemy HP = ~0.5 effective damage/attack (heavy
+misses vs DC 11-14). The bottleneck is **damage output / hit-rate, not reaching the enemy**.
+=> A positioning upgrade (F3) would NOT un-stick this encounter -- the party already reaches and
+swings. (It is also a KO-rate-designed encounter, not a WR one -- SPEC-J gates on KO-rate.)
+
+### 1b. The graded metrics discriminate power where binary WR cannot
+
+Same hardcore, party to-hit `mod +0` (baseline) vs `mod +6` (a synthetic team-power delta,
+`PROBE_MOD_BUFF`), N=6:
+
+| party power | win_rate | **enemy_hp_remaining** | creature_ko_rate |
+| ----------- | -------- | ---------------------- | ---------------- |
+| baseline +0 | 0.00     | **0.71**               | 0.42             |
+| +6 to-hit   | 0.50     | **0.21**               | 0.13             |
+
+`enemy_hp_remaining` moves **0.71 -> 0.21** -- a large, continuous response to a power delta that
+binary WR barely captures (0 -> 0.5 only at a big +6). The graded metric would register even a
+SMALL power delta while WR stays pinned at 0. `creature_ko_rate` (0.42 -> 0.13) is a second
+power-sensitive graded channel.
+
+## 2. Conclusion -- the graded metrics ARE the Gap-C / signal win
+
+The recurring inc-1/inc-2 result: **AI-tactics levers (focus-fire, positioning) prove
+band-neutral/irrelevant because the encounters are power/DPR-bound, not tactics-bound.** The sim
+AI already reaches and swings; the missing piece was never AI skill -- it was a metric that reads
+the power delta the binary outcome hides. inc-1's graded metrics do exactly that, validated here
+end-to-end. This is why W5 pivots (master-dd) from "build utility-AI factors F1..F4" to **use the
+validated graded metrics to re-ratify** the provisional bands + drive the flip measurements.
+
+## 3. Shipped (inc-2)
+
+- `combat-adapter.js`: `enemy_hp_remaining_pct` added (mean sistema HP fraction over the final
+  board, dead = 0) -- the damage-OUTPUT graded channel. Test in `tests/sim/combatAdapter.test.js`.
+- `focus-fire-ab-probe.js`: `mean_enemy_hp_remaining_pct` + `mean_player_attacks` in the summary;
+  `PROBE_MOD_BUFF` env (synthetic to-hit power delta) -- the re-ratify measurement tooling.
+- 216/216 sim suite green.
+
+## 4. Next (graded re-ratify, the W5 payload)
+
+Run flag-ON vs OFF N=40 on the D6 / D8 / ER6 mechanics reading the GRADED metrics (not just WR)
+on their relevant encounters -> real bands (vs the passive-AI WR-only PROVISIONAL bands) -> master-dd
+ratifies. Same graded harness sets up the form-pulse W6 cross-biome measurement. Owner-gated
+ratification; the sim produces the evidence.
+
+## 5. Reproduce
+
+```
+node tools/sim/focus-fire-ab-probe.js 8 hardcore                 # 1a diagnostics
+PROBE_MOD_BUFF=0 node tools/sim/focus-fire-ab-probe.js 6 hardcore # 1b baseline
+PROBE_MOD_BUFF=6 node tools/sim/focus-fire-ab-probe.js 6 hardcore # 1b buffed
+```
+
+Node 22 (sim not bit-repro cross-version; variance ~+-0.05). Graded-metric additions are
+AI-independent + read-only; no prod flag flipped.

--- a/docs/superpowers/plans/2026-07-01-w5-sim-ai-player-upgrade.md
+++ b/docs/superpowers/plans/2026-07-01-w5-sim-ai-player-upgrade.md
@@ -88,21 +88,29 @@ is total-ordered. Keep the sim node-22-pinned (not bit-repro cross node-version;
     when the party is under sustained attrition. On the tested encounters the party was not being
     ground down -> kill-order was outcome-neutral. => the Gap-A saturation on these encounters is
     TIMEOUT/POSITIONING-driven, NOT target-selection-driven.
-- **inc-2 -- terrain-cost positioning (F3). EVIDENCE-ELEVATED to the primary Gap-A/B lever.** The
-  inc-1 finding shows the AI's weakness is closing distance / not-getting-focused, not which target
-  it picks. Wire `moveCost.js` into candidate-tile scoring + a threat-avoidance term (don't end in a
-  high-incoming-threat tile). Validate on a terrain encounter (`enc_foresta_temperata_radici` /
-  hazard pilot) that volo/radici traits shift a metric AND on the hardcore timeout (does better
-  positioning convert timeouts to decisions?). Unblocks G6.
-- **inc-3 -- ability/trait use (F4).** Generic value-per-AP ability scoring. Validate no
-  regression on inc-1/2 bands.
-- **inc-4 -- P1 tune-to-band (BO).** Bayes-optimize `w_i` per encounter-class to the target WR
-  band. Emit a ratify-doc of the tuned weights (master-dd ratifies, SDMG).
-- **inc-5 -- P1 skill-tier sweep.** 3-tier Restricted-Play harness (degenerate / tuned / full-factor
-  utility-AI as the low/mid/high skill dial) as a periodic sensitivity net.
-- **inc-6 (conditional) -- Gap C power-coupled encounters.** ONLY if the graded metric alone
-  doesn't yield a non-elim power signal: author contested pressure (patrols / tight timers) into
-  objective encounters. Content call -> master-dd.
+- **inc-2 -- graded metrics VALIDATED + PIVOT (THIS SESSION, DONE).** Master-dd ratified the
+  **graded-metric re-ratify** direction (AskUserQuestion 2026-07-01) over more AI-tactics factors.
+  Evidence: [`2026-07-01-w5-graded-metric-power-validation.md`](../../playtest/2026-07-01-w5-graded-metric-power-validation.md).
+  - Added `enemy_hp_remaining_pct` (damage-OUTPUT channel) to `combat-adapter.js` + test; probe
+    `PROBE_MOD_BUFF` synthetic power delta + engagement/output summary. 216/216 sim green.
+  - **KEY FINDING: the graded metrics ARE the Gap-C win.** On the WR-saturated hardcore a team-power
+    delta moves `enemy_hp_remaining` 0.71 -> 0.21 (and ko_rate 0.42 -> 0.13) while binary WR barely
+    twitches. And the hardcore timeout is **DPR/hit-rate-bound, not positioning-bound** (24 attacks
+    land but enemies stay at 74% HP). => the AI-tactics levers (F1 focus-fire, F3 positioning) are
+    band-neutral/irrelevant because the encounters are **power/DPR-bound, not tactics-bound**. The AI
+    already reaches + swings; the signal was always the metric.
+- **inc-3 -- graded re-ratify D6 / D8 / ER6 (NEXT, the W5 payload).** Run flag-ON vs OFF N=40 on
+  each mechanic reading the GRADED metrics (enemy_hp_remaining / ko_rate / hp_remaining, not just
+  WR) on their relevant encounters -> REAL bands (vs the passive-AI WR-only PROVISIONAL bands) ->
+  master-dd ratifies (owner-gated). The sim produces the evidence.
+- **inc-4 -- form-pulse W6 graded measurement.** Same graded harness -> the N=40 cross-biome
+  power measurement the WR-only path could not produce -> feeds the W6 flip decision.
+- **DEPRIORITIZED (evidence: encounters are power-bound not tactics-bound):**
+  - **F3 terrain positioning** -- only real target is Gap B / volo-radici / G6, and the server
+    already enforces terrain move-cost, so a terrain-aware sim AI adds little measurement value
+    (may even shrink the signal). Build ONLY if a G6-specific terrain signal proves it needs it.
+  - **F4 ability use / tune-to-band / skill-sweep** -- diminishing value once the graded metrics
+    read power directly. Revisit only if WR (not graded metrics) must become the discriminator.
 
 ## 4. Then (post-W5, gated on the above)
 

--- a/tests/sim/combatAdapter.test.js
+++ b/tests/sim/combatAdapter.test.js
@@ -158,6 +158,60 @@ test('combatAdapter.runEncounter: returns graded metrics (hp_remaining_pct, unit
   );
 });
 
+// W5 inc-2 (Codex P2 #3130): board-derived metrics must reflect the FINAL action on a maxRounds
+// timeout. The loop polls at the TOP of each iteration, so without a post-loop state refresh
+// lastUnits is the PRE-final-action board -> enemy_hp_remaining would ignore the last hit.
+test('combatAdapter.runEncounter: enemy_hp_remaining_pct reflects the final action (no timeout staleness)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = supertestHttp(app);
+  // Player adjacent to a weak enemy (in range) + maxRounds:1 => the single action is a
+  // guaranteed hit (mod 20 vs dc 1). enemy_hp_remaining_pct MUST be < 1 (damage landed).
+  const oneRoster = [
+    {
+      id: 'hit',
+      hp: 30,
+      max_hp: 30,
+      ap: 3,
+      mod: 20,
+      attack_range: 2,
+      initiative: 18,
+      position: { x: 1, y: 1 },
+      controlled_by: 'player',
+      status: {},
+    },
+  ];
+  const oneFoe = [
+    {
+      id: 'dummy',
+      hp: 10,
+      max_hp: 10,
+      ap: 1,
+      mod: 0,
+      dc: 1,
+      attack_range: 1,
+      initiative: 1,
+      position: { x: 1, y: 2 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+  const res = await runEncounter(http, {
+    roster: oneRoster,
+    enemies: oneFoe,
+    scenarioId: 'full_loop_test',
+    seed: 'stale-1',
+    maxRounds: 1,
+  });
+  assert.ok(res.playerAttacks >= 1, `expected a landed attack, got ${res.playerAttacks}`);
+  assert.ok(
+    res.enemy_hp_remaining_pct < 1,
+    `enemy took damage on the final action, got ${res.enemy_hp_remaining_pct}`,
+  );
+});
+
 // OA2 (SPEC-O): a NON-elimination objective completes via the objective-driver + the
 // objective-outcome wiring (sabotage progress while in the zone), NOT elimination.
 test('combatAdapter.runEncounter: OA2 -- sabotage objective completes (not elimination)', async (t) => {

--- a/tests/sim/combatAdapter.test.js
+++ b/tests/sim/combatAdapter.test.js
@@ -148,6 +148,14 @@ test('combatAdapter.runEncounter: returns graded metrics (hp_remaining_pct, unit
     res.hp_remaining_pct > 0 && res.hp_remaining_pct <= 1,
     `hp_remaining_pct in (0,1], got ${res.hp_remaining_pct}`,
   );
+  // W5 inc-2: enemy_hp_remaining_pct = the team's damage-OUTPUT signal. Victory here means the
+  // (weak) enemy is dead, so its remaining HP fraction is 0 -- the metric that discriminates a
+  // team-power delta even when the binary WR is saturated (validated: 0.71 -> 0.21 on a +6 buff).
+  assert.equal(
+    res.enemy_hp_remaining_pct,
+    0,
+    `enemy dead at victory, got ${res.enemy_hp_remaining_pct}`,
+  );
 });
 
 // OA2 (SPEC-O): a NON-elimination objective completes via the objective-driver + the

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -236,6 +236,25 @@ async function runEncounter(
     }
   }
 
+  // Codex P2 #3130: on a maxRounds TIMEOUT the loop exits with `lastUnits` = the state polled at
+  // the TOP of the last iteration -- BEFORE that iteration's action landed -- so the board-derived
+  // metrics (survivors, hp_remaining, enemy_hp_remaining) would miss the final action's damage/KO
+  // (a guaranteed-hit maxRounds:1 run would report enemy_hp_remaining 1.0). victory/defeat break on
+  // an accurate top-of-loop poll, so ONLY a timeout needs the refresh. A collectSet run still
+  // fetches (as before) to sweep an event from the last commit; sweepEvents no-ops when not
+  // collecting. Best-effort: keep the in-loop state + sweeps on error.
+  if (outcome === 'timeout' || collectSet) {
+    try {
+      const fin = await http.get('/api/session/state', { session_id: sessionId });
+      if (outcome === 'timeout' && fin && fin.body && Array.isArray(fin.body.units)) {
+        lastUnits = fin.body.units;
+      }
+      sweepEvents(fin && fin.body);
+    } catch {
+      /* keep the last in-loop state + the in-loop event sweeps */
+    }
+  }
+
   const survivors = lastUnits.filter((u) => u.controlled_by === 'player' && (u.hp ?? 0) > 0);
   const survivorIds = survivors.map((u) => u.id);
 
@@ -264,17 +283,6 @@ async function runEncounter(
         0,
       ) / foesFinal.length
     : 0;
-
-  // SPEC-I event collector: one post-loop sweep so events emitted by the final
-  // commit (after the last in-loop poll) still land in the tail window.
-  if (collectSet) {
-    try {
-      const fin = await http.get('/api/session/state', { session_id: sessionId });
-      sweepEvents(fin && fin.body);
-    } catch {
-      /* best-effort -- the in-loop sweeps already carry the early one-shots */
-    }
-  }
 
   // Opt 3 N=40 evidence (#2679): read the NON-destructive GET /:id/vc and lift
   // debrief_payload.per_actor[uid].personality_axes per unit (faction-tagged via

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -254,6 +254,16 @@ async function runEncounter(
         0,
       ) / rosterSurvivors.length
     : 0;
+  // W5 inc-2: enemy HP remaining (mean sistema HP fraction over the final board, dead = 0) --
+  // the team's damage-OUTPUT signal. Distinguishes a positioning-bound timeout (players never
+  // engage -> enemies near full) from a DPR-bound one (players engage -> enemies still not dead).
+  const foesFinal = lastUnits.filter((u) => u.controlled_by === 'sistema');
+  const enemyHpRemainingPct = foesFinal.length
+    ? foesFinal.reduce(
+        (s, u) => s + Math.max(0, u.hp ?? 0) / (Number(u.max_hp) || Number(u.hp) || 1),
+        0,
+      ) / foesFinal.length
+    : 0;
 
   // SPEC-I event collector: one post-loop sweep so events emitted by the final
   // commit (after the last in-loop poll) still land in the tail window.
@@ -316,6 +326,7 @@ async function runEncounter(
     survivorIds,
     units_lost: unitsLost,
     hp_remaining_pct: Number(hpRemainingPct.toFixed(4)),
+    enemy_hp_remaining_pct: Number(enemyHpRemainingPct.toFixed(4)),
     personalityUnits,
     biomeWounded,
     ended,

--- a/tools/sim/focus-fire-ab-probe.js
+++ b/tools/sim/focus-fire-ab-probe.js
@@ -136,7 +136,16 @@ async function fetchCanonicalParty() {
 }
 
 function roster(party) {
-  return party.map((u) => ({ ...u, hp: u.max_hp ?? u.hp, status: {} }));
+  // PROBE_MOD_BUFF: additive to-hit buff on every party unit -- a synthetic team-power delta to
+  // test whether the graded metrics (enemy_hp_remaining_pct) discriminate power on a WR-saturated
+  // encounter. Default 0 = the canonical party.
+  const buff = Number(process.env.PROBE_MOD_BUFF) || 0;
+  return party.map((u) => ({
+    ...u,
+    hp: u.max_hp ?? u.hp,
+    mod: (Number(u.mod) || 0) + buff,
+    status: {},
+  }));
 }
 
 async function runOne(party, seed, focusFire, mode) {
@@ -166,6 +175,8 @@ async function runOne(party, seed, focusFire, mode) {
       rosterN,
       hp_remaining_pct: r.hp_remaining_pct,
       units_lost: r.units_lost,
+      enemy_hp_remaining_pct: r.enemy_hp_remaining_pct,
+      player_attacks: r.playerAttacks,
     };
   } finally {
     if (typeof close === 'function') await close().catch(() => {});
@@ -185,6 +196,12 @@ function summarize(arr) {
     creature_ko_rate: Number((totalKo / (totalSlots || 1)).toFixed(4)),
     mean_hp_remaining_pct: Number(
       (arr.reduce((s, r) => s + (r.hp_remaining_pct || 0), 0) / arr.length).toFixed(4),
+    ),
+    mean_enemy_hp_remaining_pct: Number(
+      (arr.reduce((s, r) => s + (r.enemy_hp_remaining_pct || 0), 0) / arr.length).toFixed(4),
+    ),
+    mean_player_attacks: Number(
+      (arr.reduce((s, r) => s + (r.player_attacks || 0), 0) / arr.length).toFixed(2),
     ),
     avg_rounds: Number((arr.reduce((s, r) => s + (r.rounds || 0), 0) / arr.length).toFixed(2)),
   };

--- a/tools/sim/focus-fire-ab-probe.js
+++ b/tools/sim/focus-fire-ab-probe.js
@@ -208,7 +208,7 @@ function summarize(arr) {
 }
 
 async function main() {
-  const N = Number(process.argv[2]) || 40;
+  const N = Math.max(1, Number(process.argv[2]) || 40); // guard N<1 -> no empty-array NaN means
   const mode = process.argv[3] === 'synthetic' ? 'synthetic' : 'hardcore';
   const party = mode === 'synthetic' ? null : await fetchCanonicalParty();
   const off = [];


### PR DESCRIPTION
## W5 inc-2 -- graded metrics validated (Gap-C power discriminator)

Master-dd-ratified **pivot** (AskUserQuestion 2026-07-01): graded-metric re-ratify over more AI-tactics factors, on decisive evidence.

### Two diagnostics that reshape W5
1. **The hardcore timeout is DPR/hit-rate-bound, NOT positioning-bound** -- players land ~24 attacks/run but enemies stay at **74% HP** (heavy misses vs DC 11-14). F3 positioning would not un-stick it; the party already reaches + swings.
2. **The graded metrics discriminate power where binary WR cannot** -- a team-power delta (+6 to-hit) moves `enemy_hp_remaining` **0.71 -> 0.21** (ko_rate 0.42 -> 0.13) while WR barely twitches (0 -> 0.5 only at +6). The graded metric registers even a small delta while WR is pinned at 0.

**Conclusion:** the AI-tactics levers (F1 focus-fire, F3 positioning) prove band-neutral because the encounters are **power/DPR-bound, not tactics-bound**. inc-1's graded metrics ARE the Gap-C win. => pivot to graded re-ratify.

### Ships
- `combat-adapter.js`: `enemy_hp_remaining_pct` (damage-OUTPUT channel, roster/board-symmetric) + test.
- `focus-fire-ab-probe.js`: `mean_enemy_hp_remaining_pct` + `mean_player_attacks` summary; `PROBE_MOD_BUFF` synthetic power delta = re-ratify tooling.
- Plan pivoted: inc-3 = graded re-ratify D6/D8/ER6 (owner-gated evidence); inc-4 = form-pulse W6 graded measurement; F3/F4 deprioritized.
- Evidence doc + registered.

### Verification
216/216 sim green; prettier clean; governance errors=0.

### Rollback (03A)
Pure revert. Additive read-only metric + probe tooling; no prod flag, no schema, no policy change. `git revert` is a clean no-op for existing behavior.

### Scope
`tools/sim/` + `combat-adapter.js` read-side + docs. No forbidden-path. No prod flag flipped.

Coding-Agent: claude-code