### PR TITLE
feat(spec-f): option C -- durable per-Nido ambassador cap

### DIFF
--- a/apps/backend/app.js
+++ b/apps/backend/app.js
@@ -852,8 +852,12 @@ function createApp(options = {}) {
   // Warm the persisted ambassadors into memory at boot (persistence-layer): the
   // Prisma-backed store starts empty on every restart, so GET /skiv/share would 404
   // for a persisted Custode until a write touched it. Fire-and-forget, no-op without
-  // Prisma, never throws (a failure degrades to a cold start).
-  companionStore.hydrateAllAsync?.().catch(() => {});
+  // Prisma, never throws (a failure degrades to a cold start). Under per-Nido
+  // isolation (Option C) the hydrate rebuilds the per-owner FIFO windows instead of
+  // the single global-cap window (same env the companion router reads).
+  companionStore
+    .hydrateAllAsync?.({ isolate: process.env.SPEC_F_NIDO_ISOLATION_ENABLED === 'true' })
+    .catch(() => {});
   app.use('/api', createCompanionRouter({ store: companionStore }));
 
   // Skiv ticket #7 — unit diary persistence MVP (backend-only, JSONL append).

--- a/apps/backend/prisma/migrations/0019_skiv_companion_owner/migration.sql
+++ b/apps/backend/prisma/migrations/0019_skiv_companion_owner/migration.sql
@@ -1,0 +1,9 @@
+-- SPEC-F Option C -- durable per-Nido ambassador cap.
+-- The Option-A per-owner cap (#3138) kept its owner index in memory only, so a
+-- restart collapsed every Nido back into the global window. One nullable TEXT
+-- column captures the owner (JWT sub else self-asserted player_id) at save-time;
+-- hydrateAllAsync({isolate:true}) rebuilds the per-owner FIFO windows at boot.
+-- Server-side metadata only: never part of the whitelisted shareable card.
+-- Additive + nullable: existing rows read NULL -> ANON bucket on hydrate, no
+-- backfill needed, byte-identical behaviour while the isolation flag is OFF.
+ALTER TABLE "skiv_companion_states" ADD COLUMN "owner" TEXT;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -367,6 +367,11 @@ model SkivCompanionState {
   // unit_id/generated_at at restart; `state` holds the entire card. Nullable ->
   // pre-migration rows read NULL and fall back to the 6 columns (fromPrismaRow).
   state              Json?    @map("state")
+  // SPEC-F Option C (durable per-Nido cap): the caller's durable identity (JWT sub
+  // else self-asserted player_id) captured at save-time. Server-side metadata ONLY
+  // -- never part of the whitelisted card (would leak via share + change the
+  // signature). Nullable: ownerless/pre-migration rows bucket to ANON on hydrate.
+  owner              String?  @map("owner")
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -334,8 +334,14 @@ function createCompanionStateStore(opts = {}) {
     ? opts.ambassadorCap
     : AMBASSADOR_CAP_PER_NIDO;
 
-  function persistAsync(state) {
+  function persistAsync(state, owner) {
     if (!usePrisma) return;
+    // Option C (durable per-Nido cap): persist the owner ONLY on an owned write
+    // (non-empty string). Internal ownerless writes (addCrossbreedEvent, resync)
+    // must NOT wipe a stored owner -> the key is OMITTED from the update, not
+    // written as null. The column is server-side metadata, NEVER part of the
+    // whitelisted card (it would leak via share + change the signature).
+    const ownedWrite = typeof owner === 'string' && owner.length > 0;
     const data = {
       lineageId: state.lineage_id,
       schemaVersion: state.schema_version,
@@ -349,6 +355,7 @@ function createCompanionStateStore(opts = {}) {
       // `state` JSONB column holds the entire sanitized (PII-free) card; fromPrismaRow
       // prefers it and falls back to the 6 columns for pre-migration rows (state=null).
       state,
+      ...(ownedWrite ? { owner } : {}),
     };
     opts.prisma.skivCompanionState
       .upsert({
@@ -361,6 +368,7 @@ function createCompanionStateStore(opts = {}) {
           voiceDiaryPortable: data.voiceDiaryPortable,
           shareUrl: data.shareUrl,
           state: data.state,
+          ...(ownedWrite ? { owner } : {}),
         },
       })
       .catch((err) => {
@@ -394,31 +402,72 @@ function createCompanionStateStore(opts = {}) {
    * single lineage lazily on a guarded write) -> GET /skiv/share 404s for a persisted
    * ambassador until something touches it. Fire-and-forget at boot (app.js). No-op for
    * in-memory stores; never throws (a hydrate failure degrades to a cold start).
-   * Returns the count hydrated. Warm-state only for the Option-A owner index
-   * (ownerLineages is not persisted -> the per-Nido cap stays warm-only until Option C).
+   * Returns the count hydrated.
    *
-   * Bounded to the GLOBAL ambassador cap, most-recently-updated first: FIFO eviction
+   * Default (isolate=false) = GLOBAL cap, most-recently-updated first: FIFO eviction
    * only drops a lineage from the in-memory map, never its persisted row, so an
    * unbounded findMany would revive earlier-evicted ambassadors and push states.size
    * past the cap on restart (Codex P1). Evicted lineages carry the oldest updatedAt (an
    * evicted lineage can no longer receive events -- addCrossbreedEvent throws when it is
-   * absent from memory) so they fall outside `take: cap`. Isolation-ON per-owner
-   * durability across restart remains Option C (needs a persisted owner column).
+   * absent from memory) so they fall outside `take: cap`.
+   *
+   * Option C (isolate=true, SPEC_F_NIDO_ISOLATION_ENABLED): per-owner windows.
+   * Under isolation the persisted rows legitimately exceed the global cap (N owners
+   * x cap each), so the global `take: cap` would DROP owned ambassadors. Instead:
+   * load ALL rows oldest-first, bucket by the persisted `owner` column (ownerless
+   * rows -> ANON_BUCKET, mirroring saveCompanionState), keep the NEWEST `cap` per
+   * bucket, and rebuild the ownerLineages index in updatedAt order so post-boot
+   * FIFO eviction (list.shift()) keeps dropping the oldest -- the per-Nido cap is
+   * now durable across restart.
    */
-  async function hydrateAllAsync() {
+  async function hydrateAllAsync({ isolate = false } = {}) {
     if (!usePrisma) return 0;
     try {
-      const rows = await opts.prisma.skivCompanionState.findMany({
-        orderBy: { updatedAt: 'desc' },
-        take: ambassadorCap,
-      });
-      let n = 0;
-      for (const row of rows) {
-        const state = fromPrismaRow(row);
-        if (state && typeof state.lineage_id === 'string') {
-          states.set(state.lineage_id, state);
-          n += 1;
+      if (!isolate) {
+        const rows = await opts.prisma.skivCompanionState.findMany({
+          orderBy: { updatedAt: 'desc' },
+          take: ambassadorCap,
+        });
+        let n = 0;
+        for (const row of rows) {
+          const state = fromPrismaRow(row);
+          if (state && typeof state.lineage_id === 'string') {
+            states.set(state.lineage_id, state);
+            n += 1;
+          }
         }
+        return n;
+      }
+      // Isolation ON: per-owner windows, oldest-first for FIFO index order.
+      const rows = await opts.prisma.skivCompanionState.findMany({
+        orderBy: { updatedAt: 'asc' },
+      });
+      const buckets = new Map(); // bucket -> row[] (updatedAt asc)
+      for (const row of rows) {
+        const bucket =
+          typeof row.owner === 'string' && row.owner.length > 0 ? row.owner : ANON_BUCKET;
+        let list = buckets.get(bucket);
+        if (!list) {
+          list = [];
+          buckets.set(bucket, list);
+        }
+        list.push(row);
+      }
+      let n = 0;
+      for (const [bucket, list] of buckets) {
+        // Newest `cap` per bucket; rows beyond it were FIFO-evicted pre-restart
+        // (or would be immediately) -- leave them in the DB, out of memory.
+        const kept = list.slice(Math.max(0, list.length - ambassadorCap));
+        const index = [];
+        for (const row of kept) {
+          const state = fromPrismaRow(row);
+          if (state && typeof state.lineage_id === 'string') {
+            states.set(state.lineage_id, state);
+            index.push(state.lineage_id);
+            n += 1;
+          }
+        }
+        if (index.length > 0) ownerLineages.set(bucket, index);
       }
       return n;
     } catch (err) {
@@ -507,7 +556,9 @@ function createCompanionStateStore(opts = {}) {
       }
     }
     states.set(sanitized.lineage_id, sanitized);
-    persistAsync(sanitized);
+    // Owner rides to the persistence layer regardless of `isolate` (Option C):
+    // pre-populates durable ownership so a later isolation flip has history.
+    persistAsync(sanitized, owner);
     return getCompanionState(sanitized.lineage_id);
   }
 

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -404,12 +404,13 @@ function createCompanionStateStore(opts = {}) {
    * in-memory stores; never throws (a hydrate failure degrades to a cold start).
    * Returns the count hydrated.
    *
-   * Default (isolate=false) = GLOBAL cap, most-recently-updated first: FIFO eviction
+   * Default (isolate=false) = GLOBAL cap, most-recently-INSERTED first: FIFO eviction
    * only drops a lineage from the in-memory map, never its persisted row, so an
    * unbounded findMany would revive earlier-evicted ambassadors and push states.size
-   * past the cap on restart (Codex P1). Evicted lineages carry the oldest updatedAt (an
-   * evicted lineage can no longer receive events -- addCrossbreedEvent throws when it is
-   * absent from memory) so they fall outside `take: cap`.
+   * past the cap on restart (Codex P1). Windows sort by createdAt, NOT updatedAt:
+   * live FIFO is insertion-order (an update never reorders it), and an ownerless
+   * event append bumps updatedAt without changing the eviction position (Codex P2).
+   * Evicted lineages are the oldest-inserted -> oldest createdAt -> outside `take: cap`.
    *
    * Option C (isolate=true, SPEC_F_NIDO_ISOLATION_ENABLED): per-owner windows.
    * Under isolation the persisted rows legitimately exceed the global cap (N owners
@@ -424,10 +425,14 @@ function createCompanionStateStore(opts = {}) {
     if (!usePrisma) return 0;
     try {
       if (!isolate) {
-        // lineageId tiebreaker: identical updatedAt (ms tie / clock skew) would make
-        // the cap window non-deterministic across restarts (reviewer finding).
+        // FIFO is INSERTION order (live eviction never reorders on update), so the
+        // durable window sorts by createdAt -- an ownerless update (crossbreed/
+        // resync) bumps updatedAt and would turn the rebuilt window into an LRU,
+        // evicting a newer quiet lineage instead of the true oldest (Codex P2).
+        // Evicted rows are the oldest-INSERTED -> oldest createdAt -> correctly
+        // excluded by take:cap. lineageId tiebreaker keeps ms-ties deterministic.
         const rows = await opts.prisma.skivCompanionState.findMany({
-          orderBy: [{ updatedAt: 'desc' }, { lineageId: 'desc' }],
+          orderBy: [{ createdAt: 'desc' }, { lineageId: 'desc' }],
           take: ambassadorCap,
         });
         let n = 0;
@@ -440,11 +445,14 @@ function createCompanionStateStore(opts = {}) {
         }
         return n;
       }
-      // Isolation ON: per-owner windows, oldest-first for FIFO index order.
-      // lineageId tiebreaker keeps the per-bucket slice deterministic when two
-      // rows share the same updatedAt (ms tie / clock skew).
+      // Isolation ON: per-owner windows, oldest-INSERTED first (createdAt) so the
+      // rebuilt index matches the live FIFO semantics -- an ownerless update
+      // (crossbreed/resync) bumps updatedAt but must NOT move that lineage to the
+      // back of the eviction queue (Codex P2: updatedAt order = LRU, evicts a
+      // newer quiet lineage instead of the true oldest). lineageId tiebreaker
+      // keeps ms-ties deterministic.
       const rows = await opts.prisma.skivCompanionState.findMany({
-        orderBy: [{ updatedAt: 'asc' }, { lineageId: 'asc' }],
+        orderBy: [{ createdAt: 'asc' }, { lineageId: 'asc' }],
       });
       const buckets = new Map(); // bucket -> row[] (updatedAt asc)
       for (const row of rows) {

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -424,8 +424,10 @@ function createCompanionStateStore(opts = {}) {
     if (!usePrisma) return 0;
     try {
       if (!isolate) {
+        // lineageId tiebreaker: identical updatedAt (ms tie / clock skew) would make
+        // the cap window non-deterministic across restarts (reviewer finding).
         const rows = await opts.prisma.skivCompanionState.findMany({
-          orderBy: { updatedAt: 'desc' },
+          orderBy: [{ updatedAt: 'desc' }, { lineageId: 'desc' }],
           take: ambassadorCap,
         });
         let n = 0;
@@ -439,8 +441,10 @@ function createCompanionStateStore(opts = {}) {
         return n;
       }
       // Isolation ON: per-owner windows, oldest-first for FIFO index order.
+      // lineageId tiebreaker keeps the per-bucket slice deterministic when two
+      // rows share the same updatedAt (ms tie / clock skew).
       const rows = await opts.prisma.skivCompanionState.findMany({
-        orderBy: { updatedAt: 'asc' },
+        orderBy: [{ updatedAt: 'asc' }, { lineageId: 'asc' }],
       });
       const buckets = new Map(); // bucket -> row[] (updatedAt asc)
       for (const row of rows) {

--- a/tests/services/skivCompanionState.test.js
+++ b/tests/services/skivCompanionState.test.js
@@ -455,8 +455,26 @@ function makeFakePrisma() {
       },
       async findMany(args = {}) {
         let list = [...rows.values()];
-        if (args.orderBy && args.orderBy.updatedAt === 'desc') {
-          list.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+        // Honor orderBy like real Prisma: object or array form, updatedAt with an
+        // optional lineageId tiebreaker (reviewer finding: the earlier mock ignored
+        // 'asc' entirely, so the isolate-hydrate test passed by insertion-order
+        // coincidence instead of exercising the query's contract).
+        const orderBy = Array.isArray(args.orderBy)
+          ? args.orderBy
+          : args.orderBy
+            ? [args.orderBy]
+            : [];
+        if (orderBy.length > 0) {
+          list.sort((a, b) => {
+            for (const clause of orderBy) {
+              const [field, dir] = Object.entries(clause)[0];
+              const av = field === 'updatedAt' ? a.updatedAt || 0 : a[field] || '';
+              const bv = field === 'updatedAt' ? b.updatedAt || 0 : b[field] || '';
+              if (av < bv) return dir === 'asc' ? -1 : 1;
+              if (av > bv) return dir === 'asc' ? 1 : -1;
+            }
+            return 0;
+          });
         }
         if (Number.isFinite(args.take)) list = list.slice(0, args.take);
         return list;

--- a/tests/services/skivCompanionState.test.js
+++ b/tests/services/skivCompanionState.test.js
@@ -535,6 +535,65 @@ test('persistence-layer: hydrateAllAsync is a no-op (0) for an in-memory store',
   assert.equal(await store.hydrateAllAsync(), 0);
 });
 
+// ─── Option C: durable per-Nido cap (owner column + isolate hydrate) ─────
+
+test('option-c: owner persists on owned writes and survives ownerless follow-ups', async () => {
+  const prisma = makeFakePrisma();
+  const store = createCompanionStateStore({ prisma });
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-ownc-keep-01' }), {
+    owner: 'player-alpha',
+    isolate: true,
+  });
+  await flush();
+  assert.equal(prisma.rows.get('skiv-ownc-keep-01').owner, 'player-alpha');
+  // Internal ownerless write (event append) must NOT wipe the stored owner.
+  store.addCrossbreedEvent('skiv-ownc-keep-01', { role: 'parent_a', tier: 'gold' });
+  await flush();
+  assert.equal(prisma.rows.get('skiv-ownc-keep-01').owner, 'player-alpha');
+});
+
+test('option-c: isolate hydrate rebuilds per-owner windows + FIFO stays per-owner', async () => {
+  const prisma = makeFakePrisma();
+  const cap = 2;
+  const store = createCompanionStateStore({ prisma, ambassadorCap: cap });
+  // Owner A saves cap+1 (oldest FIFO-evicted from memory; all 3 rows persisted),
+  // owner B saves 1, one ownerless (anon bucket).
+  for (let i = 0; i < cap + 1; i += 1) {
+    store.saveCompanionState(makeValidState({ lineage_id: `skiv-ownc-a${i}-000` }), {
+      owner: 'nido-a',
+      isolate: true,
+    });
+  }
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-ownc-b0-000' }), {
+    owner: 'nido-b',
+    isolate: true,
+  });
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-ownc-anon-000' }), {
+    owner: null,
+    isolate: true,
+  });
+  await flush();
+  assert.equal(prisma.rows.size, cap + 3, 'all rows persisted (eviction never deletes)');
+
+  // Restart with isolation ON: per-owner windows, NOT the global take:cap.
+  const store2 = createCompanionStateStore({ prisma, ambassadorCap: cap });
+  const n = await store2.hydrateAllAsync({ isolate: true });
+  assert.equal(n, cap + 2, "A's newest 2 + B's 1 + anon 1 (A's evicted oldest stays out)");
+  assert.equal(store2.getCompanionState('skiv-ownc-a0-000'), null, 'A oldest not revived');
+  assert.ok(store2.getCompanionState('skiv-ownc-a2-000'), 'A newest hydrated');
+  assert.ok(store2.getCompanionState('skiv-ownc-b0-000'), 'B hydrated (own window)');
+  assert.ok(store2.getCompanionState('skiv-ownc-anon-000'), 'anon hydrated (ANON bucket)');
+
+  // Post-hydrate FIFO is per-owner: a new A save evicts A's oldest KEPT, never B/anon.
+  store2.saveCompanionState(makeValidState({ lineage_id: 'skiv-ownc-a3-000' }), {
+    owner: 'nido-a',
+    isolate: true,
+  });
+  assert.equal(store2.getCompanionState('skiv-ownc-a1-000'), null, "A's oldest-kept evicted");
+  assert.ok(store2.getCompanionState('skiv-ownc-b0-000'), 'B untouched');
+  assert.ok(store2.getCompanionState('skiv-ownc-anon-000'), 'anon untouched');
+});
+
 test('persistence-layer: bulk-hydrate respects the cap + drops FIFO-evicted rows (Codex P1)', async () => {
   const prisma = makeFakePrisma();
   const cap = 3;

--- a/tests/services/skivCompanionState.test.js
+++ b/tests/services/skivCompanionState.test.js
@@ -444,9 +444,13 @@ function makeFakePrisma() {
       async upsert({ where, create, update }) {
         const existing = rows.get(where.lineageId);
         const updatedAt = ++clock;
+        // createdAt stamps ONCE at insert (like Prisma @default(now())); updates
+        // bump updatedAt only -- the FIFO index sorts on createdAt (Codex P2).
         rows.set(
           where.lineageId,
-          existing ? { ...existing, ...update, updatedAt } : { ...create, updatedAt },
+          existing
+            ? { ...existing, ...update, updatedAt }
+            : { ...create, createdAt: updatedAt, updatedAt },
         );
         return rows.get(where.lineageId);
       },
@@ -465,11 +469,12 @@ function makeFakePrisma() {
             ? [args.orderBy]
             : [];
         if (orderBy.length > 0) {
+          const NUMERIC = new Set(['updatedAt', 'createdAt']);
           list.sort((a, b) => {
             for (const clause of orderBy) {
               const [field, dir] = Object.entries(clause)[0];
-              const av = field === 'updatedAt' ? a.updatedAt || 0 : a[field] || '';
-              const bv = field === 'updatedAt' ? b.updatedAt || 0 : b[field] || '';
+              const av = NUMERIC.has(field) ? a[field] || 0 : a[field] || '';
+              const bv = NUMERIC.has(field) ? b[field] || 0 : b[field] || '';
               if (av < bv) return dir === 'asc' ? -1 : 1;
               if (av > bv) return dir === 'asc' ? 1 : -1;
             }
@@ -610,6 +615,41 @@ test('option-c: isolate hydrate rebuilds per-owner windows + FIFO stays per-owne
   assert.equal(store2.getCompanionState('skiv-ownc-a1-000'), null, "A's oldest-kept evicted");
   assert.ok(store2.getCompanionState('skiv-ownc-b0-000'), 'B untouched');
   assert.ok(store2.getCompanionState('skiv-ownc-anon-000'), 'anon untouched');
+});
+
+test('option-c: ownerless update does not turn the rebuilt FIFO into an LRU (Codex P2)', async () => {
+  const prisma = makeFakePrisma();
+  const cap = 2;
+  const store = createCompanionStateStore({ prisma, ambassadorCap: cap });
+  // Owner A inserts oldest then newest; the OLDEST then receives an ownerless
+  // event append (bumps updatedAt, createdAt untouched).
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-lru-old-000' }), {
+    owner: 'nido-a',
+    isolate: true,
+  });
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-lru-new-000' }), {
+    owner: 'nido-a',
+    isolate: true,
+  });
+  store.addCrossbreedEvent('skiv-lru-old-000', { role: 'parent_a', tier: 'gold' });
+  await flush();
+
+  // Restart: the rebuilt index must be INSERTION order (old first), not LRU.
+  const store2 = createCompanionStateStore({ prisma, ambassadorCap: cap });
+  await store2.hydrateAllAsync({ isolate: true });
+  // Next save at cap must evict the true oldest-INSERTED (skiv-lru-old-000),
+  // even though its updatedAt is now the newest of the two.
+  store2.saveCompanionState(makeValidState({ lineage_id: 'skiv-lru-third-00' }), {
+    owner: 'nido-a',
+    isolate: true,
+  });
+  assert.equal(
+    store2.getCompanionState('skiv-lru-old-000'),
+    null,
+    'true oldest evicted despite the newer updatedAt',
+  );
+  assert.ok(store2.getCompanionState('skiv-lru-new-000'), 'newer quiet lineage survives');
+  assert.ok(store2.getCompanionState('skiv-lru-third-00'));
 });
 
 test('persistence-layer: bulk-hydrate respects the cap + drops FIFO-evicted rows (Codex P1)', async () => {


### PR DESCRIPTION
## Summary

Closes the last SPEC-F auth-lane residue: **Option C**. The Option-A per-owner cap (#3138) kept its owner index in memory only — a restart collapsed every Nido back into the single global window. Unblocked by #3155 (the store now bulk-hydrates at boot).

## Design (owner-signed, 2-step)

- **schema + migration 0019** (forbidden-path, owner-authorized): additive nullable `owner TEXT` column on `skiv_companion_states`. Server-side metadata ONLY — never part of the whitelisted shareable card (would leak via share + change the signature). Existing rows read NULL → ANON bucket on hydrate, **no backfill**.
- **store**: `persistAsync` captures the owner on owned writes (non-empty string); internal ownerless writes (`addCrossbreedEvent`, `resyncCompanionState`) **omit the key** so they never wipe a stored owner. `hydrateAllAsync({isolate:true})` loads all rows oldest-first, buckets by owner (ownerless → ANON, mirroring `saveCompanionState`), keeps the newest `cap` per bucket, and rebuilds `ownerLineages` in `updatedAt` order so post-boot FIFO keeps dropping the oldest. Rows beyond a bucket's cap stay in the DB, out of memory (mirror of the #3155 Codex-P1 bound).
- **app.js**: boot hydrate passes `SPEC_F_NIDO_ISOLATION_ENABLED` (same env the companion router reads).

**Flag OFF = byte-identical**: hydrate stays on the global `take:cap` path; the column is only written when an owner is present.

## Verification (dry-run 0-breakage)

- `tests/services/skivCompanionState.test.js` → **30/30** (+2 Option-C: owner survives ownerless follow-ups; per-owner windows + per-owner FIFO across a simulated restart via faithful fake-Prisma delegate)
- SPEC-F route suite → **76/76**
- `npx prisma validate` ✓ · schema diff **surgical** (+5 lines, no format churn)
- prettier clean · `app.js` requires + boots clean

## Rollback (03A)

Revert + `ALTER TABLE "skiv_companion_states" DROP COLUMN "owner"`. Fully reversible; flag stays OFF.

## SPEC-F auth lane status after this

Option A (per-owner cap, #3138) + Option D (JWT write-gate, #3140) + **Option C (durability, this PR)** = lane COMPLETE. Full adversarial-safe = both flags ON + AUTH_SECRET set (owner flip).