### PR TITLE
chore(governance): doc-pins guardrail follow-ups (visibility + OD-060)

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -69,6 +69,27 @@ jobs:
           path: reports/docs/governance_drift_report.json
           if-no-files-found: warn
 
+      - name: Broken doc-pin visibility (warning-tier surface)
+        if: always()
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, pathlib
+          rep = pathlib.Path("reports/docs/governance_drift_report.json")
+          pins = []
+          if rep.exists():
+              data = json.loads(rep.read_text(encoding="utf-8"))
+              pins = [i for i in data.get("issues", []) if i.get("code") == "broken_doc_pin"]
+          print("## Broken doc-pins (warning-tier)")
+          if pins:
+              print(f"{len(pins)} non-baselined code/config reference(s) to missing docs/ paths:")
+              for p in pins[:20]:
+                  print(f"- `{p.get('path','')}` -- {p.get('message','')}")
+              if len(pins) > 20:
+                  print(f"- ... and {len(pins) - 20} more (see the uploaded governance report)")
+          else:
+              print("None new (baseline clean).")
+          PY
+
       - name: Workflow summary
         if: always()
         run: |

--- a/OPEN_DECISIONS.md
+++ b/OPEN_DECISIONS.md
@@ -15,8 +15,9 @@
 
 _Generato da `tools/generate_open_decisions.py`. NON editare a mano: edita i comment `<!-- od … -->` di ogni sezione e rigenera._
 
-| OD  | Titolo | Livello | Ref |
-| --- | ------ | ------- | --- |
+| OD                                                                     | Titolo                                               | Livello                                                                 | Ref      |
+| ---------------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------- | -------- |
+| [OD-060](#od-060-doc-pins-guardrail----pins-strict-flip-prerequisites) | doc-pins guardrail -- pins-strict flip prerequisites | P2 (governance DX; opened as the PR #3191 doc-pins guardrail follow-up) | PR #3191 |
 
 <!-- /gen:od-open -->
 
@@ -584,6 +585,16 @@ Se la decisione:
 allora **non basta questo file**: serve **checkpoint umano** + **ADR ufficiale** in `docs/adr/`. OPEN_DECISIONS è per ambiguità tattiche operative.
 
 **Anti-pattern**: accumulare OD senza review. Periodicamente (ogni 2-3 sprint) → batch review + chiusura o escalation ad ADR.
+
+### [OD-060] doc-pins guardrail -- pins-strict flip prerequisites
+
+<!-- od id=OD-060 status=open -->
+
+- **Livello**: P2 (governance DX; opened as the PR #3191 doc-pins guardrail follow-up)
+- **Contesto**: `broken_doc_pin` (PR #3191) e' warning-tier -- diagnostico, non preventivo: un doc-move che rompe un ref docs/ in un workflow/tool passa CI verde. Il valore anti-regressione arriva solo col flip a `--pins-strict`.
+- **Prerequisiti al flip** (harsh-review PR #3191): (1) enforcement baseline decreasing-only -- un CI-assert che `docs/governance/doc_pins_baseline.json` non e' cresciuto vs origin/main (diff-count), cosi' la baseline non diventa un canale di silenziamento non-ratcheted accanto al gate; (2) audit case-sensitivity -- l'existence-check `(repo_root / pin).exists()` e' case-sensitive su Linux-CI ma case-insensitive su dev-Windows, quindi un pin con case sbagliato passa in locale e romperebbe solo in CI al flip.
+- **Default proposto**: restare warning-tier finche' i 2 prereq non sono soddisfatti. La visibilita' e' gia' migliorata -- i broken pin non-baselined ora appaiono nel `$GITHUB_STEP_SUMMARY` del job docs-governance (stesso follow-up PR).
+- **Ref**: PR #3191
 
 ## Ref
 


### PR DESCRIPTION
Two Eduardo-approved follow-ups to the merged doc-pins guardrail (#3191), from the harsh-review findings:

**Q1 -- visibility (Significant #1)**: new `docs-governance.yml` step "Broken doc-pin visibility" surfaces the non-baselined `broken_doc_pin` issues from the governance report into the job `$GITHUB_STEP_SUMMARY` (mirrors the `link_check` pattern). While the check stays warning-tier (pre `--pins-strict`), broken pins are now VISIBLE in the PR instead of buried in the uploaded artifact -- turning the guardrail from silently-diagnostic to visibly-diagnostic. Verified: YAML parses, the heredoc+filter runs green in bash on both the empty and pins-present paths (re-checked AFTER the husky prettier reformat), added lines ASCII-clean, the tracked report is git-restored (no timestamp churn committed).

**Q2 -- flip prerequisites (Significant #2)**: `OPEN_DECISIONS.md` **OD-060** tracks the `--pins-strict` flip prereqs so the debt is explicit: (1) baseline decreasing-only enforcement (diff-count vs main), (2) case-sensitivity audit (`exists()` is case-insensitive on dev-Windows, case-sensitive on Linux-CI). Table regenerated via `generate_open_decisions.py` (`--check` in sync).

Both are additive (+34/-2). MERGE = Eduardo (governance-critical; the changes were explicitly requested).
