### PR TITLE
fix(telemetry): retune riformatore setup_ratio 0.5 -> 0.3 (canon)

### DIFF
--- a/data/core/narrative/ennea_voices/type_1.yaml
+++ b/data/core/narrative/ennea_voices/type_1.yaml
@@ -4,7 +4,7 @@
 # critico, alta precisione, rigore morale. Voice persona: chi misura ogni gesto
 # contro standard interno. Sigla: "Bene fatto."
 #
-# Trigger telemetry: setup_ratio>0.5 && attack_hit_rate>0.65
+# Trigger telemetry: setup_ratio>0.3 && attack_hit_rate>0.65 (retune 2026-07-02)
 # Cross-ref museum: docs/museum/cards/enneagramma-mechanics-registry.md
 schema_version: "0.1.0"
 archetype_id: "Riformatore(1)"

--- a/data/core/telemetry.yaml
+++ b/data/core/telemetry.yaml
@@ -87,9 +87,12 @@ ennea_themes:
   # parziali). Soglie conservative — calibrabili in iter2 post-playtest.
   #
   # Riformatore(1) — perfezionista/principi: attacco metodico + precisione.
-  #   setup_ratio > 0.5      → maggioranza attacchi preceduti da posizionamento
+  #   setup_ratio > 0.3      → quota setup significativa. Retune canon
+  #     2026-07-02: 0.5 strutturalmente irraggiungibile (gli attacchi
+  #     diluiscono il ratio; EndTurnAction nel ledger lo stringe ancora).
+  #     Evidenza: GGv2 docs/godot-v2/qa/2026-07-02-ennea-pulse-firing-rate-sweep.md
   #   attack_hit_rate > 0.65 → alta precisione
-  - {id: "Riformatore(1)",   when: "setup_ratio>0.5 && attack_hit_rate>0.65"}
+  - {id: "Riformatore(1)",   when: "setup_ratio>0.3 && attack_hit_rate>0.65"}
   # Individualista(4) — identita/melanconia: resilienza emotiva sotto pressione.
   #   low_hp_time > 0.4      → tempo significativo in zona critica
   #   damage_dealt_total > 0 → contribuisce nonostante la sofferenza

--- a/tests/services/enneaEffectsWire.test.js
+++ b/tests/services/enneaEffectsWire.test.js
@@ -369,14 +369,17 @@ test('decay coerenza: Lealista(6) duration=2 → buff persiste 2 round end', () 
 // computeEnneaArchetypes config-driven trigger eval (raw-metrics)
 // ─────────────────────────────────────────────────────────────────
 
-test('computeEnneaArchetypes: Riformatore(1) trigger when setup_ratio>0.5 && attack_hit_rate>0.65', () => {
+test('computeEnneaArchetypes: Riformatore(1) trigger when setup_ratio>0.3 && attack_hit_rate>0.65', () => {
   const { computeEnneaArchetypes } = require('../../apps/backend/services/vcScoring');
+  // Retune canon 2026-07-02: era setup_ratio>0.5, strutturalmente
+  // irraggiungibile nel metric-space Godot (QA GGv2 firing-rate sweep).
+  // Il caso 0.35 fira SOLO con la soglia retuned: prova che il canon e' attivo.
   const config = {
-    ennea_themes: [{ id: 'Riformatore(1)', when: 'setup_ratio>0.5 && attack_hit_rate>0.65' }],
+    ennea_themes: [{ id: 'Riformatore(1)', when: 'setup_ratio>0.3 && attack_hit_rate>0.65' }],
   };
   const aggregate = {};
   const triggered = computeEnneaArchetypes(aggregate, config, {
-    setup_ratio: 0.6,
+    setup_ratio: 0.35,
     attack_hit_rate: 0.7,
   });
   assert.equal(triggered.length, 1);
@@ -384,7 +387,7 @@ test('computeEnneaArchetypes: Riformatore(1) trigger when setup_ratio>0.5 && att
   assert.equal(triggered[0].triggered, true);
 
   const notTrig = computeEnneaArchetypes(aggregate, config, {
-    setup_ratio: 0.3,
+    setup_ratio: 0.25,
     attack_hit_rate: 0.7,
   });
   assert.equal(notTrig[0].triggered, false);


### PR DESCRIPTION
## Cosa

Retune canon del trigger Riformatore(1) in `ennea_themes`: `setup_ratio>0.5` -> `setup_ratio>0.3` (hit_rate invariato). **Parity cross-repo** con GGv2 [MasterDD-L34D/Game-Godot-v2#579](https://github.com/MasterDD-L34D/Game-Godot-v2/pull/579) (stessa soglia in `vc_scoring.gd`). Ticket T1 arco Ennea Combat Pulse (hub handoff `2026-07-02-ryzen-ennea-tickets-arc.md`).

## Perche

Evidenza QA GGv2 `docs/godot-v2/qa/2026-07-02-ennea-pulse-firing-rate-sweep.md` esito 3: trigger auto-contraddittorio nel metric-space Godot (gli attacchi richiesti da hit_rate diluiscono setup_ratio sotto 0.5). Il yaml stesso marca le soglie 9/9-coverage come "conservative -- calibrabili in iter2 post-playtest": questa e' la prima calibrazione, guidata da sweep riproducibile.

`vcScoring.js` parsa `ennea_themes[].when` dal yaml -> nessun hardcode JS da toccare; la parity backend arriva dal dato.

## Verifica

- Sweep GGv2 v4: Riformatore raggiungibile su HP 7/15/32 (profilo tactician), zero falsi positivi (righe altri profili invariate), copertura mechanical 7/7 per fascia.
- `node --test tests/services/enneaEffectsWire.test.js`: **31/31 pass**. Fixture aggiornata: il caso 0.35 fira SOLO con la soglia retuned (prova che il canon nuovo e' attivo), 0.25 resta sotto.
- Prettier check clean sui 3 file.

## File

- `data/core/telemetry.yaml` -- soglia canon + rationale nel commento
- `data/core/narrative/ennea_voices/type_1.yaml` -- commento mirror
- `tests/services/enneaEffectsWire.test.js` -- fixture parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)