### PR TITLE
fix(sim): opt probe scripts into endSession so session logs get session_end

### DIFF
--- a/tools/sim/d6-imprint-grant-graded-probe.js
+++ b/tools/sim/d6-imprint-grant-graded-probe.js
@@ -187,6 +187,7 @@ async function runOne(http, roster, biomeId, seed) {
     seed,
     maxRounds: 40,
     gridSize: 10, // no-op without inline terrain (Codex #3139 P2); identical board across arms
+    endSession: true, // #3157 F4: close the session so the log gets session_end
   });
   const rosterN = (r.rosterIds || []).length || roster.length;
   const kos = Number.isFinite(r.units_lost)

--- a/tools/sim/d8-chain-fire-count.js
+++ b/tools/sim/d8-chain-fire-count.js
@@ -179,6 +179,7 @@ async function main() {
         maxRounds: 160,
         pressureStart: MP.pressureStart,
         modulation: 'duo_hardcore',
+        endSession: true, // #3157 F4: close the session so the log gets session_end
       });
       // Codex #3136 P2: runEncounter returns { outcome:'error' } instead of throwing on a
       // /start or wiring failure. Aborting here prevents a harness/setup error from silently

--- a/tools/sim/d8-chain-graded-probe.js
+++ b/tools/sim/d8-chain-graded-probe.js
@@ -106,6 +106,7 @@ async function runArm(chainOn, N, seedBase) {
         maxRounds: 160,
         pressureStart: MP.pressureStart,
         modulation: 'duo_hardcore',
+        endSession: true, // #3157 F4: close the session so the log gets session_end
       });
       const rosterN = (res.rosterIds || []).length || 1;
       runs.push({

--- a/tools/sim/er6-carryover-graded-probe.js
+++ b/tools/sim/er6-carryover-graded-probe.js
@@ -80,6 +80,7 @@ async function runArm(carryOn, N, seedBase) {
         collectEvents: ER6.collectEvents,
         pressureStart: ER6.pressureStart,
         modulation: 'duo_hardcore',
+        endSession: true, // #3157 F4: close the session so the log gets session_end
       });
       const ev = extractStresswave(res.collectedEvents);
       const rosterN = (res.rosterIds || []).length || 1;

--- a/tools/sim/focus-fire-ab-probe.js
+++ b/tools/sim/focus-fire-ab-probe.js
@@ -160,6 +160,7 @@ async function runOne(party, seed, focusFire, mode) {
       maxRounds: 40,
       gridSize: synthetic ? 8 : 10,
       focusFire,
+      endSession: true, // #3157 F4: close the session so the log gets session_end
     });
     const rosterN = (r.rosterIds || []).length || 4;
     // Prefer the adapter's roster-scoped units_lost (a spawned minion is player-controlled but

--- a/tools/sim/form-pulse-v2-graded-ab-probe.js
+++ b/tools/sim/form-pulse-v2-graded-ab-probe.js
@@ -246,6 +246,7 @@ async function runOne(http, roster, biomeId, seed) {
     // is on the SAME 6x6-clamped board those validated as power-sensitive. All 3 arms share the board,
     // so the DELTAS (the ratify signal) are unaffected; only the absolute-difficulty label was wrong.
     gridSize: 10,
+    endSession: true, // #3157 F4: close the session so the log gets session_end
   });
   const rosterN = (r.rosterIds || []).length || roster.length;
   const kos = Number.isFinite(r.units_lost)

