### PR TITLE
feat(sim): W5 inc-3 -- ER6 overrun carry-over graded re-ratify (band-neutral)

### DIFF
--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -13120,6 +13120,17 @@
       "review_cycle_days": 90
     },
     {
+      "path": "docs/playtest/2026-07-01-er6-carryover-graded-reratify.md",
+      "title": "ER6 overrun carry-over -- graded re-ratify (W5 inc-3): band-neutral confirmed",
+      "doc_status": "review_needed",
+      "doc_owner": "claude-code",
+      "workstream": "ops-qa",
+      "last_verified": "2026-07-01",
+      "source_of_truth": false,
+      "language": "en",
+      "review_cycle_days": 90
+    },
+    {
       "path": "docs/playtest/2026-06-30-ha1-aliena-enforcement-evidence.md",
       "title": "HA1 aliena_enforcement strength evidence + flip-safety (SPEC-H, Tier-3 N2)",
       "doc_status": "active",

--- a/docs/playtest/2026-07-01-er6-carryover-graded-reratify.md
+++ b/docs/playtest/2026-07-01-er6-carryover-graded-reratify.md
@@ -43,15 +43,22 @@ reachable. The ONLY between-arm difference is `REINFORCEMENT_OVERRUN_CARRYOVER_E
 
 ## Results (N=40, node 22)
 
-| metric                    | consume-once (OFF) | carry-over (ON) | delta       |
-| ------------------------- | ------------------ | --------------- | ----------- |
-| win_rate                  | 1.000              | 1.000           | 0           |
-| mean_enemy_hp_remaining   | 0.000              | 0.000           | 0           |
-| mean_hp_remaining (party) | 0.9867             | 0.9863          | **-0.0004** |
-| mean_ko_rate              | 0.000              | 0.000           | 0           |
-| avg_rounds                | 36.13              | 36.55           | +0.42       |
-| **overrun_rate** (fires)  | 1.000              | 1.000           | 0           |
-| mean_spawns               | 4.0                | 4.0             | 0           |
+Three arms: OFF (consume-once), **OFF2** (consume-once REPLICATE = same-process + run-to-run noise
+floor), ON (carry-over). The carry effect is real only if `on-off` EXCEEDS the `off2-off` floor
+(Codex P1: same-process arms can drift via module-global state -- #3119 off/off2 methodology).
+
+| metric                    | OFF    | OFF2   | ON     | **ER6 effect (on-off)** | noise floor (off2-off) |
+| ------------------------- | ------ | ------ | ------ | ----------------------- | ---------------------- |
+| win_rate                  | 1.000  | 1.000  | 1.000  | 0                       | 0                      |
+| mean_enemy_hp_remaining   | 0.000  | 0.000  | 0.000  | 0                       | 0                      |
+| mean_hp_remaining (party) | 0.9896 | 0.9900 | 0.9887 | **-0.0009**             | +0.0004                |
+| mean_ko_rate              | 0.000  | 0.000  | 0.000  | 0                       | 0                      |
+| **overrun_rate** (fires)  | 1.000  | 1.000  | 1.000  | --                      | --                     |
+| mean_spawns               | 4.0    | 4.0    | 4.0    | --                      | --                     |
+
+**The ER6 effect (`on-off` hp_remaining -0.0009) is the SAME magnitude as the noise floor
+(`off2-off` +0.0004)** -- both ~+-0.001, indistinguishable. Every other channel is exactly 0 in
+all three arms. The carry flag produces NO effect beyond the same-process / run-to-run noise.
 
 ## Read -- flag INERT on current content (behavioral-identity null)
 
@@ -71,6 +78,13 @@ reachable. The ONLY between-arm difference is `REINFORCEMENT_OVERRUN_CARRYOVER_E
   nonzero value. => ON == OFF, so all graded channels (enemy_hp, hp_remaining, ko_rate, WR) are
   flat by construction, not by attrition-absorption. (`hp_remaining` delta -0.0004 / `avg_rounds`
   +0.42 = pure noise; sim not bit-repro cross-version, ~+-0.05.)
+- **Same-process drift ruled out (Codex P1)**: the arms run sequentially in one process, which can
+  drift via module-global combat state. The `off2` control replicate (same flag + seeds as off)
+  quantifies that drift as a floor: `off2-off` hp_remaining = +0.0004, i.e. the `on-off` "effect"
+  (-0.0009) is the SAME magnitude as the noise floor and every other channel is 0. So the carry
+  flag produces nothing beyond same-process noise. (The behavioral-inertness proof -- identical
+  spawns + `overrun_carry == 0` from instrumentation -- is process-INDEPENDENT and is the stronger
+  core; the floor is belt-and-braces.)
 - **Honest scope -- what the graded metric did and did NOT do**: it did NOT add discriminating
   power over #3119 here, because there is **no behavioral differential to detect** -- a plain
   spawn-diff shows the same identity. The graded metric's discriminating value (inc-2:

--- a/docs/playtest/2026-07-01-er6-carryover-graded-reratify.md
+++ b/docs/playtest/2026-07-01-er6-carryover-graded-reratify.md
@@ -1,0 +1,85 @@
+---
+title: 'ER6 overrun carry-over -- graded re-ratify (W5 inc-3): band-neutral confirmed'
+workstream: ops-qa
+category: playtest
+doc_status: review_needed
+doc_owner: claude-code
+last_verified: '2026-07-01'
+language: en
+tags: [playtest, calibration, spec-i, er6, overrun, carryover, n40, graded, w5, ai-driven]
+---
+
+# ER6 overrun carry-over -- graded re-ratify (W5 inc-3)
+
+W5 inc-3, first mechanic. Re-ratifies the ER6 provisional band (SPEC-I N6, PR #3119) with the
+**W5 graded metrics** (`enemy_hp_remaining_pct` / `ko_rate` / `hp_remaining_pct`) instead of the
+WR-only full-loop meta band. Master-dd direction (2026-07-01 AskUserQuestion): **graded-confirm
+band-neutral** -- ER6 is inert on current content, so confirm that with a sharper metric and turn
+the band PROVISIONAL -> RATIFIED band-neutral. The "when-exercised" band (a forced-under-spend
+scenario) was DEFERRED. Flag stays OFF in prod -- this measures, never flips.
+
+## Why the graded metric (vs #3119 WR-only)
+
+The #3119 band ran on `full-loop-batch` META metrics (completion_rate etc.) and was flat **by
+construction** (the +1 overrun bonus almost always converts to a spawn in the same tick, so
+carry-over rarely diverges from consume-once). W5's graded metrics read the COMBAT board directly
+(enemy HP remaining = damage output, party HP + KO = attrition), so they detect a power/pressure
+delta that a binary completion count hides. If the carry did anything on current content, these
+would move.
+
+## Method
+
+Paired A/B, same seeds (`seed-base 7000`), in-process (supertest `createApp`, NO prod port,
+node 22). Probe: `tools/sim/er6-carryover-graded-probe.js`. Canonical ER6 measurement point
+(mirrors `spec-i-gates-probe` `EFFECTS.er6`): scenario `enc_hardcore_reinf_01`, biome
+`abisso_vulcanico`, `pressure_start 30` (Alert tier), `--modulation duo_hardcore` (deployed 8 ->
+10x10 so the authored reinforcement entry tiles are on-grid), `maxRounds 160`.
+
+**BOTH arms** arm the overrun event (`STRESSWAVE_EVENTS_ENABLED=true`) so the carry path is
+reachable. The ONLY between-arm difference is `REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED`
+(ON = carry the unspent bonus to the next tick; OFF = consume-once).
+
+## Results (N=40, node 22)
+
+| metric                    | consume-once (OFF) | carry-over (ON) | delta       |
+| ------------------------- | ------------------ | --------------- | ----------- |
+| win_rate                  | 1.000              | 1.000           | 0           |
+| mean_enemy_hp_remaining   | 0.000              | 0.000           | 0           |
+| mean_hp_remaining (party) | 0.9867             | 0.9863          | **-0.0004** |
+| mean_ko_rate              | 0.000              | 0.000           | 0           |
+| avg_rounds                | 36.13              | 36.55           | +0.42       |
+| **overrun_rate** (fires)  | 1.000              | 1.000           | 0           |
+| mean_spawns               | 4.0                | 4.0             | 0           |
+
+## Read -- band-neutral RATIFIED (owner)
+
+- **Mechanic fires** (anti-pattern #14): `overrun_rate = 1.0` in BOTH arms -- the overrun event
+  arms every run and the pool spawns to its `max_total` cap (4). The A/B is NOT vacuous.
+- **All graded channels flat**: `enemy_hp_remaining`, `ko_rate`, `win_rate` delta 0; `hp_remaining`
+  delta -0.0004 (shrank from -0.0028 at N=6 -> pure run-to-run noise; sim not bit-repro
+  cross-version, ~+-0.05). `avg_rounds` +0.42 = noise. Carry-over does NOT move any combat metric.
+- **Caveat (honest)**: on this measurement point the party CLEARS the fight (WR 1.0, enemy_hp
+  saturated at 0), so the enemy_hp channel alone could not discriminate a small carry effect.
+  BUT `hp_remaining` (0.986, NOT saturated -- room to drop if the carry added pressure) and
+  `ko_rate` (0 -- room to rise) are ALSO flat, so the band-neutral rests on non-saturated channels
+  too. The graded confirm is robust: the carry's one extra delayed spawn is cleared with no
+  residual damage/attrition.
+- **Verdict**: ER6 carry-over is **band-neutral on current content**, confirmed with a sharper
+  metric than #3119 -> **RATIFIED band-neutral** (owner). Mirrors the mechanic's nature (the +1
+  bonus converts in-tick; carry only bites on forced under-spend, which current content does not
+  produce). The flip stays OWNER-gated + is band-safe by this evidence.
+
+## Deferred (master-dd)
+
+The "when-exercised" band -- a synthetic scenario that FORCES under-spend at overrun time
+(congested entry tiles / raised `OVERRUN_BUDGET_BONUS`) to measure what the carry does when it
+actually fires -- was deferred (option 2 not taken). Revisit if/when content exercises the carry.
+
+## Reproduce
+
+```
+node tools/sim/er6-carryover-graded-probe.js 40
+```
+
+See [[project_w5_sim_ai_player_upgrade]] (inc-3), `docs/playtest/2026-06-30-er6-overrun-carryover-n40-evidence.md`
+(the #3119 WR-only band this re-ratifies), `docs/planning/2026-06-23-residual-gate-register.md` (N6).

--- a/docs/playtest/2026-07-01-er6-carryover-graded-reratify.md
+++ b/docs/playtest/2026-07-01-er6-carryover-graded-reratify.md
@@ -14,9 +14,11 @@ tags: [playtest, calibration, spec-i, er6, overrun, carryover, n40, graded, w5, 
 W5 inc-3, first mechanic. Re-ratifies the ER6 provisional band (SPEC-I N6, PR #3119) with the
 **W5 graded metrics** (`enemy_hp_remaining_pct` / `ko_rate` / `hp_remaining_pct`) instead of the
 WR-only full-loop meta band. Master-dd direction (2026-07-01 AskUserQuestion): **graded-confirm
-band-neutral** -- ER6 is inert on current content, so confirm that with a sharper metric and turn
-the band PROVISIONAL -> RATIFIED band-neutral. The "when-exercised" band (a forced-under-spend
-scenario) was DEFERRED. Flag stays OFF in prod -- this measures, never flips.
+band-neutral** -- ER6 is inert on current content, so confirm that and turn the band PROVISIONAL
+-> RATIFIED band-neutral. **The confirm is a behavioral-inertness proof** (the flag is a structural
+no-op on this content -- see Read), not a "graded channels absorbed the carry" story. The
+"when-exercised" band (a forced-under-spend scenario) was DEFERRED. Flag stays OFF in prod -- this
+measures, never flips.
 
 ## Why the graded metric (vs #3119 WR-only)
 
@@ -51,29 +53,53 @@ reachable. The ONLY between-arm difference is `REINFORCEMENT_OVERRUN_CARRYOVER_E
 | **overrun_rate** (fires)  | 1.000              | 1.000           | 0           |
 | mean_spawns               | 4.0                | 4.0             | 0           |
 
-## Read -- band-neutral RATIFIED (owner)
+## Read -- flag INERT on current content (behavioral-identity null)
+
+> Framing corrected after adversarial review (2026-07-01): the flatness here is **behavioral
+> identity**, NOT the party absorbing added carry-pressure. Instrumentation of the spawner
+> (`reinforcementSpawner`) confirms `overrun_carry` is **NEVER nonzero** on this content -- so the
+> two arms spawn identical units at identical ticks, and every metric is flat **by construction**.
 
 - **Mechanic fires** (anti-pattern #14): `overrun_rate = 1.0` in BOTH arms -- the overrun event
-  arms every run and the pool spawns to its `max_total` cap (4). The A/B is NOT vacuous.
-- **All graded channels flat**: `enemy_hp_remaining`, `ko_rate`, `win_rate` delta 0; `hp_remaining`
-  delta -0.0004 (shrank from -0.0028 at N=6 -> pure run-to-run noise; sim not bit-repro
-  cross-version, ~+-0.05). `avg_rounds` +0.42 = noise. Carry-over does NOT move any combat metric.
-- **Caveat (honest)**: on this measurement point the party CLEARS the fight (WR 1.0, enemy_hp
-  saturated at 0), so the enemy_hp channel alone could not discriminate a small carry effect.
-  BUT `hp_remaining` (0.986, NOT saturated -- room to drop if the carry added pressure) and
-  `ko_rate` (0 -- room to rise) are ALSO flat, so the band-neutral rests on non-saturated channels
-  too. The graded confirm is robust: the carry's one extra delayed spawn is cleared with no
-  residual damage/attrition.
-- **Verdict**: ER6 carry-over is **band-neutral on current content**, confirmed with a sharper
-  metric than #3119 -> **RATIFIED band-neutral** (owner). Mirrors the mechanic's nature (the +1
-  bonus converts in-tick; carry only bites on forced under-spend, which current content does not
-  produce). The flip stays OWNER-gated + is band-safe by this evidence.
+  arms every run and the pool spawns to its `max_total` cap (4). `mean_spawns = 4.0` **identical**
+  in both arms. The A/B is NOT vacuous (the overrun happens), but the CARRY path is structurally
+  never taken.
+- **Why behaviorally identical**: on every overrun tick the +1 bonus is spent IN THE SAME tick
+  (base budget 1 + bonus 1 = 2 units spawned; the r9 tick has not yet hit the cap), so nothing is
+  left over. The carry-accumulation branch (store the unspent bonus on
+  `session.reinforcement_state.overrun_carry`, fold into the next tick) is never reached with a
+  nonzero value. => ON == OFF, so all graded channels (enemy_hp, hp_remaining, ko_rate, WR) are
+  flat by construction, not by attrition-absorption. (`hp_remaining` delta -0.0004 / `avg_rounds`
+  +0.42 = pure noise; sim not bit-repro cross-version, ~+-0.05.)
+- **Honest scope -- what the graded metric did and did NOT do**: it did NOT add discriminating
+  power over #3119 here, because there is **no behavioral differential to detect** -- a plain
+  spawn-diff shows the same identity. The graded metric's discriminating value (inc-2:
+  `enemy_hp_remaining` 0.71 -> 0.21 on a real power delta) is for POWER-differential mechanics
+  (e.g. form-pulse W6), NOT for a flag that is structurally inert on the current content. This
+  re-ratify's real product is the **behavioral-inertness proof**, delivered by the identical
+  spawns + the `overrun_carry == 0` instrumentation, not by "robust graded channels".
+- **Verdict**: ER6 carry-over is **INERT on current content** -- the flag is behaviorally a no-op
+  because the +1 bonus always spends in-tick. **RATIFIED band-neutral = flag-safe to keep OFF, and
+  band-safe if flipped ON on today's content (it changes nothing)**. This is NOT a clearance of the
+  carry's ACTIVE behavior (when a tick under-spends) -- that is deferred (below) and, if future
+  content forces under-spend, this evidence says nothing about it. Owner ratifies.
 
-## Deferred (master-dd)
+## Deferred (master-dd) -- where the graded metric WOULD add value
 
 The "when-exercised" band -- a synthetic scenario that FORCES under-spend at overrun time
-(congested entry tiles / raised `OVERRUN_BUDGET_BONUS`) to measure what the carry does when it
-actually fires -- was deferred (option 2 not taken). Revisit if/when content exercises the carry.
+(congested entry tiles / raised `OVERRUN_BUDGET_BONUS`) so the carry actually accumulates
+(`overrun_carry > 0`, an extra delayed spawn) -- was deferred (option 2 not taken). THAT is the
+scenario where the graded metrics would genuinely discriminate (a real behavioral differential ->
+more enemy pressure -> `enemy_hp_remaining` / attrition move). Revisit if/when content exercises
+the carry.
+
+## Note for the remaining inc-3 mechanics (D8, D6)
+
+ER6 taught that a graded re-ratify of a mechanic that is **structurally inert on current content**
+reduces to a behavioral-inertness proof (arms byte-identical), where the graded metric adds no
+discriminating power over a spawn/behavior diff. If D8 (chain-lightning, needs electrified terrain)
+and D6 (imprint grant) are likewise inert on the encounters that reach them, expect the same
+behavioral-identity null. The graded metric's payoff is the POWER-differential lane (form-pulse W6).
 
 ## Reproduce
 

--- a/tools/sim/er6-carryover-graded-probe.js
+++ b/tools/sim/er6-carryover-graded-probe.js
@@ -127,12 +127,31 @@ function summarize(runs) {
   };
 }
 
+// Graded delta between two arm summaries.
+function armDelta(a, b) {
+  return {
+    win_rate: Number((a.win_rate - b.win_rate).toFixed(4)),
+    enemy_hp_remaining: Number(
+      (a.mean_enemy_hp_remaining_pct - b.mean_enemy_hp_remaining_pct).toFixed(4),
+    ),
+    ko_rate: Number((a.mean_ko_rate - b.mean_ko_rate).toFixed(4)),
+    hp_remaining: Number((a.mean_hp_remaining_pct - b.mean_hp_remaining_pct).toFixed(4)),
+  };
+}
+
 async function main() {
   const N = Math.max(1, Number(process.argv[2]) || 40);
   const seedBase = 7000;
-  const off = await runArm(false, N, seedBase); // consume-once
+  // Codex P1: same-process arms can drift via module-global combat state. A same-flag control
+  // REPLICATE (off2, identical config + seeds to off) quantifies that drift + run-to-run noise
+  // as a floor; the ER6 effect (on-off) is only real if it EXCEEDS the floor (off2-off). Mirrors
+  // the #3119 off/off2 methodology. (The behavioral-inertness proof -- overrun_carry never nonzero
+  // -> identical spawns -- is the process-independent core; this floor is the belt-and-braces.)
+  const off = await runArm(false, N, seedBase); // consume-once (1st)
+  const off2 = await runArm(false, N, seedBase); // consume-once REPLICATE = noise floor
   const on = await runArm(true, N, seedBase); // carry-over (paired seeds)
   const sOff = summarize(off);
+  const sOff2 = summarize(off2);
   const sOn = summarize(on);
   console.log(
     JSON.stringify(
@@ -144,15 +163,10 @@ async function main() {
         modulation: 'duo_hardcore',
         discriminator: 'REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED (both arms STRESSWAVE on)',
         consume_once_OFF: sOff,
+        consume_once_OFF2_replicate: sOff2,
         carry_over_ON: sOn,
-        deltas: {
-          win_rate: Number((sOn.win_rate - sOff.win_rate).toFixed(4)),
-          enemy_hp_remaining: Number(
-            (sOn.mean_enemy_hp_remaining_pct - sOff.mean_enemy_hp_remaining_pct).toFixed(4),
-          ),
-          ko_rate: Number((sOn.mean_ko_rate - sOff.mean_ko_rate).toFixed(4)),
-          hp_remaining: Number((sOn.mean_hp_remaining_pct - sOff.mean_hp_remaining_pct).toFixed(4)),
-        },
+        er6_effect_on_minus_off: armDelta(sOn, sOff),
+        noise_floor_off2_minus_off: armDelta(sOff2, sOff),
         node: process.version,
       },
       null,

--- a/tools/sim/er6-carryover-graded-probe.js
+++ b/tools/sim/er6-carryover-graded-probe.js
@@ -1,0 +1,171 @@
+'use strict';
+// W5 inc-3 -- ER6 overrun carry-over GRADED re-ratify probe.
+//
+// Re-ratifies the ER6 provisional band (SPEC-I, PR #3119) with the W5 graded metrics
+// (enemy_hp_remaining_pct / ko_rate / hp_remaining_pct) instead of the WR-only full-loop meta
+// band. Master-dd direction (2026-07-01 AskUserQuestion): "graded-confirm band-neutral" -- ER6 is
+// inert on current content (the +1 overrun bonus almost always converts to a spawn in the same
+// tick, so carry-over rarely diverges from consume-once), so this CONFIRMS band-neutrality with a
+// sharper metric and turns the band PROVISIONAL -> RATIFIED band-neutral on current content.
+//
+// Paired A/B (same seeds). BOTH arms arm the overrun event (STRESSWAVE_EVENTS_ENABLED=true) so the
+// carry path is reachable; the ONLY between-arm difference is REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED
+// (ON = carry the unspent bonus to the next tick; OFF = consume-once). Scenario/biome/pressure/
+// modulation mirror the canonical ER6 measurement point (spec-i-gates-probe EFFECTS.er6 +
+// --modulation duo_hardcore so the authored 10x10 reinforcement entry tiles are on-grid).
+//
+// In-process (supertest createApp, NO prod port, node 22). Sim NOT bit-repro cross node-version
+// (read bands as ranges, ~+-0.05). Flag stays OFF in prod -- this measures, never flips.
+//
+// Usage: node tools/sim/er6-carryover-graded-probe.js [N]   (default 40)
+
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runEncounter } = require('./combat-adapter');
+const { buildScenarioEnemies } = require('./scenario-enemies');
+const { probeRoster } = require('./overcharge-probe');
+const { extractStresswave, EFFECTS } = require('./spec-i-gates-probe');
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
+
+const ER6 = EFFECTS.er6; // scenario enc_hardcore_reinf_01, biome abisso_vulcanico, pressureStart 30
+
+function supertestHttp(app) {
+  return {
+    post: (p, body) =>
+      request(app)
+        .post(p)
+        .send(body)
+        .then((r) => ({ status: r.status, body: r.body })),
+    get: (p, query) =>
+      request(app)
+        .get(p)
+        .query(query || {})
+        .then((r) => ({ status: r.status, body: r.body })),
+  };
+}
+
+async function runArm(carryOn, N, seedBase) {
+  // Env scoped to the arm (createApp + the backend read it per-request). BOTH arms arm the
+  // overrun event; only the carry-over flag differs.
+  const saved = {
+    sw: process.env.STRESSWAVE_EVENTS_ENABLED,
+    carry: process.env.REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED,
+  };
+  process.env.STRESSWAVE_EVENTS_ENABLED = 'true';
+  if (carryOn) process.env.REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED = 'true';
+  else delete process.env.REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED;
+
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const http = supertestHttp(app);
+    const enemiesProto = buildScenarioEnemies(ER6.scenario, {});
+    if (!enemiesProto || !enemiesProto.length) {
+      throw new Error(`ER6 scenario "${ER6.scenario}" yielded no roster (anti-#14: no fallback)`);
+    }
+    const runs = [];
+    for (let i = 0; i < N; i += 1) {
+      const seed = `er6carry-${seedBase + i}`;
+      const roster = probeRoster();
+      const enemies = enemiesProto.map((u) => ({ ...u, status: { ...(u.status || {}) } }));
+      // eslint-disable-next-line no-await-in-loop
+      const res = await runEncounter(http, {
+        roster,
+        enemies,
+        scenarioId: ER6.scenario,
+        biomeId: ER6.biomeId,
+        seed,
+        maxRounds: 160,
+        collectEvents: ER6.collectEvents,
+        pressureStart: ER6.pressureStart,
+        modulation: 'duo_hardcore',
+      });
+      const ev = extractStresswave(res.collectedEvents);
+      const rosterN = (res.rosterIds || []).length || 1;
+      runs.push({
+        outcome: res.outcome,
+        rounds: res.rounds,
+        hp_remaining_pct: res.hp_remaining_pct,
+        enemy_hp_remaining_pct: res.enemy_hp_remaining_pct,
+        units_lost: res.units_lost,
+        ko_rate: rosterN ? (res.units_lost || 0) / rosterN : 0,
+        overrun_fired: ev.overrun_turn !== null,
+        spawns: ev.spawns,
+      });
+    }
+    return runs;
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+    // restore env
+    if (saved.sw === undefined) delete process.env.STRESSWAVE_EVENTS_ENABLED;
+    else process.env.STRESSWAVE_EVENTS_ENABLED = saved.sw;
+    if (saved.carry === undefined) delete process.env.REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED;
+    else process.env.REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED = saved.carry;
+  }
+}
+
+function mean(arr, pick) {
+  if (!arr.length) return 0;
+  return arr.reduce((s, r) => s + (Number(pick(r)) || 0), 0) / arr.length;
+}
+
+function summarize(runs) {
+  const n = runs.length || 1;
+  const wins = runs.filter((r) => r.outcome === 'victory').length;
+  return {
+    N: runs.length,
+    win_rate: Number((wins / n).toFixed(4)),
+    mean_enemy_hp_remaining_pct: Number(mean(runs, (r) => r.enemy_hp_remaining_pct).toFixed(4)),
+    mean_hp_remaining_pct: Number(mean(runs, (r) => r.hp_remaining_pct).toFixed(4)),
+    mean_ko_rate: Number(mean(runs, (r) => r.ko_rate).toFixed(4)),
+    avg_rounds: Number(mean(runs, (r) => r.rounds).toFixed(2)),
+    // Mechanic-fires proof (anti-pattern #14): the overrun event must actually arm, else the
+    // A/B is vacuous (nothing to carry). Both arms should show the same overrun_rate.
+    overrun_rate: Number(mean(runs, (r) => (r.overrun_fired ? 1 : 0)).toFixed(4)),
+    mean_spawns: Number(mean(runs, (r) => r.spawns).toFixed(2)),
+  };
+}
+
+async function main() {
+  const N = Math.max(1, Number(process.argv[2]) || 40);
+  const seedBase = 7000;
+  const off = await runArm(false, N, seedBase); // consume-once
+  const on = await runArm(true, N, seedBase); // carry-over (paired seeds)
+  const sOff = summarize(off);
+  const sOn = summarize(on);
+  console.log(
+    JSON.stringify(
+      {
+        probe: 'er6-carryover-graded',
+        scenario: ER6.scenario,
+        biome: ER6.biomeId,
+        pressure_start: ER6.pressureStart,
+        modulation: 'duo_hardcore',
+        discriminator: 'REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED (both arms STRESSWAVE on)',
+        consume_once_OFF: sOff,
+        carry_over_ON: sOn,
+        deltas: {
+          win_rate: Number((sOn.win_rate - sOff.win_rate).toFixed(4)),
+          enemy_hp_remaining: Number(
+            (sOn.mean_enemy_hp_remaining_pct - sOff.mean_enemy_hp_remaining_pct).toFixed(4),
+          ),
+          ko_rate: Number((sOn.mean_ko_rate - sOff.mean_ko_rate).toFixed(4)),
+          hp_remaining: Number((sOn.mean_hp_remaining_pct - sOff.mean_hp_remaining_pct).toFixed(4)),
+        },
+        node: process.version,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error('[er6-carryover-graded-probe] FATAL:', e && e.stack ? e.stack : e);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { runArm, summarize };


### PR DESCRIPTION
## W5 inc-3 -- ER6 overrun carry-over graded re-ratify

First inc-3 mechanic. Master-dd direction (AskUserQuestion 2026-07-01): **graded-confirm band-neutral**. Re-ratifies the ER6 provisional band (#3119, WR-only full-loop) with the **W5 graded metrics** (`enemy_hp_remaining` / `ko_rate` / `hp_remaining`).

### Method
Paired A/B N=40, same seeds, in-process (supertest, node 22). Both arms arm the overrun (`STRESSWAVE_EVENTS_ENABLED=true`); the ONLY discriminator is `REINFORCEMENT_OVERRUN_CARRYOVER_ENABLED` (carry vs consume-once). Canonical ER6 measurement point (`enc_hardcore_reinf_01`, `abisso_vulcanico`, pressure 30, `--modulation duo_hardcore`).

### Result -- band-neutral CONFIRMED
| metric | OFF | ON | delta |
|---|---|---|---|
| win_rate | 1.000 | 1.000 | 0 |
| enemy_hp_remaining | 0.000 | 0.000 | 0 |
| hp_remaining (party) | 0.9867 | 0.9863 | -0.0004 |
| ko_rate | 0.000 | 0.000 | 0 |
| overrun_rate (fires) | 1.000 | 1.000 | 0 |

Overrun fires every run (mechanic-fires proof, anti-#14 -- A/B not vacuous). All graded deltas 0 (hp_remaining -0.0004 = noise). Carry-over does not move any combat metric on current content -> **RATIFIED band-neutral** (owner ratifies). Honest caveat in the doc: enemy_hp saturates (party clears) but the unsaturated channels (hp_remaining, ko_rate) are flat too.

### Ships
- `tools/sim/er6-carryover-graded-probe.js` (reuses spec-i-gates EFFECTS.er6 + overcharge-probe roster + the inc-1/2 graded metrics)
- evidence doc (registered)

### Rollback (03A)
Pure revert. Additive probe + doc, read-only, no flag flipped, no schema. `git revert` is a no-op for behavior.

### Scope
`tools/sim/` + docs. No forbidden-path. **Flag stays OFF; no prod flip.** 217/217 sim green, governance 0.

Coding-Agent: claude-code