### PR TITLE
docs(sim): ER7 reproduce -- add --seed-base to the aggregate step (Codex P2 #3160)

### DIFF
--- a/docs/playtest/2026-07-01-er7-population-flag-on-n40.md
+++ b/docs/playtest/2026-07-01-er7-population-flag-on-n40.md
@@ -125,7 +125,10 @@ for arm in off off2 on_depleted on_abundant; do
   node tools/sim/spec-i-gates-probe.js --effect er7 --arms $arm --runs 40 --seed-base 52000 \
     --out reports/sim/er7-population-n40
 done
-node tools/sim/spec-i-gates-probe.js --effect er7 --aggregate --out reports/sim/er7-population-n40
+# --seed-base MUST match the per-arm runs: the aggregate stamps args metadata and a missing
+# --seed-base defaults to 51000 (parseArgs), which would rewrite the metadata out of sync.
+node tools/sim/spec-i-gates-probe.js --effect er7 --aggregate --seed-base 52000 \
+  --out reports/sim/er7-population-n40
 # then read reports/sim/er7-population-n40/summary.json (isolated_arms:true + summaries + deltas + extras.er7)
 ```
 


### PR DESCRIPTION
Codex P2 on #3160: the Reproduce block's aggregate command omitted `--seed-base`, so following it would regenerate `summary.json` with the parseArgs default 51000 while the per-arm runs use 52000 -- reintroducing the exact metadata mismatch #3160 fixed. Added `--seed-base 52000` + a comment that it MUST match the per-arm runs. Doc only, one command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)