### PR TITLE
fix(sim): tag scenario_id on /session/start across python batch harnesses

### DIFF
--- a/tools/py/batch_calibrate_badlands_ambient_01.py
+++ b/tools/py/batch_calibrate_badlands_ambient_01.py
@@ -500,6 +500,8 @@ def probe_one(host):
     units = sc["units"]
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         "modulation": "full",
         "sistema_pressure_start": sc.get("sistema_pressure_start", 75),
         "hazard_tiles": sc.get("hazard_tiles", []),
@@ -636,6 +638,8 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
     # Start.
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
         # None -> key omitted -> backend stays on Math.random (no behavior change).
         **({"seed": seed} if seed is not None else {}),

--- a/tools/py/batch_calibrate_badlands_elite_01.py
+++ b/tools/py/batch_calibrate_badlands_elite_01.py
@@ -501,6 +501,8 @@ def probe_one(host):
     units = sc["units"]
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         "modulation": "full",
         "sistema_pressure_start": sc.get("sistema_pressure_start", 75),
         "hazard_tiles": sc.get("hazard_tiles", []),
@@ -637,6 +639,8 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
     # Start.
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
         # None -> key omitted -> backend stays on Math.random (no behavior change).
         **({"seed": seed} if seed is not None else {}),

--- a/tools/py/batch_calibrate_badlands_pilot_01.py
+++ b/tools/py/batch_calibrate_badlands_pilot_01.py
@@ -500,6 +500,8 @@ def probe_one(host):
     units = sc["units"]
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         "modulation": "full",
         "sistema_pressure_start": sc.get("sistema_pressure_start", 75),
         "hazard_tiles": sc.get("hazard_tiles", []),
@@ -636,6 +638,8 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
     # Start.
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
         # None -> key omitted -> backend stays on Math.random (no behavior change).
         **({"seed": seed} if seed is not None else {}),

--- a/tools/py/batch_calibrate_foresta_pilot_01.py
+++ b/tools/py/batch_calibrate_foresta_pilot_01.py
@@ -501,6 +501,8 @@ def probe_one(host):
     units = sc["units"]
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         "modulation": "full",
         "sistema_pressure_start": sc.get("sistema_pressure_start", 75),
         "hazard_tiles": sc.get("hazard_tiles", []),
@@ -637,6 +639,8 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
     # Start.
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
         # None -> key omitted -> backend stays on Math.random (no behavior change).
         **({"seed": seed} if seed is not None else {}),

--- a/tools/py/batch_calibrate_hardcore06.py
+++ b/tools/py/batch_calibrate_hardcore06.py
@@ -493,6 +493,8 @@ def probe_one(host):
     units = sc["units"]
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         "modulation": "full",
         "sistema_pressure_start": sc.get("sistema_pressure_start", 75),
         "hazard_tiles": sc.get("hazard_tiles", []),
@@ -629,6 +631,8 @@ def run_one(host, run_idx, turn_limit_defeat=None, biome_id=None, seed=None,
     # Start.
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
         # None -> key omitted -> backend stays on Math.random (no behavior change).
         **({"seed": seed} if seed is not None else {}),

--- a/tools/py/batch_calibrate_hardcore06_quartet.py
+++ b/tools/py/batch_calibrate_hardcore06_quartet.py
@@ -50,6 +50,8 @@ def run_one_quartet(host, run_idx, seed=None, policy="greedy", rng=None):
 
     status, start = post(f"{host}/api/session/start", {
         "units": quartet_units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
         **({"seed": seed} if seed is not None else {}),
         "modulation": "quartet",

--- a/tools/py/batch_calibrate_hardcore07.py
+++ b/tools/py/batch_calibrate_hardcore07.py
@@ -169,6 +169,8 @@ def run_one(host, run_idx, seed=None, policy="greedy", rng=None):
 
     status, start = post(f"{host}/api/session/start", {
         "units": sc["units"],
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": SCENARIO_ID,
         # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay.
         # None -> key omitted -> backend stays on Math.random (no behavior change).
         **({"seed": seed} if seed is not None else {}),

--- a/tools/py/batch_calibrate_skiv_solo_pack.py
+++ b/tools/py/batch_calibrate_skiv_solo_pack.py
@@ -250,6 +250,8 @@ def run_one(host, run_idx, seed=None):
     units = build_skiv_units()
     status, start = post(f"{host}/api/session/start", {
         "units": units,
+        # #3157 F3: tag the session so per-scenario telemetry stops logging null
+        "scenario_id": ENCOUNTER_ID,
         # TKT-PLAYTEST-SEED: pin backend combat RNG for bit-identical replay
         # (single-unit survival scenario -> only --seed; no player-ladder policy).
         **({"seed": seed} if seed is not None else {}),

--- a/tools/py/batch_sweep_tutorials.py
+++ b/tools/py/batch_sweep_tutorials.py
@@ -57,6 +57,8 @@ def run_one(host, scenario_id):
         f"{host}/api/session/start",
         {
             "units": units,
+            # #3157 F3: tag the session so per-scenario telemetry stops logging null
+            "scenario_id": scenario_id,
             "modulation": sc.get("recommended_modulation", "full"),
             "sistema_pressure_start": sc.get("sistema_pressure_start", 50),
             "hazard_tiles": sc.get("hazard_tiles", []),


### PR DESCRIPTION
## Cosa

Fix F3 di #3157 (layer harness): 14 body `/api/session/start` in 9 script python batch ora inviano `scenario_id` (prima: server default null a `routes/session.js:2414` -> 92.5% del corpus untagged, telemetria per-scenario cieca).

Famiglia batch_calibrate via `SCENARIO_ID` module const; skiv_solo_pack via `ENCOUNTER_ID`; sweep_tutorials via parametro `scenario_id` di run_one.

## Fuori scope (dichiarato)

Host web-v1 archiviati (apps/play, Playtest.html): omettono scenario_id ma il client canonico Godot non chiama /session/start (combat host-local) -- fixare UI morta = zero valore telemetrico. ai-driven-sim.js lo invia gia'.

## Verifica

py_compile 9/9 pulito. E2E backend live dal branch: `hardcore07 --n 1` -> log `scenario_id=enc_tutorial_07_hardcore_pod_rush` (stesso run su main: null).

Sweep meccanico multi-agent con audit call-site finale (14/14 siti coperti). Provenienza: hub codemasterdd, follow-up #3157. Merge = Eduardo.