--- a/tools/sim/move-terrain-hazard-encounter-probe.js
+++ b/tools/sim/move-terrain-hazard-encounter-probe.js
@@ -65,6 +65,7 @@ async function runArm(flagOn, seed, scale) {
       maxRounds: 30,
       terrainFeatures: TERRAIN,
       gridSize: 8,
+      endSession: true, // #3157 F4: close the session so the log gets session_end
     });
     return { outcome: r.outcome, rounds: r.rounds };
   } finally {

--- a/tools/sim/move-terrain-hazard-probe.js
+++ b/tools/sim/move-terrain-hazard-probe.js
@@ -100,6 +100,7 @@ async function runArm(flagOn, seed, scale) {
       maxRounds: 30,
       terrainFeatures: hazardWall(),
       gridSize: 8,
+      endSession: true, // #3157 F4: close the session so the log gets session_end
     });
     return { outcome: r.outcome, rounds: r.rounds };
   } finally {

--- a/tools/sim/move-terrain-n40-probe.js
+++ b/tools/sim/move-terrain-n40-probe.js
@@ -133,6 +133,7 @@ async function runArm(flagOn, seed, scale) {
       maxRounds: 30,
       terrainFeatures: TERRAIN,
       gridSize: 6,
+      endSession: true, // #3157 F4: close the session so the log gets session_end
     });
     return { outcome: r.outcome, rounds: r.rounds };
   } finally {

--- a/tools/sim/overcharge-probe.js
+++ b/tools/sim/overcharge-probe.js
@@ -202,6 +202,7 @@ async function runArm({ scenario, runs, seedBase, armOpts, scaling, onRun }) {
         maxRounds: 160,
         ...(armOpts && armOpts.overcharge ? { overcharge: armOpts.overcharge } : {}),
         ...(initialSg ? { initialSg } : {}),
+        endSession: true, // #3157 F4: close the session so the log gets session_end
       });
       const rec = {
         seed,

--- a/tools/sim/pressure-floor-probe.js
+++ b/tools/sim/pressure-floor-probe.js
@@ -301,6 +301,7 @@ async function runArm({ scenario, arm, runs, seedBase, scaling, roster: rosterNa
         maxRounds: 160,
         ...(enc.modulation ? { modulation: enc.modulation } : {}),
         ...(enc.reinf ? { collectEvents: ['reinforcement_spawn'] } : {}),
+        endSession: true, // #3157 F4: close the session so the log gets session_end
       });
       const spawns = enc.reinf
         ? (res.collectedEvents || []).filter((e) => e && e.action_type === 'reinforcement_spawn')

--- a/tools/sim/radici-band-probe.js
+++ b/tools/sim/radici-band-probe.js
@@ -209,6 +209,7 @@ async function runArm(withRadici, seed, scale) {
       seed,
       maxRounds: 30,
       gridSize: 6,
+      endSession: true, // #3157 F4: close the session so the log gets session_end
     });
     return { outcome: r.outcome, rounds: r.rounds, survivors: (r.survivorIds || []).length };
   } finally {

--- a/tools/sim/spec-i-gates-probe.js
+++ b/tools/sim/spec-i-gates-probe.js
@@ -374,6 +374,11 @@ async function runArm({ effect, armName, armDef, runs, seedBase, scaling, onRun 
         // ER1 eco-apply proof reads the FIRST poll (pre-any-action): post-run
         // state is polluted by dynamic AI ability buffs on the same field.
         ...(armDef.jobs ? { captureFirstState: true } : {}),
+        // #3157 F4: endSession INTENTIONALLY OMITTED here -- ER7 arms share one
+        // campaign as a FIXED population condition across seeds ("combat never
+        // mutates it here", above); /end would run the wound-persist pipeline on
+        // campaign.woundedBiomes and contaminate later seeds' measurements.
+        // Truncated logs from this probe are the accepted cost.
       });
       const rec = {
         seed,

--- a/tools/sim/ultima-caccia-band-probe.js
+++ b/tools/sim/ultima-caccia-band-probe.js
@@ -129,6 +129,7 @@ async function runOne(party, seed) {
       seed,
       maxRounds: 40,
       gridSize: 10,
+      endSession: true, // #3157 F4: close the session so the log gets session_end
     });
     const rosterN = (r.rosterIds || []).length || 4;
     const survivors = (r.survivorIds || []).length;

--- a/tools/sim/wound-magnitude-probe.js
+++ b/tools/sim/wound-magnitude-probe.js
@@ -104,6 +104,7 @@ async function runArm({ scenario, runs, seedBase, arm, scaling, onRun }) {
         scenarioId: scenario,
         seed,
         maxRounds: 160,
+        endSession: true, // #3157 F4: close the session so the log gets session_end
       });
       const rec = {
         seed,


### PR DESCRIPTION
## Cosa

Fix F4 di #3157 (layer probe): 14 probe sim chiamavano `runEncounter()` senza `endSession` -> la route di chiusura sessione non veniva mai chiamata, sessioni server leaked, log troncati (13% del corpus senza `session_end`).

`endSession` resta opt-in documentato sull'adapter (A13 write-side trigger): questa PR opta i probe IN esplicitamente, NON flippa il default. Bonus: l'adapter dichiara gia' `{outcome}` per timeout/defeat alla chiusura (fix-A #2703) -> i probe optati smettono anche di produrre 'abandon' spuri.

## Esclusione intenzionale (il catch della review)

`spec-i-gates-probe.js` NON optato: gli arm ER7 condividono UN campaign come condizione di popolazione FISSA cross-seed ("combat never mutates it here"); la chiusura sessione esegue la wound-persist pipeline su `campaign.woundedBiomes` e contaminerebbe le misure dei seed successivi (ER7 appena ratificato #3156/#3158). Documentato inline nel file; log troncati li' = costo accettato.

`full-loop-runner.js` mantiene il suo endSession a13-gated (by design).

## Verifica

node --check 15/15; audit call-site runEncounter 15/16 coperti (16mo = full-loop-runner, intenzionale). Path chiusura+declare gia' provato E2E in PR #3164.

Sweep meccanico multi-agent + review umano-in-loop che ha beccato il caso campaignId. Provenienza: hub codemasterdd, follow-up #3157. Merge = Eduardo.
