### PR TITLE
feat(species): O8 design pass -- 12 non-default resistance_archetype

### DIFF
--- a/data/codex/amorphovenator_magneticus.yaml
+++ b/data/codex/amorphovenator_magneticus.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Scogliera Luminescente
     biome_trait: Barriere coralline sintetiche con correnti luminescenti e fauna sensibile alla risonanza
     lineage: forme a morfologia amorfo
-    archetype: adattivo
+    archetype: bioelettrico
     morphotype: amorfo
     job: ranger
     role: predatore secondario
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: adattivo'
+      - 'resistance_archetype: bioelettrico'
       - 'role_trofico: predatore_secondario; sentient: False'
       - 'trait_refs: filamenti_digestivi_compattanti, olfatto_risonanza_magnetica, struttura_elastica_amorfa, lamelle_termoforetiche, scheletro_idro_regolante'
       cross_ref:
@@ -61,8 +61,8 @@ codex_entry:
       - trait:struttura_elastica_amorfa
       - trait:lamelle_termoforetiche
       - trait:scheletro_idro_regolante
-      game_impact: Archetipo adattivo.
-      content: 'Il sondatore amorfo evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- filamenti digestivi compattanti, olfatto risonanza magnetica, struttura elastica amorfa, lamelle termoforetiche, scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
+      game_impact: Archetipo bioelettrico.
+      content: 'Il sondatore amorfo evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- filamenti digestivi compattanti, olfatto risonanza magnetica, struttura elastica amorfa, lamelle termoforetiche, scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo bioelettrico.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/data/codex/cryptopennatus_psionicus.yaml
+++ b/data/codex/cryptopennatus_psionicus.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Canopia Ionica
     biome_trait: Foresta verticale sospesa da campi elettrostatici e rampicanti conduttivi
     lineage: forme a morfologia aliante mimetico
-    archetype: adattivo
+    archetype: psionico
     morphotype: aliante mimetico
     job: ranger
     role: esploratore
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: adattivo'
+      - 'resistance_archetype: psionico'
       - 'role_trofico: esploratore; sentient: True'
       - 'trait_refs: mimetismo_cromatico_passivo, sacche_galleggianti_ascensoriali, struttura_elastica_amorfa, focus_frazionato, pathfinder, ali_fono_risonanti, spore_psichiche_silenziate, occhi_cristallo_modulare'
       cross_ref:
@@ -64,7 +64,7 @@ codex_entry:
       - trait:ali_fono_risonanti
       - trait:spore_psichiche_silenziate
       - trait:occhi_cristallo_modulare
-      game_impact: Archetipo adattivo.
+      game_impact: Archetipo psionico.
       content: 'La linea dell''esploratore di chioma porta i segni di mimetismo cromatico passivo, sacche galleggianti ascensoriali, struttura elastica amorfa, focus frazionato, pathfinder, ali fono risonanti: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico

--- a/data/codex/illusiopardus_psionicus.yaml
+++ b/data/codex/illusiopardus_psionicus.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Foresta Temperata Umida
     biome_trait: Boschi piovosi con canopy densa, nebbie calde e radure bioenergetiche
     lineage: forme a morfologia felino psionico
-    archetype: adattivo
+    archetype: psionico
     morphotype: felino psionico
     job: skirmisher
     role: predatore terziario
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: adattivo'
+      - 'resistance_archetype: psionico'
       - 'role_trofico: predatore_terziario; sentient: True'
       - 'trait_refs: artigli_psionici, tessuti_adattivi, empatia_coordinativa'
       cross_ref:
@@ -59,7 +59,7 @@ codex_entry:
       - trait:artigli_psionici
       - trait:tessuti_adattivi
       - trait:empatia_coordinativa
-      game_impact: Archetipo adattivo.
+      game_impact: Archetipo psionico.
       content: 'La linea del mascheraio illusorio porta i segni di artigli psionici, tessuti adattivi, empatia coordinativa: ogni tratto core e'' la cicatrice di una pressione del bioma. Attraversa le fasi un ciclo di adattamento continuo, conservando solo cio'' che sopravvive.'
     I_impianto:
       heading: Impianto morfo-fisiologico

