### PR TITLE
feat(combat): LOS on overwatch + bond counter-attack (dormant)

### DIFF
--- a/apps/backend/services/combat/bondReactionTrigger.js
+++ b/apps/backend/services/combat/bondReactionTrigger.js
@@ -24,6 +24,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const yaml = require('js-yaml');
+const { losClearOnGrid } = require('./losForGrid');
 
 const DEFAULT_PATH = path.join(process.cwd(), 'data', 'core', 'companion', 'creature_bonds.yaml');
 
@@ -158,6 +159,10 @@ function fireCounterAttack(session, ally, attacker, bond, performAttack) {
   if (typeof performAttack !== 'function') return null;
   const range = Number(ally.attack_range) || 1;
   if (manhattan(ally.position, attacker.position) > range) return null;
+
+  // COMBAT_LOS_ENABLED (default OFF): the bonded ally cannot counter-strike an
+  // attacker it has no line of sight to. Flag OFF -> no-op (byte-identical).
+  if (!losClearOnGrid(session.grid, ally.position, attacker.position)) return null;
 
   const attackerHpBefore = attacker.hp;
   const res = performAttack(ally, attacker);

--- a/apps/backend/services/reactionEngine.js
+++ b/apps/backend/services/reactionEngine.js
@@ -19,6 +19,8 @@
 
 'use strict';
 
+const { losClearOnGrid } = require('./combat/losForGrid');
+
 function manhattan(a, b) {
   return Math.abs(Number(a.x) - Number(b.x)) + Math.abs(Number(a.y) - Number(b.y));
 }
@@ -135,6 +137,12 @@ function triggerOnMove(session, mover, fromPos, performAttack) {
     if (distBefore <= range) continue; // already was in range — not "INTO"
     const found = findReaction(unit, 'enemy_moves_in_range');
     if (!found) continue;
+
+    // COMBAT_LOS_ENABLED (default OFF): a watcher cannot overwatch-shoot a mover
+    // it has no line of sight to. Flag OFF -> losClearOnGrid()===true -> no-op
+    // (the reaction is neither skipped nor consumed). Watcher fires at the mover's
+    // destination cell (mover.position is already the post-move cell here).
+    if (!losClearOnGrid(session.grid, unit.position, mover.position)) continue;
 
     const reaction = found.reaction;
     consumeReaction(unit, found.index);

--- a/tests/ai/bondReactionTrigger.test.js
+++ b/tests/ai/bondReactionTrigger.test.js
@@ -331,6 +331,104 @@ test('triggerBondReaction counter_attack -1 step_mod refund prevents 1-shot kill
 });
 
 // ─────────────────────────────────────────────────────────────────
+// fireCounterAttack — COMBAT_LOS_ENABLED gate (dormant, default OFF)
+// ─────────────────────────────────────────────────────────────────
+
+function makeCounterFixture(gridOverride) {
+  const target = makeUnit({ id: 't', species_id: 'dune_stalker', position: { x: 5, y: 0 } });
+  const ally = makeUnit({
+    id: 'a',
+    species_id: 'dune_stalker',
+    position: { x: 5, y: 1 }, // adjacent to target (bond trigger_range=1)
+    attack_range: 5,
+  });
+  const attacker = makeUnit({
+    id: 'foe',
+    species_id: 'goblin',
+    controlled_by: 'sistema',
+    position: { x: 9, y: 1 }, // same row as ally (manhattan=4, within ally.attack_range=5)
+    hp: 8,
+    max_hp: 8,
+  });
+  const session = makeSession([target, ally, attacker]);
+  session.grid = gridOverride;
+  return { target, ally, attacker, session };
+}
+
+test('LOS flag OFF: counter fires even with a roccia blocker between ally and attacker (byte-identical)', () => {
+  delete process.env.COMBAT_LOS_ENABLED;
+  const { target, ally, attacker, session } = makeCounterFixture({
+    terrain_features: [{ x: 7, y: 1, type: 'roccia' }], // strictly between ally(5,1) and attacker(9,1)
+  });
+
+  let called = false;
+  const performAttack = (a, t) => {
+    called = true;
+    t.hp = Math.max(0, t.hp - 4);
+    return { result: { hit: true, mos: 3, die: 14, roll: 14 }, damageDealt: 4 };
+  };
+
+  const res = triggerBondReaction(session, attacker, target, 3, {
+    bonds: [COUNTER_BOND],
+    performAttack,
+  });
+  assert.ok(res, 'counter fires regardless of blocker when flag is off');
+  assert.equal(res.type, 'counter_attack');
+  assert.equal(called, true, 'performAttack was called');
+  assert.equal(ally._bond_round_used, session.turn, 'reaction fired + cap marker set');
+});
+
+test('LOS flag ON + roccia blocker between ally and attacker: fireCounterAttack (via triggerBondReaction) returns null, no performAttack', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  try {
+    const { target, ally, attacker, session } = makeCounterFixture({
+      terrain_features: [{ x: 7, y: 1, type: 'roccia' }],
+    });
+
+    let called = false;
+    const performAttack = (a, t) => {
+      called = true;
+      t.hp = Math.max(0, t.hp - 4);
+      return { result: { hit: true, mos: 3, die: 14, roll: 14 }, damageDealt: 4 };
+    };
+
+    const res = triggerBondReaction(session, attacker, target, 3, {
+      bonds: [COUNTER_BOND],
+      performAttack,
+    });
+    assert.equal(res, null, 'counter suppressed when blind');
+    assert.equal(called, false, 'performAttack NOT called');
+    assert.equal(ally._bond_round_used, undefined, 'cap not consumed on miss-fire');
+  } finally {
+    delete process.env.COMBAT_LOS_ENABLED;
+  }
+});
+
+test('LOS flag ON + clear line: fireCounterAttack (via triggerBondReaction) fires', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  try {
+    const { target, ally, attacker, session } = makeCounterFixture({ terrain_features: [] });
+
+    let called = false;
+    const performAttack = (a, t) => {
+      called = true;
+      t.hp = Math.max(0, t.hp - 4);
+      return { result: { hit: true, mos: 3, die: 14, roll: 14 }, damageDealt: 4 };
+    };
+
+    const res = triggerBondReaction(session, attacker, target, 3, {
+      bonds: [COUNTER_BOND],
+      performAttack,
+    });
+    assert.ok(res, 'counter fires with clear line');
+    assert.equal(res.type, 'counter_attack');
+    assert.equal(called, true, 'performAttack was called');
+  } finally {
+    delete process.env.COMBAT_LOS_ENABLED;
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────
 // triggerBondReaction — shield_ally
 // ─────────────────────────────────────────────────────────────────
 

--- a/tests/services/reactionEngine.test.js
+++ b/tests/services/reactionEngine.test.js
@@ -286,3 +286,105 @@ test('triggerOnMove respects single-actor reaction cap (consumed not refireable)
   const res3 = reactionEngine.triggerOnMove(session, mover, { x: 9, y: 5 }, performAttack);
   assert.equal(res3, null, 'reaction not refired (cap 1/actor)');
 });
+
+// ─────────────────────────────────────────────────────────────────
+// triggerOnMove — COMBAT_LOS_ENABLED gate (dormant, default OFF)
+// ─────────────────────────────────────────────────────────────────
+
+test('triggerOnMove LOS flag OFF: overwatch fires even with a roccia blocker between (byte-identical)', () => {
+  delete process.env.COMBAT_LOS_ENABLED;
+  const overwatcher = makeUnit({
+    id: 'ranger',
+    position: { x: 0, y: 0 },
+    attack_range: 5,
+    reactions: [{ trigger: 'enemy_moves_in_range', ability_id: 'overwatch_shot' }],
+  });
+  const mover = makeUnit({
+    id: 'enemy',
+    controlled_by: 'sistema',
+    position: { x: 4, y: 0 },
+    hp: 8,
+  });
+  const fromPos = { x: 9, y: 0 };
+  const session = makeSession([overwatcher, mover]);
+  session.grid = { terrain_features: [{ x: 2, y: 0, type: 'roccia' }] };
+
+  let called = false;
+  const performAttack = () => {
+    called = true;
+    return { result: { hit: true, mos: 3, die: 14, roll: 14 }, damageDealt: 3 };
+  };
+
+  const res = reactionEngine.triggerOnMove(session, mover, fromPos, performAttack);
+  assert.ok(res, 'overwatch fires regardless of blocker when flag is off');
+  assert.equal(called, true, 'performAttack spy was called');
+  assert.equal(overwatcher.reactions.length, 0, 'reaction consumed');
+});
+
+test('triggerOnMove LOS flag ON + roccia blocker between watcher and mover: overwatch does NOT fire, reaction NOT consumed', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  try {
+    const overwatcher = makeUnit({
+      id: 'ranger',
+      position: { x: 0, y: 0 },
+      attack_range: 5,
+      reactions: [{ trigger: 'enemy_moves_in_range', ability_id: 'overwatch_shot' }],
+    });
+    const mover = makeUnit({
+      id: 'enemy',
+      controlled_by: 'sistema',
+      position: { x: 4, y: 0 },
+      hp: 8,
+    });
+    const fromPos = { x: 9, y: 0 };
+    const session = makeSession([overwatcher, mover]);
+    session.grid = { terrain_features: [{ x: 2, y: 0, type: 'roccia' }] };
+
+    let called = false;
+    const performAttack = () => {
+      called = true;
+      return { result: { hit: true, mos: 3, die: 14, roll: 14 }, damageDealt: 3 };
+    };
+
+    const res = reactionEngine.triggerOnMove(session, mover, fromPos, performAttack);
+    assert.equal(res, null, 'blind watcher does not fire');
+    assert.equal(called, false, 'performAttack NOT called');
+    assert.equal(overwatcher.reactions.length, 1, 'reaction NOT consumed');
+  } finally {
+    delete process.env.COMBAT_LOS_ENABLED;
+  }
+});
+
+test('triggerOnMove LOS flag ON + clear line: overwatch fires', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  try {
+    const overwatcher = makeUnit({
+      id: 'ranger',
+      position: { x: 0, y: 0 },
+      attack_range: 5,
+      reactions: [{ trigger: 'enemy_moves_in_range', ability_id: 'overwatch_shot' }],
+    });
+    const mover = makeUnit({
+      id: 'enemy',
+      controlled_by: 'sistema',
+      position: { x: 4, y: 0 },
+      hp: 8,
+    });
+    const fromPos = { x: 9, y: 0 };
+    const session = makeSession([overwatcher, mover]);
+    session.grid = { terrain_features: [] };
+
+    let called = false;
+    const performAttack = () => {
+      called = true;
+      return { result: { hit: true, mos: 3, die: 14, roll: 14 }, damageDealt: 3 };
+    };
+
+    const res = reactionEngine.triggerOnMove(session, mover, fromPos, performAttack);
+    assert.ok(res, 'overwatch fires with clear line');
+    assert.equal(called, true, 'performAttack spy was called');
+    assert.equal(overwatcher.reactions.length, 0, 'reaction consumed');
+  } finally {
+    delete process.env.COMBAT_LOS_ENABLED;
+  }
+});


### PR DESCRIPTION
Closes the slice-1 reaction-path known-gap for the paths that are actually line-of-fire attacks. GATED (flag-dormant, COMBAT_LOS_ENABLED OFF): overwatch (reactionEngine.triggerOnMove) and the bond counter-attack (bondReactionTrigger.fireCounterAttack) -- both fire a real performAttack from one cell to another, so a blocker between them now stops the shot when LOS is on. NOT gated (recon-verified as having no attacker->target line, LOS inapplicable): triggerOnDamage (adjacent-ally intercept/HP-absorb), terrainReactTile (single-tile AOE burst), beastBondReaction + bond shield_ally (aura/HP-transfer buff). Terrain-only (3-arg losClearOnGrid, matches main). Flag OFF => byte-identical; full reaction regression green. Merge = Eduardo.