### PR TITLE
fix(vc): aggregate per-actor VC into session_end (vc_mbti was null forever)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -43,7 +43,11 @@ const {
   evaluateMovementTraits,
 } = require('../services/traitEffects');
 const { loadFairnessConfig, checkCapPtBudget, consumeCapPt } = require('../services/fairnessCap');
-const { loadTelemetryConfig, buildVcSnapshot } = require('../services/vcScoring');
+const {
+  loadTelemetryConfig,
+  buildVcSnapshot,
+  aggregateVcSnapshot,
+} = require('../services/vcScoring');
 // SPEC-A Device Input Ledger: validate + consent-gate device events into the
 // session event log, and tier-filter the TV-mirror channel (public + aggregated).
 const { ingest: ingestDeviceEvent } = require('../services/deviceInput');
@@ -4494,6 +4498,9 @@ function createSessionRouter(options = {}) {
       } catch {
         /* best-effort -- epigenome accumulation never blocks session end */
       }
+      const vcAgg = vcSnapshot
+        ? aggregateVcSnapshot(vcSnapshot)
+        : { aggregate: null, mbti: null, ennea: null };
       await appendEvent(session, {
         action_type: 'session_end',
         turn: session.turn,
@@ -4509,9 +4516,12 @@ function createSessionRouter(options = {}) {
         pressure_end: session.pressure ?? null,
         player_alive: playerAlive,
         sistema_alive: sistemaAlive,
-        vc_aggregate: vcSnapshot?.aggregate ?? null,
-        vc_mbti: vcSnapshot?.mbti ?? null,
-        vc_ennea: vcSnapshot?.ennea ?? null,
+        // #3157 follow-up: vcSnapshot has NO top-level aggregate/mbti/ennea
+        // (PR #1535 assumed it did -> null in every session_end ever logged).
+        // Aggregate per_actor session-side via vcScoring.aggregateVcSnapshot.
+        vc_aggregate: vcAgg.aggregate,
+        vc_mbti: vcAgg.mbti,
+        vc_ennea: vcAgg.ennea,
         automatic: true,
       });
       // Funnel telemetry auto-log (agent telemetry-viz-illuminator P0 #2).

--- a/apps/backend/services/vcScoring.js
+++ b/apps/backend/services/vcScoring.js
@@ -1060,6 +1060,66 @@ function buildVcSnapshot(session, config) {
   };
 }
 
+// #3157 follow-up (P4 analytics unblock) -- session-level VC aggregation for
+// the session_end telemetry event. PR #1535 wrote vcSnapshot.aggregate/.mbti/
+// .ennea into session_end, but buildVcSnapshot never returned those top-level
+// fields, so every session since logged null. Axis averaging mirrors
+// narrative/qbnEngine.extractQualities; ennea counts only TRIGGERED archetypes;
+// null indices (e.g. tilt, window-based) are skipped, never averaged as 0.
+function aggregateVcSnapshot(vcSnapshot) {
+  const actors = Object.values(vcSnapshot?.per_actor || {});
+  if (!actors.length) return { aggregate: null, mbti: null, ennea: null };
+
+  const axisSums = { T_F: 0, S_N: 0, E_I: 0, J_P: 0 };
+  let axisCount = 0;
+  const typeCounts = {};
+  const enneaCounts = {};
+  const indexSums = {};
+  const indexCounts = {};
+
+  for (const a of actors) {
+    const axes = a?.mbti_axes || {};
+    if (typeof axes.T_F === 'number') {
+      axisSums.T_F += axes.T_F;
+      axisSums.S_N += axes.S_N ?? 0.5;
+      axisSums.E_I += axes.E_I ?? 0.5;
+      axisSums.J_P += axes.J_P ?? 0.5;
+      axisCount++;
+    }
+    if (a?.mbti_type) typeCounts[a.mbti_type] = (typeCounts[a.mbti_type] || 0) + 1;
+    for (const arc of a?.ennea_archetypes || []) {
+      if (arc?.triggered && arc.id) enneaCounts[arc.id] = (enneaCounts[arc.id] || 0) + 1;
+    }
+    for (const [name, entry] of Object.entries(a?.aggregate_indices || {})) {
+      const v = entry && typeof entry === 'object' && 'value' in entry ? entry.value : null;
+      if (typeof v === 'number' && Number.isFinite(v)) {
+        indexSums[name] = (indexSums[name] || 0) + v;
+        indexCounts[name] = (indexCounts[name] || 0) + 1;
+      }
+    }
+  }
+
+  const avgAxes = axisCount
+    ? {
+        T_F: axisSums.T_F / axisCount,
+        S_N: axisSums.S_N / axisCount,
+        E_I: axisSums.E_I / axisCount,
+        J_P: axisSums.J_P / axisCount,
+      }
+    : null;
+  const aggregate = {};
+  for (const name of Object.keys(indexSums)) {
+    aggregate[name] = indexSums[name] / indexCounts[name];
+  }
+
+  return {
+    aggregate: Object.keys(aggregate).length ? aggregate : null,
+    mbti:
+      avgAxes || Object.keys(typeCounts).length ? { avg_axes: avgAxes, types: typeCounts } : null,
+    ennea: Object.keys(enneaCounts).length ? { triggered: enneaCounts } : null,
+  };
+}
+
 // 2026-05-14 OD-024 Phase B3 ai-station — sentience tier resolver.
 // Reads species_catalog.json (Game/ data/core/species/) and maps each unit
 // to its sentience_index via species_id lookup. Cache catalog per call site
