### PR TITLE
fix(session): canonicalize species ids to underscore at normaliseUnit

### DIFF
--- a/apps/backend/routes/sessionHelpers.js
+++ b/apps/backend/routes/sessionHelpers.js
@@ -87,7 +87,12 @@ function normaliseUnit(raw, fallbackIndex, bounds) {
     : JOB_ARCHETYPE[job] || null;
   const unit = {
     id,
-    species: input.species ? String(input.species) : 'unknown',
+    // #3157 F1: pack scenario builders inject kebab-case YAML ids
+    // ('dune-stalker') while the runtime canon is underscore
+    // (data/core/species/species_catalog.json; see
+    // services/species/wikiLinkBridge.js). Canonicalize at this single unit
+    // choke point so telemetry carries ONE id format regardless of source.
+    species: input.species ? String(input.species).replace(/-/g, '_') : 'unknown',
     job,
     traits,
     hp,

--- a/tests/api/normaliseUnitSpeciesFormat.test.js
+++ b/tests/api/normaliseUnitSpeciesFormat.test.js
@@ -1,0 +1,36 @@
+// tests/api/normaliseUnitSpeciesFormat.test.js
+// TDD: verify normaliseUnit canonicalizes species ids to the runtime underscore
+// format (species_catalog.json convention, documented in
+// services/species/wikiLinkBridge.js).
+//
+// Regression guard for issue #3157 F1: pack-based scenario builders
+// (badlandsPilotScenario.js and siblings) inject kebab-case YAML ids
+// ('dune-stalker') as unit.species while tutorial/hardcoded scenarios use
+// underscore ('dune_stalker'), so telemetry carried BOTH formats for the same
+// species and per-species analytics silently split.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { normaliseUnit } = require('../../apps/backend/routes/sessionHelpers');
+
+test('normaliseUnit: kebab-case species is canonicalized to underscore', () => {
+  const unit = normaliseUnit({ id: 'u1', species: 'dune-stalker' }, 0);
+  assert.equal(unit.species, 'dune_stalker');
+});
+
+test('normaliseUnit: underscore species passes through unchanged', () => {
+  const unit = normaliseUnit({ id: 'u1', species: 'dune_stalker' }, 0);
+  assert.equal(unit.species, 'dune_stalker');
+});
+
+test('normaliseUnit: multi-hyphen species fully canonicalized', () => {
+  const unit = normaliseUnit({ id: 'u1', species: 'ferrimordax-rutilus' }, 0);
+  assert.equal(unit.species, 'ferrimordax_rutilus');
+});
+
+test('normaliseUnit: missing species still defaults to unknown', () => {
+  const unit = normaliseUnit({ id: 'u1' }, 0);
+  assert.equal(unit.species, 'unknown');
+});


### PR DESCRIPTION
## Cosa

Fix del finding **F1 di #3157**: la telemetria portava DUE formati per la stessa specie (`dune_stalker` tutorial/hardcoded vs `dune-stalker` scenari pack badlands/foresta/ultima_caccia) -> analytics per-specie silenziosamente splittate.

Una riga in `normaliseUnit` (`apps/backend/routes/sessionHelpers.js`): canonicalizza kebab->underscore al choke point unico attraverso cui passa ogni unita' di `/api/session/start`.

## Perche' boundary e NON rename degli YAML

Il suggerimento originale dell'indagine (#3157) era rinominare gli id YAML del pack. Recon pre-build: i file kebab nel pack sono **105** su ~48 biomi -- kebab e' LA convenzione pack/wiki-slug by design (`services/species/wikiLinkBridge.js` documenta underscore_case come canone runtime e converte underscore->kebab per i wiki link). Le due convenzioni di layer restano intatte; normalizza solo il boundary runtime. Diff minimo, zero churn canon, copre anche fonti future.

Nessun consumer downstream confronta species kebab (grep su apps/backend: zero match); `speciesBaseStats.js` calcola solo bounds, non lookup per-id.

## Test (output nel commit)

- **TDD**: `tests/api/normaliseUnitSpeciesFormat.test.js` scritto RED prima (2 fail attesi), GREEN dopo il fix (4/4: kebab canonicalizzato, underscore passthrough, multi-hyphen, missing->unknown).
- **Regressione**: 23/23 pass su normaliseUnitBounds + staminaFatigueRefill + hardcoreScenario.
- **E2E**: backend live dal branch + `batch_calibrate_badlands_pilot_01.py --n 1` -> log con `actor_species` tutti underscore (`dune_stalker`, `nano_rust_bloom`, `rust_scavenger`, `ferrocolonia_magnetotattica`), dove il corpus 2517-file portava le varianti kebab.

## Impatto

Da questo fix i log nuovi hanno un solo formato specie. Il corpus storico resta split (fix non retroattivo): le analytics per-specie su dati pre-fix devono mergiare i due formati (nota in #3157; la dashboard PR #3159 li tiene volutamente separati per rendere visibile lo split finche' questo fix non e' mergiato).

Provenienza: hub codemasterdd, follow-up issue #3157 (F1 = priorita' 2, dopo F2 = PR #3164). Merge = Eduardo.
