### PR TITLE
feat(combat): fase-2c grid-wiring -- honor authored grid_size via board_scale (band-neutral, opt-in)

### DIFF
--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -20,7 +20,7 @@
 ## Index per data (cronologico)
 
 <!-- gen:adr-index -->
-_Generato da `tools/generate_decisions_log.py` (73 ADR). NON editare a mano: editi gli ADR in `docs/adr/`._
+_Generato da `tools/generate_decisions_log.py` (74 ADR). NON editare a mano: editi gli ADR in `docs/adr/`._
 
 | Data | ADR | Titolo | Status |
 | --- | --- | --- | --- |
@@ -97,6 +97,7 @@ _Generato da `tools/generate_decisions_log.py` (73 ADR). NON editare a mano: edi
 | 2026-06-08 | [ADR-2026-06-08-i18n-unify-data-i18n](docs/adr/ADR-2026-06-08-i18n-unify-data-i18n.md) | ADR 2026-06-08 -- i18n: unificare su data/i18n come sorgente unica (QA3) | Accepted |
 | 2026-06-08 | [ADR-2026-06-08-onboarding-per-creature-trait](docs/adr/ADR-2026-06-08-onboarding-per-creature-trait.md) | ADR 2026-06-08 -- Onboarding: trait per-creatura + branco emergente (supersede 51-ONBOARDING-60S, MA1) | Accepted |
 | 2026-06-19 | [ADR-2026-06-19-taxonomy-authoring-sot-steady-state](docs/adr/ADR-2026-06-19-taxonomy-authoring-sot-steady-state.md) | ADR-2026-06-19 -- taxonomy authoring SoT steady-state (RFC #4 S3 NO-GO) | Accepted |
+| 2026-07-03 | [ADR-2026-07-03-authored-grid-board-scale](docs/adr/ADR-2026-07-03-authored-grid-board-scale.md) | ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in) | Proposed |
 <!-- /gen:adr-index -->
 
 ## Index per tag

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2392,24 +2392,6 @@ function createSessionRouter(options = {}) {
         console.warn('[damage-curves] apply failed:', err.message);
       }
 
-      // ADR-2026-04-17: grid auto-scale basato su deployed PG count (party.yaml)
-      let gridW = GRID_SIZE;
-      let gridH = GRID_SIZE;
-      try {
-        const { gridSizeFor, getModulation } = require('../../../services/party/loader');
-        const requestedModulation = req.body?.modulation;
-        let deployedCount = units.filter((u) => u && u.controlled_by === 'player').length;
-        if (requestedModulation) {
-          const preset = getModulation(requestedModulation);
-          if (preset) deployedCount = preset.deployed;
-        }
-        const [gw, gh] = gridSizeFor(deployedCount);
-        gridW = gw;
-        gridH = gh;
-      } catch {
-        // fallback GRID_SIZE default
-      }
-
       // SPRINT_020: calcola turn_order via iniziativa descending.
       const turnOrder = buildTurnOrder(units);
       const firstActiveId = turnOrder[0] || null;