@@ -1147,6 +1207,7 @@ module.exports = {
   deriveMbtiType,
   computeEnneaArchetypes,
   buildVcSnapshot,
+  aggregateVcSnapshot,
   tokenizeCondition,
   evaluateCondition,
   SCORING_VERSION,

--- a/tests/services/vcAggregateSnapshot.test.js
+++ b/tests/services/vcAggregateSnapshot.test.js
@@ -1,0 +1,80 @@
+// tests/services/vcAggregateSnapshot.test.js
+// TDD for aggregateVcSnapshot (issue #3157 follow-up, P4 analytics unblock).
+//
+// Root cause being fixed: PR #1535 wrote vcSnapshot.aggregate/.mbti/.ennea into
+// the session_end telemetry event, but buildVcSnapshot never returned those
+// top-level fields -- vc_aggregate/vc_mbti/vc_ennea logged null for EVERY
+// session since. This helper aggregates per_actor into session-level values
+// (axis average mirrors narrative/qbnEngine.extractQualities).
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { aggregateVcSnapshot } = require('../../apps/backend/services/vcScoring');
+
+function actor(overrides = {}) {
+  return {
+    mbti_axes: { T_F: 0.8, S_N: 0.6, E_I: 0.4, J_P: 0.2 },
+    mbti_type: 'ISTJ',
+    ennea_archetypes: [
+      { id: 'Individualista(4)', triggered: true },
+      { id: 'Perfezionista(1)', triggered: false },
+    ],
+    aggregate_indices: {
+      aggro: { value: 0.5 },
+      risk: { value: 0.3 },
+      tilt: null, // window-based, null on snapshots by design
+    },
+    ...overrides,
+  };
+}
+
+test('aggregates axes, types, triggered ennea and indices across actors', () => {
+  const snap = {
+    per_actor: {
+      a: actor(),
+      b: actor({
+        mbti_axes: { T_F: 0.2, S_N: 0.4, E_I: 0.6, J_P: 0.8 },
+        mbti_type: 'ENFP',
+        ennea_archetypes: [{ id: 'Individualista(4)', triggered: true }],
+        aggregate_indices: { aggro: { value: 0.7 }, risk: { value: 0.5 }, tilt: null },
+      }),
+    },
+  };
+  const out = aggregateVcSnapshot(snap);
+  assert.ok(out.mbti, 'mbti aggregated');
+  assert.equal(out.mbti.avg_axes.T_F, 0.5);
+  assert.equal(out.mbti.avg_axes.J_P, 0.5);
+  assert.deepEqual(out.mbti.types, { ISTJ: 1, ENFP: 1 });
+  assert.deepEqual(out.ennea, { triggered: { 'Individualista(4)': 2 } });
+  assert.equal(out.aggregate.aggro, 0.6);
+  assert.equal(out.aggregate.risk, 0.4);
+  assert.ok(!('tilt' in out.aggregate), 'null indices are skipped, not averaged as 0');
+});
+
+test('empty snapshot -> all nulls (session_end stays backward-compatible)', () => {
+  assert.deepEqual(aggregateVcSnapshot({ per_actor: {} }), {
+    aggregate: null,
+    mbti: null,
+    ennea: null,
+  });
+  assert.deepEqual(aggregateVcSnapshot(null), { aggregate: null, mbti: null, ennea: null });
+});
+
+test('actor without numeric axes does not poison the average', () => {
+  const snap = {
+    per_actor: {
+      good: actor(),
+      broken: actor({
+        mbti_axes: {},
+        mbti_type: null,
+        ennea_archetypes: [],
+        aggregate_indices: {},
+      }),
+    },
+  };
+  const out = aggregateVcSnapshot(snap);
+  assert.equal(out.mbti.avg_axes.T_F, 0.8, 'only the valid actor counts');
+  assert.deepEqual(out.mbti.types, { ISTJ: 1 });
+});


### PR DESCRIPTION
Salvage follow-up #3157: session_end scriveva vc_mbti/vc_ennea/vc_aggregate sempre null (PR #1535 leggeva campi che buildVcSnapshot non ha mai restituito). Nuovo vcScoring.aggregateVcSnapshot + wiring nel /end. TDD RED->GREEN 3/3 + regressione 60/60 + E2E: primo session_end popolato di sempre (types ESTJ, ennea triggered, 4 indici). Sblocca P4 Temperamenti analytics. Merge su CI verde autorizzato Eduardo.