--- a/data/codex/lithoconstructus_inhibens.yaml
+++ b/data/codex/lithoconstructus_inhibens.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Caverna Risonante
     biome_trait: Gallerie cristalline dove eco e pressioni invertite modellano la fauna
     lineage: forme a morfologia costrutto corazzato
-    archetype: adattivo
+    archetype: corazzato
     morphotype: costrutto corazzato
     job: warden
     role: guardiano artificiale
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: adattivo'
+      - 'resistance_archetype: corazzato'
       - 'role_trofico: guardiano_artificiale; sentient: False'
       - 'trait_refs: armatura_pietra_planare, carapace_fase_variabile, matrice_antimagia, nuclei_di_controllo'
       cross_ref:
@@ -60,8 +60,8 @@ codex_entry:
       - trait:carapace_fase_variabile
       - trait:matrice_antimagia
       - trait:nuclei_di_controllo
-      game_impact: Archetipo adattivo.
-      content: 'Il litoautoma inibitore evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- armatura pietra planare, carapace fase variabile, matrice antimagia, nuclei di controllo -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
+      game_impact: Archetipo corazzato.
+      content: 'Il litoautoma inibitore evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- armatura pietra planare, carapace fase variabile, matrice antimagia, nuclei di controllo -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo corazzato.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/data/codex/pyroflagellum_meteoriticum.yaml
+++ b/data/codex/pyroflagellum_meteoriticum.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Abisso Vulcanico
     biome_trait: Camini abissali con lava pressurizzata e fauna bio-termica
     lineage: forme a morfologia alato corazzato
-    archetype: adattivo
+    archetype: termico
     morphotype: alato corazzato
     job: vanguard
     role: predatore terziario
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: adattivo'
+      - 'resistance_archetype: termico'
       - 'role_trofico: predatore_terziario; sentient: False'
       - 'trait_refs: adattamento_volo, frusta_fiammeggiante, mantello_meteoritico, armatura_pietra_planare, artigli_sette_vie, carapace_fase_variabile'
       cross_ref:
@@ -62,8 +62,8 @@ codex_entry:
       - trait:armatura_pietra_planare
       - trait:artigli_sette_vie
       - trait:carapace_fase_variabile
-      game_impact: Archetipo adattivo.
-      content: 'Il flagello igneo evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- adattamento volo, frusta fiammeggiante, mantello meteoritico, armatura pietra planare, artigli sette vie, carapace fase variabile -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
+      game_impact: Archetipo termico.
+      content: 'Il flagello igneo evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- adattamento volo, frusta fiammeggiante, mantello meteoritico, armatura pietra planare, artigli sette vie, carapace fase variabile -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo termico.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/data/codex/rotabrachium_ferox.yaml
+++ b/data/codex/rotabrachium_ferox.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Abisso Vulcanico
     biome_trait: Camini abissali con lava pressurizzata e fauna bio-termica
     lineage: forme a morfologia multi arto rotante
-    archetype: adattivo
+    archetype: termico
     morphotype: multi arto rotante
     job: vanguard
     role: predatore apex
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: adattivo'
+      - 'resistance_archetype: termico'
       - 'role_trofico: predatore_apex; sentient: False'
       - 'trait_refs: nucleo_ovomotore_rotante, frusta_fiammeggiante, mantello_meteoritico, focus_frazionato, artigli_sette_vie, coda_frusta_cinetica, empatia_coordinativa'
       cross_ref:
@@ -63,8 +63,8 @@ codex_entry:
       - trait:artigli_sette_vie
       - trait:coda_frusta_cinetica
       - trait:empatia_coordinativa
-      game_impact: Archetipo adattivo.
-      content: 'Il rotabraccio evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- nucleo ovomotore rotante, frusta fiammeggiante, mantello meteoritico, focus frazionato, artigli sette vie, coda frusta cinetica -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
+      game_impact: Archetipo termico.
+      content: 'Il rotabraccio evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- nucleo ovomotore rotante, frusta fiammeggiante, mantello meteoritico, focus frazionato, artigli sette vie, coda frusta cinetica -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo termico.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/data/codex/tellurmordax_phasicus.yaml
+++ b/data/codex/tellurmordax_phasicus.yaml
@@ -21,7 +21,7 @@ codex_entry:
     biome_name: Calanchi Ferromagnetici
     biome_trait: Altipiani arrugginiti con tempeste ferrose e rovine sepolte
     lineage: forme a morfologia scavatore corazzato