@@ -2459,6 +2441,24 @@ function createSessionRouter(options = {}) {
         refreshNucleiCoordinamento(units);
       } catch (err) {
         console.warn('[coordinamento] refresh failed:', err.message);
+      }
+
+      // ADR-2026-04-17 (default 'party_sized') + ADR-2026-07-03 (opt-in 'grid_sized'): la board =
+      // grid_size autorato se l'encounter opta board_scale:'grid_sized' con grid_size valido,
+      // altrimenti party fill-ratio (gridSizeFor). resolveBoardSize = unico punto board. Collocato
+      // dopo la risoluzione di encounterPayload (incl. YAML via loadEncounter) cosi' che il grid
+      // autorato sia disponibile qui (il vecchio blocco stava prima e non lo vedeva).
+      let gridW = GRID_SIZE;
+      let gridH = GRID_SIZE;
+      try {
+        const { resolveBoardSize } = require('../../../services/party/loader');
+        const requestedModulation = req.body?.modulation;
+        const deployedCount = units.filter((u) => u && u.controlled_by === 'player').length;
+        const [gw, gh] = resolveBoardSize(deployedCount, encounterPayload, requestedModulation);
+        gridW = gw;
+        gridH = gh;
+      } catch {
+        // fallback GRID_SIZE default
       }
 
       const session = {

--- a/docs/adr/ADR-2026-07-03-authored-grid-board-scale.md
+++ b/docs/adr/ADR-2026-07-03-authored-grid-board-scale.md
@@ -1,0 +1,159 @@
+---
+title: 'ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in)'
+doc_status: draft
+doc_owner: master-dd
+workstream: combat
+last_verified: 2026-07-03
+source_of_truth: false
+language: it
+review_cycle_days: 90
+proposed_by: claude-code (fase-2c grid-wiring, sot-planner)
+owner: master-dd
+related_adr:
+  - docs/adr/ADR-2026-04-17-coop-scaling-4to8.md
+  - docs/adr/ADR-2026-04-16-grid-type-hex-axial.md
+  - docs/adr/ADR-2026-04-28-grid-type-square-final.md
+related_spec:
+  - docs/superpowers/specs/2026-07-03-fase2c-grid-wiring-design.md
+related_files:
+  - schemas/evo/encounter.schema.json
+  - services/party/loader.js
+  - apps/backend/routes/session.js
+  - tools/sim/scenario-enemies.js
+  - docs/core/15-LEVEL_DESIGN.md
+---
+
+# ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in)
+
+## Status
+
+**SIGNED-OFF** owner 2026-07-03 (opzione 1; naming ratificato `party_sized`/`grid_sized`). Il campo
+`doc_status` resta `draft` finche' il build-PR non atterra (flip -> `active` al land, scelta owner).
+Draft prodotto da `sot-planner`. Il BUILD (implementazione + N=40 re-ratify se/quando un encounter
+opta `grid_sized`) e' partito su go-signal esplicito owner nella sessione fresca (vedi Sequencing).
+
+## Contesto
+
+Il campo `encounter.grid_size` (`[w, h]`, array 2 interi, schema `schemas/evo/encounter.schema.json`)
+e' **autorato ma inerte a runtime**. La dimensione della board effettivamente giocata e' decisa da
+`gridSizeFor(deployedCount)` (`services/party/loader.js:55`), guidata da `data/core/party.yaml
+grid_scaling` (6x6 / 8x8 / 10x10 per fascia di PG schierati, derivazione ratificata da
+ADR-2026-04-17 "co-op scaling 4->8"). `apps/backend/routes/session.js:2396-2410` chiama
+`gridSizeFor(deployedCount)` direttamente per calcolare `gridW`/`gridH`; `encounter.grid_size` non
+viene letto in nessun punto del path di dimensionamento board. Il simulatore
+(`tools/sim/scenario-enemies.js:41`) segue lo stesso schema: dimensiona da `gridSizeFor` e clampa
+gli spawn autorati a `GRID_SAFE_MAX=5`, con un commento nel codice che marca esplicitamente
+"authored per-encounter grid e' fase-2c".
+
+Un mito documentale rinforza la confusione: `docs/core/15-LEVEL_DESIGN.md:122` afferma che
+l'encounter `hardcore-06` usa un "override esplicito 10x10 via `grid_size: 10`" -- affermazione
+FALSA/fuorviante verificata contro il codice: quel 10x10 e' prodotto dalla modulation a 8 PG
+(`gridSizeFor` fascia `deployed_7_8`), non da un campo YAML. Il documento va corretto nel BUILD
+(fuori scope qui).
+
+Il vincolo di fill-ratio in `party.yaml grid_scaling` (mantenere fill < 25% a roster fisso) e' un
+vincolo di **leggibilita' tattica**, non un cap di difficolta' -- e' cosi che l'ha inquadrato la
+ricerca del big-maps arc padre (D1 ratificato: "per-cella, board grandi subito"): una board grande a
+fill basso resta leggibile se la densita' viene da terrain/objective invece che da conteggio unita'.
+Questo e' il motivo per cui onorare il grid autorato non e' semplicemente "rendere il campo YAML
+funzionante", ma richiede una decisione ADR-level che si posiziona rispetto alla derivazione
+party-grid gia' governata da ADR-2026-04-16 (hex axial, superseded) e ADR-2026-04-17 (coop-scaling
+4->8, la derivazione attualmente vigente).
+
+Ground-truth verificato origin/main 2026-07-03, post-merge #3197 (xpBudget geometry gate, flag OFF,
+author-guard grid-ratify + baseline). Dettaglio completo in
+`docs/superpowers/specs/2026-07-03-fase2c-grid-wiring-design.md`.
+
+## Decisione
+
+**La board autorata per-encounter (`encounter.grid_size`) e' il path sancito per gli encounter che
+optano esplicitamente `board_scale: grid_sized`** (board non vincolate dalla leggibilita' a
+roster-fisso). **`gridSizeFor` (derivazione party fill-ratio, ADR-2026-04-17) resta il default per
+`board_scale: party_sized`.**
+
+Meccanismo (opt-in, band-neutral di default):
+
+- Nuovo campo encounter `board_scale: party_sized | grid_sized`, default `party_sized`.
+- `party_sized` (default, tutti i 21 encounter esistenti): comportamento attuale, byte-identical --
+  `gridSizeFor(deployedCount)` decide la board, `encounter.grid_size` resta ignorato per quell'
+  encounter.
+- `grid_sized`: la board usa `encounter.grid_size` cosi come autorato, bypassando `gridSizeFor`.
+- `gridSizeFor` e la derivazione ADR-2026-04-17 restano **invariati** -- questa decisione e'
+  un'estensione opt-in, non una riscrittura della derivazione party-grid esistente.
+- Nessun cambio al cap dello schema (`grid_size` max resta 20).
+
+## Conseguenze
+
+### Positive
+
+- **Band-neutral per costruzione**: con `board_scale: party_sized` come default su tutti i 21
+  encounter attuali, `resolveBoardSize == gridSizeFor` -> board identica -> zero cambio di
+  difficolta'/sim. Solo un encounter che opta esplicitamente `grid_sized` cambia board.
+- Sblocca il D1 del big-maps arc padre ("per-cella, board grandi subito") senza toccare il default
+  ne' richiedere un re-balance di massa sui 21 encounter esistenti.
+- Coerente con D10 (visual-first) del padre: il wiring e' backend/opt-in, non ingrandisce nulla di
+  default, non tocca il render/Godot.
+
+### Negative / rischi
+
+- **Introduce un secondo path di dimensionamento board** (party-derived vs grid_sized) -- superficie
+  di manutenzione aggiuntiva in `services/party/loader.js` e nei consumer (`session.js`,
+  `tools/sim/scenario-enemies.js`). Mitigazione: un solo helper puro (`resolveBoardSize`) come
+  unico punto di decisione, entrambi i path lo attraversano.
+- Ogni encounter che passa a `grid_sized` con una board ridimensionata **deve** ripassare il ciclo
+  N=10 probe -> N=40 ratify (vedi Sequencing) -- non e' un flip gratuito.
+- Board `grid_sized` grandi a fill basso sono ora **accettate per design** (non piu' un anti-pattern
+  da evitare) -- la review balance deve giudicare la leggibilita' su terrain/objective density
+  invece che sul rapporto unita'/tile. Questo e' un cambio di criterio di review, non solo di
+  codice.
+
+### Neutral
+
+- Il mito hardcore-06 in `docs/core/15-LEVEL_DESIGN.md:122` va corretto (fuori scope in questo ADR,
+  parte del BUILD).
+
+## Alternative considerate
+
+### A. Riscrivere ADR-2026-04-17 per rendere il grid autorato il default
+
+**Rigettata.** Romperebbe la band-neutrality sui 21 encounter esistenti (tutti verrebbero
+riletti come "grid_sized" o richiederebbero una migrazione dati esplicita) e violerebbe D10
+(visual-first: nessun cambio di board non richiesto). Il default fill-ratio party-derived resta
+corretto per il contenuto non-autorato -- non c'e' evidenza che vada sostituito ovunque, solo che
+serva un'via di fuga opt-in per encounter specifici.
+
+### B. Override scalare `grid_size: 10` (il "mito" hardcore-06)
+
+**Rigettata.** Non rappresentabile nello schema attuale: `grid_size` richiede un array `[w, h]`, non
+uno scalare. Inoltre il comportamento che il mito descrive (10x10 su hardcore-06) e' gia' prodotto
+oggi dalla modulation a 8 giocatori (`gridSizeFor` fascia `deployed_7_8`), non da un campo YAML --
+quindi anche se lo schema accettasse uno scalare, non risolverebbe il problema reale (grid_size
+autorato inerte), risolverebbe solo un sintomo gia' spiegato da un meccanismo diverso.
+
+## Sequencing
+
+Ordine di dipendenza tra questo ADR, il gate di geometria gia' mergiato, e il flip finale:
+
+1. **#3197 (merged, main `879c11864` e successivi)** -- xpBudget geometry gate (flag OFF) +
+   author-guard grid-ratify (`tools/js/validate_encounter_grid_ratify.js`) + regola L-069 codificata
+   (cambio `grid_size` -> re-run N=10 probe -> N=40 ratify; la ratifica non si trasferisce tra
+   resize). Questo e' il **prerequisito di safety**: rende gate-safe qualunque resize futuro prima
+   che il wiring lo renda possibile.
+2. **Questo ADR + wiring fase-2c (sessione fresca, BUILD)** -- implementa `board_scale` +
+   `resolveBoardSize` + wire in `session.js` + parity in `tools/sim/scenario-enemies.js` + doc
+   correction. Band-neutral: nessun encounter esistente cambia board (tutti restano `party_sized`).
+3. **Autorare >=1 encounter `board_scale: grid_sized`** con un `grid_size` ridimensionato --
+   attiva l'obbligo di re-ratify.
+4. **N=10 probe -> N=40 ratify** sull'encounter `grid_sized` (author-guard #3197 lo richiede).
+5. **Flip del gate geometria** (xpBudget hazard/activation, oggi flag OFF) post-N=40, quando si
+   vuole misurare hazard/activation sul board reale autorato.
+
+Il wiring di questo ADR **abilita** il resize che #3197 rende gate-safe; non lo sostituisce e non
+salta la sequenza di ratifica.
+
+## Decisioni owner (2026-07-03, risolte)
+
+- Naming: **RATIFICATO** `board_scale` (`party_sized`/`grid_sized`) -- owner sign-off 2026-07-03.
+- `doc_status`: resta `draft` fino al merge del build-PR, poi flip -> `active` (scelta owner).
+- Accettazione != start-build automatico per design; il build e' partito su go-signal esplicito
+  ("parti col build") nella stessa sessione.

