### PR TITLE
fix(balance): trim mantello_meteoritico buff_amount 4->3 (outlier at hybrid tier)

### DIFF
--- a/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
+++ b/packs/evo_tactics_pack/data/balance/trait_mechanics.yaml
@@ -24,7 +24,8 @@ notes: >
   armatura_pietra_planare_guard). NON violano il budget 2 AP/turn: si consumano via
   Overcharge (spendi 3 SG -> +1 AP questo turno; apps/backend/services/combat/overchargeEngine.js,
   route POST /session/:id/overcharge), il gemello simmetrico di /defy. Riclassificato
-  mantello_meteoritico defensive -> hybrid: tanka (def+2, buff+4) E colpisce (meteor_strike 1d8+2).
+  mantello_meteoritico defensive -> hybrid: tanka (def+2, buff+3) E colpisce (meteor_strike 1d8+2).
+  Outlier-trim 2026-07-04: buff 4->3 (era unico max file, comb/AP 3.50 top -> 3.17 al cap).
 
 # O1 pattern (OpenRA template inheritance): baseline defaults per classe.
 # Trait possono usare `inherits: <class>` per ereditare campi dalla classe.
@@ -574,7 +575,12 @@ traits:
         cost_ap: 3
         effect_type: buff
         buff_stat: defense_mod
-        buff_amount: 4
+        # balance 2026-07-04: buff_amount 4->3 = allinea al cap del file (era unico max).
+        # Post-reclassify hybrid (TKT-P6-AP3) l'outlier era comb/AP 3.50 (top file);
+        # trim al cap -> 3.17 (pareggia il top tier, non lo supera). Nuke intatto.
+        # Evidenza EV-parity statico (balance-auditor): la policy sim non esercita
+        # cost_ap 2-3 -> N=40 WR = false-null, EV-parity = fonte (precedente #2381).
+        buff_amount: 3
         buff_duration: 1
         target: self
       - ability_id: meteor_strike
@@ -584,7 +590,7 @@ traits:
         damage_dice: { count: 1, sides: 8, modifier: 2 }
         channel: earth
         target: enemy
-    notes: "Hybrid class (TKT-P6-AP3: tanks def+2/buff+4 E nukes meteor_strike 1d8+2, ex-defensive). T3 bump applied to defense_mod. Sprint 6: ability earth + resistance earth+15. cost_ap:3 ultimate = Overcharge-gated."
+    notes: "Hybrid class (TKT-P6-AP3: tanks def+2/buff+3 E nukes meteor_strike 1d8+2, ex-defensive). T3 bump applied to defense_mod. Sprint 6: ability earth + resistance earth+15. cost_ap:3 ultimate = Overcharge-gated. buff 4->3 (2026-07-04) = outlier-trim al cap del file."
   lingua_tattile_trama:
     attack_mod: 0
     defense_mod: 0


### PR DESCRIPTION
## Follow-up to TKT-P6-AP3 (#3208) -- confirmed outlier trim

The reclassify close (#3208) was doc-only (band-neutral) and correct. But it made `mantello_meteoritico` the file's richest trait as a hybrid, and it was never sim-verified under the hybrid lens. `balance-auditor` ran the outlier check.

### Verdict: OUTLIER (over-band as hybrid)

Combined power-density per AP = **3.50 -- the highest in the file**, above even the pure nuke `power_strike` (3.00), while ALSO carrying a defensive buff, passive tankiness, and 3-channel resistances the nukes lack.

| trait | class | comb/AP |
|---|---|---|
| **mantello_meteoritico** | hybrid | **3.50** |
| power_strike | hybrid | 3.00 |
| coda_frusta (2 AP) | hybrid | 2.75 |
| sonic_blast | offensive | 2.67 |

Root-cause: the reclassify kept every defensive-tier number byte-identical and added the nuke on top, never re-normalizing for the hybrid tier. `meteoric_shield buff_amount:4` was the **unique file-wide max** (every other buff caps at 3, including its own ultimate-tier peers).

### Change (option A, master-dd verdict)
`meteoric_shield.buff_amount: 4 -> 3` -- aligns to the file cap. Post-trim combined/AP = **3.17**: ties the top tier instead of exceeding it. The newly-legalized nuke (the point of TKT-P6-AP3) is left untouched; only the pre-existing defensive over-value is cut. One-line value change + provenance comments + notes/header sync.

### Evidence: EV-parity static, NOT a WR sim (exercise-limit)
Verified `tools/sim/combat-policy.js:135` only issues basic 1-AP attacks and never invokes cost_ap 2-3 abilities. No policy in `tools/sim/` exercises `meteoric_shield`/`meteor_strike`, so an N=40 WR probe = false-null (~0% usage regardless of power). Per the #2381 precedent, the deterministic EV/AP static analysis is the evidentiary path. Documented honestly, not papered over.

### Gates
- validate-datasets: valid
- contracts-trait-mechanics: 16/16
- AI suite: 570/570
- combat-oracle: runs on CI (band check)

### Rollback
Revert this commit -- restores buff_amount:4. No runtime state touched.

Merge = master-dd. No self-merge.