-    archetype: adattivo
+    archetype: corazzato
     morphotype: scavatore corazzato
     job: vanguard
     role: predatore terziario
@@ -51,7 +51,7 @@ codex_entry:
     L_linee_evolutive:
       heading: Linee evolutive
       key_facts:
-      - 'resistance_archetype: adattivo'
+      - 'resistance_archetype: corazzato'
       - 'role_trofico: predatore_terziario; sentient: False'
       - 'trait_refs: carapace_fase_variabile, coda_frusta_cinetica, armatura_pietra_planare, scheletro_idro_regolante'
       cross_ref:
@@ -60,8 +60,8 @@ codex_entry:
       - trait:coda_frusta_cinetica
       - trait:armatura_pietra_planare
       - trait:scheletro_idro_regolante
-      game_impact: Archetipo adattivo.
-      content: 'Il tellumordace di fase evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- carapace fase variabile, coda frusta cinetica, armatura pietra planare, scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo adattivo.'
+      game_impact: Archetipo corazzato.
+      content: 'Il tellumordace di fase evolve lungo le fasi un ciclo di adattamento continuo. I suoi tratti -- carapace fase variabile, coda frusta cinetica, armatura pietra planare, scheletro idro regolante -- non sono ornamenti ma risposte: ognuno racconta una pressione superata, in archetipo corazzato.'
     I_impianto:
       heading: Impianto morfo-fisiologico
       key_facts:

--- a/packs/evo_tactics_pack/data/species/abisso_vulcanico/pyroflagellum-meteoriticum.yaml
+++ b/packs/evo_tactics_pack/data/species/abisso_vulcanico/pyroflagellum-meteoriticum.yaml
@@ -1,6 +1,6 @@
 id: pyroflagellum_meteoriticum
 schema_version: '1.7'
-resistance_archetype: adattivo
+resistance_archetype: termico
 display_name: Flagello igneo
 biomes:
 - abisso_vulcanico

--- a/packs/evo_tactics_pack/data/species/abisso_vulcanico/rotabrachium-ferox.yaml
+++ b/packs/evo_tactics_pack/data/species/abisso_vulcanico/rotabrachium-ferox.yaml
@@ -1,6 +1,6 @@
 id: rotabrachium_ferox
 schema_version: '1.7'
-resistance_archetype: adattivo
+resistance_archetype: termico
 display_name: Rotabraccio
 biomes:
 - abisso_vulcanico

--- a/packs/evo_tactics_pack/data/species/badlands/tellurmordax-phasicus.yaml
+++ b/packs/evo_tactics_pack/data/species/badlands/tellurmordax-phasicus.yaml
@@ -1,6 +1,6 @@
 id: tellurmordax_phasicus
 schema_version: '1.7'
-resistance_archetype: adattivo
+resistance_archetype: corazzato
 display_name: Tellumordace di fase
 biomes:
 - badlands

--- a/packs/evo_tactics_pack/data/species/canopia_ionica/cryptopennatus-psionicus.yaml
+++ b/packs/evo_tactics_pack/data/species/canopia_ionica/cryptopennatus-psionicus.yaml
@@ -1,6 +1,6 @@
 id: cryptopennatus_psionicus
 schema_version: '1.7'
-resistance_archetype: adattivo
+resistance_archetype: psionico
 display_name: Esploratore di chioma
 biomes:
 - canopia_ionica

--- a/packs/evo_tactics_pack/data/species/caverna/lithoconstructus-inhibens.yaml
+++ b/packs/evo_tactics_pack/data/species/caverna/lithoconstructus-inhibens.yaml
@@ -1,6 +1,6 @@
 id: lithoconstructus_inhibens
 schema_version: '1.7'
-resistance_archetype: adattivo
+resistance_archetype: corazzato
 display_name: Litoautoma inibitore
 biomes:
 - caverna

--- a/packs/evo_tactics_pack/data/species/foresta_temperata/illusiopardus-psionicus.yaml
+++ b/packs/evo_tactics_pack/data/species/foresta_temperata/illusiopardus-psionicus.yaml
@@ -1,6 +1,6 @@
 id: illusiopardus_psionicus
 schema_version: '1.7'
-resistance_archetype: adattivo
+resistance_archetype: psionico
 display_name: Mascheraio illusorio
 biomes:
 - foresta_temperata