--- a/docs/core/15-LEVEL_DESIGN.md
+++ b/docs/core/15-LEVEL_DESIGN.md
@@ -119,7 +119,7 @@ Grid size deriva da **deployed PG** via `party.yaml` grid_scaling: 1-4 PG → 6�
 
 Turn_limit_defeat (ADR-2026-04-20 + M9 P6): hardcore=25, boss=20 (force decision pressure Long War pattern).
 
-**Note**: encounter tutorial 01-05 usano 6×6 perché modulation scout (2 PG). Hardcore-06 override esplicito 10×10 via `grid_size: 10` (8 PG full modulation). Vedi `apps/backend/services/party/loader.js` `gridSizeFor(deployed)`.
+**Note**: encounter tutorial 01-05 usano 6x6 perche' modulation scout (2 PG). Hardcore-06 gioca 10x10 perche' la **modulation 8-PG full-coop** (`gridSizeFor` fascia `deployed_7_8`), NON perche' il campo `grid_size` -- che di default (`board_scale: party_sized`) resta **inerte** per il dimensionamento della board (la board la decide `gridSizeFor(deployed)`; il vecchio "`grid_size: 10`" era un mito -- scalare non rappresentabile, lo schema vuole `[w, h]`). Per una board **autorata** indipendente dal party, l'encounter deve optare `board_scale: grid_sized` (ADR-2026-07-03): allora la board = il suo `grid_size` `[w, h]` via `resolveBoardSize`. Vedi `services/party/loader.js` (`resolveBoardSize` / `gridSizeFor`). Una board `grid_sized` ridimensionata DEVE ripassare il ciclo N=10 -> N=40 (regola sotto).
 
 ### Regola re-ratify grid (2026-07-03)
 

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -13809,6 +13809,19 @@
       "review_cycle_days": 90,
       "primary": false,
       "track": "active"
