### PR TITLE
refactor(combat): extract shared losForGrid LOS rule

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -89,9 +89,7 @@ const { evaluateVoiceTriggers, describeVoice } = require('../services/narrative/
 // l'orchestratore del turno (createSistemaTurnRunner) in services/ai/sistemaTurnRunner.js.
 // DEFAULT_ATTACK_RANGE e' ora autoritativo in policy.js (usato sia qui che dall'IA).
 const { DEFAULT_ATTACK_RANGE } = require('../services/ai/policy');
-const { lineOfSightClear } = require('../services/grid/squareLos');
-const { terrainAtFromFeatures } = require('../services/combat/moveCost');
-const { terrainBlocksLos } = require('../services/combat/losBlockers');
+const { losClearOnGrid } = require('../services/combat/losForGrid');
 const { createSistemaTurnRunner } = require('../services/ai/sistemaTurnRunner');
 const { createDeclareSistemaIntents } = require('../services/ai/declareSistemaIntents');
 const { loadAiProfiles } = require('../services/ai/aiProfilesLoader');
@@ -326,11 +324,10 @@ const {
 // (imported above). Only createSessionRouter closure remains inline.
 
 // COMBAT_LOS_ENABLED (default OFF): true iff a terrain blocker sits strictly
-// between attacker and target. Pure + exported for testing.
+// between attacker and target. Thin negation of the shared combat LOS rule
+// (services/combat/losForGrid.js). Exported for testing.
 function losGateBlocks(grid, fromPos, toPos) {
-  if (process.env.COMBAT_LOS_ENABLED !== 'true') return false;
-  const terrainAt = terrainAtFromFeatures((grid && grid.terrain_features) || []);
-  return !lineOfSightClear(fromPos, toPos, (x, y) => terrainBlocksLos(terrainAt(x, y)));
+  return !losClearOnGrid(grid, fromPos, toPos);
 }
 
 function createSessionRouter(options = {}) {

--- a/apps/backend/services/ai/policy.js
+++ b/apps/backend/services/ai/policy.js
@@ -24,9 +24,7 @@
 // (REGOLA_003 kite, stati emotivi panic/rage/confused, ecc.) senza
 // toccare l'orchestrazione di runSistemaTurn (vedi sistemaTurnRunner.js).
 
-const { lineOfSightClear } = require('../grid/squareLos');
-const { terrainAtFromFeatures } = require('../combat/moveCost');
-const { terrainBlocksLos } = require('../combat/losBlockers');
+const { losClearOnGrid } = require('../combat/losForGrid');
 
 // --- AI Intent Score Registry (W3 pattern) ---
 // Valori di default inline, sovrascrivibili via loadAiConfig() da YAML.
@@ -296,11 +294,11 @@ function scoreObjectives(actor, target, objectives = DEFAULT_OBJECTIVES) {
 }
 
 // COMBAT_LOS_ENABLED (default OFF): true when target is visible to actor.
+// Thin alias over the shared combat LOS rule (services/combat/losForGrid.js);
+// kept so declareSistemaIntents.js and the AI LOS tests keep importing it here.
 // Flag OFF -> always true (band-neutral). Pure + exported for testing.
 function losClearForAi(grid, fromPos, toPos) {
-  if (process.env.COMBAT_LOS_ENABLED !== 'true') return true;
-  const terrainAt = terrainAtFromFeatures((grid && grid.terrain_features) || []);
-  return lineOfSightClear(fromPos, toPos, (x, y) => terrainBlocksLos(terrainAt(x, y)));
+  return losClearOnGrid(grid, fromPos, toPos);
 }
 
 module.exports = {

--- a/apps/backend/services/combat/losForGrid.js
+++ b/apps/backend/services/combat/losForGrid.js
@@ -1,0 +1,24 @@
+// apps/backend/services/combat/losForGrid.js
+'use strict';
+
+// Combat LOS slice-1 shared rule (COMBAT_LOS_ENABLED, default OFF).
+// Single source of truth for "can the attacker at `from` see the target at `to`
+// on this grid" -- consumed by the human attack path (routes/session.js
+// losGateBlocks), the AI target seam (services/ai/policy.js losClearForAi) and
+// the batch-sim (tools/sim/combat-policy.js) so all three run the identical
+// predicate. Extracted at the 3rd consumer (slice-1 QUALITY.md fast-follow) to
+// drop the duplicated 2-line body and the implicit sim -> ai/policy.js coupling.
+//
+// Returns true when the target is VISIBLE. Flag OFF -> always true
+// (band-neutral, byte-identical to pre-LOS behavior). Pure + exported for tests.
+const { lineOfSightClear } = require('../grid/squareLos');
+const { terrainAtFromFeatures } = require('./moveCost');
+const { terrainBlocksLos } = require('./losBlockers');
+
+function losClearOnGrid(grid, fromPos, toPos) {
+  if (process.env.COMBAT_LOS_ENABLED !== 'true') return true;
+  const terrainAt = terrainAtFromFeatures((grid && grid.terrain_features) || []);
+  return lineOfSightClear(fromPos, toPos, (x, y) => terrainBlocksLos(terrainAt(x, y)));
+}
+
+module.exports = { losClearOnGrid };

--- a/tests/services/losForGrid.test.js
+++ b/tests/services/losForGrid.test.js
@@ -1,0 +1,24 @@
+// tests/services/losForGrid.test.js
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
+
+test('flag OFF: always visible (band-neutral) even with a blocker', () => {
+  delete process.env.COMBAT_LOS_ENABLED;
+  const grid = { terrain_features: [{ x: 2, y: 0, type: 'roccia' }] };
+  assert.equal(losClearOnGrid(grid, { x: 0, y: 0 }, { x: 4, y: 0 }), true);
+});
+
+test('flag ON: blocker between => not visible', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const grid = { terrain_features: [{ x: 2, y: 0, type: 'roccia' }] };
+  assert.equal(losClearOnGrid(grid, { x: 0, y: 0 }, { x: 4, y: 0 }), false);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON: clear line => visible', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  assert.equal(losClearOnGrid({ terrain_features: [] }, { x: 0, y: 0 }, { x: 4, y: 0 }), true);
+  delete process.env.COMBAT_LOS_ENABLED;
+});

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -12,12 +12,14 @@
 // meaningful calibration metric). In-zone -- or elimination / survival -- falls
 // back to closest-enemy. `objective` is optional: omitted => legacy behavior.
 //
-// Task 6 (Combat LOS slice 1): reuse the SAME losClearForAi the production AI
-// seam uses (apps/backend/services/ai/policy.js) so the batch-sim ratify
-// measures "% shots blocked" against the real rule, not a re-implementation.
-// COMBAT_LOS_ENABLED default OFF -> losClearForAi always returns true -> the
+// Task 6 (Combat LOS slice 1): reuse the shared services/combat/losForGrid.js
+// rule -- the SAME predicate the production AI seam uses (via its thin alias
+// in apps/backend/services/ai/policy.js) -- so the batch-sim ratify measures
+// "% shots blocked" against the real rule, not a re-implementation, and sim
+// parity no longer rides on ai/policy.js.
+// COMBAT_LOS_ENABLED default OFF -> losClearOnGrid always returns true -> the
 // LOS filter keeps every in-range candidate (byte-identical to pre-Task-6).
-const { losClearForAi } = require('../../apps/backend/services/ai/policy');
+const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
 
 const ZONE_PURSUIT_OBJECTIVES = new Set(['capture_point', 'sabotage', 'escape', 'escort']);
 
@@ -132,9 +134,9 @@ function pickInRangeTarget(actor, enemies, focusFire, losFn) {
 
 function selectPlayerAction(actor, units, objective, opts = {}) {
   // Task 6: shared production LOS rule, built once from opts.terrainFeatures (threaded by
-  // combat-adapter.js). COMBAT_LOS_ENABLED OFF -> losClearForAi always true -> no-op filter.
+  // combat-adapter.js). COMBAT_LOS_ENABLED OFF -> losClearOnGrid always true -> no-op filter.
   const losFn = (from, to) =>
-    losClearForAi({ terrain_features: (opts && opts.terrainFeatures) || [] }, from, to);
+    losClearOnGrid({ terrain_features: (opts && opts.terrainFeatures) || [] }, from, to);
 
   // OA2 zone-pursuit: a zone objective + actor outside the zone -> move toward it.
   const objType = objective && objective.type;


### PR DESCRIPTION
Fast-follow from LOS slice-1 QUALITY.md: extract the triplicated COMBAT_LOS_ENABLED wrapper into a single shared `apps/backend/services/combat/losForGrid.js` (`losClearOnGrid`). The human path (`losGateBlocks`), AI path (`losClearForAi`, kept as a thin alias so declareSistemaIntents + tests keep importing it), and the sim all delegate to it -- removing the sim's implicit coupling to ai/policy.js. Pure refactor, flag OFF byte-identical, all LOS suites + regression green. Merge = Eduardo.