### PR TITLE
feat(coop): per-player profiling consent nel coop store (t2)

### DIFF
--- a/apps/backend/services/coop/coopOrchestrator.js
+++ b/apps/backend/services/coop/coopOrchestrator.js
@@ -93,6 +93,11 @@ function characterToUnit(character, { index = 0 } = {}) {
     ...(character.default_parts && typeof character.default_parts === 'object'
       ? { default_parts: character.default_parts }
       : {}),
+    // T2 privacy (arco Ennea Combat Pulse) -- carry the per-player style
+    // profiling opt-out to the unit dict: the Godot runtime gates pulses on
+    // `unit.profiling_opt_out` (GGv2 ennea_effects.gd). Additive mirror of
+    // default_parts: absent unless explicitly boolean true (back-compat).
+    ...(character.profiling_opt_out === true ? { profiling_opt_out: true } : {}),
   };
 }
 
@@ -176,6 +181,10 @@ class CoopOrchestrator {
     // UI-only `form_pulse` transient phase can populate without strict
     // coupling to PHASES enum (mirror revealAcks pattern).
     this.formPulses = new Map(); // player_id → { axes: {k:Number}, ts }
+    // T2 privacy (arco Ennea Combat Pulse) -- per-player style-profiling
+    // opt-out. Sopravvive qui per i toggle arrivati PRIMA del submit del
+    // character; al submit viene stampata sul record (vedi submitCharacter).
+    this.profilingOptOut = new Map(); // player_id → bool (true = opt-out)
     // Form-Pulse trait v2 Piece 2: per-player minor trait tracked for idempotent re-derive.
     this.playerMinorTraits = new Map(); // player_id → minor trait_id
     // #2674 -- shared branco trait emergent from the aggregated Form Pulse;
@@ -580,6 +589,11 @@ class CoopOrchestrator {
       ready: true,
       submitted_at: this.now(),
     };
+    // T2 privacy -- pref opt-out arrivata prima del submit: stampala sul
+    // record (additive: campo presente solo su opt-out, mirror default_parts).
+    if (this.profilingOptOut.get(playerId) === true) {
+      normalized.profiling_opt_out = true;
+    }
     this.characters.set(playerId, normalized);
     // N2 -- persist the created PG to party_rosters (run.id-keyed), best-effort
     // and fire-and-forget. Never block / throw into the submit path: the sync
@@ -834,6 +848,30 @@ class CoopOrchestrator {
       submitted: Array.from(this.formPulses.keys()),
       emergent_branco_trait: emergent,
     };
+  }
+
+  /**
+   * T2 privacy (arco Ennea Combat Pulse) -- consenso profilazione stile
+   * per-player. `enabled=false` -> opt-out: stampato sul character record
+   * (quando gia' presente) cosi' characterToUnit porta `profiling_opt_out`
+   * nel payload /session/start; il runtime Godot gate-a i pulse per-unit
+   * (GGv2 ennea_effects.gd) e l'host fa amnesia live sul broadcast.
+   * Pattern precedente session-scoped: routes/session.js device-event
+   * `session.profilingConsent`.
+   * @returns { player_id, profiling_opt_out } snapshot per broadcast/ack.
+   */
+  setProfilingConsent(playerId, enabled) {
+    if (!playerId) throw new Error('player_id_required');
+    const optOut = enabled !== true;
+    this.profilingOptOut.set(playerId, optOut);
+    const ch = this.characters.get(playerId);
+    if (ch) {
+      if (optOut) ch.profiling_opt_out = true;
+      else delete ch.profiling_opt_out;
+    }
+    const snap = { player_id: playerId, profiling_opt_out: optOut };
+    this._emit('profiling_consent_set', snap);
+    return snap;
   }
 
   /**

--- a/apps/backend/services/network/wsSession.js
+++ b/apps/backend/services/network/wsSession.js
@@ -2104,6 +2104,34 @@ function createWsServer({
             }
             return;
           }
+          // T2 privacy (arco Ennea Combat Pulse) -- drain profiling_consent_set
+          // server-side via coopOrchestrator.setProfilingConsent (mirror del
+          // drain form_pulse_submit: nessun pushIntent relay, l'host Godot non
+          // ha drain GDScript generico). Broadcast `profiling_consent_update`
+          // cosi' l'host applica il gate per-unit + amnesia live
+          // (GGv2 main_profiling_consent.gd); ack al sender.
+          if (action === 'profiling_consent_set' && coopStore) {
+            try {
+              const orch = coopStore.get(room.code);
+              if (!orch) {
+                socket.send(
+                  JSON.stringify({ type: 'error', payload: { code: 'run_not_started' } }),
+                );
+                return;
+              }
+              const snap = orch.setProfilingConsent(playerId, msg.payload?.enabled === true);
+              room.broadcast({ type: 'profiling_consent_update', payload: snap });
+              socket.send(JSON.stringify({ type: 'profiling_consent_accepted', payload: snap }));
+            } catch (err) {
+              socket.send(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { code: err.message || 'profiling_consent_failed' },
+                }),
+              );
+            }
+            return;
+          }
           // 2026-05-06 phone smoke W7 fix — drain next_macro server-side via
           // coopOrchestrator.submitNextMacro. Host-only post-debrief macro
           // navigation choice {advance, branch, retreat}. Pre-fix relay

--- a/tests/api/coopProfilingConsent.test.js
+++ b/tests/api/coopProfilingConsent.test.js
@@ -1,0 +1,90 @@
+// T2 privacy -- arco Ennea Combat Pulse: consenso profilazione stile
+// per-player nel coop store. Precedente session-scoped:
+// routes/session.js device-event `session.profilingConsent`. Qui la pref
+// e' per-player e room-scoped: stampata sul character record cosi'
+// characterToUnit la porta nel payload /session/start (additive, mirror
+// del pattern default_parts: campo ASSENTE quando il consenso e' attivo,
+// presente solo su opt-out -- back-compat totale).
+// Consumer runtime Godot: unit.profiling_opt_out gate in
+// GGv2 scripts/ai/ennea_effects.gd:206.
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  CoopOrchestrator,
+  characterToUnit,
+} = require('../../apps/backend/services/coop/coopOrchestrator');
+
+const ALL = { allPlayerIds: ['p_a', 'p_b'] };
+
+function mk(n) {
+  return { name: n, form_id: 'f', species_id: 's', job_id: 'guerriero' };
+}
+
+function partyOrch() {
+  const co = new CoopOrchestrator({ roomCode: 'PRIV', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('character_creation');
+  co.submitCharacter('p_a', mk('A'), ALL);
+  co.submitCharacter('p_b', mk('B'), ALL);
+  return co;
+}
+
+test('default: nessuna pref -> unit senza campo profiling_opt_out (back-compat)', () => {
+  const co = partyOrch();
+  const { units } = co.buildSessionStartPayload();
+  assert.equal(units.length, 2);
+  for (const u of units) {
+    assert.equal('profiling_opt_out' in u, false);
+  }
+});
+
+test('setProfilingConsent(false) -> character stampato + unit porta profiling_opt_out', () => {
+  const co = partyOrch();
+  const snap = co.setProfilingConsent('p_a', false);
+  assert.deepEqual(snap, { player_id: 'p_a', profiling_opt_out: true });
+  assert.equal(co.characters.get('p_a').profiling_opt_out, true);
+  const { units } = co.buildSessionStartPayload();
+  const ua = units.find((u) => u.owner_id === 'p_a');
+  const ub = units.find((u) => u.owner_id === 'p_b');
+  assert.equal(ua.profiling_opt_out, true);
+  assert.equal('profiling_opt_out' in ub, false, 'pref di p_a non tocca p_b');
+});
+
+test('re-enable -> campo assente di nuovo (nessun residuo opt-out)', () => {
+  const co = partyOrch();
+  co.setProfilingConsent('p_a', false);
+  const snap = co.setProfilingConsent('p_a', true);
+  assert.deepEqual(snap, { player_id: 'p_a', profiling_opt_out: false });
+  assert.equal('profiling_opt_out' in co.characters.get('p_a'), false);
+  const { units } = co.buildSessionStartPayload();
+  const ua = units.find((u) => u.owner_id === 'p_a');
+  assert.equal('profiling_opt_out' in ua, false);
+});
+
+test('pref settata PRIMA di submitCharacter -> applicata al submit', () => {
+  const co = new CoopOrchestrator({ roomCode: 'PRIV', hostId: 'p_h' });
+  co.startOnboarding({ scenarioStack: ['enc_demo'] });
+  co._setPhase('character_creation');
+  co.setProfilingConsent('p_a', false);
+  co.submitCharacter('p_a', mk('A'), { allPlayerIds: ['p_a'] });
+  const { units } = co.buildSessionStartPayload();
+  assert.equal(units[0].profiling_opt_out, true);
+});
+
+test('characterToUnit: passthrough additive (host-forward /session/start parity)', () => {
+  const base = { name: 'A', form_id: 'f', species_id: 's', player_id: 'p_a' };
+  const withOptOut = characterToUnit({ ...base, profiling_opt_out: true });
+  assert.equal(withOptOut.profiling_opt_out, true);
+  const without = characterToUnit(base);
+  assert.equal('profiling_opt_out' in without, false);
+  // Solo boolean true stampa il campo: valori truthy sporchi non passano.
+  const dirty = characterToUnit({ ...base, profiling_opt_out: 'yes' });
+  assert.equal('profiling_opt_out' in dirty, false);
+});
+
+test('player_id vuoto -> throw player_id_required', () => {
+  const co = partyOrch();
+  assert.throws(() => co.setProfilingConsent('', false), /player_id_required/);
+});


### PR DESCRIPTION
## Cosa

Ticket T2 arco Ennea Combat Pulse (hub handoff `2026-07-02-ryzen-ennea-tickets-arc.md`): pref privacy "profilazione stile" **per-player** nel coop store. Precedente session-scoped: `session.profilingConsent` (routes/session.js device-event).

**Parity GGv2**: da mergiare insieme alla PR GGv2 cross-linkata (toggle phone + host mirror) -- link nel primo commento.

## Come

- `coopOrchestrator.setProfilingConsent(playerId, enabled)`: opt-out stampato sul **character record** (additive, mirror `default_parts`: campo presente SOLO su opt-out = back-compat totale) + Map per i toggle arrivati prima del submit.
- `characterToUnit`: passthrough additive di `profiling_opt_out` -- vale sia per `buildSessionStartPayload` sia per il forward host a `/session/start`; il runtime Godot gate-a i pulse per-unit (`ennea_effects.gd`).
- `wsSession`: drain intent `profiling_consent_set` (mirror `form_pulse_submit`: no pushIntent relay) -> broadcast `profiling_consent_update` (host applica gate + amnesia live) + ack sender-only.

## Verifica

- `node --test tests/api/coopProfilingConsent.test.js`: **6/6** (default assente, stamp+isolamento per-player, re-enable senza residui, pref pre-submit, passthrough con guard anti-truthy-sporchi, throw su player_id vuoto).
- Regressione coop completa: **252/252**. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)