--- a/packs/evo_tactics_pack/data/species/reef_luminescente/amorphovenator-magneticus.yaml
+++ b/packs/evo_tactics_pack/data/species/reef_luminescente/amorphovenator-magneticus.yaml
@@ -1,6 +1,6 @@
 id: amorphovenator_magneticus
 schema_version: '1.7'
-resistance_archetype: adattivo
+resistance_archetype: bioelettrico
 display_name: Sondatore amorfo
 biomes:
 - reef_luminescente

--- a/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
@@ -1,3 +1,3 @@
-resistance_archetype: adattivo
+resistance_archetype: termico
 id: balor-fission
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'

--- a/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
@@ -1,3 +1,3 @@
-resistance_archetype: adattivo
+resistance_archetype: psionico
 id: banshee-risonante
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'

--- a/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
@@ -1,3 +1,3 @@
-resistance_archetype: adattivo
+resistance_archetype: corazzato
 id: bulette-fase
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'

--- a/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
@@ -1,3 +1,3 @@
-resistance_archetype: adattivo
+resistance_archetype: corazzato
 id: golem-runico
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'

--- a/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
@@ -1,3 +1,3 @@
-resistance_archetype: adattivo
+resistance_archetype: psionico
 id: rakshasa-corte
 notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'

--- a/tests/codex/archetypeCoherence.test.js
+++ b/tests/codex/archetypeCoherence.test.js
@@ -133,8 +133,9 @@ test('normSpeciesId aliases hyphens to underscores (pack ids are inconsistent)',
 test('loadSpeciesArchetypes resolves a known species id by its id field', () => {
   // Filenames hyphenate (lithoconstructus-inhibens.yaml) but ids underscore;
   // resolution must key on the in-file `id`, not the filename.
+  // Value = corazzato since the O8 design pass (owner-ratified 2026-07-02).
   const m = loadSpeciesArchetypes(REPO_ROOT);
-  assert.equal(m.get('lithoconstructus_inhibens'), 'adattivo');
+  assert.equal(m.get('lithoconstructus_inhibens'), 'corazzato');
 });
 
 test('loadSpeciesArchetypes resolves a HYPHEN-id species (Codex P1 #3090 gap)', () => {


### PR DESCRIPTION
## Summary

Owner-ratified design pass (AskUserQuestion 2026-07-02) closing the **O8 follow-up** to #3147: 12 species whose biome/name/trait kit strongly indicates a real archetype leave the `adattivo` default. Grounded in engine semantics (`resistanceEngine.js` + `species_resistances.yaml` profiles).

| Archetype | Species | Evidence |
|---|---|---|
| termico | pyroflagellum_meteoriticum, rotabrachium_ferox | fire kit (`fire_lash`, mantello meteoritico), abisso_vulcanico |
| termico | balor-fission | fire-demon stub |
| psionico | illusiopardus_psionicus, cryptopennatus_psionicus | declared psionic kits |
| psionico | banshee-risonante, rakshasa-corte | engine-LIVE psychic trait kits |
| corazzato | lithoconstructus_inhibens, tellurmordax_phasicus | armored construct / burrower (badlands pattern) |
| corazzato | golem-runico, bulette-fase | armored stubs |
| bioelettrico | amorphovenator_magneticus | the assigner's own magnet→bioelettrico rule |

**Deferred by owner**: orbital-ascendant (biome says psionico, keeper bioelettrico — decide at rostering). Skipped as weak: treant-portale, sonovespera, auroserpens.

## Codex coherence

The #3090 guard caught **7** codex entries with archetype prose (5 more than the initial grep — the guard earns its keep): all aligned surgically (lore_vars.archetype + key_fact + game_impact + prose tail, pattern #3087 — no regen, `codex_archive` untouched). +1 test pin updated to the ratified value.

## Band impact

**All 12 combat-INERT today**: zero hits in `data/encounters/*.yaml` + backend scenario builders (verified per-species). Archetype bites only at future rostering, where N=40 gating already exists.

## Verification

- `tests/codex/*` + `speciesArchetypeReferences` + `contracts-species-archetype` → **39/39**
- `validate-datasets` → green (14 checks)
- prettier clean

## Rollback (03A)

Revert — data-only, no runtime contract, no flag.