### PR TITLE
feat(spec-f): import foreign signed card as ambassador (B4 sez.6)

### DIFF
--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -8,18 +8,20 @@
 //   POST /api/companion/pick    — runtime pick from skiv_archetype_pool.yaml
 //   GET  /api/companion/pool    — debug: enumerate full pool for biome
 //
-// SPEC-F (Custode Portable Framework) store-backed surface — slices 0-2
-// (read + propose, NO persisted mutation). Route PATHS per spec :51-52, served
-// from this DI-clean router (NOT routes/skiv.js, the fs-json monitor):
-//   GET  /api/skiv/share/:lineage_id?format=json       — share-safe export card
-//   GET  /api/skiv/crossbreed/history/:lineage_id       — crossbreed log read
-//   POST /api/skiv/crossbreed                           — offspring proposal (+ crossbreed_seed)
-//   POST /api/skiv/crossbreed/confirm                   — commit (persist + cooldown + rate-limit)
-// Slice 3 policies are ADR-2026-04-27 ratified (cooldown 1/campaign, rate-limit
-// 10/h IP, history FIFO cap 10) -- impl of ratified defaults, no open design-call.
+// SPEC-F (Custode Portable Framework) store-backed surface. Route PATHS per spec
+// :51-52, served from this DI-clean router (NOT routes/skiv.js, the fs-json monitor):
+//   GET  /api/skiv/share/:lineage_id?format=json|card|qr — share-safe export card
+//   POST /api/skiv/offspring/:id/promote                 — offspring -> ambassador (B4)
+//   POST /api/skiv/import                                — foreign card -> ambassador (B4, sez.6)
+//   GET  /api/skiv/crossbreed/history/:lineage_id        — crossbreed log read
+//   POST /api/skiv/crossbreed                            — offspring proposal (+ crossbreed_seed)
+//   POST /api/skiv/crossbreed/confirm                    — commit (persist + cooldown + rate-limit)
+// Policies are ADR-2026-04-27 ratified (cooldown 1/campaign, rate-limit 10/h IP,
+// history/ambassador FIFO cap 10) -- impl of ratified defaults, no open design-call.
 //
-// Auth: stateless (read-only data lookup, no mutation). Future hardening
-// can add JWT token check via shared AUTH_SECRET if exposed publicly.
+// Auth: FC4-A v1 = signature-verify (transport integrity, NOT anti-forgery) +
+// rate-limit; no allowlist/per-Nido isolation yet (SPEC-F-wide, owner-gated).
+// Future hardening can add a JWT gate via shared AUTH_SECRET (middleware/auth.js).
 
 'use strict';
 