+    },
+    {
+      "path": "docs/superpowers/plans/2026-07-03-fase2c-grid-wiring.md",
+      "title": "fase-2c grid-wiring: honor authored grid_size via board_scale -- implementation plan (as-built)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "combat",
+      "last_verified": "2026-07-03",
+      "source_of_truth": false,
+      "language": "it-en",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "active"
     }
   ]
 }

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -13796,6 +13796,19 @@
       "review_cycle_days": 90,
       "primary": false,
       "track": "new"
+    },
+    {
+      "path": "docs/adr/ADR-2026-07-03-authored-grid-board-scale.md",
+      "title": "ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in)",
+      "doc_status": "draft",
+      "doc_owner": "master-dd",
+      "workstream": "combat",
+      "last_verified": "2026-07-03",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "active"
     }
   ]
 }

--- a/docs/superpowers/plans/2026-07-03-fase2c-grid-wiring.md
+++ b/docs/superpowers/plans/2026-07-03-fase2c-grid-wiring.md
@@ -1,0 +1,85 @@
+---
+title: 'fase-2c grid-wiring: honor authored grid_size via board_scale -- implementation plan (as-built)'
+date: 2026-07-03
+doc_status: active
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-07-03'
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+tags: [combat, encounter, grid, board-size, party, big-maps, board-scale, tdd, adr, fase-2c]
+---
+
+# fase-2c grid-wiring -- implementation plan (as-built)
+
+**Goal:** an authored `encounter.grid_size` sizes the played board when (and only when) the encounter
+opts into `board_scale: grid_sized`; the party fill-ratio `gridSizeFor` stays the byte-identical
+default for `party_sized` (and absent). Band-neutral: the capability ships dormant.
+
+**Design record:** spec `docs/superpowers/specs/2026-07-03-fase2c-grid-wiring-design.md` (#3198) +
+`docs/adr/ADR-2026-07-03-authored-grid-board-scale.md` (owner sign-off 2026-07-03). Parent: big-maps
+arc D1 (per-cell, big boards immediately) / D10 (visual-first -> this is backend/opt-in). Prereq:
+#3197 (xpBudget geometry gate + author-guard grid-ratify, merged).
+
+**Architecture:** one pure funnel `resolveBoardSize(deployedCount, encounter, modulation)` in
+`services/party/loader.js` is the single point that decides the board. `grid_sized` + valid
+`grid_size` -> return `grid_size`; else own the modulation->deployed fold and delegate to the
+unchanged `gridSizeFor`. `session.js` and the sim both route through it (or its `isAuthoredGrid`
+predicate). Adding the enum defaulting to `party_sized` keeps all 21 encounters structurally
+unchanged.
+
+## Ground-truth deviations from the spec literal (verified origin/main, resolved during build)
+
+1. **`session.encounter` is NOT available at the old board-resolve point** (spec sez.7 open item):
+   `encounterPayload` is built later (incl. YAML via `loadEncounter(encounter_id)` -- the primary
+   big-board authoring path). Fix: **relocate the board-resolve block to just before
+   `const session = {`** (Option B), so `resolveBoardSize` sees the fully-resolved encounter.
+   Chosen over hoisting `encounterPayload` (~5 downstream consumers) because `gridW`/`gridH` have a
+   single consumer -> lower blast radius.
+2. **`resolveBoardSize` owns the modulation->deployed fold** (session.js used to do it inline). Makes
+   the 3rd param genuinely used and satisfies "one point decides the board". Byte-identical to the
+   old inline fold for `party_sized`.
+3. **Invalid-`grid_sized` falls back to `party_sized` (fail-safe)**, not a hard reject: an authoring
+   mistake degrades to a valid party-derived board, not a 500. Schema (`additionalProperties:false`,
+   `grid_size` items 4..20) + author-guard catch bad authoring upstream; `isAuthoredGrid` mirrors the
+   bounds at runtime because it also runs on live `req.body.encounter` (may bypass schema validation).
+
+## Units (all built TDD, red -> green, band-neutral)
+
+1. **Schema** `schemas/evo/encounter.schema.json` (FORBIDDEN-PATH, master-dd review): additive
+   `board_scale` enum `[party_sized, grid_sized]`, default `party_sized`. Not required. `c566beb5b`.
+2. **Resolver** `services/party/loader.js`: `resolveBoardSize` + `isAuthoredGrid`; `gridSizeFor`/
+   `getModulation` untouched. Test `tests/services/resolveBoardSize.test.js` (6 cases: byte-identical
+   party_sized/absent, modulation fold crossing a grid bracket, grid_sized returns grid_size,
+   invalid fail-safe, no aliasing). `7258f9950`.
+3. **Session wire** `apps/backend/routes/session.js`: board block relocated + calls `resolveBoardSize`.
+   Test `tests/api/sessionStartBoardScale.test.js` (grid_sized -> authored board; party_sized/absent
+   -> party board). `d944af7df`.
+4. **Sim parity** `tools/sim/scenario-enemies.js`: authored spawn clamps to `grid_size-1` per axis
+   via `isAuthoredGrid`; party_sized keeps `GRID_SAFE_MAX=5`. Test
+   `tests/sim/scenarioEnemiesAuthoredGrid.test.js`. `ba64dcd20`.
+5. **Doc** `docs/core/15-LEVEL_DESIGN.md`: corrected the hardcore-06 "`grid_size: 10`" myth (the 10x10
+   comes from 8-PG modulation `deployed_7_8`, not the YAML field); documented `board_scale: grid_sized`.
+   `387b9d38b`.
+
+ADR + registry: `4dad847d2`.
+
+## DoD outcome (spec sez.6)
+
+- `resolveBoardSize` regression: party_sized/absent == `gridSizeFor` byte-identical -- PASS (6/6).
+- `node --test tests/ai/*.test.js` -- PASS 567/567.
+- `npm run test:api` -- EXIT 0, 25 sub-suites, 0 fail (incl. the wire + resolver tests).
+- Sim authored spawn on-grid (no over-clamp) -- PASS; existing sim suite byte-identical (12/12).
+- `npm run schema:lint` + `validate-datasets` -- PASS (all 21 encounters `party_sized`).
+- `npm run format:check` on changed files -- clean (repo baseline drift on untouched files is not ours).
+- `check_docs_governance.py --strict` -- errors=0.
+- Commits: ADR-0011 trailers (`Coding-Agent: claude-opus-4-8` + `Trace-Id` uuidv7), no `Co-Authored-By`.
+- Forbidden-path `schemas/evo` flagged for master-dd. No new deps. Band-neutral.
+
+## Downstream (out of scope for this PR -- capability only)
+
+Authoring a big-board `grid_sized` encounter is NOT in this PR. Any encounter later set to
+`grid_sized` + resized MUST re-run N=10 probe -> N=40 ratify (author-guard
+`tools/js/validate_encounter_grid_ratify.js`, #3197). Sequence: this wiring -> author `grid_sized`
+encounter -> N=40 -> flip the xpBudget geometry gate. See ADR-2026-07-03 Sequencing.

--- a/schemas/evo/encounter.schema.json
+++ b/schemas/evo/encounter.schema.json
@@ -38,6 +38,12 @@
       "maxItems": 2,
       "description": "[width, height] in hex cells"
     },
+    "board_scale": {
+      "type": "string",
+      "enum": ["party_sized", "grid_sized"],
+      "default": "party_sized",
+      "description": "Board-size policy (ADR-2026-07-03). 'party_sized' (default) = party fill-ratio via gridSizeFor (ADR-2026-04-17), byte-identical al legacy: grid_size ignorato per il dimensionamento. 'grid_sized' = la board usa questo grid_size (board non-legibility-constrained). Passare a 'grid_sized' con una board ridimensionata richiede re-ratify N=10 -> N=40 (author-guard validate_encounter_grid_ratify)."
+    },
     "grid": {
       "type": "object",
       "additionalProperties": false,

--- a/services/party/loader.js
+++ b/services/party/loader.js
@@ -73,6 +73,45 @@ function gridSizeFor(deployedCount) {
 }
 
 /**
+ * True se l'encounter opta un grid autorato valido: board_scale === 'grid_sized' e grid_size e'
+ * un array [w, h] di due interi entro i bound schema (4..20). Mirror di encounter.schema.json
+ * (grid_size: items integer 4..20, arity 2). ADR-2026-07-03.
+ */
+function isAuthoredGrid(encounter) {
+  if (!encounter || encounter.board_scale !== 'grid_sized') return false;
+  const gs = encounter.grid_size;
+  return (
+    Array.isArray(gs) &&
+    gs.length === 2 &&
+    Number.isInteger(gs[0]) &&
+    Number.isInteger(gs[1]) &&
+    gs[0] >= 4 &&
+    gs[0] <= 20 &&
+    gs[1] >= 4 &&
+    gs[1] <= 20
+  );
+}
+
+/**
+ * Risolve la board size [w, h] per una sessione: unico punto che decide la board (ADR-2026-07-03).
+ * - board_scale === 'grid_sized' con grid_size valido -> board = grid_size autorato (nuovo array,
+ *   nessun aliasing dell'encounter).
+ * - altrimenti ('party_sized'/assente/invalido) -> party fill-ratio: la modulation (se preset noto)
+ *   determina il deployed effettivo, poi gridSizeFor. Byte-identical al path legacy (ADR-2026-04-17).
+ */
+function resolveBoardSize(deployedCount, encounter, modulation) {
+  if (isAuthoredGrid(encounter)) {
+    return [encounter.grid_size[0], encounter.grid_size[1]];
+  }
+  let effectiveDeployed = deployedCount;
+  if (modulation) {
+    const preset = getModulation(modulation);
+    if (preset) effectiveDeployed = preset.deployed;
+  }
+  return gridSizeFor(effectiveDeployed);
+}
+
+/**
  * Ritorna modulation preset by name oppure null.
  */
 function getModulation(name) {
@@ -98,6 +137,8 @@ function listModulations() {
 module.exports = {
   getPartyConfig,
   gridSizeFor,
+  resolveBoardSize,
+  isAuthoredGrid,
   getModulation,
   listModulations,
   loadFromDisk,

--- a/tests/api/sessionStartBoardScale.test.js
+++ b/tests/api/sessionStartBoardScale.test.js
@@ -1,0 +1,53 @@
+// fase-2c grid-wiring (ADR-2026-07-03): POST /api/session/start must honor an encounter that opts
+// into board_scale:'grid_sized' (board = authored grid_size), while board_scale:'party_sized'
+// (or absent) keeps the party fill-ratio board (gridSizeFor), byte-identical to legacy.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+
+const units = [
+  { id: 'p1', controlled_by: 'player', hp: 10, max_hp: 10, position: { x: 0, y: 0 } },
+  { id: 's1', controlled_by: 'sistema', hp: 10, max_hp: 10, position: { x: 1, y: 1 } },
+];
+
+test('grid_sized encounter sizes the played board from grid_size', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units, encounter: { board_scale: 'grid_sized', grid_size: [14, 14] } });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.grid.width, 14);
+  assert.equal(res.body.state.grid.height, 14);
+});
+
+test('party_sized encounter ignores grid_size, keeps party fill-ratio board', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app)
+    .post('/api/session/start')
+    .send({ units, encounter: { board_scale: 'party_sized', grid_size: [14, 14] } });
+  assert.equal(res.status, 200);
+  // 1 player deployed -> gridSizeFor(1) -> 6x6; authored grid_size ignored under party_sized.
+  assert.equal(res.body.state.grid.width, 6);
+  assert.equal(res.body.state.grid.height, 6);
+});
+
+test('absent encounter keeps party fill-ratio board (legacy default)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const res = await request(app).post('/api/session/start').send({ units });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.state.grid.width, 6);
+  assert.equal(res.body.state.grid.height, 6);
+});

