### PR TITLE
feat(spec-f): promotable crossbreed offspring via descriptor + genome map

### DIFF
--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -30,6 +30,7 @@ const { sanitizeWhitelist, signatureFor } = require('../services/skiv/companionS
 const { toDisplayCard, toQrPayload } = require('../services/skiv/companionCardExport');
 const { rollMatingOffspring: rollMatingOffspringDefault } = require('../services/metaProgression');
 const offspringStoreDefault = require('../services/lineage/offspringStore');
+const { resolveOffspringGenome } = require('../services/skiv/offspringGenome');
 
 // SPEC-F slice 3 -- crossbreed offspring is rolled by the engine, but with a
 // SEEDED rng so the proposal preview (slice 2) and the committed confirm
@@ -235,28 +236,30 @@ function createCompanionRouter({
 
   /**
    * POST /api/skiv/offspring/:offspring_id/promote
-   * Body: { species_id, unit_id? }
+   * Body: { species_id, unit_id?, offspring? }
    *
-   * SPEC-F B4 slice 2 -- offspring -> playable lineage. FC3 (spec :162): an
-   * EXPLICIT per-offspring extraction (not mass-export). Persists the offspring as
-   * an ambassador companion card (reuses saveCompanionState + the cap-10 FIFO); the
-   * card is the portable, spawnable genome (species + mutations + lineage) AND a
-   * crossbreed-able ambassador. Also returns a thin `spawn_descriptor` = the genome
-   * a session/Godot needs to spawn the offspring as a playable unit; combat-stat
-   * derivation + live-run roster injection are DOWNSTREAM (session lane), not wired
-   * here. Species is resolved at promote-time from the body (the offspring record
-   * carries no species field; adding one = forbidden-path packages/contracts).
+   * SPEC-F B4 -- offspring -> playable lineage. FC3 (spec :162): an EXPLICIT
+   * per-offspring extraction (not mass-export). Persists the offspring as an
+   * ambassador companion card (reuses saveCompanionState + the cap-10 FIFO); the
+   * card is the portable, spawnable genome AND a crossbreed-able ambassador. Also
+   * returns a thin `spawn_descriptor` = the genome a session/Godot needs to spawn
+   * the offspring as a playable unit; combat-stat derivation + live-run roster
+   * injection are DOWNSTREAM (session lane), not wired here. Species is resolved at
+   * promote-time from the body (the offspring record carries no species field;
+   * adding one = forbidden-path packages/contracts).
    *
-   * SCOPE: operates on a PERSISTED offspring lineage record (offspringStore, i.e.
-   * the /api/lineage/offspring-ritual path). Crossbreed-confirm offspring
-   * (rollMatingOffspring result) are NOT persisted to offspringStore and use a
-   * different shape (gene_slots/tier_bonus_traits/biome_id_at_mating), and confirm
-   * is campaign-scoped while offspringStore requires a session_id -> wiring
-   * confirm -> offspringStore.create (to make crossbreed offspring promotable) is a
-   * follow-up with a scoping decision, not this slice. Unknown id -> 404.
+   * Two offspring sources (master-dd 2026-07-01 = promote-from-descriptor):
+   *   - body.offspring = the CROSSBREED result (rollMatingOffspring, from the
+   *     /crossbreed/confirm response) -- not persisted, different shape; used when
+   *     present. Trusting the client descriptor is consistent with FC4 (signature =
+   *     integrity, not authenticity) + confirm already trusting client partner cards.
+   *   - else offspringStore.getById(:offspring_id) = a PERSISTED ritual record.
+   * resolveOffspringGenome() normalizes both shapes + applies the ratified genome
+   * projection (env_mutation+fusions -> mutations, bonus+gene_slots -> cabinet).
    *
-   * Response: 201 { ambassador, spawn_descriptor } | 400 species_required
-   *           404 offspring_not_found | 422 promote_failed | 429 rate_limited
+   * Response: 201 { ambassador, spawn_descriptor } | 400 species_required |
+   *           400 lineage_id_required | 404 offspring_not_found |
+   *           422 promote_failed | 429 rate_limited
    */
   router.post('/skiv/offspring/:offspring_id/promote', async (req, res) => {
     if (!requireStore(res)) return;
@@ -273,26 +276,34 @@ function createCompanionRouter({
         hint: 'the offspring record carries no species; pass species_id in the body',
       });
     }
-    let offspring;
-    try {
-      offspring = await offspringStore.getById(offspringId);
-    } catch (err) {
-      return res
-        .status(500)
-        .json({ error: 'offspring_lookup_failed', message: String(err.message || err) });
-    }
+    // Prefer a body-supplied crossbreed descriptor; else look up a persisted ritual record.
+    let offspring = body.offspring && typeof body.offspring === 'object' ? body.offspring : null;
     if (!offspring) {
-      return res.status(404).json({ error: 'offspring_not_found' });
+      try {
+        offspring = await offspringStore.getById(offspringId);
+      } catch (err) {
+        return res
+          .status(500)
+          .json({ error: 'offspring_lookup_failed', message: String(err.message || err) });
+      }
+      if (!offspring) {
+        return res.status(404).json({ error: 'offspring_not_found' });
+      }
+    }
+    const genome = resolveOffspringGenome(offspring);
+    if (!genome.lineage_id) {
+      return res.status(400).json({ error: 'lineage_id_required' });
     }
     // Ambassador companion card (saveCompanionState applies cap-10 FIFO + signs).
     // Only offspring-derived fields are set -- no fabricated mbti/aspect/progression.
     const ambassadorState = {
       schema_version: '0.2.0',
-      unit_id: body.unit_id ? String(body.unit_id) : `offspring-${offspring.lineage_id}`,
+      unit_id: body.unit_id ? String(body.unit_id) : `offspring-${genome.lineage_id}`,
       species_id: speciesId,
-      biome_id: offspring.biome_origin || null,
-      lineage_id: offspring.lineage_id,
-      mutations: Array.isArray(offspring.mutations) ? offspring.mutations : [],
+      biome_id: genome.biome_id,
+      lineage_id: genome.lineage_id,
+      mutations: genome.mutations,
+      cabinet: { unlocked: genome.cabinet_unlocked },
     };
     let ambassador;
     try {
@@ -301,11 +312,11 @@ function createCompanionRouter({
       return res.status(422).json({ error: 'promote_failed', message: String(err.message || err) });
     }
     const spawnDescriptor = {
-      lineage_id: offspring.lineage_id,
+      lineage_id: genome.lineage_id,
       species_id: speciesId,
-      applied_mutations: Array.isArray(offspring.mutations) ? offspring.mutations : [],
-      trait_ids: Array.isArray(offspring.trait_inherited) ? offspring.trait_inherited : [],
-      biome_origin: offspring.biome_origin || null,
+      applied_mutations: genome.mutations,
+      trait_ids: genome.trait_ids,
+      biome_origin: genome.biome_id,
     };
     return res.status(201).json({ ambassador, spawn_descriptor: spawnDescriptor });
   });

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -259,6 +259,7 @@ function createCompanionRouter({
    *
    * Response: 201 { ambassador, spawn_descriptor } | 400 species_required |
    *           400 lineage_id_required | 404 offspring_not_found |
+   *           409 lineage_already_promoted | 422 invalid_offspring |
    *           422 promote_failed | 429 rate_limited
    */
   router.post('/skiv/offspring/:offspring_id/promote', async (req, res) => {
@@ -290,9 +291,30 @@ function createCompanionRouter({
         return res.status(404).json({ error: 'offspring_not_found' });
       }
     }
-    const genome = resolveOffspringGenome(offspring);
+    // Defense-in-depth: body.offspring is untrusted -> never let a malformed
+    // descriptor throw out of the async handler (unhandled rejection = crash).
+    let genome;
+    try {
+      genome = resolveOffspringGenome(offspring);
+    } catch (err) {
+      return res
+        .status(422)
+        .json({ error: 'invalid_offspring', message: String(err.message || err) });
+    }
     if (!genome.lineage_id) {
       return res.status(400).json({ error: 'lineage_id_required' });
+    }
+    // Refuse to overwrite an existing ambassador: promote CREATES a new one, and
+    // the (crossbreed-descriptor) lineage_id is client-supplied -> refusing an
+    // in-place overwrite stops a caller clobbering another lineage's card
+    // (species/mutations/cabinet) by re-using its lineage_id (store is keyed by it).
+    if (
+      typeof store.getCompanionState === 'function' &&
+      store.getCompanionState(genome.lineage_id)
+    ) {
+      return res
+        .status(409)
+        .json({ error: 'lineage_already_promoted', lineage_id: genome.lineage_id });
     }
     // Ambassador companion card (saveCompanionState applies cap-10 FIFO + signs).
     // Only offspring-derived fields are set -- no fabricated mbti/aspect/progression.

--- a/apps/backend/services/skiv/offspringGenome.js
+++ b/apps/backend/services/skiv/offspringGenome.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// SPEC-F B4 -- normalize an offspring (two shapes) into a companion-card genome.
+//
+// Two offspring sources exist:
+//   RITUAL  (offspringStore record, /api/lineage/offspring-ritual):
+//           { lineage_id, mutations, trait_inherited, biome_origin }
+//   CROSSBREED (rollMatingOffspring result, /skiv/crossbreed/confirm response):
+//           { lineage_id, gene_slots[{slot_id,value}], environmental_mutation{id,type,tier},
+//             tier_bonus_traits[str], hybrid_fusions[obj], biome_id_at_mating }
+// The crossbreed shape is NOT persisted, so promote accepts it in the request body.
+//
+// Genome projection (master-dd ratified 2026-07-01):
+//   mutations (obj[], card cap 3) = environmental_mutation + hybrid_fusions (acquired changes)
+//   cabinet.unlocked (str[])       = tier_bonus_traits + gene_slot ids (inherited/bonus loadout)
+// Ritual shape is passed through (mutations as-is, cabinet.unlocked = trait_inherited).
+
+function _isCrossbreedShape(o) {
+  return Boolean(
+    o && ('gene_slots' in o || 'tier_bonus_traits' in o || 'environmental_mutation' in o),
+  );
+}
+
+/**
+ * Normalize either offspring shape into { lineage_id, mutations, cabinet_unlocked,
+ * biome_id, trait_ids }. Pure; never throws on missing fields (returns empties).
+ */
+function resolveOffspringGenome(offspring) {
+  if (!offspring || typeof offspring !== 'object') {
+    throw new TypeError('resolveOffspringGenome: offspring object required');
+  }
+  if (_isCrossbreedShape(offspring)) {
+    const mutations = [offspring.environmental_mutation, ...(offspring.hybrid_fusions || [])]
+      .filter((m) => m && typeof m === 'object')
+      .slice(0, 3);
+    const geneSlotIds = (Array.isArray(offspring.gene_slots) ? offspring.gene_slots : [])
+      .map((s) => (s && (s.slot_id || s.id)) || null)
+      .filter((t) => typeof t === 'string' && t);
+    const cabinetUnlocked = [
+      ...(Array.isArray(offspring.tier_bonus_traits) ? offspring.tier_bonus_traits : []),
+      ...geneSlotIds,
+    ].filter((t) => typeof t === 'string' && t);
+    return {
+      lineage_id: offspring.lineage_id || null,
+      mutations,
+      cabinet_unlocked: cabinetUnlocked,
+      biome_id: offspring.biome_id_at_mating || null,
+      trait_ids: cabinetUnlocked,
+    };
+  }
+  // Ritual (offspringStore) shape.
+  const traitInherited = Array.isArray(offspring.trait_inherited) ? offspring.trait_inherited : [];
+  return {
+    lineage_id: offspring.lineage_id || null,
+    mutations: Array.isArray(offspring.mutations) ? offspring.mutations : [],
+    cabinet_unlocked: traitInherited,
+    biome_id: offspring.biome_origin || null,
+    trait_ids: traitInherited,
+  };
+}
+
+module.exports = { resolveOffspringGenome };

--- a/apps/backend/services/skiv/offspringGenome.js
+++ b/apps/backend/services/skiv/offspringGenome.js
@@ -30,7 +30,8 @@ function resolveOffspringGenome(offspring) {
     throw new TypeError('resolveOffspringGenome: offspring object required');
   }
   if (_isCrossbreedShape(offspring)) {
-    const mutations = [offspring.environmental_mutation, ...(offspring.hybrid_fusions || [])]
+    const hybridFusions = Array.isArray(offspring.hybrid_fusions) ? offspring.hybrid_fusions : [];
+    const mutations = [offspring.environmental_mutation, ...hybridFusions]
       .filter((m) => m && typeof m === 'object')
       .slice(0, 3);
     const geneSlotIds = (Array.isArray(offspring.gene_slots) ? offspring.gene_slots : [])

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -397,6 +397,47 @@ test('POST promote a CROSSBREED descriptor (body.offspring) maps genome + no sto
   assert.equal(r.body.spawn_descriptor.biome_origin, 'savana');
 });
 
+test('POST promote crossbreed descriptor with non-array hybrid_fusions does NOT crash (Codex P1)', async () => {
+  const app = buildApp({
+    store: createCompanionStateStore(),
+    offspringStore: makeOffspringStoreStub(),
+  });
+  // malformed unauthenticated input: a non-array (non-iterable) hybrid_fusions
+  const xbred = makeCrossbreedOffspring({ hybrid_fusions: { not: 'an array' } });
+  const r = await postJson(app, `/api/skiv/offspring/${xbred.lineage_id}/promote`, {
+    species_id: 'dune_stalker',
+    offspring: xbred,
+  });
+  // gracefully handled (fusions ignored), not a 500/crash
+  assert.equal(r.status, 201);
+  assert.deepEqual(
+    r.body.ambassador.mutations.map((m) => m.id),
+    ['mut_glow'],
+  );
+});
+
+test('POST promote refuses to overwrite an existing ambassador → 409 (anti-clobber)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store, offspringStore: makeOffspringStoreStub() });
+  const xbred = makeCrossbreedOffspring();
+  // first promote creates the ambassador
+  const first = await postJson(app, `/api/skiv/offspring/${xbred.lineage_id}/promote`, {
+    species_id: 'dune_stalker',
+    offspring: xbred,
+  });
+  assert.equal(first.status, 201);
+  // an attacker re-uses the SAME lineage_id with different species -> refused, not clobbered
+  const attack = await postJson(app, `/api/skiv/offspring/${xbred.lineage_id}/promote`, {
+    species_id: 'attacker_sp',
+    offspring: makeCrossbreedOffspring({ tier_bonus_traits: ['attacker_trait'] }),
+  });
+  assert.equal(attack.status, 409);
+  assert.equal(attack.body.error, 'lineage_already_promoted');
+  // victim card unchanged
+  const share = await getJson(app, `/api/skiv/share/${xbred.lineage_id}`);
+  assert.equal(share.body.species_id, 'dune_stalker');
+});
+
 test('POST promote crossbreed descriptor without lineage_id → 400 lineage_id_required', async () => {
   const app = buildApp({
     store: createCompanionStateStore(),

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -115,6 +115,25 @@ function makeOffspring(overrides = {}) {
   };
 }
 
+// Crossbreed-confirm offspring shape (rollMatingOffspring result), NOT persisted.
+function makeCrossbreedOffspring(overrides = {}) {
+  return {
+    lineage_id: 'skiv-savana-2026-0427-xbred',
+    gene_slots: [
+      { slot_id: 'gs_speed', value: 3 },
+      { slot_id: 'gs_armor', value: 2 },
+    ],
+    environmental_mutation: { id: 'mut_glow', type: 'mutation', tier: 2 },
+    tier_bonus_traits: ['ambush', 'burrow'],
+    hybrid_fusions: [{ id: 'fus_x', type: 'fusion' }],
+    tier: 2,
+    parent_a_id: 'skiv',
+    parent_b_id: 'partner',
+    biome_id_at_mating: 'savana',
+    ...overrides,
+  };
+}
+
 async function getJson(app, path) {
   return new Promise((resolve, reject) => {
     const server = app.listen(0, async () => {
@@ -347,6 +366,49 @@ test('POST promote rate-limits after 10/h per IP → 429 (parity w/ crossbreed w
   }
   assert.equal(last.status, 429);
   assert.equal(last.body.error, 'rate_limited');
+});
+
+test('POST promote a CROSSBREED descriptor (body.offspring) maps genome + no store lookup', async () => {
+  // Empty offspringStore -> proves the body descriptor path does not need a persisted record.
+  const app = buildApp({
+    store: createCompanionStateStore(),
+    offspringStore: makeOffspringStoreStub(),
+  });
+  const xbred = makeCrossbreedOffspring();
+  const r = await postJson(app, `/api/skiv/offspring/${xbred.lineage_id}/promote`, {
+    species_id: 'dune_stalker',
+    offspring: xbred,
+  });
+  assert.equal(r.status, 201);
+  assert.equal(r.body.ambassador.lineage_id, xbred.lineage_id);
+  // genome projection: env_mutation + hybrid_fusions -> mutations (objects, cap 3)
+  assert.deepEqual(
+    r.body.ambassador.mutations.map((m) => m.id),
+    ['mut_glow', 'fus_x'],
+  );
+  // tier_bonus_traits + gene_slot ids -> cabinet.unlocked
+  assert.deepEqual(r.body.ambassador.cabinet.unlocked, [
+    'ambush',
+    'burrow',
+    'gs_speed',
+    'gs_armor',
+  ]);
+  assert.deepEqual(r.body.spawn_descriptor.trait_ids, ['ambush', 'burrow', 'gs_speed', 'gs_armor']);
+  assert.equal(r.body.spawn_descriptor.biome_origin, 'savana');
+});
+
+test('POST promote crossbreed descriptor without lineage_id → 400 lineage_id_required', async () => {
+  const app = buildApp({
+    store: createCompanionStateStore(),
+    offspringStore: makeOffspringStoreStub(),
+  });
+  const xbred = makeCrossbreedOffspring({ lineage_id: undefined });
+  const r = await postJson(app, '/api/skiv/offspring/x/promote', {
+    species_id: 'dune_stalker',
+    offspring: xbred,
+  });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'lineage_id_required');
 });
 
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────


### PR DESCRIPTION
## Cosa
Chiude il gap di B4 slice 2 (Codex #3129 P2): gli offspring da **crossbreed** sono ora promuovibili ad ambassador.

Verdetti master-dd (AskUserQuestion):
- **Routing = promote-from-descriptor**: la promote accetta `body.offspring` (il `result.offspring` che `/crossbreed/confirm` gia' restituisce). Niente persistenza, nessun muro session-scoping, zero cambio al flow ratificato. Fida del descriptor client (coerente FC4: signature=integrita' + il confirm gia' fida delle partner card).
- **Genome-map**: `environmental_mutation` + `hybrid_fusions` -> `mutations` (obj[], cap 3); `tier_bonus_traits` + gene_slot ids -> `cabinet.unlocked` (str[]).

Nuovo helper puro `services/skiv/offspringGenome.js` (`resolveOffspringGenome`) normalizza **entrambe** le shape (record ritual offspringStore + result crossbreed rollMatingOffspring) in `{lineage_id, mutations, cabinet_unlocked, biome_id, trait_ids}`. La promote preferisce `body.offspring`, altrimenti `getById`. `lineage_id_required` (400) guarda un descriptor senza lineage_id.

## Sicurezza / scope
Path ritual preservato (test esistenti verdi) + ora riempie anche `cabinet.unlocked` da `trait_inherited`. Band-neutral (companion store, no combat/session). Zero collisione col lane form-pulse/W5. Rate-limit 10/h gia' presente (ereditato da slice 2).

## Test
41/41 (2 nuovi crossbreed: genome projection + lineage_id_required).

## Residuo
Live-run unit injection (session.js roster, = W5 lane) + `POST /skiv/import` card esterna = slice separate.