@@ -64,23 +66,29 @@ function createCompanionRouter({
 } = {}) {
   const router = express.Router();
 
-  // Per-router in-memory crossbreed/confirm rate-limit (10/h per IP, ADR-04-27).
-  // Per-instance so each test app + each backend process tracks independently.
-  const _crossbreedHits = new Map(); // ip -> number[] (ms timestamps within the window)
-  function crossbreedRateLimited(ip) {
-    const now = Date.now();
-    const key = ip || 'unknown';
-    const recent = (_crossbreedHits.get(key) || []).filter(
-      (t) => now - t < CROSSBREED_RATE_WINDOW_MS,
-    );
-    if (recent.length >= CROSSBREED_RATE_LIMIT) {
-      _crossbreedHits.set(key, recent);
-      return true;
-    }
-    recent.push(now);
-    _crossbreedHits.set(key, recent);
-    return false;
+  // Each store-growing write (crossbreed, promote, import) gets its OWN 10/h-per-IP
+  // budget (ADR-04-27): independent so a griefer exhausting one cannot also block
+  // the others (partial mitigation of cap-10 FIFO eviction grief; full per-Nido
+  // isolation = SPEC-F-wide auth, see header). Per-router Map (per-process/per-run
+  // durability, matching the in-memory cooldown below).
+  function makeRateLimiter() {
+    const hits = new Map(); // ip -> number[] (ms timestamps within the window)
+    return function limited(ip) {
+      const now = Date.now();
+      const key = ip || 'unknown';
+      const recent = (hits.get(key) || []).filter((t) => now - t < CROSSBREED_RATE_WINDOW_MS);
+      if (recent.length >= CROSSBREED_RATE_LIMIT) {
+        hits.set(key, recent);
+        return true;
+      }
+      recent.push(now);
+      hits.set(key, recent);
+      return false;
+    };
   }
+  const crossbreedRateLimited = makeRateLimiter();
+  const promoteRateLimited = makeRateLimiter();
+  const importRateLimited = makeRateLimiter();
 
   // Cooldown 1 crossbreed per campaign per lineage (ADR-04-27). Tracked IN-MEMORY
   // (per-router), NOT on the crossbreed_history item: the ratified
@@ -90,25 +98,6 @@ function createCompanionRouter({
   // a durable cross-restart cooldown needs a contracts schema field = master-dd.
   const _crossbreedCampaigns = new Set(); // `${campaignId}::${lineageId}`
   const cooldownKey = (campaignId, lineageId) => `${campaignId}::${lineageId}`;
-
-  // Promote (offspring->ambassador) is the other write that grows the capped
-  // ambassador registry, so it gets the same 10/h-per-IP posture as the crossbreed
-  // write (partial mitigation of cap-10 FIFO eviction grief; full per-Nido
-  // isolation = SPEC-F-wide auth, see header). Independent budget so a griefer
-  // cannot also exhaust the crossbreed quota.
-  const _promoteHits = new Map();
-  function promoteRateLimited(ip) {
-    const now = Date.now();
-    const key = ip || 'unknown';
-    const recent = (_promoteHits.get(key) || []).filter((t) => now - t < CROSSBREED_RATE_WINDOW_MS);
-    if (recent.length >= CROSSBREED_RATE_LIMIT) {
-      _promoteHits.set(key, recent);
-      return true;
-    }
-    recent.push(now);
-    _promoteHits.set(key, recent);
-    return false;
-  }
 
   /**
    * POST /api/companion/pick
@@ -341,6 +330,76 @@ function createCompanionRouter({
       biome_origin: genome.biome_id,
     };
     return res.status(201).json({ ambassador, spawn_descriptor: spawnDescriptor });
+  });
+
+  /**
+   * POST /api/skiv/import
+   * Body: { card }
+   *
+   * SPEC-F sez.6 -- import a signed FOREIGN card (the GET /skiv/share?format=json
+   * output of ANOTHER Nido) as a permanent ambassador (spec :120-121, acceptance
+   * #4). FC4-A trust model (ratified 2026-06-08): accept a card on a VALID
+   * companion_card_signature (tamper-detect on transport, spec :112-113) +
+   * rate-limit 10/h per IP (ADR-04-27); no allowlist/registry (= "B se abuso").
+   *
+   * The signature detects CORRUPTION, not FORGERY (public sha256, no server
+   * secret, spec :217-219) -- so rate-limit + refuse-overwrite + whitelist
+   * sanitize are the real guards. saveCompanionState re-signs server-side over its
+   * OWN whitelist (client sig + any PII on the card are dropped). FC1
+   * home-authoritative: an import NEVER overwrites an existing local lineage (409);
+   * additive resync of a returning Custode is a separate slice.
+   *
+   * Response: 201 { ambassador } | 400 card_required | 400 card_invalid |
+   *           400 signature_mismatch | 400 lineage_id_required |
+   *           409 lineage_already_imported | 422 import_failed | 429 rate_limited
+   */
+  router.post('/skiv/import', (req, res) => {
+    if (!requireStore(res)) return;
+    // Rate-limit FIRST (before body validation): every attempt -- incl. malformed
+    // -- counts against the IP budget, so a garbage flood cannot probe the endpoint
+    // for free, and the cap-10 FIFO write path stays behind the same budget.
+    // Mirrors /promote's rate-limit-first posture.
+    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    if (importRateLimited(ip)) {
+      return res.status(429).json({ error: 'rate_limited' });
+    }
+    const body = req.body || {};
+    // Untrusted body: reject a non-object OR array card (arrays are typeof
+    // 'object' but never a valid card -- Array.isArray boundary-hygiene, #3131).
+    const card =
+      body.card && typeof body.card === 'object' && !Array.isArray(body.card) ? body.card : null;
+    if (!card) {
+      return res.status(400).json({ error: 'card_required' });
+    }
+    // Verify transport integrity: signatureFor(card) must match the card's own sig.
+    let expectedSig;
+    try {
+      expectedSig = signatureFor(card);
+    } catch (err) {
+      return res.status(400).json({ error: 'card_invalid', message: String(err.message || err) });
+    }
+    if (card.companion_card_signature !== expectedSig) {
+      return res.status(400).json({ error: 'signature_mismatch' });
+    }
+    const lineageId = card.lineage_id ? String(card.lineage_id) : '';
+    if (lineageId.length < 4) {
+      return res.status(400).json({ error: 'lineage_id_required' });
+    }
+    // FC1 home-authoritative: refuse to overwrite an existing local ambassador
+    // (import CREATES; lineage_id is client-supplied + the store is keyed by it ->
+    // without this an importer clobbers another lineage's card by re-using its id).
+    if (typeof store.getCompanionState === 'function' && store.getCompanionState(lineageId)) {
+      return res.status(409).json({ error: 'lineage_already_imported', lineage_id: lineageId });
+    }
+    // Persist: saveCompanionState sanitizes to whitelist (drops PII), re-signs
+    // server-side, applies cap-10 FIFO. Wrap: a malformed card must 422, not throw.
+    let ambassador;
+    try {
+      ambassador = store.saveCompanionState(card);
+    } catch (err) {
+      return res.status(422).json({ error: 'import_failed', message: String(err.message || err) });
+    }
+    return res.status(201).json({ ambassador });
   });
 
   /**

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -99,6 +99,26 @@ function createCompanionRouter({
   const _crossbreedCampaigns = new Set(); // `${campaignId}::${lineageId}`
   const cooldownKey = (campaignId, lineageId) => `${campaignId}::${lineageId}`;
 
+  // Overwrite guard for the ambassador registry. getCompanionState reads the
+  // in-memory Map only, but saveCompanionState upserts to Prisma -> after a
+  // backend restart a persisted ambassador is absent from memory and a
+  // client-supplied lineage_id would slip past a memory-only check + overwrite
+  // the persisted row (violating FC1 home-authoritative). Hydrate the row first
+  // so promote/import refuse cross-restart collisions too. No-op for in-memory
+  // stores (hydrateAsync returns null when Prisma is absent); a hydrate failure
+  // degrades to same-process only and never blocks a valid write.
+  async function lineageExists(lineageId) {
+    if (typeof store.getCompanionState !== 'function') return false;
+    if (typeof store.hydrateAsync === 'function') {
+      try {
+        await store.hydrateAsync(lineageId);
+      } catch {
+        /* non-fatal: fall through to the in-memory check */
+      }
+    }
+    return Boolean(store.getCompanionState(lineageId));
+  }
+
   /**
    * POST /api/companion/pick
    * Body: { biome_id, form_axes?, run_seed?, trainer_canonical? }
@@ -296,11 +316,9 @@ function createCompanionRouter({
     // Refuse to overwrite an existing ambassador: promote CREATES a new one, and
     // the (crossbreed-descriptor) lineage_id is client-supplied -> refusing an
     // in-place overwrite stops a caller clobbering another lineage's card
-    // (species/mutations/cabinet) by re-using its lineage_id (store is keyed by it).
-    if (
-      typeof store.getCompanionState === 'function' &&
-      store.getCompanionState(genome.lineage_id)
-    ) {
+    // (species/mutations/cabinet) by re-using its lineage_id (store is keyed by
+    // it). lineageExists hydrates so this holds across a restart too.
+    if (await lineageExists(genome.lineage_id)) {
       return res
         .status(409)
         .json({ error: 'lineage_already_promoted', lineage_id: genome.lineage_id });
@@ -353,7 +371,7 @@ function createCompanionRouter({
    *           400 signature_mismatch | 400 lineage_id_required |
    *           409 lineage_already_imported | 422 import_failed | 429 rate_limited
    */
-  router.post('/skiv/import', (req, res) => {
+  router.post('/skiv/import', async (req, res) => {
     if (!requireStore(res)) return;
     // Rate-limit FIRST (before body validation): every attempt -- incl. malformed
     // -- counts against the IP budget, so a garbage flood cannot probe the endpoint
@@ -388,7 +406,8 @@ function createCompanionRouter({
     // FC1 home-authoritative: refuse to overwrite an existing local ambassador
     // (import CREATES; lineage_id is client-supplied + the store is keyed by it ->
     // without this an importer clobbers another lineage's card by re-using its id).
-    if (typeof store.getCompanionState === 'function' && store.getCompanionState(lineageId)) {
+    // lineageExists hydrates the persistent store so this also holds after a restart.
+    if (await lineageExists(lineageId)) {
       return res.status(409).json({ error: 'lineage_already_imported', lineage_id: lineageId });
     }
     // Persist: saveCompanionState sanitizes to whitelist (drops PII), re-signs

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -452,6 +452,113 @@ test('POST promote crossbreed descriptor without lineage_id → 400 lineage_id_r
   assert.equal(r.body.error, 'lineage_id_required');
 });
 
+// --- B4: POST /skiv/import (foreign card -> ambassador, FC4-A signature+rate-limit) ---
+
+test('POST /skiv/import missing card → 400 card_required', async () => {
+  const app = buildApp({ store: createCompanionStateStore() });
+  const r = await postJson(app, '/api/skiv/import', {});
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'card_required');
+});
+
+test('POST /skiv/import tampered signature → 400 signature_mismatch', async () => {
+  const app = buildApp({ store: createCompanionStateStore() });
+  const card = makePartnerCard();
+  card.companion_card_signature = 'deadbeef'.repeat(8); // 64 hex, wrong
+  const r = await postJson(app, '/api/skiv/import', { card });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'signature_mismatch');
+});
+
+test('POST /skiv/import card without lineage_id → 400 lineage_id_required', async () => {
+  const app = buildApp({ store: createCompanionStateStore() });
+  // a validly-signed card that simply has no lineage_id
+  const card = makePartnerCard({ lineage_id: undefined });
+  const r = await postJson(app, '/api/skiv/import', { card });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'lineage_id_required');
+});
+
+test('POST /skiv/import valid foreign card → 201 persists ambassador (server re-signs)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store });
+  const card = makePartnerCard();
+  const r = await postJson(app, '/api/skiv/import', { card });
+  assert.equal(r.status, 201);
+  assert.equal(r.body.ambassador.lineage_id, card.lineage_id);
+  assert.equal(r.body.ambassador.species_id, 'reef_drifter');
+  // server recomputes the signature over its own whitelist (never trusts client sig)
+  assert.match(r.body.ambassador.companion_card_signature, /^[a-f0-9]{64}$/);
+  // persisted: a later /share returns the imported ambassador
+  const share = await getJson(app, `/api/skiv/share/${card.lineage_id}`);
+  assert.equal(share.status, 200);
+  assert.equal(share.body.species_id, 'reef_drifter');
+});
+
+test('POST /skiv/import strips PII present on the incoming card (whitelist-only persist)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store });
+  // a signed card that also carries ephemeral PII -> must never be persisted
+  const card = makePartnerCard();
+  card.session_id = 'sess-leak';
+  card.hp_current = 3;
+  // (adding PII does not change the signature: signatureFor sanitizes to whitelist)
+  const r = await postJson(app, '/api/skiv/import', { card });
+  assert.equal(r.status, 201);
+  assert.equal('session_id' in r.body.ambassador, false);
+  assert.equal('hp_current' in r.body.ambassador, false);
+});
+
+test('POST /skiv/import refuses to overwrite an existing lineage → 409 (FC1 home-authoritative)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store });
+  const card = makePartnerCard();
+  const first = await postJson(app, '/api/skiv/import', { card });
+  assert.equal(first.status, 201);
+  // an attacker re-imports the SAME lineage_id with a different (validly-signed) species
+  const attack = makePartnerCard({ species_id: 'attacker_sp' });
+  attack.lineage_id = card.lineage_id;
+  attack.companion_card_signature = signatureFor(attack);
+  const r = await postJson(app, '/api/skiv/import', { card: attack });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'lineage_already_imported');
+  // victim card unchanged
+  const share = await getJson(app, `/api/skiv/share/${card.lineage_id}`);
+  assert.equal(share.body.species_id, 'reef_drifter');
+});
+
+test('POST /skiv/import rate-limits after 10/h per IP → 429', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store });
+  let last;
+  for (let i = 0; i < 11; i += 1) {
+    // distinct lineage each time so the cap/overwrite guard never trips first
+    const card = makePartnerCard({ lineage_id: `partner-lineage-import-${i}` });
+    card.companion_card_signature = signatureFor(card);
+    last = await postJson(app, '/api/skiv/import', { card });
+  }
+  assert.equal(last.status, 429);
+  assert.equal(last.body.error, 'rate_limited');
+});
+
+test('POST /skiv/import array card → 400 card_required (Array.isArray guard, #3131)', async () => {
+  const app = buildApp({ store: createCompanionStateStore() });
+  const r = await postJson(app, '/api/skiv/import', { card: [] });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'card_required');
+});
+
+test('POST /skiv/import garbage requests DO consume the rate-limit budget → 429', async () => {
+  const app = buildApp({ store: createCompanionStateStore() });
+  let last;
+  for (let i = 0; i < 11; i += 1) {
+    // empty body (no card) -> each is a 400 card_required, but still counts.
+    last = await postJson(app, '/api/skiv/import', {});
+  }
+  assert.equal(last.status, 429);
+  assert.equal(last.body.error, 'rate_limited');
+});
+
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────
 
 test('GET /skiv/crossbreed/history unknown lineage → [] count 0', async () => {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -82,6 +82,36 @@ function makeStoreStub(seed = {}) {
   };
 }
 
+// Store stub simulating Prisma-backed persistence: getCompanionState reads the
+// in-memory map only; saveCompanionState upserts to BOTH memory + a persistent
+// map; hydrateAsync repopulates memory from persistence. _restart() clears memory
+// (mimics a backend restart) while the persisted rows survive -- the exact shape
+// that exposes a memory-only overwrite guard (Codex P1).
+function makePersistentStoreStub() {
+  const persistent = new Map();
+  const memory = new Map();
+  return {
+    getCompanionState(id) {
+      return memory.get(id) || null;
+    },
+    saveCompanionState(state) {
+      const saved = { ...state, companion_card_signature: signatureFor(state) };
+      memory.set(state.lineage_id, saved);
+      persistent.set(state.lineage_id, saved);
+      return saved;
+    },
+    async hydrateAsync(id) {
+      const row = persistent.get(id);
+      if (!row) return null;
+      memory.set(id, row);
+      return row;
+    },
+    _restart() {
+      memory.clear();
+    },
+  };
+}
+
 function buildApp({ store, rollMatingOffspring, offspringStore } = {}) {
   const app = express();
   app.use(express.json());
@@ -438,6 +468,24 @@ test('POST promote refuses to overwrite an existing ambassador → 409 (anti-clo
   assert.equal(share.body.species_id, 'dune_stalker');
 });
 
+test('POST promote refuses a cross-restart overwrite (hydrates persistent store → 409, Codex P1)', async () => {
+  const store = makePersistentStoreStub();
+  const app = buildApp({ store, offspringStore: makeOffspringStoreStub() });
+  const xbred = makeCrossbreedOffspring();
+  const first = await postJson(app, `/api/skiv/offspring/${xbred.lineage_id}/promote`, {
+    species_id: 'dune_stalker',
+    offspring: xbred,
+  });
+  assert.equal(first.status, 201);
+  store._restart(); // memory cleared, persisted ambassador survives
+  const r = await postJson(app, `/api/skiv/offspring/${xbred.lineage_id}/promote`, {
+    species_id: 'attacker_sp',
+    offspring: makeCrossbreedOffspring({ tier_bonus_traits: ['attacker_trait'] }),
+  });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'lineage_already_promoted');
+});
+
 test('POST promote crossbreed descriptor without lineage_id → 400 lineage_id_required', async () => {
   const app = buildApp({
     store: createCompanionStateStore(),
@@ -557,6 +605,23 @@ test('POST /skiv/import garbage requests DO consume the rate-limit budget → 42
   }
   assert.equal(last.status, 429);
   assert.equal(last.body.error, 'rate_limited');
+});
+
+test('POST /skiv/import refuses a cross-restart overwrite (hydrates persistent store → 409, Codex P1)', async () => {
+  const store = makePersistentStoreStub();
+  const app = buildApp({ store });
+  const card = makePartnerCard();
+  assert.equal((await postJson(app, '/api/skiv/import', { card })).status, 201);
+  // backend restart: memory cleared, the persisted ambassador row survives.
+  store._restart();
+  // a validly-signed re-import of the SAME lineage_id must STILL be refused
+  // (memory-only guard would 201 here and overwrite the persisted row).
+  const attack = makePartnerCard({ species_id: 'attacker_sp' });
+  attack.lineage_id = card.lineage_id;
+  attack.companion_card_signature = signatureFor(attack);
+  const r = await postJson(app, '/api/skiv/import', { card: attack });
+  assert.equal(r.status, 409);
+  assert.equal(r.body.error, 'lineage_already_imported');
 });
 
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────


### PR DESCRIPTION
## SPEC-F B4 -- POST /api/skiv/import (foreign card -> ambassador)

Closes the last buildable slice of the SPEC-F export/import arc: importing a
signed card from **another Nido** as a permanent ambassador. Continuation of the
B4 arc (#3128 card/qr export, #3129 offspring promote, #3131 crossbreed promote).

### What
`POST /api/skiv/import` body `{ card }` -- the `GET /skiv/share?format=json`
output of another Nido. Steps:
- **rate-limit 10/h per IP** first (every attempt, incl. garbage, counts);
- **signature-verify** (`signatureFor(card)` must equal the card's own sig --
  transport integrity, spec :112-113); `400 signature_mismatch` else;
- **lineage_id required** (`400`);
- **FC1 home-authoritative refuse-overwrite** (`409 lineage_already_imported`) --
  an import never clobbers an existing local lineage;
- **persist** via `saveCompanionState` -- whitelist-only (drops any PII on the
  card), re-signs server-side, cap-10 FIFO.

`201 { ambassador }`.

### Design fidelity
- **FC4-A** (ratified 2026-06-08): accept on valid signature + rate-limit, no
  allowlist ("B se abuso"). The sig detects **corruption, not forgery** (public
  sha256, no server secret, spec :217-219) -- so rate-limit + refuse-overwrite +
  whitelist sanitize are the real guards.
- Closes **SPEC-F acceptance #4** (import respects ADR-2026-04-27: cap 10,
  rate-limit 10/h, signature-verify, whitelist-only).
- Spec: `docs/design/evo-tactics-custode-portable-framework.md` sez.6.

### Safety
- **Band-neutral**: no combat/session/N=40 touch (pure store surface).
- **No flag, reversible, additive.** No forbidden-path (only `apps/backend/` +
  `tests/`; `packages/contracts` untouched -- schema unchanged).
- DRY: the 3 inline rate-limiters collapsed to a `makeRateLimiter()` factory
  (net-less code, independent per-write budgets preserved).

### Security (untrusted-card mutation route)
Adversarial 3-lens review (security / spec-fidelity / correctness, refute-by-default
+ verify). 1 confirmed P3 (rate-limit ordering -> moved rate-limit first so garbage
counts) + `Array.isArray` card guard (#3131 boundary-hygiene) applied. No unguarded
spread of `body.card`; client sig + PII dropped by `saveCompanionState`.

### Residue (owner/coordination-gated, unchanged)
- Full **per-Nido auth isolation** (store is a process-global singleton, cap-10
  global) -- owner design-call + `packages/contracts` schema (nido_id) = forbidden-path.
- **Additive resync** (FC1) of a returning Custode = separate slice.
- Live-run unit injection (session.js roster) = W5/form-pulse lane.

### Tests
`node --test tests/routes/skivCustode.test.js` -> **45/45** (9 new import tests
incl. array-guard + garbage-counts + refuse-overwrite + PII-strip). AI 567/567,
companion 7/7, format clean.

## Rollback
Revert the commit -- additive, no data migration, no flag, no schema change.

Coding-Agent: claude-code