--- a/tests/services/resolveBoardSize.test.js
+++ b/tests/services/resolveBoardSize.test.js
@@ -1,0 +1,82 @@
+'use strict';
+// fase-2c grid-wiring (ADR-2026-07-03): resolveBoardSize is the single point that decides the
+// played board. 'party_sized' (default/absent) must be byte-identical to the legacy gridSizeFor
+// path; 'grid_sized' returns the authored encounter.grid_size. See services/party/loader.js.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  resolveBoardSize,
+  isAuthoredGrid,
+  gridSizeFor,
+  getModulation,
+} = require('../../services/party/loader');
+
+test('party_sized/absent board_scale is byte-identical to gridSizeFor', () => {
+  for (const n of [1, 2, 4, 5, 6, 7, 8]) {
+    assert.deepStrictEqual(resolveBoardSize(n, null, undefined), gridSizeFor(n));
+    assert.deepStrictEqual(
+      resolveBoardSize(n, { board_scale: 'party_sized' }, undefined),
+      gridSizeFor(n),
+    );
+    assert.deepStrictEqual(resolveBoardSize(n, {}, undefined), gridSizeFor(n));
+    // an authored grid_size present but board_scale != grid_sized stays party_sized (ignored).
+    assert.deepStrictEqual(
+      resolveBoardSize(n, { board_scale: 'party_sized', grid_size: [16, 16] }, undefined),
+      gridSizeFor(n),
+    );
+  }
+});
+
+test('modulation preset folds into deployed for party_sized (mirrors legacy session.js)', () => {
+  // 'full' -> deployed 8 -> 10x10, distinct from raw count 1 -> 6x6, so the fold is observable.
+  const full = getModulation('full');
+  assert.ok(full && Number.isInteger(full.deployed) && full.deployed !== 1);
+  assert.deepStrictEqual(resolveBoardSize(1, null, 'full'), gridSizeFor(full.deployed));
+  assert.notDeepStrictEqual(resolveBoardSize(1, null, 'full'), gridSizeFor(1));
+  // unknown modulation name -> no override -> raw deployed used.
+  assert.deepStrictEqual(resolveBoardSize(2, null, 'nope_not_a_preset'), gridSizeFor(2));
+});
+
+test('grid_sized board_scale returns the authored grid_size', () => {
+  assert.deepStrictEqual(
+    resolveBoardSize(2, { board_scale: 'grid_sized', grid_size: [12, 12] }, undefined),
+    [12, 12],
+  );
+  // grid_sized ignores modulation and deployed entirely.
+  assert.deepStrictEqual(
+    resolveBoardSize(8, { board_scale: 'grid_sized', grid_size: [16, 10] }, 'full'),
+    [16, 10],
+  );
+});
+
+test('grid_sized with invalid grid_size falls back to party_sized (fail-safe)', () => {
+  const bad = [
+    { board_scale: 'grid_sized', grid_size: [3, 3] }, // below min 4
+    { board_scale: 'grid_sized', grid_size: [21, 21] }, // above max 20
+    { board_scale: 'grid_sized', grid_size: [10] }, // wrong arity
+    { board_scale: 'grid_sized', grid_size: [10, 'x'] }, // non-integer
+    { board_scale: 'grid_sized', grid_size: [10.5, 10] }, // float
+    { board_scale: 'grid_sized' }, // missing grid_size
+    { board_scale: 'grid_sized', grid_size: null },
+  ];
+  for (const enc of bad) {
+    assert.deepStrictEqual(resolveBoardSize(4, enc, undefined), gridSizeFor(4));
+    assert.strictEqual(isAuthoredGrid(enc), false);
+  }
+});
+
+test('isAuthoredGrid true only for a valid grid_sized encounter', () => {
+  assert.strictEqual(isAuthoredGrid({ board_scale: 'grid_sized', grid_size: [12, 12] }), true);
+  assert.strictEqual(isAuthoredGrid({ board_scale: 'grid_sized', grid_size: [4, 20] }), true);
+  assert.strictEqual(isAuthoredGrid({ board_scale: 'party_sized', grid_size: [12, 12] }), false);
+  assert.strictEqual(isAuthoredGrid(null), false);
+  assert.strictEqual(isAuthoredGrid(undefined), false);
+});
+
+test('resolveBoardSize returns a fresh array (no aliasing of encounter.grid_size)', () => {
+  const enc = { board_scale: 'grid_sized', grid_size: [12, 12] };
+  const out = resolveBoardSize(2, enc, undefined);
+  out[0] = 99;
+  assert.strictEqual(enc.grid_size[0], 12); // caller mutation must not corrupt the encounter
+});

