### PR TITLE
feat(combat): unit-blocking LOS (dormant, flag+config gated)

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -325,9 +325,11 @@ const {
 
 // COMBAT_LOS_ENABLED (default OFF): true iff a terrain blocker sits strictly
 // between attacker and target. Thin negation of the shared combat LOS rule
-// (services/combat/losForGrid.js). Exported for testing.
-function losGateBlocks(grid, fromPos, toPos) {
-  return !losClearOnGrid(grid, fromPos, toPos);
+// (services/combat/losForGrid.js). Optional `units` also gates a live
+// interposed unit (units_block_los config, default false -- dormant). Exported
+// for testing.
+function losGateBlocks(grid, fromPos, toPos, units) {
+  return !losClearOnGrid(grid, fromPos, toPos, units);
 }
 
 function createSessionRouter(options = {}) {
@@ -2924,7 +2926,7 @@ function createSessionRouter(options = {}) {
           });
         }
 
-        if (losGateBlocks(session.grid, actor.position, target.position)) {
+        if (losGateBlocks(session.grid, actor.position, target.position, session.units)) {
           console.warn(
             `[combat-los] blocked ranged attack ${actor.id} -> ${target.id} (LOS ostruita)`,
           );
@@ -3489,7 +3491,10 @@ function createSessionRouter(options = {}) {
           // be redundant and would perturb the batch-sim ratify. Flag OFF ->
           // losGateBlocks returns false -> this branch is dead -> byte-identical to
           // the pre-gate loop.
-          if (source === 'player' && losGateBlocks(session.grid, actor.position, target.position)) {
+          if (
+            source === 'player' &&
+            losGateBlocks(session.grid, actor.position, target.position, session.units)
+          ) {
             console.warn(
               `[combat-los] blocked round-dispatch attack ${actor.id} -> ${target.id} (LOS ostruita)`,
             );

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -467,7 +467,7 @@ function createDeclareSistemaIntents(deps) {
       if (
         policy &&
         policy.intent === 'attack' &&
-        !losClearForAi(session.grid, actor.position, target.position)
+        !losClearForAi(session.grid, actor.position, target.position, session.units)
       ) {
         policy = { ...policy, intent: 'approach', rule: `${policy.rule || 'REGOLA'}_LOS_BLOCKED` };
       }

--- a/apps/backend/services/ai/policy.js
+++ b/apps/backend/services/ai/policy.js
@@ -296,9 +296,11 @@ function scoreObjectives(actor, target, objectives = DEFAULT_OBJECTIVES) {
 // COMBAT_LOS_ENABLED (default OFF): true when target is visible to actor.
 // Thin alias over the shared combat LOS rule (services/combat/losForGrid.js);
 // kept so declareSistemaIntents.js and the AI LOS tests keep importing it here.
-// Flag OFF -> always true (band-neutral). Pure + exported for testing.
-function losClearForAi(grid, fromPos, toPos) {
-  return losClearOnGrid(grid, fromPos, toPos);
+// Optional `units` also gates a live interposed unit (units_block_los config,
+// default false -- dormant). Flag OFF -> always true (band-neutral). Pure +
+// exported for testing.
+function losClearForAi(grid, fromPos, toPos, units) {
+  return losClearOnGrid(grid, fromPos, toPos, units);
 }
 
 module.exports = {

--- a/apps/backend/services/combat/losForGrid.js
+++ b/apps/backend/services/combat/losForGrid.js
@@ -11,14 +11,46 @@
 //
 // Returns true when the target is VISIBLE. Flag OFF -> always true
 // (band-neutral, byte-identical to pre-LOS behavior). Pure + exported for tests.
+//
+// unit-blocking fast-follow (closes the slice-1 "shoot-through-allies" known
+// gap): takes an optional `units` arg (live units on this grid). A strictly-
+// interposed live unit blocks LOS same as a terrain blocker, gated by the
+// `units_block_los` config (data/core/balance/los.yaml, default false) so this
+// stays dormant/byte-identical until an owner explicitly flips the config.
 const { lineOfSightClear } = require('../grid/squareLos');
 const { terrainAtFromFeatures } = require('./moveCost');
-const { terrainBlocksLos } = require('./losBlockers');
+const { terrainBlocksLos, unitsBlockLos } = require('./losBlockers');
 
-function losClearOnGrid(grid, fromPos, toPos) {
-  if (process.env.COMBAT_LOS_ENABLED !== 'true') return true;
-  const terrainAt = terrainAtFromFeatures((grid && grid.terrain_features) || []);
-  return lineOfSightClear(fromPos, toPos, (x, y) => terrainBlocksLos(terrainAt(x, y)));
+// Pure occupancy predicate from live units, gated by `enabled` (the units_block_los
+// config). Disabled OR no units -> no-op (keeps terrain-only slice-1 behavior
+// byte-identical). Endpoints are excluded by lineOfSightClear, so a unit on the
+// attacker/target cell never self-blocks. Exported for testing.
+function _unitBlocker(units, enabled) {
+  if (!enabled || !Array.isArray(units) || units.length === 0) return () => false;
+  const occ = new Set();
+  for (const u of units) {
+    if (
+      u &&
+      u.position &&
+      (u.hp ?? 0) > 0 &&
+      Number.isFinite(u.position.x) &&
+      Number.isFinite(u.position.y)
+    ) {
+      occ.add(`${u.position.x},${u.position.y}`);
+    }
+  }
+  return (x, y) => occ.has(`${x},${y}`);
 }
 
-module.exports = { losClearOnGrid };
+function losClearOnGrid(grid, fromPos, toPos, units) {
+  if (process.env.COMBAT_LOS_ENABLED !== 'true') return true;
+  const terrainAt = terrainAtFromFeatures((grid && grid.terrain_features) || []);
+  const unitBlocks = _unitBlocker(units, unitsBlockLos());
+  return lineOfSightClear(
+    fromPos,
+    toPos,
+    (x, y) => terrainBlocksLos(terrainAt(x, y)) || unitBlocks(x, y),
+  );
+}
+
+module.exports = { losClearOnGrid, _unitBlocker };

--- a/tests/services/losForGrid.test.js
+++ b/tests/services/losForGrid.test.js
@@ -2,7 +2,8 @@
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
+const { losClearOnGrid, _unitBlocker } = require('../../apps/backend/services/combat/losForGrid');
+const { lineOfSightClear } = require('../../apps/backend/services/grid/squareLos');
 
 test('flag OFF: always visible (band-neutral) even with a blocker', () => {
   delete process.env.COMBAT_LOS_ENABLED;
@@ -20,5 +21,46 @@ test('flag ON: blocker between => not visible', () => {
 test('flag ON: clear line => visible', () => {
   process.env.COMBAT_LOS_ENABLED = 'true';
   assert.equal(losClearOnGrid({ terrain_features: [] }, { x: 0, y: 0 }, { x: 4, y: 0 }), true);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('_unitBlocker disabled: no cell blocks (no-op)', () => {
+  const blk = _unitBlocker([{ position: { x: 2, y: 0 }, hp: 5 }], false);
+  assert.equal(blk(2, 0), false);
+});
+
+test('_unitBlocker enabled: a live unit occupies its cell', () => {
+  const blk = _unitBlocker([{ position: { x: 2, y: 0 }, hp: 5 }], true);
+  assert.equal(blk(2, 0), true);
+  assert.equal(blk(3, 0), false);
+});
+
+test('_unitBlocker enabled: a dead unit (hp<=0) does not block', () => {
+  const blk = _unitBlocker([{ position: { x: 2, y: 0 }, hp: 0 }], true);
+  assert.equal(blk(2, 0), false);
+});
+
+test('_unitBlocker enabled: a unit with missing hp is treated as not-live (house `?? 0`)', () => {
+  const blk = _unitBlocker([{ position: { x: 2, y: 0 } }], true);
+  assert.equal(blk(2, 0), false);
+});
+
+test('unit-blocking geometry: interposed live unit blocks the ray (via squareLos)', () => {
+  const units = [{ position: { x: 2, y: 0 }, hp: 5 }];
+  assert.equal(lineOfSightClear({ x: 0, y: 0 }, { x: 4, y: 0 }, _unitBlocker(units, true)), false);
+});
+
+test('unit-blocking endpoint-exclusion: a unit ON the target does NOT block', () => {
+  const units = [{ position: { x: 4, y: 0 }, hp: 5 }];
+  assert.equal(lineOfSightClear({ x: 0, y: 0 }, { x: 4, y: 0 }, _unitBlocker(units, true)), true);
+});
+
+test('losClearOnGrid dormant: flag ON but units_block_los config false => unit does NOT block (band-neutral)', () => {
+  // los.yaml ships units_block_los:false, so even with the LOS flag ON and a unit
+  // between, the shared rule stays terrain-only (byte-identical to slice-1).
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const grid = { terrain_features: [] };
+  const units = [{ position: { x: 2, y: 0 }, hp: 5 }];
+  assert.equal(losClearOnGrid(grid, { x: 0, y: 0 }, { x: 4, y: 0 }, units), true);
   delete process.env.COMBAT_LOS_ENABLED;
 });

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -135,8 +135,10 @@ function pickInRangeTarget(actor, enemies, focusFire, losFn) {
 function selectPlayerAction(actor, units, objective, opts = {}) {
   // Task 6: shared production LOS rule, built once from opts.terrainFeatures (threaded by
   // combat-adapter.js). COMBAT_LOS_ENABLED OFF -> losClearOnGrid always true -> no-op filter.
+  // unit-blocking fast-follow: also threads `units` (units_block_los config, default false
+  // -- dormant/no-op until an owner flips the config).
   const losFn = (from, to) =>
-    losClearOnGrid({ terrain_features: (opts && opts.terrainFeatures) || [] }, from, to);
+    losClearOnGrid({ terrain_features: (opts && opts.terrainFeatures) || [] }, from, to, units);
 
   // OA2 zone-pursuit: a zone objective + actor outside the zone -> move toward it.
   const objType = objective && objective.type;


### PR DESCRIPTION
Closes the slice-1 shoot-through-allies known gap: an interposed live unit blocks LOS. DORMANT at merge -- gated by COMBAT_LOS_ENABLED (env, OFF) AND units_block_los (los.yaml, false); with either off it is byte-identical (terrain-only). Design: any live interposed unit blocks (ally or enemy); endpoints excluded by squareLos. Threaded through both human seams (losGateBlocks: /action + /round/execute), the AI seam (losClearForAi), and the sim. Full regression green (dormant). Merge = Eduardo; flipping units_block_los is a later owner-gated + ratify step.