### PR TITLE
feat(spec-f): Option D JWT write-gate + wire tests/routes into CI

### DIFF
--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -95,10 +95,13 @@ function createCompanionRouter({
 
   // Option D write-gate middleware: enforce/populate auth on SPEC-F writes when
   // opted in (else a passthrough -> open, byte-identical). Injected `authenticate`
-  // wins (tests); otherwise the shared createAuthHandlers().authenticate is used
-  // (JWT-enforce when AUTH_SECRET set, noop -> open otherwise). Reads never get it.
+  // wins (tests); otherwise createAuthHandlers is used JWT-ONLY: `legacyToken:null`
+  // DISABLES the shared TRAIT_EDITOR_TOKEN/TRAITS_API_TOKEN fallback (Codex P2) --
+  // a SPEC-F write must be bound to a per-player JWT sub, never the shared static
+  // trait-editor token (wrong credential + no per-owner identity). So: JWT-enforce
+  // when AUTH_SECRET set, noop -> open otherwise (regardless of the trait tokens).
   const writeAuth = writeAuthEnabled
-    ? authenticate || createAuthHandlers().authenticate
+    ? authenticate || createAuthHandlers({ legacyToken: null }).authenticate
     : (_req, _res, next) => next();
 
   // SPEC-F per-Nido isolation (Option A). Owner = the caller's durable identity:

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -25,7 +25,9 @@
 // cap is scoped PER-OWNER (JWT sub / self-asserted player_id) so honest Nidos stop
 // FIFO-evicting each other; the write rate-limit goes per-owner ONLY for a JWT-trusted
 // owner (a self-asserted player_id stays per-IP so a rotating-id flood can't bypass it).
-// Durable per-Nido cap + a JWT write-gate (middleware/auth.js) = Option C/D, owner-gated.
+// Option D (SPEC_F_WRITE_AUTH_ENABLED, OFF by default) adds a JWT enforce-gate on the
+// WRITES (not the public reads) so req.auth.userId becomes the trusted owner ->
+// adversarial-safe isolation. Durable per-Nido cap (persisted nidoId, Prisma) = Option C.
 
 'use strict';
 
@@ -37,6 +39,7 @@ const { toDisplayCard, toQrPayload } = require('../services/skiv/companionCardEx
 const { rollMatingOffspring: rollMatingOffspringDefault } = require('../services/metaProgression');
 const offspringStoreDefault = require('../services/lineage/offspringStore');
 const { resolveOffspringGenome } = require('../services/skiv/offspringGenome');
+const { createAuthHandlers } = require('../middleware/auth');
 
 // SPEC-F slice 3 -- crossbreed offspring is rolled by the engine, but with a
 // SEEDED rng so the proposal preview (slice 2) and the committed confirm
@@ -70,14 +73,33 @@ const CROSSBREED_RATE_WINDOW_MS = 60 * 60 * 1000;
 // Warm-state only (owner index resets on restart; durable = Option C Prisma migration).
 const NIDO_ISOLATION_ENABLED = process.env.SPEC_F_NIDO_ISOLATION_ENABLED === 'true';
 
+// SPEC-F Option D: optional JWT gate on the WRITE routes (not the public-tier reads).
+// OFF by default = writes stay open, byte-identical. ON = the shared auth handler
+// enforces a valid token IF AUTH_SECRET is configured (else a noop -> still open);
+// a verified token populates req.auth.userId (JWT sub), so deriveOwner returns a
+// crypto-bound (trusted) owner and the per-Nido isolation becomes adversarial-safe
+// (closes the self-asserted player_id spoof/rotation ceiling). Needs the isolation
+// flag too for the per-owner cap; independent so auth + cap can be staged separately.
+const WRITE_AUTH_ENABLED = process.env.SPEC_F_WRITE_AUTH_ENABLED === 'true';
+
 function createCompanionRouter({
   companionPicker = companionPickerDefault,
   store = null,
   rollMatingOffspring = rollMatingOffspringDefault,
   offspringStore = offspringStoreDefault,
   nidoIsolationEnabled = NIDO_ISOLATION_ENABLED,
+  writeAuthEnabled = WRITE_AUTH_ENABLED,
+  authenticate = null,
 } = {}) {
   const router = express.Router();
+
+  // Option D write-gate middleware: enforce/populate auth on SPEC-F writes when
+  // opted in (else a passthrough -> open, byte-identical). Injected `authenticate`
+  // wins (tests); otherwise the shared createAuthHandlers().authenticate is used
+  // (JWT-enforce when AUTH_SECRET set, noop -> open otherwise). Reads never get it.
+  const writeAuth = writeAuthEnabled
+    ? authenticate || createAuthHandlers().authenticate
+    : (_req, _res, next) => next();
 
   // SPEC-F per-Nido isolation (Option A). Owner = the caller's durable identity:
   // JWT sub (req.auth.userId, present only when an AUTH_SECRET middleware ran) else
@@ -311,7 +333,7 @@ function createCompanionRouter({
    *           409 lineage_already_promoted | 422 invalid_offspring |
    *           422 promote_failed | 429 rate_limited
    */
-  router.post('/skiv/offspring/:offspring_id/promote', async (req, res) => {
+  router.post('/skiv/offspring/:offspring_id/promote', writeAuth, async (req, res) => {
     if (!requireStore(res)) return;
     const owner = deriveOwner(req);
     if (promoteRateLimited(rateKey(req, owner))) {
@@ -414,7 +436,7 @@ function createCompanionRouter({
    *           400 signature_mismatch | 400 lineage_id_required |
    *           409 lineage_already_imported | 422 import_failed | 429 rate_limited
    */
-  router.post('/skiv/import', async (req, res) => {
+  router.post('/skiv/import', writeAuth, async (req, res) => {
     if (!requireStore(res)) return;
     // Rate-limit FIRST (before body validation): every attempt -- incl. malformed
     // -- counts against the IP budget, so a garbage flood cannot probe the endpoint
@@ -591,7 +613,7 @@ function createCompanionRouter({
    * = the Nido lineage record). A NEW playable lineage/ambassador from the
    * offspring is SPEC-E follow-up; this records the event + returns the card.
    */
-  router.post('/skiv/crossbreed/confirm', (req, res) => {
+  router.post('/skiv/crossbreed/confirm', writeAuth, (req, res) => {
     if (!requireStore(res)) return;
     const body = req.body || {};
     const lineageId = String(body.lineage_id || '');

--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -54,6 +54,13 @@ const steps = [
   // The validator test runs the script against every real data/codex entry
   // (errors=0), so wiring this glob makes the authoring gate an enforced check.
   'node --test tests/codex/*.test.js',
+  // tests/routes/** -- SPEC-F Custode HTTP routes (companion + skivCustode: share/
+  // export/promote/import/crossbreed + per-Nido isolation Option A + write-gate
+  // Option D). Same anti-pattern #10 risk: these express app.listen(0)+fetch tests
+  // are the ONLY coverage of the flag-OFF byte-identical guards + the untrusted-body
+  // and eviction-isolation invariants, but no glob above matched tests/routes/*.
+  // Flat subtree -> single-* glob; wiring makes them an enforced gate.
+  'node --test tests/routes/*.test.js',
 ];
 
 const baseEnv = {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -808,6 +808,26 @@ test('Option D ON: public reads stay open (GET share needs no token)', async () 
   assert.equal(r.status, 200); // reads are public-tier, never gated
 });
 
+test('Option D ON without AUTH_SECRET does NOT fall back to the legacy trait token (Codex P2)', async () => {
+  const prevSecret = process.env.AUTH_SECRET;
+  const prevTrait = process.env.TRAIT_EDITOR_TOKEN;
+  delete process.env.AUTH_SECRET;
+  process.env.TRAIT_EDITOR_TOKEN = 'legacy-secret'; // present, but must NOT gate SPEC-F writes
+  try {
+    const store = createCompanionStateStore();
+    // NO injected authenticate -> exercises the real createAuthHandlers({legacyToken:null}).
+    const app = buildApp({ store, writeAuthEnabled: true });
+    const card = makePartnerCard();
+    const r = await postJson(app, '/api/skiv/import', { card }); // no token
+    assert.equal(r.status, 201); // open (noop), NOT 401 legacy-token-gated
+  } finally {
+    if (prevSecret === undefined) delete process.env.AUTH_SECRET;
+    else process.env.AUTH_SECRET = prevSecret;
+    if (prevTrait === undefined) delete process.env.TRAIT_EDITOR_TOKEN;
+    else process.env.TRAIT_EDITOR_TOKEN = prevTrait;
+  }
+});
+
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────
 
 test('GET /skiv/crossbreed/history unknown lineage → [] count 0', async () => {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -117,6 +117,8 @@ function buildApp({
   rollMatingOffspring,
   offspringStore,
   nidoIsolationEnabled,
+  writeAuthEnabled,
+  authenticate,
   authStub,
 } = {}) {
   const app = express();
@@ -133,9 +135,29 @@ function buildApp({
   }
   app.use(
     '/api',
-    createCompanionRouter({ store, rollMatingOffspring, offspringStore, nidoIsolationEnabled }),
+    createCompanionRouter({
+      store,
+      rollMatingOffspring,
+      offspringStore,
+      nidoIsolationEnabled,
+      writeAuthEnabled,
+      authenticate,
+    }),
   );
   return app;
+}
+
+// Option D enforce stub (mirrors createAuthHandlers().authenticate when AUTH_SECRET
+// is set): require body.token==='ok', then set req.auth.userId = body.player_id
+// (the verified JWT sub); else 401. Injected as `authenticate` for the write-gate.
+function makeEnforceAuth() {
+  return (req, res, next) => {
+    if (!req.body || req.body.token !== 'ok') {
+      return res.status(401).json({ error: 'unauthorized' });
+    }
+    req.auth = { userId: String(req.body.player_id || 'sub') };
+    next();
+  };
 }
 
 // Minimal offspringStore stub -- only getById is called by the promote route.
@@ -731,6 +753,59 @@ test('isolation ON: a non-string player_id (object) is ignored, not used as a ke
   // malformed untrusted input: player_id as an object must never become a Map/rate key.
   const r = await postJson(app, '/api/skiv/import', { card, player_id: { evil: 1 } });
   assert.equal(r.status, 201); // treated as anonymous (global path), no crash / no [object Object]
+});
+
+// --- B4: Option D JWT write-gate (flag SPEC_F_WRITE_AUTH_ENABLED) ---
+
+test('Option D OFF (default): writes stay open, no token required (byte-identical)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store }); // write-auth off
+  const card = makePartnerCard();
+  const r = await postJson(app, '/api/skiv/import', { card });
+  assert.equal(r.status, 201);
+});
+
+test('Option D ON: a write without a valid token is rejected (401)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({ store, writeAuthEnabled: true, authenticate: makeEnforceAuth() });
+  const card = makePartnerCard();
+  const r = await postJson(app, '/api/skiv/import', { card }); // no token
+  assert.equal(r.status, 401);
+});
+
+test('Option D ON: a valid token succeeds + owner is JWT-trusted (per-owner rate-limit)', async () => {
+  const store = createCompanionStateStore();
+  const app = buildApp({
+    store,
+    nidoIsolationEnabled: true,
+    writeAuthEnabled: true,
+    authenticate: makeEnforceAuth(),
+  });
+  // playerA (verified sub) exhausts its own 10/h; playerB is unaffected -> the JWT sub
+  // is the trusted owner key (adversarial-safe, not the self-asserted body path).
+  let last;
+  for (let i = 0; i < 11; i += 1) {
+    const card = makePartnerCard({ lineage_id: `A-d-${i}-zzzz` });
+    card.companion_card_signature = signatureFor(card);
+    last = await postJson(app, '/api/skiv/import', { card, token: 'ok', player_id: 'playerA' });
+  }
+  assert.equal(last.status, 429);
+  const cardB = makePartnerCard({ lineage_id: 'B-d-0-zzzz' });
+  cardB.companion_card_signature = signatureFor(cardB);
+  const rB = await postJson(app, '/api/skiv/import', {
+    card: cardB,
+    token: 'ok',
+    player_id: 'playerB',
+  });
+  assert.notEqual(rB.status, 429);
+});
+
+test('Option D ON: public reads stay open (GET share needs no token)', async () => {
+  const lineageId = 'skiv-savana-2026-0427-test';
+  const store = makeStoreStub({ [lineageId]: makeShareState() });
+  const app = buildApp({ store, writeAuthEnabled: true, authenticate: makeEnforceAuth() });
+  const r = await getJson(app, `/api/skiv/share/${lineageId}`);
+  assert.equal(r.status, 200); // reads are public-tier, never gated
 });
 
 // ─── Slice 1: GET /api/skiv/crossbreed/history/:lineage_id ──────────────


### PR DESCRIPTION
## SPEC-F Option D -- JWT write-gate + CI wiring for tests/routes

Makes the per-Nido isolation (Option A, #3138) **adversarial-safe** and closes a
real CI-coverage gap found in review.

### Option D (flag `SPEC_F_WRITE_AUTH_ENABLED`, OFF by default)
- Applies the shared `createAuthHandlers().authenticate` (same as `routes/traits.js`)
  to the **3 WRITE routes** (`POST /skiv/offspring/:id/promote`, `/skiv/import`,
  `/skiv/crossbreed/confirm`) -- **not** the public-tier GET reads, **not** the
  `/skiv/crossbreed` propose (no persist).
- **OFF (default)** = writes stay open, **byte-identical** (writeAuth is a passthrough;
  `createAuthHandlers` is not even constructed).
- **ON** = the handler **enforces** a valid JWT when `AUTH_SECRET` is configured (else a
  noop -> still open). A verified token populates `req.auth.userId` (JWT sub), so
  `deriveOwner` returns a **crypto-bound trusted owner** -> the isolation cap + rate-limit
  key on the sub, closing the self-asserted-`player_id` spoof/rotation ceiling.
- Independent flag from `SPEC_F_NIDO_ISOLATION_ENABLED` so auth + cap can be staged
  separately; full adversarial-safe isolation = both flags ON + `AUTH_SECRET` set.

### Review P1 (real) -- anti-pattern #10: CI-orphaned tests
`tests/routes/**` (companion + skivCustode) had **no matching glob** in
`scripts/run-test-api.cjs` -- so the entire SPEC-F route suite (share/export/promote/
**import** #3135 + **isolation** #3138 + the flag-OFF byte-identical guards + the
untrusted-body + eviction-isolation invariants) **never ran in CI**. Same class the repo
already fixed for `tests/services`, `tests/difficulty`, `tests/codex`. Wired
`node --test tests/routes/*.test.js` -> the guards are now enforced at merge, and this
**retroactively CI-covers the #3135/#3138 tests** too.

### Safety
- Flag OFF by default, reversible. No forbidden-path (`apps/backend/` + `tests/` +
  `scripts/run-test-api.cjs`; `scripts/` is not a forbidden path). `packages/contracts`,
  Prisma, `.github/workflows` untouched.
- Review: 2-lens adversarial workflow (auth-bypass / flag-off-byte-identical, refute-by-
  default + verify). The one CONFIRMED finding (CI-orphan) is fixed here.

### Tests
`node --test tests/routes/*.test.js` -> **65/65** (Option D: 401 without token, 201 +
trusted-owner with token, reads-open, flag-OFF open). AI 567/567, format clean.

## Rollback
Revert the commit -- flag-OFF, additive, no schema/migration.

Coding-Agent: claude-code