--- a/tests/sim/scenarioEnemiesAuthoredGrid.test.js
+++ b/tests/sim/scenarioEnemiesAuthoredGrid.test.js
@@ -1,0 +1,61 @@
+'use strict';
+// fase-2c grid-wiring (ADR-2026-07-03) sim parity: for a board_scale:'grid_sized' encounter the sim
+// must clamp authored spawn points to the AUTHORED bound (grid_size), not the conservative
+// GRID_SAFE_MAX(5). party_sized/absent keeps the GRID_SAFE_MAX clamp (byte-identical).
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { buildScenarioEnemies } = require('../../tools/sim/scenario-enemies');
+
+const DIR = path.resolve(__dirname, '../../docs/planning/encounters');
+const AUTH_ID = 'enc__test_fase2c_authored__';
+const PARTY_ID = 'enc__test_fase2c_party__';
+const authFile = path.join(DIR, `${AUTH_ID}.yaml`);
+const partyFile = path.join(DIR, `${PARTY_ID}.yaml`);
+
+// Spawn at (10, 9): on a 12x12 authored board it is valid; under the legacy GRID_SAFE_MAX(5)
+// clamp it would be squashed to (5, 5).
+const AUTH_YAML = `board_scale: grid_sized
+grid_size: [12, 12]
+objective: { type: elimination }
+waves:
+  - turn_trigger: 0
+    spawn_points: [[10, 9]]
+    units: [{ species: predoni_nomadi, tier: base, count: 1 }]
+`;
+const PARTY_YAML = `board_scale: party_sized
+grid_size: [12, 12]
+objective: { type: elimination }
+waves:
+  - turn_trigger: 0
+    spawn_points: [[10, 9]]
+    units: [{ species: predoni_nomadi, tier: base, count: 1 }]
+`;
+
+before(() => {
+  fs.writeFileSync(authFile, AUTH_YAML, 'utf8');
+  fs.writeFileSync(partyFile, PARTY_YAML, 'utf8');
+});
+after(() => {
+  for (const f of [authFile, partyFile]) {
+    try {
+      fs.unlinkSync(f);
+    } catch {}
+  }
+});
+
+test('grid_sized board: authored spawn stays on-grid (not clamped to GRID_SAFE_MAX)', () => {
+  const enemies = buildScenarioEnemies(AUTH_ID);
+  assert.ok(Array.isArray(enemies) && enemies.length === 1);
+  assert.equal(enemies[0].position.x, 10); // pre-fase-2c this was clamped to 5
+  assert.equal(enemies[0].position.y, 9);
+});
+
+test('party_sized board: spawn clamped to GRID_SAFE_MAX (byte-identical legacy)', () => {
+  const enemies = buildScenarioEnemies(PARTY_ID);
+  assert.ok(Array.isArray(enemies) && enemies.length === 1);
+  assert.equal(enemies[0].position.x, 5); // GRID_SAFE_MAX clamp unchanged
+  assert.equal(enemies[0].position.y, 5);
+});

