### PR TITLE
feat(spec-f): durable crossbreed cooldown (server-side column)

### DIFF
--- a/apps/backend/prisma/migrations/0020_skiv_crossbreed_cooldown/migration.sql
+++ b/apps/backend/prisma/migrations/0020_skiv_crossbreed_cooldown/migration.sql
@@ -1,0 +1,8 @@
+-- SPEC-F -- durable crossbreed cooldown (ADR-04-27 "1 crossbreed per campaign per
+-- lineage"). The cooldown lived in a per-router in-memory Set, so a backend restart
+-- reset it (re-crossbreed exploit). One nullable JSONB column holds the campaign ids
+-- a lineage crossbred in (FIFO cap 20 app-level); boot bulk-hydrate reloads it.
+-- Server-side metadata like `owner`: campaign_id never enters the whitelisted
+-- shareable card (the privacy leak that killed the #3101 contracts-field approach).
+-- Additive + nullable: existing rows read NULL -> empty list, no backfill.
+ALTER TABLE "skiv_companion_states" ADD COLUMN "crossbreed_campaigns" JSONB;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -372,6 +372,11 @@ model SkivCompanionState {
   // -- never part of the whitelisted card (would leak via share + change the
   // signature). Nullable: ownerless/pre-migration rows bucket to ANON on hydrate.
   owner              String?  @map("owner")
+  // Durable crossbreed cooldown (ADR-04-27 "1/campaign/lineage"): campaign ids this
+  // lineage crossbred in (FIFO cap 20, app-level). Server-side metadata like owner
+  // -- keeping campaign_id OFF the shareable card is the privacy line that killed
+  // the #3101 contracts-field approach. Nullable: pre-migration rows read NULL -> [].
+  crossbreedCampaigns Json?   @map("crossbreed_campaigns")
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -701,6 +701,13 @@ function createCompanionRouter({
     if (!campaignId) {
       return res.status(400).json({ error: 'campaign_id_required' });
     }
+    // Trust-boundary bound: campaign_id lands in the durable crossbreed_campaigns
+    // JSONB column (FIFO cap 20 bounds the COUNT, not the per-id size) -- an
+    // unbounded client string would bloat the column (reviewer finding). 128 chars
+    // covers uuid/slug ids with slack.
+    if (campaignId.length > 128) {
+      return res.status(400).json({ error: 'campaign_id_invalid' });
+    }
     // Rate-limit BEFORE any store work (cheap abuse guard, ADR-04-27).
     const owner = deriveOwner(req);
     if (crossbreedRateLimited(rateKey(req, owner))) {

--- a/apps/backend/routes/companion.js
+++ b/apps/backend/routes/companion.js
@@ -157,14 +157,13 @@ function createCompanionRouter({
   const importRateLimited = makeRateLimiter();
   const resyncRateLimited = makeRateLimiter();
 
-  // Cooldown 1 crossbreed per campaign per lineage (ADR-04-27). Tracked IN-MEMORY
-  // (per-router), NOT on the crossbreed_history item: the ratified
-  // skiv_companion schema (packages/contracts, additionalProperties:false) does
-  // not model a campaign_id on the event, and that schema is a forbidden-path
-  // change. In-memory matches the rate-limit's durability (per-process / per-run);
-  // a durable cross-restart cooldown needs a contracts schema field = master-dd.
-  const _crossbreedCampaigns = new Set(); // `${campaignId}::${lineageId}`
-  const cooldownKey = (campaignId, lineageId) => `${campaignId}::${lineageId}`;
+  // Cooldown 1 crossbreed per campaign per lineage (ADR-04-27). DURABLE since the
+  // persistence layer (owner direction 2026-07-02): the STORE keeps a per-lineage
+  // campaign list in the server-side crossbreed_campaigns JSONB column (rehydrated
+  // at boot) -- NOT on the crossbreed_history item, so campaign_id never enters the
+  // whitelisted shareable card (the privacy leak that killed the #3101
+  // contracts-field approach). In-memory store mode degrades to per-process
+  // durability, same as the old per-router Set this replaces.
 
   // Overwrite guard for the ambassador registry. getCompanionState reads the
   // in-memory Map only, but saveCompanionState upserts to Prisma -> after a
@@ -733,7 +732,9 @@ function createCompanionRouter({
       return res.status(422).json({ error: 'crossbreed_requires_biological' });
     }
     // Cooldown 1/campaign (ADR-04-27): this campaign already crossbred this lineage.
-    if (_crossbreedCampaigns.has(cooldownKey(campaignId, lineageId))) {
+    // Store-backed (durable across restart when Prisma is wired; boot bulk-hydrate
+    // reloads the per-lineage campaign list).
+    if (store.getCrossbreedCampaigns(lineageId).includes(campaignId)) {
       return res.status(409).json({ error: 'crossbreed_cooldown_active' });
     }
     // Roll with the preview seed (or a fresh one) so confirm == the previewed offspring.
@@ -778,8 +779,8 @@ function createCompanionRouter({
         .status(500)
         .json({ error: 'companion_crossbreed_failed', message: String(err.message || err) });
     }
-    // Mark this campaign+lineage as having crossbred (cooldown 1/campaign).
-    _crossbreedCampaigns.add(cooldownKey(campaignId, lineageId));
+    // Mark this campaign+lineage as having crossbred (cooldown 1/campaign, durable).
+    store.recordCrossbreedCampaign(lineageId, campaignId);
     return res.json({
       confirmed: true,
       offspring: result.offspring,

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -410,7 +410,9 @@ function createCompanionStateStore(opts = {}) {
    */
   function recordCrossbreedCampaign(lineageId, campaignId) {
     if (!lineageId || typeof lineageId !== 'string') return;
-    if (!campaignId || typeof campaignId !== 'string') return;
+    // Defense-in-depth size bound (the route 400s >128 first): the id lands in a
+    // durable JSONB array -- cap COUNT is 20, this caps the per-id size.
+    if (!campaignId || typeof campaignId !== 'string' || campaignId.length > 128) return;
     const list = crossbreedCampaigns.get(lineageId) || [];
     if (list.includes(campaignId)) return;
     const next = fifoBounded([...list, campaignId], CROSSBREED_CAMPAIGNS_MAX);

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -403,10 +403,13 @@ function createCompanionStateStore(opts = {}) {
 
   /**
    * Record that a lineage crossbred in a campaign (ADR-04-27 cooldown source of
-   * truth). FIFO-bounded, idempotent, persisted to the crossbreed_campaigns JSONB
-   * column (fire-and-forget UPDATE: the lineage row already exists on the confirm
-   * path -- the route 404s on a missing local lineage before it gets here; a miss
-   * degrades to warm-only, never blocks the crossbreed).
+   * truth). FIFO-bounded, idempotent, persisted fire-and-forget. UPSERT, not
+   * UPDATE (Codex P2): saveCompanionState's own upsert is fire-and-forget too, so
+   * a confirm right after a first import/promote can reach this write BEFORE the
+   * row exists -- an update would throw, get swallowed, and the durable cooldown
+   * would silently stay warm-only. The minimal create relies on the schema
+   * defaults (schema_version/history/diary); the in-flight card upsert then takes
+   * its UPDATE branch and converges the row.
    */
   function recordCrossbreedCampaign(lineageId, campaignId) {
     if (!lineageId || typeof lineageId !== 'string') return;
@@ -419,7 +422,11 @@ function createCompanionStateStore(opts = {}) {
     crossbreedCampaigns.set(lineageId, next);
     if (!usePrisma) return;
     opts.prisma.skivCompanionState
-      .update({ where: { lineageId }, data: { crossbreedCampaigns: next } })
+      .upsert({
+        where: { lineageId },
+        create: { lineageId, crossbreedCampaigns: next },
+        update: { crossbreedCampaigns: next },
+      })
       .catch((err) => {
         log.warn?.(
           `[companionStateStore] cooldown persist failed for ${lineageId}:`,

--- a/apps/backend/services/skiv/companionStateStore.js
+++ b/apps/backend/services/skiv/companionStateStore.js
@@ -21,6 +21,11 @@ const crypto = require('node:crypto');
 const AMBASSADOR_CAP_PER_NIDO = 10;
 const VOICE_DIARY_MAX_ENTRIES = 5;
 const CROSSBREED_HISTORY_MAX_ENTRIES = 10;
+// Durable cooldown (ADR-04-27 "1 crossbreed per campaign per lineage"): per-lineage
+// FIFO cap on the remembered campaign ids -- bounds the server-side column without
+// weakening the policy in practice (a lineage spanning >20 campaigns re-enables the
+// oldest, mirroring the pre-durability per-process reset but far rarer).
+const CROSSBREED_CAMPAIGNS_MAX = 20;
 const CURRENT_SCHEMA_VERSION = '0.2.0';
 // Shared bucket for ownerless writes under per-Nido isolation (SPEC-F Option A):
 // keeps anonymous saves from evicting an owned Nido's ambassador (see saveCompanionState).
@@ -328,6 +333,12 @@ function createCompanionStateStore(opts = {}) {
   // the global cap path below is byte-identical. Warm-state only (not persisted;
   // resets on restart -- durable per-Nido cap = Option C, a Prisma migration).
   const ownerLineages = new Map(); // owner → lineage_id[]
+  // Durable crossbreed cooldown (SPEC-F, owner direction 2026-07-02): campaign ids a
+  // lineage has crossbred in. Server-side metadata like `owner` -- NEVER on the
+  // whitelisted card (campaign_id in the shared card = the privacy leak that killed
+  // the #3101 contracts-field approach). Persisted in the crossbreed_campaigns JSONB
+  // column; rehydrated at boot so a restart no longer resets the cooldown.
+  const crossbreedCampaigns = new Map(); // lineage_id → campaignId[] (FIFO, cap 20)
   const usePrisma = prismaSupportsSkivCompanion(opts.prisma);
   const log = opts.logger || console;
   const ambassadorCap = Number.isFinite(opts.ambassadorCap)
@@ -379,6 +390,48 @@ function createCompanionStateStore(opts = {}) {
       });
   }
 
+  // Load the persisted cooldown campaigns off a Prisma row into the in-memory map.
+  function hydrateCrossbreedCampaigns(row) {
+    const list = parseJsonSafe(row.crossbreedCampaigns);
+    if (Array.isArray(list) && list.length > 0 && typeof row.lineageId === 'string') {
+      crossbreedCampaigns.set(
+        row.lineageId,
+        list.filter((c) => typeof c === 'string' && c.length > 0),
+      );
+    }
+  }
+
+  /**
+   * Record that a lineage crossbred in a campaign (ADR-04-27 cooldown source of
+   * truth). FIFO-bounded, idempotent, persisted to the crossbreed_campaigns JSONB
+   * column (fire-and-forget UPDATE: the lineage row already exists on the confirm
+   * path -- the route 404s on a missing local lineage before it gets here; a miss
+   * degrades to warm-only, never blocks the crossbreed).
+   */
+  function recordCrossbreedCampaign(lineageId, campaignId) {
+    if (!lineageId || typeof lineageId !== 'string') return;
+    if (!campaignId || typeof campaignId !== 'string') return;
+    const list = crossbreedCampaigns.get(lineageId) || [];
+    if (list.includes(campaignId)) return;
+    const next = fifoBounded([...list, campaignId], CROSSBREED_CAMPAIGNS_MAX);
+    crossbreedCampaigns.set(lineageId, next);
+    if (!usePrisma) return;
+    opts.prisma.skivCompanionState
+      .update({ where: { lineageId }, data: { crossbreedCampaigns: next } })
+      .catch((err) => {
+        log.warn?.(
+          `[companionStateStore] cooldown persist failed for ${lineageId}:`,
+          err?.message || err,
+        );
+      });
+  }
+
+  /** Campaign ids this lineage crossbred in (durable cooldown read side). */
+  function getCrossbreedCampaigns(lineageId) {
+    if (!lineageId || typeof lineageId !== 'string') return [];
+    return [...(crossbreedCampaigns.get(lineageId) || [])];
+  }
+
   async function hydrateAsync(lineageId) {
     if (!usePrisma) return null;
     try {
@@ -386,6 +439,7 @@ function createCompanionStateStore(opts = {}) {
       if (!row) return null;
       const state = fromPrismaRow(row);
       states.set(lineageId, state);
+      hydrateCrossbreedCampaigns(row);
       return state;
     } catch (err) {
       log.warn?.(
@@ -440,6 +494,7 @@ function createCompanionStateStore(opts = {}) {
           const state = fromPrismaRow(row);
           if (state && typeof state.lineage_id === 'string') {
             states.set(state.lineage_id, state);
+            hydrateCrossbreedCampaigns(row);
             n += 1;
           }
         }
@@ -475,6 +530,7 @@ function createCompanionStateStore(opts = {}) {
           const state = fromPrismaRow(row);
           if (state && typeof state.lineage_id === 'string') {
             states.set(state.lineage_id, state);
+            hydrateCrossbreedCampaigns(row);
             index.push(state.lineage_id);
             n += 1;
           }
@@ -676,6 +732,7 @@ function createCompanionStateStore(opts = {}) {
     const n = states.size;
     states.clear();
     ownerLineages.clear();
+    crossbreedCampaigns.clear();
     return n;
   }
 
@@ -691,6 +748,8 @@ function createCompanionStateStore(opts = {}) {
     clearAll,
     hydrateAsync,
     hydrateAllAsync,
+    recordCrossbreedCampaign,
+    getCrossbreedCampaigns,
     _mode: usePrisma ? 'prisma' : 'in-memory',
   };
 }
@@ -711,6 +770,7 @@ module.exports = {
   AMBASSADOR_CAP_PER_NIDO,
   VOICE_DIARY_MAX_ENTRIES,
   CROSSBREED_HISTORY_MAX_ENTRIES,
+  CROSSBREED_CAMPAIGNS_MAX,
   CURRENT_SCHEMA_VERSION,
   WHITELIST_TOP_FIELDS,
   BLACKLIST_FIELDS,

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -78,10 +78,11 @@ function makeStoreStub(seed = {}) {
       states.set(lineageId, s);
       return s;
     },
-    // Durable cooldown (mirror of the real store's crossbreedCampaigns map).
+    // Durable cooldown (mirror of the real store's crossbreedCampaigns map,
+    // FIFO cap 20 like CROSSBREED_CAMPAIGNS_MAX).
     recordCrossbreedCampaign(lineageId, campaignId) {
       const list = campaigns.get(lineageId) || [];
-      if (!list.includes(campaignId)) campaigns.set(lineageId, [...list, campaignId]);
+      if (!list.includes(campaignId)) campaigns.set(lineageId, [...list, campaignId].slice(-20));
     },
     getCrossbreedCampaigns(lineageId) {
       return [...(campaigns.get(lineageId) || [])];
@@ -1306,6 +1307,18 @@ test('POST /skiv/crossbreed/confirm missing campaign_id → 400', async () => {
   });
   assert.equal(r.status, 400);
   assert.equal(r.body.error, 'campaign_id_required');
+});
+
+test('POST /skiv/crossbreed/confirm oversized campaign_id (>128) → 400', async () => {
+  const store = makeStoreStub({ [LINEAGE]: makeShareState() });
+  const app = buildApp({ store, rollMatingOffspring: rollStubOk() });
+  const r = await postJson(app, '/api/skiv/crossbreed/confirm', {
+    lineage_id: LINEAGE,
+    partner_card_json: makePartnerCard(),
+    campaign_id: 'c'.repeat(129),
+  });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.error, 'campaign_id_invalid');
 });
 
 test('POST /skiv/crossbreed/confirm rate-limit: 11th request in-window → 429', async () => {

--- a/tests/routes/skivCustode.test.js
+++ b/tests/routes/skivCustode.test.js
@@ -59,6 +59,7 @@ function makeShareState(overrides = {}) {
 // routes call: getCompanionState, getCrossbreedHistory.
 function makeStoreStub(seed = {}) {
   const states = new Map(Object.entries(seed));
+  const campaigns = new Map(); // lineage_id -> campaignId[] (durable-cooldown mirror)
   return {
     getCompanionState(lineageId) {
       return states.get(lineageId) || null;
@@ -76,6 +77,14 @@ function makeStoreStub(seed = {}) {
       s.crossbreed_history = [...(s.crossbreed_history || []), { ...event, ts }].slice(-10);
       states.set(lineageId, s);
       return s;
+    },
+    // Durable cooldown (mirror of the real store's crossbreedCampaigns map).
+    recordCrossbreedCampaign(lineageId, campaignId) {
+      const list = campaigns.get(lineageId) || [];
+      if (!list.includes(campaignId)) campaigns.set(lineageId, [...list, campaignId]);
+    },
+    getCrossbreedCampaigns(lineageId) {
+      return [...(campaigns.get(lineageId) || [])];
     },
     signatureFor,
     _states: states,

--- a/tests/services/skivCompanionState.test.js
+++ b/tests/services/skivCompanionState.test.js
@@ -457,6 +457,12 @@ function makeFakePrisma() {
       async findUnique({ where }) {
         return rows.get(where.lineageId) || null;
       },
+      async update({ where, data }) {
+        const existing = rows.get(where.lineageId);
+        if (!existing) throw new Error(`update: no row for ${where.lineageId}`);
+        rows.set(where.lineageId, { ...existing, ...data, updatedAt: ++clock });
+        return rows.get(where.lineageId);
+      },
       async findMany(args = {}) {
         let list = [...rows.values()];
         // Honor orderBy like real Prisma: object or array form, updatedAt with an
@@ -650,6 +656,49 @@ test('option-c: ownerless update does not turn the rebuilt FIFO into an LRU (Cod
   );
   assert.ok(store2.getCompanionState('skiv-lru-new-000'), 'newer quiet lineage survives');
   assert.ok(store2.getCompanionState('skiv-lru-third-00'));
+});
+
+// ─── Durable crossbreed cooldown (crossbreed_campaigns column) ───────────
+
+test('cooldown: record/get + idempotent + FIFO cap 20', () => {
+  const store = createCompanionStateStore();
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-cd-basic-000' }));
+  store.recordCrossbreedCampaign('skiv-cd-basic-000', 'camp-A');
+  store.recordCrossbreedCampaign('skiv-cd-basic-000', 'camp-A'); // idempotent
+  store.recordCrossbreedCampaign('skiv-cd-basic-000', 'camp-B');
+  assert.deepEqual(store.getCrossbreedCampaigns('skiv-cd-basic-000'), ['camp-A', 'camp-B']);
+  // FIFO cap 20: 21st campaign drops the oldest.
+  for (let i = 0; i < 20; i += 1) {
+    store.recordCrossbreedCampaign('skiv-cd-basic-000', `camp-${i}`);
+  }
+  const list = store.getCrossbreedCampaigns('skiv-cd-basic-000');
+  assert.equal(list.length, 20);
+  assert.equal(list.includes('camp-A'), false, 'oldest dropped at cap');
+  assert.ok(list.includes('camp-19'));
+  // Unknown lineage / bad input -> [] (never throws).
+  assert.deepEqual(store.getCrossbreedCampaigns('unknown'), []);
+  assert.deepEqual(store.getCrossbreedCampaigns(null), []);
+});
+
+test('cooldown: campaigns survive a restart via bulk-hydrate (durable cooldown)', async () => {
+  const prisma = makeFakePrisma();
+  const store = createCompanionStateStore({ prisma });
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-cd-dur-0001' }));
+  await flush(); // row exists before the cooldown UPDATE fires
+  store.recordCrossbreedCampaign('skiv-cd-dur-0001', 'camp-X');
+  await flush();
+  assert.deepEqual(prisma.rows.get('skiv-cd-dur-0001').crossbreedCampaigns, ['camp-X']);
+
+  // Restart: fresh store, bulk-hydrate -> the cooldown set is BACK (the old
+  // per-router Set reset here = the re-crossbreed exploit this closes).
+  const store2 = createCompanionStateStore({ prisma });
+  await store2.hydrateAllAsync();
+  assert.deepEqual(store2.getCrossbreedCampaigns('skiv-cd-dur-0001'), ['camp-X']);
+
+  // Lazy per-lineage hydrate path carries it too (guarded-write path).
+  const store3 = createCompanionStateStore({ prisma });
+  await store3.hydrateAsync('skiv-cd-dur-0001');
+  assert.deepEqual(store3.getCrossbreedCampaigns('skiv-cd-dur-0001'), ['camp-X']);
 });
 
 test('persistence-layer: bulk-hydrate respects the cap + drops FIFO-evicted rows (Codex P1)', async () => {

--- a/tests/services/skivCompanionState.test.js
+++ b/tests/services/skivCompanionState.test.js
@@ -708,6 +708,33 @@ test('cooldown: campaigns survive a restart via bulk-hydrate (durable cooldown)'
   assert.deepEqual(store3.getCrossbreedCampaigns('skiv-cd-dur-0001'), ['camp-X']);
 });
 
+test('cooldown: survives when recorded BEFORE the first card upsert lands (Codex P2 race)', async () => {
+  const prisma = makeFakePrisma();
+  const store = createCompanionStateStore({ prisma });
+  // First-save race: confirm path records the cooldown while the lineage row does
+  // NOT yet exist in Prisma (saveCompanionState's own upsert still in flight).
+  // An UPDATE would throw + get swallowed -> durable cooldown silently lost.
+  store.recordCrossbreedCampaign('skiv-cd-race-001', 'camp-R');
+  await flush();
+  assert.deepEqual(
+    prisma.rows.get('skiv-cd-race-001').crossbreedCampaigns,
+    ['camp-R'],
+    'upsert created the row instead of failing',
+  );
+  // The in-flight card save then converges the same row (update branch).
+  store.saveCompanionState(makeValidState({ lineage_id: 'skiv-cd-race-001' }));
+  await flush();
+  const row = prisma.rows.get('skiv-cd-race-001');
+  assert.deepEqual(row.crossbreedCampaigns, ['camp-R'], 'cooldown kept through card save');
+  assert.ok(row.state, 'card converged onto the same row');
+
+  // Restart: BOTH the card and the cooldown hydrate.
+  const store2 = createCompanionStateStore({ prisma });
+  await store2.hydrateAllAsync();
+  assert.ok(store2.getCompanionState('skiv-cd-race-001'));
+  assert.deepEqual(store2.getCrossbreedCampaigns('skiv-cd-race-001'), ['camp-R']);
+});
+
 test('persistence-layer: bulk-hydrate respects the cap + drops FIFO-evicted rows (Codex P1)', async () => {
   const prisma = makeFakePrisma();
   const cap = 3;

--- a/tests/services/skivCompanionState.test.js
+++ b/tests/services/skivCompanionState.test.js
@@ -678,6 +678,13 @@ test('cooldown: record/get + idempotent + FIFO cap 20', () => {
   // Unknown lineage / bad input -> [] (never throws).
   assert.deepEqual(store.getCrossbreedCampaigns('unknown'), []);
   assert.deepEqual(store.getCrossbreedCampaigns(null), []);
+  // Defense-in-depth: an oversized campaign id is rejected (route 400s first;
+  // this guards any future non-route caller from bloating the JSONB column).
+  store.recordCrossbreedCampaign('skiv-cd-basic-000', 'x'.repeat(129));
+  assert.equal(
+    store.getCrossbreedCampaigns('skiv-cd-basic-000').some((c) => c.length > 128),
+    false,
+  );
 });
 
 test('cooldown: campaigns survive a restart via bulk-hydrate (durable cooldown)', async () => {


### PR DESCRIPTION
## Summary

Closes the **last SPEC-F buildable residue**: the ADR-04-27 cooldown (1 crossbreed per campaign per lineage) lived in a per-router in-memory Set → a backend restart reset it (**re-crossbreed exploit**).

Why now: the #3101 contracts-field approach died on (a) a privacy leak — `campaign_id` would ship in the whitelisted shareable card — and (b) a store that never hydrated. Both premises fell: #3155 added boot bulk-hydrate, #3169 established the server-side-column pattern.

## Design (owner-signed direction: JSON column set-faithful)

- **schema + migration 0020** (forbidden-path, owner-authorized): additive nullable `crossbreed_campaigns JSONB`. Server-side metadata like `owner` — campaign_id **never enters the card** (whitelist untouched, share/signature unchanged).
- **store**: `crossbreedCampaigns` Map + `recordCrossbreedCampaign` (idempotent, FIFO cap 20, fire-and-forget UPDATE — the lineage row exists on the confirm path) + `getCrossbreedCampaigns`; both bulk-hydrate paths AND the lazy per-lineage hydrate reload it.
- **route**: per-router Set **replaced** by the store-backed check (single source). In-memory store mode = same per-process durability as before; Prisma mode = durable across restart.
- Set-faithful semantics: blocks ALL previously-crossbred campaigns (not just the last one). FIFO cap 20 bounds the column (documented tradeoff).

## Verification

- store **33/33** (+2: cap/idempotence; survive-restart via bulk AND lazy hydrate on a faithful fake-Prisma) · routes **76/76** (existing same-process 409 test passes on the swapped path)
- `prisma validate` ✓ · schema diff surgical (+5) · prettier + boot clean

## Rollback (03A)

Revert + `DROP COLUMN "crossbreed_campaigns"`. Route degrades to warm-only cooldown (pre-PR behavior).