### PR TITLE
docs(handoff): sync Next-entry-point to ratified anchor (Codex P2 #3153)

### DIFF
--- a/docs/planning/2026-07-01-session-handoff-w5-d8-w6-close.md
+++ b/docs/planning/2026-07-01-session-handoff-w5-d8-w6-close.md
@@ -99,7 +99,9 @@ delete the 3 lines (OFF = byte-identical).
 
 ## Next entry point
 
-The continuation chip (spawned this session): **D6 graded re-ratify -> N3 ER7 flag-ON N=40 -> G6
-move-terrain Godot**, plus the W6 owner follow-through (anchor decision + prod deploy/restart).
+D6 graded re-ratify = **DONE** (REAL band, mapping validated 8/8 live; #3149 + fix #3151). The W6
+anchor is **RATIFIED 1.15** (owner 2026-07-01; #3152/#3153, keys.env staged). The remaining W6
+follow-through is **only the flip = prod deploy to main `>= 92e52636` + restart** (owner; the anchor is
+no longer open). N3 ER7 flag-ON N=40 -> G6 move-terrain Godot = the paused graded lane (owner unpauses).
 Memory: `project_w5_sim_ai_player_upgrade` + `project_form_pulse_v2_flip_readiness` +
 `lesson_numeric_seeds_paired_sim`.


### PR DESCRIPTION
Codex P2 on #3153: the handoff's Next-entry-point still listed the W6 "anchor decision" as owner follow-through -- the anchor is RATIFIED 1.15, so only the flip (deploy `>= 92e52636` + restart) remains. Grep-all confirmed no other doc frames the anchor as open (last of the async-cascade). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)