### PR TITLE
docs(adr): flip ADR-2026-07-03 board_scale draft -> active (build #3199 merged)

### DIFF
--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -97,7 +97,7 @@ _Generato da `tools/generate_decisions_log.py` (74 ADR). NON editare a mano: edi
 | 2026-06-08 | [ADR-2026-06-08-i18n-unify-data-i18n](docs/adr/ADR-2026-06-08-i18n-unify-data-i18n.md) | ADR 2026-06-08 -- i18n: unificare su data/i18n come sorgente unica (QA3) | Accepted |
 | 2026-06-08 | [ADR-2026-06-08-onboarding-per-creature-trait](docs/adr/ADR-2026-06-08-onboarding-per-creature-trait.md) | ADR 2026-06-08 -- Onboarding: trait per-creatura + branco emergente (supersede 51-ONBOARDING-60S, MA1) | Accepted |
 | 2026-06-19 | [ADR-2026-06-19-taxonomy-authoring-sot-steady-state](docs/adr/ADR-2026-06-19-taxonomy-authoring-sot-steady-state.md) | ADR-2026-06-19 -- taxonomy authoring SoT steady-state (RFC #4 S3 NO-GO) | Accepted |
-| 2026-07-03 | [ADR-2026-07-03-authored-grid-board-scale](docs/adr/ADR-2026-07-03-authored-grid-board-scale.md) | ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in) | Proposed |
+| 2026-07-03 | [ADR-2026-07-03-authored-grid-board-scale](docs/adr/ADR-2026-07-03-authored-grid-board-scale.md) | ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in) | Accepted |
 <!-- /gen:adr-index -->
 
 ## Index per tag

--- a/docs/adr/ADR-2026-07-03-authored-grid-board-scale.md
+++ b/docs/adr/ADR-2026-07-03-authored-grid-board-scale.md
@@ -1,6 +1,6 @@
 ---
 title: 'ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in)'
-doc_status: draft
+doc_status: active
 doc_owner: master-dd
 workstream: combat
 last_verified: 2026-07-03
@@ -27,10 +27,10 @@ related_files:
 
 ## Status
 
-**SIGNED-OFF** owner 2026-07-03 (opzione 1; naming ratificato `party_sized`/`grid_sized`). Il campo
-`doc_status` resta `draft` finche' il build-PR non atterra (flip -> `active` al land, scelta owner).
-Draft prodotto da `sot-planner`. Il BUILD (implementazione + N=40 re-ratify se/quando un encounter
-opta `grid_sized`) e' partito su go-signal esplicito owner nella sessione fresca (vedi Sequencing).
+**ACCEPTED** owner 2026-07-03 (opzione 1; naming ratificato `party_sized`/`grid_sized`). Il build-PR
+fase-2c e' atterrato su main (#3199, merge `6703f782`) -> `doc_status` flippato `draft` -> `active`.
+Draft prodotto da `sot-planner`. Il BUILD (wiring band-neutral) e' shippato; la N=40 re-ratify resta
+dovuta se/quando un encounter opta `grid_sized` (vedi Sequencing).
 
 ## Contesto
 
@@ -154,6 +154,6 @@ salta la sequenza di ratifica.
 ## Decisioni owner (2026-07-03, risolte)
 
 - Naming: **RATIFICATO** `board_scale` (`party_sized`/`grid_sized`) -- owner sign-off 2026-07-03.
-- `doc_status`: resta `draft` fino al merge del build-PR, poi flip -> `active` (scelta owner).
+- `doc_status`: flippato `draft` -> `active` al merge del build-PR #3199 (2026-07-03, scelta owner).
 - Accettazione != start-build automatico per design; il build e' partito su go-signal esplicito
   ("parti col build") nella stessa sessione.

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -13800,7 +13800,7 @@
     {
       "path": "docs/adr/ADR-2026-07-03-authored-grid-board-scale.md",
       "title": "ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in)",
-      "doc_status": "draft",
+      "doc_status": "active",
       "doc_owner": "master-dd",
       "workstream": "combat",
       "last_verified": "2026-07-03",


### PR DESCRIPTION
Flip `doc_status: draft -> active` per `ADR-2026-07-03-authored-grid-board-scale.md` dopo il merge del build-PR fase-2c [#3199](https://github.com/MasterDD-L34D/Game/pull/3199) (`6703f782`).

- Frontmatter + entry registry + prose Status (SIGNED-OFF -> ACCEPTED, nota il merge #3199).
- Docs-only. Zero forbidden-path, zero dep. `check_docs_governance.py --strict` verde (errors=0).
- Owner-requested flip ("I merged it -- flip the ADR to active").

🤖 Generated with [Claude Code](https://claude.com/claude-code)