### PR TITLE
feat(spec-f): per-Nido isolation Option A (in-memory, flag-OFF)

### DIFF
--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -20,8 +20,12 @@
 // history/ambassador FIFO cap 10) -- impl of ratified defaults, no open design-call.
 //
 // Auth: FC4-A v1 = signature-verify (transport integrity, NOT anti-forgery) +
-// rate-limit; no allowlist/per-Nido isolation yet (SPEC-F-wide, owner-gated).
-// Future hardening can add a JWT gate via shared AUTH_SECRET (middleware/auth.js).
+// rate-limit. Per-Nido isolation (Option A) behind SPEC_F_NIDO_ISOLATION_ENABLED
+// (OFF by default = global cap + per-IP rate-limit, byte-identical). ON: the ambassador
+// cap is scoped PER-OWNER (JWT sub / self-asserted player_id) so honest Nidos stop
+// FIFO-evicting each other; the write rate-limit goes per-owner ONLY for a JWT-trusted
+// owner (a self-asserted player_id stays per-IP so a rotating-id flood can't bypass it).
+// Durable per-Nido cap + a JWT write-gate (middleware/auth.js) = Option C/D, owner-gated.
 
 'use strict';
 
@@ -58,13 +62,49 @@ function randomCrossbreedSeed() {
 const CROSSBREED_RATE_LIMIT = 10;
 const CROSSBREED_RATE_WINDOW_MS = 60 * 60 * 1000;
 
+// SPEC-F per-Nido isolation (Option A, in-memory). OFF by default = today's global
+// ambassador cap + per-IP rate-limit, byte-identical. ON = the store's cap scopes
+// PER-OWNER (owner = JWT sub, else the request's player_id) so honest Nidos stop
+// FIFO-evicting each other; the write rate-limit goes per-owner ONLY for a JWT-trusted
+// owner (self-asserted player_id stays per-IP -- a rotating-id flood can't mint budgets).
+// Warm-state only (owner index resets on restart; durable = Option C Prisma migration).
+const NIDO_ISOLATION_ENABLED = process.env.SPEC_F_NIDO_ISOLATION_ENABLED === 'true';
+
 function createCompanionRouter({
   companionPicker = companionPickerDefault,
   store = null,
   rollMatingOffspring = rollMatingOffspringDefault,
   offspringStore = offspringStoreDefault,
+  nidoIsolationEnabled = NIDO_ISOLATION_ENABLED,
 } = {}) {
   const router = express.Router();
+
+  // SPEC-F per-Nido isolation (Option A). Owner = the caller's durable identity:
+  // JWT sub (req.auth.userId, present only when an AUTH_SECRET middleware ran) else
+  // the request's player_id (body/query -- already the primary id, campaign.js:216).
+  // null when unknown -> the write degrades to the global cap + per-IP rate-limit.
+  //
+  // TRUST CEILING (load-bearing for the flip decision): the JWT sub is
+  // cryptographically bound (`trusted:true`); player_id is SELF-ASSERTED
+  // (`trusted:false`). Returns { id, trusted }. id is coerced to a string-or-null
+  // (an object/array player_id must never become a Map/rate-limit key).
+  function deriveOwner(req) {
+    const jwtSub = req.auth && typeof req.auth.userId === 'string' ? req.auth.userId : null;
+    if (jwtSub) return { id: jwtSub, trusted: true };
+    const body = req.body && typeof req.body.player_id === 'string' ? req.body.player_id : null;
+    const query = req.query && typeof req.query.player_id === 'string' ? req.query.player_id : null;
+    return { id: body || query || null, trusted: false };
+  }
+  // Rate-limit key: per-owner ONLY for a crypto-bound (JWT-trusted) owner. A
+  // SELF-ASSERTED player_id stays PER-IP on purpose -- otherwise a griefer rotating
+  // distinct player_id strings would mint a fresh 10/h budget each request and flood
+  // the store unbounded (the per-owner cap removes the global ceiling). Per-owner
+  // isolation of the CAP is still cooperative for self-asserted owners; the per-IP
+  // rate-limit is what bounds a rotating-id flood.
+  function rateKey(req, owner) {
+    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    return nidoIsolationEnabled && owner.id && owner.trusted ? `owner:${owner.id}` : ip;
+  }
 
   // Each store-growing write (crossbreed, promote, import) gets its OWN 10/h-per-IP
   // budget (ADR-04-27): independent so a griefer exhausting one cannot also block
@@ -273,8 +313,8 @@ function createCompanionRouter({
    */
   router.post('/skiv/offspring/:offspring_id/promote', async (req, res) => {
     if (!requireStore(res)) return;
-    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
-    if (promoteRateLimited(ip)) {
+    const owner = deriveOwner(req);
+    if (promoteRateLimited(rateKey(req, owner))) {
       return res.status(429).json({ error: 'rate_limited' });
     }
     const offspringId = String(req.params.offspring_id || '');
@@ -336,7 +376,10 @@ function createCompanionRouter({
     };
     let ambassador;
     try {
-      ambassador = store.saveCompanionState(ambassadorState);
+      ambassador = store.saveCompanionState(ambassadorState, {
+        owner: owner.id,
+        isolate: nidoIsolationEnabled,
+      });
     } catch (err) {
       return res.status(422).json({ error: 'promote_failed', message: String(err.message || err) });
     }
@@ -377,8 +420,8 @@ function createCompanionRouter({
     // -- counts against the IP budget, so a garbage flood cannot probe the endpoint
     // for free, and the cap-10 FIFO write path stays behind the same budget.
     // Mirrors /promote's rate-limit-first posture.
-    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
-    if (importRateLimited(ip)) {
+    const owner = deriveOwner(req);
+    if (importRateLimited(rateKey(req, owner))) {
       return res.status(429).json({ error: 'rate_limited' });
     }
     const body = req.body || {};
@@ -414,7 +457,10 @@ function createCompanionRouter({
     // server-side, applies cap-10 FIFO. Wrap: a malformed card must 422, not throw.
     let ambassador;
     try {
-      ambassador = store.saveCompanionState(card);
+      ambassador = store.saveCompanionState(card, {
+        owner: owner.id,
+        isolate: nidoIsolationEnabled,
+      });
     } catch (err) {
       return res.status(422).json({ error: 'import_failed', message: String(err.message || err) });
     }
@@ -558,8 +604,8 @@ function createCompanionRouter({
       return res.status(400).json({ error: 'campaign_id_required' });
     }
     // Rate-limit BEFORE any store work (cheap abuse guard, ADR-04-27).
-    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
-    if (crossbreedRateLimited(ip)) {
+    const owner = deriveOwner(req);
+    if (crossbreedRateLimited(rateKey(req, owner))) {
       return res.status(429).json({ error: 'rate_limited' });
     }
     let local;

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -250,6 +250,12 @@ function parseJsonSafe(raw) {
 function createCompanionStateStore(opts = {}) {
   const states = new Map(); // lineage_id → state
   // FIFO insertion order for cap eviction (Map preserves insertion order in JS).
+  // SPEC-F per-Nido isolation (Option A, in-memory): owner → lineage_ids in
+  // insertion order, used ONLY when a save opts in with { owner, isolate:true }
+  // (flag SPEC_F_NIDO_ISOLATION_ENABLED, wired in the router). Off by default ->
+  // the global cap path below is byte-identical. Warm-state only (not persisted;
+  // resets on restart -- durable per-Nido cap = Option C, a Prisma migration).
+  const ownerLineages = new Map(); // owner → lineage_id[]
   const usePrisma = prismaSupportsSkivCompanion(opts.prisma);
   const log = opts.logger || console;
   const ambassadorCap = Number.isFinite(opts.ambassadorCap)
@@ -325,7 +331,7 @@ function createCompanionStateStore(opts = {}) {
    *
    * Returns the canonical stored state (with computed signature).
    */
-  function saveCompanionState(rawState) {
+  function saveCompanionState(rawState, { owner = null, isolate = false } = {}) {
     // Step 1: schema_version migrate-if-legacy.
     const stateInput = isLegacySchema(rawState) ? migrateLegacyState(rawState) : rawState;
     // Step 2: assert invariants.
@@ -344,8 +350,28 @@ function createCompanionStateStore(opts = {}) {
     sanitized.share_url = sanitized.share_url ?? null;
     // Step 4: compute signature server-side (ignore any client-supplied value).
     sanitized.companion_card_signature = signatureFor(sanitized);
-    // Step 5: ambassador cap FIFO eviction (per Nido = global registry, default 10).
-    if (!states.has(sanitized.lineage_id) && states.size >= ambassadorCap) {
+    // Step 5: ambassador cap FIFO eviction.
+    const isNewLineage = !states.has(sanitized.lineage_id);
+    if (isolate && owner) {
+      // Per-Nido cap (SPEC-F isolation ON): each owner keeps its OWN cap window;
+      // an owner's (cap+1)th add evicts THAT owner's oldest, never another Nido's.
+      let list = ownerLineages.get(owner);
+      if (!list) {
+        list = [];
+        ownerLineages.set(owner, list);
+      }
+      if (isNewLineage && list.length >= ambassadorCap) {
+        const oldest = list.shift();
+        if (oldest !== undefined) {
+          states.delete(oldest);
+          log.debug?.(
+            `[companionStateStore] per-owner FIFO eviction: owner ${owner} cap ${ambassadorCap} reached, dropped ${oldest}`,
+          );
+        }
+      }
+      if (isNewLineage) list.push(sanitized.lineage_id);
+    } else if (isNewLineage && states.size >= ambassadorCap) {
+      // Global cap (default / isolation OFF): current behavior, byte-identical.
       const oldestKey = states.keys().next().value;
       if (oldestKey !== undefined) {
         states.delete(oldestKey);
@@ -412,6 +438,7 @@ function createCompanionStateStore(opts = {}) {
   function clearAll() {
     const n = states.size;
     states.clear();
+    ownerLineages.clear();
     return n;
   }
 

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -22,6 +22,9 @@ const AMBASSADOR_CAP_PER_NIDO = 10;
 const VOICE_DIARY_MAX_ENTRIES = 5;
 const CROSSBREED_HISTORY_MAX_ENTRIES = 10;
 const CURRENT_SCHEMA_VERSION = '0.2.0';
+// Shared bucket for ownerless writes under per-Nido isolation (SPEC-F Option A):
+// keeps anonymous saves from evicting an owned Nido's ambassador (see saveCompanionState).
+const ANON_BUCKET = '__anon__';
 
 // Whitelist campi share-safe per signature + persistenza (ADR §D).
 // NON includere: session_id, hp_current, sg_current, pressure_tier, ap_current,
@@ -352,20 +355,26 @@ function createCompanionStateStore(opts = {}) {
     sanitized.companion_card_signature = signatureFor(sanitized);
     // Step 5: ambassador cap FIFO eviction.
     const isNewLineage = !states.has(sanitized.lineage_id);
-    if (isolate && owner) {
-      // Per-Nido cap (SPEC-F isolation ON): each owner keeps its OWN cap window;
-      // an owner's (cap+1)th add evicts THAT owner's oldest, never another Nido's.
-      let list = ownerLineages.get(owner);
+    if (isolate) {
+      // Per-Nido cap (SPEC-F isolation ON): each owner keeps its OWN cap window; an
+      // owner's (cap+1)th add evicts THAT owner's oldest, never another Nido's. An
+      // ownerless write (owner=null: no JWT/player_id) uses a SHARED anonymous bucket
+      // that can only evict OTHER anonymous entries -- otherwise dropping the owner
+      // field would fall to the global path and evict an owned ambassador, re-opening
+      // the cross-Nido eviction (Codex P2). ANON_BUCKET vs a real player_id collision
+      // is negligible (that player just shares the anon window).
+      const bucket = owner || ANON_BUCKET;
+      let list = ownerLineages.get(bucket);
       if (!list) {
         list = [];
-        ownerLineages.set(owner, list);
+        ownerLineages.set(bucket, list);
       }
       if (isNewLineage && list.length >= ambassadorCap) {
         const oldest = list.shift();
         if (oldest !== undefined) {
           states.delete(oldest);
           log.debug?.(
-            `[companionStateStore] per-owner FIFO eviction: owner ${owner} cap ${ambassadorCap} reached, dropped ${oldest}`,
+            `[companionStateStore] per-owner FIFO eviction: bucket ${bucket} cap ${ambassadorCap} reached, dropped ${oldest}`,
           );
         }
       }

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -696,12 +696,32 @@ test('isolation OFF (default): rate-limit stays per-IP -- player_id is ignored (
   assert.equal(last.status, 429);
 });
 
-test('isolation ON with no player_id falls back to global (no crash)', async () => {
+test('isolation ON with no player_id uses the shared anon bucket (no crash)', async () => {
   const store = createCompanionStateStore();
   const app = buildApp({ store, nidoIsolationEnabled: true });
   const card = makePartnerCard();
   const r = await postJson(app, '/api/skiv/import', { card }); // no player_id, no JWT
   assert.equal(r.status, 201);
+});
+
+test('isolation ON: an ownerless write cannot evict an owned Nido (Codex P2)', async () => {
+  const store = createCompanionStateStore({ ambassadorCap: 2 });
+  const app = buildApp({ store, nidoIsolationEnabled: true });
+  await importAs(app, 'A-one-1111', 'playerA');
+  await importAs(app, 'A-two-2222', 'playerA'); // playerA's bucket full at cap 2
+  // anonymous imports (no player_id) must land in the shared anon bucket + evict only
+  // each other -- NOT playerA's ambassadors (dropping the owner field must not bypass).
+  const anon = async (id) => {
+    const card = makePartnerCard({ lineage_id: id });
+    card.companion_card_signature = signatureFor(card);
+    return postJson(app, '/api/skiv/import', { card });
+  };
+  await anon('anon-one-11');
+  await anon('anon-two-22');
+  await anon('anon-thr-33'); // 3rd anon evicts anon-one (anon bucket), never playerA's
+  assert.equal((await getJson(app, '/api/skiv/share/A-one-1111')).status, 200); // A safe
+  assert.equal((await getJson(app, '/api/skiv/share/A-two-2222')).status, 200);
+  assert.equal((await getJson(app, '/api/skiv/share/anon-one-11')).status, 404); // anon evicted anon
 });
 
 test('isolation ON: a non-string player_id (object) is ignored, not used as a key', async () => {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -112,10 +112,29 @@ function makePersistentStoreStub() {
   };
 }
 
-function buildApp({ store, rollMatingOffspring, offspringStore } = {}) {
+function buildApp({
+  store,
+  rollMatingOffspring,
+  offspringStore,
+  nidoIsolationEnabled,
+  authStub,
+} = {}) {
   const app = express();
   app.use(express.json());
-  app.use('/api', createCompanionRouter({ store, rollMatingOffspring, offspringStore }));
+  if (authStub) {
+    // Simulate a configured JWT middleware: treat body.player_id as a verified sub
+    // (req.auth.userId) so deriveOwner returns { trusted:true } -- the crypto-bound path.
+    app.use((req, _res, next) => {
+      if (req.body && typeof req.body.player_id === 'string') {
+        req.auth = { userId: req.body.player_id };
+      }
+      next();
+    });
+  }
+  app.use(
+    '/api',
+    createCompanionRouter({ store, rollMatingOffspring, offspringStore, nidoIsolationEnabled }),
+  );
   return app;
 }
 
@@ -622,6 +641,76 @@ test('POST /skiv/import refuses a cross-restart overwrite (hydrates persistent s
   const r = await postJson(app, '/api/skiv/import', { card: attack });
   assert.equal(r.status, 409);
   assert.equal(r.body.error, 'lineage_already_imported');
+});
+
+// --- B4: per-Nido isolation (Option A, flag SPEC_F_NIDO_ISOLATION_ENABLED) ---
+
+// Import a distinct, validly-signed card owned by `player`.
+async function importAs(app, lineageId, player) {
+  const card = makePartnerCard({ lineage_id: lineageId });
+  card.companion_card_signature = signatureFor(card);
+  return postJson(app, '/api/skiv/import', { card, player_id: player });
+}
+
+test('isolation ON: per-owner cap -- owner B does not evict owner A (import)', async () => {
+  const store = createCompanionStateStore({ ambassadorCap: 2 });
+  const app = buildApp({ store, nidoIsolationEnabled: true });
+  await importAs(app, 'A-alpha-1111', 'playerA');
+  await importAs(app, 'A-beta-2222', 'playerA'); // A at cap 2
+  await importAs(app, 'B-gamma-3333', 'playerB'); // B's save must NOT evict A's oldest
+  assert.equal((await getJson(app, '/api/skiv/share/A-alpha-1111')).status, 200);
+  // A's 3rd add evicts A's OWN oldest only; B untouched
+  await importAs(app, 'A-delta-4444', 'playerA');
+  assert.equal((await getJson(app, '/api/skiv/share/A-alpha-1111')).status, 404); // A oldest gone
+  assert.equal((await getJson(app, '/api/skiv/share/A-beta-2222')).status, 200);
+  assert.equal((await getJson(app, '/api/skiv/share/B-gamma-3333')).status, 200); // B safe
+});
+
+test('isolation ON + JWT-trusted owner: rate-limit is per-owner (A hitting 10/h does not block B)', async () => {
+  const store = createCompanionStateStore();
+  // authStub -> body.player_id becomes a verified JWT sub (trusted owner).
+  const app = buildApp({ store, nidoIsolationEnabled: true, authStub: true });
+  let last;
+  for (let i = 0; i < 11; i += 1) last = await importAs(app, `A-rl-${i}-zzzz`, 'playerA');
+  assert.equal(last.status, 429); // A exhausted its own budget
+  const rB = await importAs(app, 'B-rl-0-zzzz', 'playerB');
+  assert.notEqual(rB.status, 429); // B has an independent budget
+});
+
+test('isolation ON + SELF-ASSERTED player_id: rate-limit stays per-IP (rotating id cannot bypass)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store, nidoIsolationEnabled: true }); // NO authStub -> untrusted
+  let last;
+  // a griefer rotating a fresh player_id each request must NOT mint fresh budgets:
+  // all share the one per-IP bucket -> the 11th is 429.
+  for (let i = 0; i < 11; i += 1) last = await importAs(app, `rot-${i}-wwww`, `griefer-${i}`);
+  assert.equal(last.status, 429);
+});
+
+test('isolation OFF (default): rate-limit stays per-IP -- player_id is ignored (byte-identical)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store }); // flag off
+  let last;
+  // distinct player_ids all share the one per-IP bucket -> 11th across owners = 429
+  for (let i = 0; i < 11; i += 1) last = await importAs(app, `mix-${i}-wwww`, i % 2 ? 'x' : 'y');
+  assert.equal(last.status, 429);
+});
+
+test('isolation ON with no player_id falls back to global (no crash)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store, nidoIsolationEnabled: true });
+  const card = makePartnerCard();
+  const r = await postJson(app, '/api/skiv/import', { card }); // no player_id, no JWT
+  assert.equal(r.status, 201);
+});
+
+test('isolation ON: a non-string player_id (object) is ignored, not used as a key', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store, nidoIsolationEnabled: true });
+  const card = makePartnerCard();
+  // malformed untrusted input: player_id as an object must never become a Map/rate key.
+  const r = await postJson(app, '/api/skiv/import', { card, player_id: { evil: 1 } });
+  assert.equal(r.status, 201); // treated as anonymous (global path), no crash / no [object Object]
 });
 
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────

--- a/tests/services/skivCompanionState.test.js
+++ b/tests/services/skivCompanionState.test.js
@@ -206,6 +206,47 @@ test('Phase 1: re-saving existing lineage does not trigger eviction', () => {
   assert.notEqual(store.getCompanionState('skiv-bbb-test'), null);
 });
 
+// ─── 5b. Per-owner cap (SPEC-F Nido isolation, Option A) ────────────────
+
+test('Phase 1: per-owner cap isolates FIFO eviction (isolate + owner)', () => {
+  const store = createCompanionStateStore({ ambassadorCap: 2 });
+  const put = (id, owner) =>
+    store.saveCompanionState(makeValidState({ lineage_id: id }), { owner, isolate: true });
+  put('A-one-xxxx', 'A');
+  put('A-two-xxxx', 'A'); // A at cap 2
+  put('B-one-xxxx', 'B');
+  put('B-two-xxxx', 'B'); // B at cap 2 -- must NOT evict any of A's (per-owner, not global)
+  assert.equal(store.size(), 4); // both Nidos hold their full cap
+  assert.ok(store.getCompanionState('A-one-xxxx'));
+  // A's 3rd add evicts A's OWN oldest (A-one), never B's
+  put('A-three-xx', 'A');
+  assert.equal(store.getCompanionState('A-one-xxxx'), null); // A's oldest gone
+  assert.ok(store.getCompanionState('A-two-xxxx'));
+  assert.ok(store.getCompanionState('B-one-xxxx')); // B untouched
+  assert.ok(store.getCompanionState('B-two-xxxx'));
+  assert.ok(store.getCompanionState('A-three-xx'));
+  assert.equal(store.size(), 4);
+});
+
+test('Phase 1: isolate=false keeps the GLOBAL cap (byte-identical default)', () => {
+  const store = createCompanionStateStore({ ambassadorCap: 2 });
+  // owners passed but isolate off -> global cap 2, cross-owner eviction (current behavior)
+  store.saveCompanionState(makeValidState({ lineage_id: 'A-one-xxxx' }), {
+    owner: 'A',
+    isolate: false,
+  });
+  store.saveCompanionState(makeValidState({ lineage_id: 'B-one-xxxx' }), {
+    owner: 'B',
+    isolate: false,
+  });
+  store.saveCompanionState(makeValidState({ lineage_id: 'B-two-xxxx' }), {
+    owner: 'B',
+    isolate: false,
+  });
+  assert.equal(store.size(), 2);
+  assert.equal(store.getCompanionState('A-one-xxxx'), null); // A-one (oldest global) evicted
+});
+
 // ─── 6. Backward-compat 0.1.0 reader ────────────────────────────────────
 
 test('Phase 1: isLegacySchema detects 0.1.x', () => {


### PR DESCRIPTION
## SPEC-F per-Nido isolation -- Option A (in-memory, flag-OFF)

Addresses the recurring SPEC-F security gap (hit 3x: eviction-grief, cross-lineage
overwrite, cross-restart overwrite). Recon (4-finder workflow) + owner design-calls
(AskUserQuestion) ratified **Option A** + `player_id`/JWT-sub owner + public reads +
defer the durable Option C.

### The gap
The companion store is a process-global singleton keyed by `lineage_id`; the cap-10 is
**global with FIFO**, so Player B saving an 11th companion silently evicts Player A's
oldest -- cross-tenant data destruction, the highest-ranked threat.

### What (flag `SPEC_F_NIDO_ISOLATION_ENABLED`, OFF by default)
- **OFF** = today's global cap + per-IP rate-limit, **byte-identical** (existing tests
  still assert the global path).
- **ON**: the ambassador cap is scoped **per-owner** (`owner` = JWT sub, else the
  request's `player_id`) via an in-memory `ownerLineages` index, so an owner's (cap+1)th
  add evicts **that owner's** oldest, never another Nido's.
- Store: `saveCompanionState(state, { owner, isolate })` gains a per-owner FIFO branch;
  global path unchanged when `isolate=false`.

### Security (untrusted owner input)
- The write **rate-limit** goes per-owner **only for a JWT-trusted owner**; a
  self-asserted `player_id` stays **per-IP** on purpose -- otherwise a griefer rotating
  distinct `player_id` strings would mint a fresh 10/h budget per request and flood the
  store unbounded (per-owner cap removes the global ceiling). Regression test included.
- `deriveOwner` **string-validates** `player_id` (an object/array never becomes a
  Map/rate-limit key).
- **Trust ceiling (documented, load-bearing for the flip):** with self-asserted
  `player_id` the **cap** isolation is *cooperative* (honest clients stop colliding, but
  a griefer who knows a target id can target it); adversarial safety requires JWT
  (`AUTH_SECRET` configured -> `req.auth.userId`). The crypto guarantee is the JWT, not
  the id string -- mirrors the FC4-A caveat. Today `/api/skiv/*` is not behind auth, so
  prod runs the safe per-IP rate-limit; the cap isolation is cooperative.
- Reads stay **public-tier** (no read-gating) -- ratified, consistent with the existing
  `share_url`.

### Safety
- **Flag OFF by default, reversible.** No forbidden-path (only `apps/backend/` + tests;
  no `packages/contracts`, no Prisma migration). Warm-state only (owner index resets on
  restart; **durable per-Nido cap = Option C**, a Prisma migration, deferred owner-gate).
- Review: 4-finder recon + 3-lens adversarial workflow (security / correctness /
  flag-off-byte-identical, refute-by-default + verify). The one raised finding
  (unbounded `ownerLineages`) was hardened by the trusted-only rate-limit + string guard.

### Tests
`node --test tests/routes/skivCustode.test.js tests/services/skivCompanionState.test.js
tests/routes/companion.test.js` -> **84/84** (per-owner cap isolation, trusted vs
self-asserted rate-limit, rotating-id-can't-bypass, object-player_id-ignored,
flag-off-byte-identical). AI 567/567, format clean.

## Rollback
Revert the commit -- additive, flag-OFF, no schema/migration.

Coding-Agent: claude-code