--- a/tools/sim/scenario-enemies.js
+++ b/tools/sim/scenario-enemies.js
@@ -19,6 +19,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const yaml = require('js-yaml');
+const { isAuthoredGrid } = require('../../services/party/loader');
 
 const ENCOUNTER_DIR = path.resolve(__dirname, '..', '..', 'docs', 'planning', 'encounters');
 const ENCOUNTER_DRAFT_DIR = path.resolve(
@@ -38,10 +39,10 @@ const TIER_HP = { base: 7, elite: 10, apex: 14 };
 const TIER_MOD = { base: 1, elite: 2, apex: 4 };
 const TIER_DC = { base: 10, elite: 11, apex: 12 };
 
-// The sim sizes the grid from the PLAYER count (gridSizeFor), NOT the YAML grid_size, so
-// authored spawn points can land off-grid (e.g. x:7 on the 2-player 6x6). Clamp positions
-// to a conservative on-grid bound so the fight is well-formed. The authored per-encounter
-// grid is a fase-2c concern (would need modulation wiring).
+// For party_sized/absent boards the sim sizes the grid from the PLAYER count (gridSizeFor), NOT the
+// YAML grid_size, so authored spawn points can land off-grid (e.g. x:7 on the 2-player 6x6); clamp
+// to this conservative bound so the fight is well-formed. fase-2c (ADR-2026-07-03): a
+// board_scale:'grid_sized' encounter instead clamps to its authored grid_size bound (see below).
 const GRID_SAFE_MAX = 5;
 
 // Only ELIMINATION encounters become scaled 'scenario' fights: the combat-adapter resolves
@@ -102,6 +103,12 @@ function buildScenarioEnemies(scenarioId, scaling = {}, opts = {}) {
   const spawnPoints =
     Array.isArray(wave1.spawn_points) && wave1.spawn_points.length ? wave1.spawn_points : [[7, 3]];
 
+  // fase-2c (ADR-2026-07-03): authored boards clamp spawn to the authored bound (grid_size - 1);
+  // party_sized/absent keeps the conservative GRID_SAFE_MAX (the sim doesn't know player count).
+  const authored = isAuthoredGrid(parsed);
+  const clampX = authored ? parsed.grid_size[0] - 1 : GRID_SAFE_MAX;
+  const clampY = authored ? parsed.grid_size[1] - 1 : GRID_SAFE_MAX;
+
   const enemies = [];
   let spIdx = 0;
   for (const unitDef of wave1.units || []) {
@@ -115,8 +122,8 @@ function buildScenarioEnemies(scenarioId, scaling = {}, opts = {}) {
     for (let i = 0; i < count; i += 1) {
       const pos = spawnPoints[spIdx % spawnPoints.length];
       spIdx += 1;
-      const px = Math.min(GRID_SAFE_MAX, Math.max(0, (pos && pos[0]) || 0));
-      const py = Math.min(GRID_SAFE_MAX, Math.max(0, (pos && pos[1]) || 0));
+      const px = Math.min(clampX, Math.max(0, (pos && pos[0]) || 0));
+      const py = Math.min(clampY, Math.max(0, (pos && pos[1]) || 0));
       enemies.push({
         id: `sis_${scenarioId}_${enemies.length + 1}`,
         species,


### PR DESCRIPTION
## fase-2c grid-wiring: honor authored `grid_size` via `board_scale`

Makes an authored `encounter.grid_size` size the played board **when (and only when)** an encounter opts into a new field `board_scale: grid_sized`. Default `party_sized` (and absent) = the legacy party fill-ratio behavior (`gridSizeFor`), byte-identical. The keystone that unlocks the parent big-maps arc D1 ("per-cell, big boards immediately") without touching the default.

**Band-neutral — capability only.** All 21 existing encounters lack the field → unchanged board, zero difficulty/sim delta. This PR does NOT author any big-board encounter.

Design record: spec [#3198](https://github.com/MasterDD-L34D/Game/pull/3198) + ADR-2026-07-03 (owner signed-off, `doc_status: draft` until this merges). Prereq: [#3197](https://github.com/MasterDD-L34D/Game/pull/3197) (xpBudget geometry gate + author-guard grid-ratify, merged).

### 🔴 FORBIDDEN-PATH — master-dd review required
`schemas/evo/encounter.schema.json` — additive optional `board_scale` enum `[party_sized, grid_sized]`, default `party_sized`, **not** required, `additionalProperties` unchanged. Existing encounters (no field) stay valid. This is the only forbidden-path touch. No `.github/workflows`, `migrations/`, `packages/contracts/`, `services/generation/`, `services/rules/`. **No new deps.**

### The 5 units (all TDD red→green)
1. **Schema** `schemas/evo/encounter.schema.json` — `board_scale` enum (forbidden-path, above).
2. **Resolver** `services/party/loader.js` — pure `resolveBoardSize(deployedCount, encounter, modulation)` = single point that decides the board + `isAuthoredGrid`. `gridSizeFor`/`getModulation` **unchanged**.
3. **Session wire** `apps/backend/routes/session.js` — routes board sizing through `resolveBoardSize`.
4. **Sim parity** `tools/sim/scenario-enemies.js` — authored spawn clamps to the authored bound (`grid_size-1`/axis); `party_sized` keeps `GRID_SAFE_MAX=5`.
5. **Doc** `docs/core/15-LEVEL_DESIGN.md` — corrected the hardcore-06 "`grid_size: 10`" myth (the 10×10 comes from 8-PG modulation `deployed_7_8`, not the YAML field); documented `board_scale: grid_sized`.

### Ground-truth deviation from the spec literal (resolved during build)
The spec assumed `session.encounter` was available at the board-resolve point (`session.js:~2396`). **It is not** — `encounterPayload` is built later (incl. YAML via `loadEncounter(encounter_id)`, the primary big-board authoring path). Fix: the board-resolve block was **relocated** to just before `const session = {`, so `resolveBoardSize` sees the fully-resolved encounter. Chosen over hoisting `encounterPayload` (~5 downstream consumers) because `gridW`/`gridH` have a single consumer → lower blast radius. Also: `resolveBoardSize` now owns the modulation→deployed fold (session.js did it inline), so "one point decides the board" holds. Invalid `grid_sized` → fail-safe fallback to `party_sized` (an authoring mistake degrades to a valid board, not a 500).

### Definition of Done
- `resolveBoardSize` regression: `party_sized`/absent == `gridSizeFor` byte-identical — **PASS** (6/6, `tests/services/resolveBoardSize.test.js`).
- `node --test tests/ai/*.test.js` — **PASS 567/567**.
- `npm run test:api` — **EXIT 0, 25 sub-suites, 0 fail** (incl. e2e wire test `tests/api/sessionStartBoardScale.test.js` + resolver).
- Sim authored spawn on-grid; existing sim suite byte-identical — **PASS 12/12** (`tests/sim/scenarioEnemiesAuthoredGrid.test.js`).
- `npm run schema:lint` + `validate-datasets` — **PASS** (all 21 encounters `party_sized`).
- `npm run format:check` on changed files — **clean** (repo baseline drift on untouched files is not from this PR).
- `check_docs_governance.py --strict` — **errors=0**.
- Commits: ADR-0011 trailers (`Coding-Agent` + `Trace-Id`), no `Co-Authored-By`.
- Adversarial pre-PR code review (feature-dev:code-reviewer) — **no P1/P2**, band-neutrality independently verified via the e2e path.

### Rollback plan (03A)
Single-branch revert. The wiring is inert until an encounter opts `grid_sized`; reverting the branch restores the exact legacy `gridSizeFor` path with zero data migration (no encounter authors the field). Each unit is an isolated commit if a partial revert is preferred (schema / resolver / session / sim / doc).

### Downstream (out of scope — gated)
Any encounter later set to `grid_sized` + resized **must** re-run N=10 probe → N=40 ratify (author-guard `tools/js/validate_encounter_grid_ratify.js`, #3197). Sequence: this wiring → author a `grid_sized` encounter → N=40 → flip the xpBudget geometry gate. See ADR-2026-07-03 Sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
