### PR TITLE
feat(combat): AI LOS-repositioning (greedy step-to-los, flag-dormant)

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -44,6 +44,7 @@ const {
   losClearForAi,
 } = require('./policy');
 const { selectAiPolicyUtility } = require('./utilityBrain');
+const { stepToRegainLos } = require('../combat/losReposition');
 const { ARCHETYPE_VULN_CHANNEL } = require('../../routes/sessionConstants');
 // A2 (TKT-PRESSURE-TIER-ENCOUNTER): per-encounter pressure_tier_floor mirror.
 // sessionHelpers owns the single effectivePressure SoT (flag-gated, default OFF).
@@ -469,7 +470,20 @@ function createDeclareSistemaIntents(deps) {
         policy.intent === 'attack' &&
         !losClearForAi(session.grid, actor.position, target.position, session.units)
       ) {
-        policy = { ...policy, intent: 'approach', rule: `${policy.rule || 'REGOLA'}_LOS_BLOCKED` };
+        const occupied = new Set(
+          (session.units || [])
+            .filter((u) => u && u.position && (u.hp ?? 0) > 0 && u.id !== actor.id)
+            .map((u) => `${u.position.x},${u.position.y}`),
+        );
+        // Reposition to regain LOS on the CHOSEN target specifically (keep engaging
+        // it, do not switch enemies) -- pass only [target]. null -> plain approach.
+        const reposition = stepToRegainLos(actor, [target], session.grid, { occupied });
+        policy = {
+          ...policy,
+          intent: 'approach',
+          rule: `${policy.rule || 'REGOLA'}_LOS_BLOCKED`,
+          reposition_to: reposition || undefined,
+        };
       }
 
       // intent='skip' non genera nessun intent: l'unit resta ferma.
@@ -524,10 +538,12 @@ function createDeclareSistemaIntents(deps) {
 
       // intent='approach' o 'retreat' → move
       const positionFrom = { ...actor.position };
+      // `reposition_to` is set by the LOS-downgrade block above when a one-tile step
+      // reopens a firing line on the target; undefined -> plain approach (stepTowards).
       const nextPos =
         policy.intent === 'retreat'
           ? stepAway(actor.position, target.position, effectiveGrid)
-          : stepTowards(actor.position, target.position);
+          : policy.reposition_to || stepTowards(actor.position, target.position);
 
       if (!nextPos || (nextPos.x === positionFrom.x && nextPos.y === positionFrom.y)) {
         decisions.push({

--- a/apps/backend/services/combat/losReposition.js
+++ b/apps/backend/services/combat/losReposition.js
@@ -1,0 +1,66 @@
+// apps/backend/services/combat/losReposition.js
+'use strict';
+
+// Greedy one-tile LOS-repositioning (COMBAT_LOS_ENABLED, default OFF).
+// When a unit wants to attack but has no line of sight to any in-range enemy,
+// stepToRegainLos returns a 4-neighbor tile that reopens a clear firing line to
+// an enemy that would be in attack_range from that tile -- or null if no single
+// legal step reopens LOS (caller then falls back to its normal approach: never
+// worse than today). Pure + deterministic (tie-break: x then y). Shared by the
+// sim player-proxy and the prod Sistema AI so the ratify measures one AI.
+//
+// The caller controls WHICH enemies are considered: stepToRegainLos opens LOS to
+// the NEAREST in-range enemy present in `enemies` and may favor a different enemy
+// than the one the caller was engaging -- so a caller that wants to keep sight on
+// a specific target should pass only that target (the Sistema AI seam), while a
+// caller that will shoot whoever is visible can pass all foes (the sim player seam).
+// LOS is checked TERRAIN-ONLY here (losClearOnGrid without a units list); unit-body
+// occlusion (units_block_los) is a separate dormant axis, not modeled by this step.
+const { losClearOnGrid } = require('./losForGrid');
+
+function _manhattan(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function stepToRegainLos(actor, enemies, grid, opts) {
+  if (process.env.COMBAT_LOS_ENABLED !== 'true') return null;
+  if (!actor || !actor.position || !Array.isArray(enemies) || enemies.length === 0) return null;
+
+  const width = (grid && grid.width) || 6;
+  const height = (grid && grid.height) || 6;
+  const occupied = (opts && opts.occupied) || new Set();
+  const range = actor.attack_range ?? 1;
+  const live = enemies.filter((e) => e && e.position && (e.hp ?? 0) > 0);
+  if (live.length === 0) return null;
+
+  const { x, y } = actor.position;
+  const candidates = [
+    { x: x - 1, y },
+    { x: x + 1, y },
+    { x, y: y - 1 },
+    { x, y: y + 1 },
+  ]
+    .filter(
+      (c) => c.x >= 0 && c.y >= 0 && c.x < width && c.y < height && !occupied.has(`${c.x},${c.y}`),
+    )
+    .sort((a, b) => a.x - b.x || a.y - b.y);
+
+  let best = null;
+  let bestMetric = Infinity;
+  for (const c of candidates) {
+    let nearest = Infinity;
+    for (const e of live) {
+      if (_manhattan(c, e.position) <= range && losClearOnGrid(grid, c, e.position)) {
+        const d = _manhattan(c, e.position);
+        if (d < nearest) nearest = d;
+      }
+    }
+    if (nearest < bestMetric) {
+      bestMetric = nearest;
+      best = c;
+    }
+  }
+  return best;
+}
+
+module.exports = { stepToRegainLos };

--- a/docs/quality/2026-07-04-ai-los-repositioning-QUALITY.md
+++ b/docs/quality/2026-07-04-ai-los-repositioning-QUALITY.md
@@ -1,0 +1,224 @@
+# QUALITY -- AI LOS-repositioning (COMBAT_LOS_ENABLED, default OFF)
+
+## Summary
+
+A shared `stepToRegainLos` greedy 4-neighbor step-to-LOS helper
+(`apps/backend/services/combat/losReposition.js`), wired into two AI seams:
+the sim player-proxy (`tools/sim/combat-policy.js`, considers ALL live enemies
+so it opens a shot on whoever becomes visible) and the production Sistema AI
+(`apps/backend/services/ai/declareSistemaIntents.js`, repositions on the
+CHOSEN target only, so a flanking Sistema keeps engaging the same foe instead
+of switching prey mid-approach). Flag-dormant: `COMBAT_LOS_ENABLED` stays OFF
+on this branch, and the helper itself no-ops (`return null`) when the flag is
+unset, so both seams are byte-identical to pre-repositioning behavior. When
+the flag is eventually flipped, the helper degrades gracefully (returns
+`null`, caller falls back to its existing `stepToward`/`stepTowards` approach)
+whenever no single legal step reopens a firing line -- never worse than
+today.
+
+Purpose: de-confound the LOS ratify. Slice-1 (COMBAT_LOS_ENABLED hard-block,
+`docs/quality/2026-07-03-combat-los-slice1-QUALITY.md`) showed a large
+win-rate gap when a wall obstructs a straight firing line, but that gap could
+have been measuring "the sim/AI can't route around an obstacle" rather than
+"terrain LOS changes the encounter's balance". This branch adds the missing
+repositioning step so the eventual flip-decision ratify measures
+terrain-balance, not dumb pathing.
+
+## Step 1 -- Smoke (happy-path green + verifiable output)
+
+Unit + integration suites (all green):
+
+| Suite                        | File                                    | Pass  |
+| ---------------------------- | --------------------------------------- | ----- |
+| shared repositioning helper  | `tests/services/losReposition.test.js`  | 5/5   |
+| sim player-proxy integration | `tests/sim/combatPolicy.test.js`        | 23/23 |
+| prod Sistema AI integration  | `tests/services/aiLosDowngrade.test.js` | 7/7   |
+
+Full flag-OFF regression gate:
+
+- `npm run test:api` (two sub-suites): `tests/api` 77/77 pass, `tests/js`
+  5/5 pass. Exit 0.
+- `node --test tests/sim/*.test.js`: 225/225 pass on a clean run.
+  Two of five repeated runs during this gate intermittently failed 1-2
+  tests in `tests/sim/metaNetworkDriver.test.js` /
+  `tests/sim/fullLoopBatch.test.js` / `tests/sim/fullLoopRunner.test.js`
+  with `EADDRINUSE` on a fixed local port (49153-49156) -- a pre-existing
+  test-infra port-collision flake in files this branch never touches (last
+  modified in unrelated commit `495f855eb`, "meta-network expansion PR2").
+  Confirmed NOT a regression: isolating the run to exclude
+  `metaNetworkDriver.test.js` still reproduced the same EADDRINUSE pattern in
+  the other two files, and the clean/flaky runs alternate with no code
+  change in between. The final recorded run (below) is a clean 225/225 pass,
+  0 fail:
+
+  ```
+  tests 225
+  pass 225
+  fail 0
+  cancelled 0
+  skipped 0
+  todo 0
+  ```
+
+Flag OFF -> `stepToRegainLos` returns `null` unconditionally (first line of
+the function body), so neither wired seam's repositioning branch executes;
+both seams fall through to their pre-existing behavior unchanged.
+
+## Step 2 -- Ricerca (edge cases covered, >=3)
+
+- **No-reopening-step -> null -> graceful fallback (both seams).** When no
+  single 4-neighbor step reopens LOS to any candidate enemy (e.g. actor fully
+  walled in), `stepToRegainLos` returns `null` and the caller falls back to
+  its pre-existing approach logic: `stepToward` in the sim seam
+  (`tests/sim/combatPolicy.test.js`, "flag ON: LOS-blocked but no reopening
+  step -> graceful stepToward fallback (never worse than today)") and
+  `stepTowards` in the prod seam (`tests/services/aiLosDowngrade.test.js`,
+  "flag ON: LOS-blocked with no reopening step -> graceful stepTowards
+  fallback").
+- **Occupied / off-board candidate exclusion.** The 4-neighbor candidate set
+  filters out grid-bounds violations and tiles occupied by another live unit
+  before scoring (`tests/services/losReposition.test.js`, "flag ON: excludes
+  occupied + off-board candidate tiles").
+- **Determinism.** Same actor/enemies/grid input always returns the same
+  candidate tile (tie-break x-then-y), verified directly
+  (`tests/services/losReposition.test.js`, "flag ON: deterministic") and by
+  the re-probe below (two runs of the N=10 probe reproduced byte-identical
+  win/defeat/timeout splits per seed).
+- **[Target]-scope difference between the two seams is intentional, not a
+  bug.** The sim player-proxy passes ALL live enemies to `stepToRegainLos`
+  (it will shoot whoever becomes visible); the prod Sistema AI passes only
+  `[target]` (its already-chosen enemy) so a repositioning Sistema keeps
+  pressuring the same foe instead of re-targeting mid-flank. Both documented
+  inline in `losReposition.js` and covered by their respective seam tests.
+- **Terrain-only LOS; unit-blocking is a separate, still-dormant axis.**
+  `stepToRegainLos` checks `losClearOnGrid(grid, candidate, enemyPos)`
+  without a `units` argument, so it never considers unit-body occlusion
+  (`units_block_los`, default false) -- consistent with slice-1's scope. A
+  live blocker unit would not affect the repositioning target choice in
+  either seam today.
+- **Investigated during re-probe (see Step 3): repositioning DOES engage in
+  the full-encounter path.** Direct instrumentation of a live encounter
+  (`losForGrid.js`/`losReposition.js`/`combat-policy.js`, reverted after use,
+  confirmed clean via `git diff HEAD`) showed `stepToRegainLos` firing
+  correctly and moving the actor along the wall until LOS reopened. The
+  wiring itself is not the gap -- see the honest Step 3 finding below.
+
+## Step 3 -- Tuning + VALIDATION (the re-probe)
+
+The direction-probe script `tools/sim/los-n-probe.js` (owned by a separate,
+unmerged branch/PR #3207) was materialized into the working tree ONLY to
+re-run it, then removed -- it is not part of this branch's diff.
+
+**Baseline (pre-repositioning, PR #3207, N=10):**
+
+```
+flag_on:  win_rate 0.70, 7 wins / 0 defeats / 3 timeouts, avg_rounds ~unreported-base
+flag_off: win_rate 1.00, 10 wins / 0 defeats / 0 timeouts
+wr_delta:         -0.30
+avg_rounds_delta: +1.1
+```
+
+**This run (post-repositioning, N=10, two repeated runs, byte-identical
+both times):**
+
+```
+flag_on:  win_rate 0.70, 7 wins / 0 defeats / 3 timeouts, avg_rounds 25.4
+flag_off: win_rate 1.00, 10 wins / 0 defeats / 0 timeouts, avg_rounds 25.6
+wr_delta:         -0.30
+avg_rounds_delta: -0.20
+```
+
+Positive control (unchanged from baseline): 5/5 intended firing pairs
+confirmed LOS-blocked by the real `losClearOnGrid` rule before the batch, so
+the wall geometry does engage LOS as designed.
+
+**Honest finding: the win-rate gap did NOT shrink.** `wr_delta` is identical
+to the pre-repositioning baseline (-0.30, same 3/10 timeouts on flag ON).
+Only `avg_rounds_delta` moved (from +1.1 to -0.20), a minor pacing shift, not
+a WR-gap improvement.
+
+Root-cause investigation (temporary source-level tracing in
+`losForGrid.js`/`losReposition.js`/`tools/sim/combat-policy.js`, reverted
+after use -- `git diff HEAD` clean before this doc's commit) found the
+repositioning wiring itself is NOT the problem:
+
+- `stepToRegainLos` fires correctly for `ranged_1` (the only roster unit
+  that starts with an in-range-but-LOS-blocked target) and walks it along the
+  wall's edge (`(2,0) -> (3,0) -> (3,1) -> (3,2) ...`), regaining LOS at each
+  step exactly as designed.
+- Both losing (timeout) seeds and winning seeds show the same repositioning
+  behavior; the difference is action economy. In this synthetic scenario,
+  only `ranged_1` ever becomes the `active_unit` across all 30 rounds
+  (`ranged_2`/`ranged_3` never take a turn) -- a pre-existing turn-order
+  characteristic of this specific 3-vs-3 fixture, reproduced identically
+  with the flag OFF (flag OFF, seed 3: also only `ranged_1` acts, 21 attacks
+  in 30 rounds, but wins because it never has to spend a turn on `move`
+  instead of `attack`).
+- With the flag ON, `ranged_1` spends some of its scarce turns moving
+  (`action_type: 'move'`) to regain LOS instead of attacking. In an
+  already turn-starved encounter (one active unit carrying the whole fight),
+  that AP-economy cost is exactly enough to push 3 of 10 seeds past the
+  30-round cap before the last enemy dies (timeout with `enemy_hp_remaining`
+  0.12-0.39, i.e. very close to a kill, not a stalemate).
+
+**Interpretation:** this is a real, honestly-reported finding, not a wiring
+defect. The greedy one-tile step is functionally correct and de-confounds
+"can the AI route around a wall at all" (it now can). But in this
+turn-starved fixture, repositioning has a real opportunity cost
+(move-instead-of-attack), and that cost alone reproduces the same win-rate
+gap the un-repositioned baseline showed -- for a different reason. The
+fixture's single-active-unit turn-order pattern (present with the flag OFF
+too) means the probe may be measuring "cost of one fewer attack in a
+tightly-timed fight" more than "cost of terrain LOS on balance". This is a
+probe-fixture caveat worth flagging to whoever runs the eventual N=40 ratify,
+not a regression on this branch (flag OFF ships band-neutral regardless).
+
+NOTE per instructions: N=10 is a direction signal only (paired-seed, but the
+encounter has randomness) -- both the baseline and this run are single N=10
+samples; the byte-identical repeat (this run, twice) rules out RNG noise as
+the explanation for the unchanged gap, but does not by itself rule out
+fixture-specific artifacts becoming different at N=40 or with a different
+board/roster geometry.
+
+## Governance (SDMG)
+
+The greedy step-to-LOS heuristic is self-designed (this branch) and is
+therefore an ipotesi alto-errore, not a decision. Before any production flip
+of `COMBAT_LOS_ENABLED` is ratified, external falsification is REQUIRED:
+
+- **harsh-reviewer** on the method itself (is greedy-4-neighbor the right
+  tool, or does the turn-starvation interaction found above call for a
+  smarter step -- e.g. multi-tile lookahead, or excluding the repositioning
+  branch when AP is already scarce).
+- **game-design-validator** on the resulting AI behavior (does a flanking
+  Sistema stay coherent, or does the target-scoped repositioning risk
+  oscillation/degenerate pacing under other geometries not covered by this
+  N=10 probe).
+
+The flip stays owner-gated post N=40 (Eduardo), and this branch's honest
+non-improvement finding should be carried into that N=40 review rather than
+re-litigated from scratch.
+
+## Follow-up noted (fast-follow, not a merge blocker)
+
+Occupancy-set construction (`{x,y} -> Set` of live-unit tiles, excluding
+self) is now duplicated ~4x across the combat stack:
+
+- `tools/sim/combat-policy.js` (`occupiedSet`)
+- `apps/backend/services/ai/declareSistemaIntents.js` (inline `new Set(...)`
+  around the LOS-reposition call)
+- `apps/backend/services/combat/losForGrid.js` (`_unitBlocker`)
+- `apps/backend/services/abilityExecutor.js` (inline `new Set(...)`)
+
+A shared `services/combat/occupiedSetFromUnits` helper is a low-risk
+fast-follow, following the same pattern as the `losForGrid.js` shared-rule
+extraction that closed the slice-1 LOS-predicate triplication.
+
+## Flag / merge discipline
+
+`COMBAT_LOS_ENABLED` ships OFF (band-neutral) on every wired seam on this
+branch: the shared helper, the sim player-proxy, and the prod Sistema AI. The
+flip to ON remains owner-gated post-N=40 (Eduardo) and now additionally
+requires resolving the honest re-probe finding above (the WR gap did not
+shrink, root-caused to a turn-starved fixture rather than a repositioning
+defect) as part of that review, not as a merge blocker for this PR.

--- a/docs/superpowers/plans/2026-07-04-ai-los-repositioning.md
+++ b/docs/superpowers/plans/2026-07-04-ai-los-repositioning.md
@@ -1,0 +1,449 @@
+# AI LOS-repositioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `COMBAT_LOS_ENABLED` is ON and a unit's attack target is line-of-sight-blocked, the unit steps to a 4-neighbor tile that reopens a clear firing line (greedy, deterministic) instead of walking straight at the blocker; falls back to today's behavior when no single step reopens LOS.
+
+**Architecture:** A shared pure helper `stepToRegainLos` (in `apps/backend/services/combat/losReposition.js`) is consumed by BOTH the sim player-proxy (`tools/sim/combat-policy.js selectPlayerAction`) and the prod Sistema AI (`apps/backend/services/ai/declareSistemaIntents.js`), so the batch-sim ratify measures the same AI as production. It is reached only on the LOS-blocked branch, which only exists when `COMBAT_LOS_ENABLED` is ON -> flag OFF is byte-identical.
+
+**Tech Stack:** Node.js (CommonJS), `node --test`, Prettier.
+
+Design spec: `docs/superpowers/specs/2026-07-04-ai-los-repositioning-design.md` (committed e7e50fd).
+Branch: `feat/combat-los-repositioning` (already created off main; spec committed).
+
+**Commit trailer (every commit):** end the message with `Coding-Agent: claude-opus-4-8` and `Trace-Id: <uuidv7>` (fresh v7 per commit; NO Co-Authored-By). Conventional Commit, lowercase after `:`, subject <= 72 chars. ASCII-only.
+
+**Ground-truth pins (verified 2026-07-04, main 866ee0d):**
+
+- `losClearOnGrid(grid, from, to, units?)` (`apps/backend/services/combat/losForGrid.js`) returns true=VISIBLE; flag OFF => always true. 3-arg terrain-only form is what this plan uses.
+- `combat-policy.js`: `selectPlayerAction(actor, units, objective, opts)` default branch ends with
+  `const nearest = enemies.slice().sort(...)[0]; return stepToward(actor, nearest.position);`.
+  `occupiedSet(units, selfId)` (line ~47) already builds a `Set<"x,y">` of live OTHER units. `dist(a,b)` = Manhattan.
+- `combat-adapter.js:212`: `selectPlayerAction(active, units, objective, { focusFire, terrainFeatures })`; `gridSize` is in scope there (default 6).
+- `declareSistemaIntents.js:472`: the attack->approach LOS downgrade
+  `policy = { ...policy, intent: 'approach', rule: `${policy.rule || 'REGOLA'}\_LOS_BLOCKED` };`.
+  `:527-530`: `const nextPos = policy.intent === 'retreat' ? stepAway(...) : stepTowards(actor.position, target.position);`.
+  `session.grid` (with width/height) and `session.units` are in scope in the actor loop.
+
+---
+
+## Task 1: `losReposition.js` -- shared greedy step-to-LOS helper
+
+**Files:**
+
+- Create: `apps/backend/services/combat/losReposition.js`
+- Test: `tests/services/losReposition.test.js`
+
+- [ ] **Step 1: Write the failing test** `tests/services/losReposition.test.js`:
+
+```javascript
+// tests/services/losReposition.test.js
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { stepToRegainLos } = require('../../apps/backend/services/combat/losReposition');
+
+// A vertical wall of roccia at x=2 (y=0..2) blocks a straight horizontal shot but
+// leaves the tile above/below the actor open to sidestep and shoot around it.
+function grid(features) {
+  return { terrain_features: features, width: 6, height: 6 };
+}
+const WALL = [
+  { x: 2, y: 0, type: 'roccia' },
+  { x: 2, y: 1, type: 'roccia' },
+];
+
+test('flag OFF: helper is a no-op (returns null even when a step would open LOS)', () => {
+  delete process.env.COMBAT_LOS_ENABLED;
+  const actor = { position: { x: 0, y: 0 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 0 }, hp: 5 }];
+  assert.equal(stepToRegainLos(actor, enemies, grid(WALL), {}), null);
+});
+
+test('flag ON: steps to a 4-neighbor tile that reopens LOS to an in-range enemy', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = { position: { x: 0, y: 0 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 0 }, hp: 5 }]; // straight line blocked by the wall
+  // Stepping to (0,2) clears the y=0..1 wall (the ray (0,2)->(4,0) misses x=2,y=0..1).
+  const dest = stepToRegainLos(actor, enemies, grid(WALL), {});
+  assert.ok(dest, 'expected a repositioning tile');
+  const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
+  assert.equal(losClearOnGrid(grid(WALL), dest, enemies[0].position), true);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON: returns null when no single 4-neighbor step reopens LOS (full wall)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const full = [
+    { x: 2, y: 0, type: 'roccia' },
+    { x: 2, y: 1, type: 'roccia' },
+    { x: 2, y: 2, type: 'roccia' },
+    { x: 2, y: 3, type: 'roccia' },
+    { x: 2, y: 4, type: 'roccia' },
+    { x: 2, y: 5, type: 'roccia' },
+  ];
+  const actor = { position: { x: 0, y: 0 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 0 }, hp: 5 }];
+  assert.equal(stepToRegainLos(actor, enemies, grid(full), {}), null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON: excludes occupied + off-board candidate tiles', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = { position: { x: 0, y: 0 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 0 }, hp: 5 }];
+  // (0,-1) and (-1,0) are off-board; occupy (0,1) so the only LOS-opening step upward is blocked.
+  const dest = stepToRegainLos(actor, enemies, grid(WALL), { occupied: new Set(['0,1']) });
+  // With (0,1) occupied, a single legal step cannot reach (0,2), so no reopening step -> null.
+  assert.equal(dest, null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON: deterministic tie-break (same input -> same tile)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = { position: { x: 3, y: 3 }, attack_range: 5 };
+  const enemies = [{ position: { x: 5, y: 3 }, hp: 5 }];
+  const feats = [{ x: 4, y: 3, type: 'roccia' }];
+  const a = stepToRegainLos(actor, enemies, grid(feats), {});
+  const b = stepToRegainLos(actor, enemies, grid(feats), {});
+  assert.deepEqual(a, b);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /c/dev/Game && node --test tests/services/losReposition.test.js`
+Expected: FAIL -- `Cannot find module '.../losReposition'`.
+
+- [ ] **Step 3: Implement `losReposition.js`**
+
+```javascript
+// apps/backend/services/combat/losReposition.js
+'use strict';
+
+// Greedy one-tile LOS-repositioning (COMBAT_LOS_ENABLED, default OFF).
+// When a unit wants to attack but has no line of sight to any in-range enemy,
+// stepToRegainLos returns a 4-neighbor tile that reopens a clear firing line to
+// an enemy that would be in attack_range from that tile -- or null if no single
+// legal step reopens LOS (caller then falls back to its normal approach: never
+// worse than today). Pure + deterministic (tie-break: x then y). Shared by the
+// sim player-proxy and the prod Sistema AI so the ratify measures one AI.
+const { losClearOnGrid } = require('./losForGrid');
+
+function _manhattan(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function stepToRegainLos(actor, enemies, grid, opts) {
+  // Flag OFF -> no repositioning (the branch that calls this only exists flag-ON;
+  // this guard makes the helper itself safe/no-op when called directly OFF).
+  if (process.env.COMBAT_LOS_ENABLED !== 'true') return null;
+  if (!actor || !actor.position || !Array.isArray(enemies) || enemies.length === 0) return null;
+
+  const width = (grid && grid.width) || 6;
+  const height = (grid && grid.height) || 6;
+  const occupied = (opts && opts.occupied) || new Set();
+  const range = actor.attack_range ?? 1;
+  const live = enemies.filter((e) => e && e.position && (e.hp ?? 1) > 0);
+  if (live.length === 0) return null;
+
+  const { x, y } = actor.position;
+  // 4-neighbor candidates in deterministic order (x then y ascending after filtering).
+  const candidates = [
+    { x: x - 1, y },
+    { x: x + 1, y },
+    { x, y: y - 1 },
+    { x, y: y + 1 },
+  ]
+    .filter(
+      (c) => c.x >= 0 && c.y >= 0 && c.x < width && c.y < height && !occupied.has(`${c.x},${c.y}`),
+    )
+    .sort((a, b) => a.x - b.x || a.y - b.y);
+
+  let best = null;
+  let bestMetric = Infinity;
+  for (const c of candidates) {
+    let nearest = Infinity;
+    for (const e of live) {
+      if (_manhattan(c, e.position) <= range && losClearOnGrid(grid, c, e.position)) {
+        const d = _manhattan(c, e.position);
+        if (d < nearest) nearest = d;
+      }
+    }
+    if (nearest < bestMetric) {
+      bestMetric = nearest;
+      best = c;
+    }
+  }
+  return best; // null if no candidate reopened LOS to an in-range enemy
+}
+
+module.exports = { stepToRegainLos };
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd /c/dev/Game && node --test tests/services/losReposition.test.js`
+Expected: PASS (5/5). If a geometry case fails, verify the expected against `losClearOnGrid` directly (the tests are the contract for the interface, but the exact reopening tile depends on `squareLos` geometry -- adjust the test's asserted tile to the algorithm's real output only after confirming the algorithm reopens LOS at all).
+
+- [ ] **Step 5: Prettier + commit**
+
+```bash
+cd /c/dev/Game && npx prettier --write apps/backend/services/combat/losReposition.js tests/services/losReposition.test.js
+cd /c/dev/Game && git add apps/backend/services/combat/losReposition.js tests/services/losReposition.test.js && git commit  # "feat(combat): greedy step-to-LOS repositioning helper"
+```
+
+---
+
+## Task 2: Wire the sim player-proxy (`combat-policy.js`) + regression
+
+**Files:**
+
+- Modify: `tools/sim/combat-policy.js` (`selectPlayerAction` default branch)
+- Modify: `tools/sim/combat-adapter.js:212` (thread `gridSize` into opts)
+- Test: `tests/sim/combatPolicy.test.js` (extend)
+
+- [ ] **Step 1: Write the failing test** -- append to `tests/sim/combatPolicy.test.js` (match the file's existing actor/enemy shape):
+
+```javascript
+test('flag ON: LOS-blocked ranged attacker repositions instead of walking at the wall', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = {
+    id: 'p1',
+    position: { x: 0, y: 0 },
+    attack_range: 5,
+    ap_remaining: 2,
+    controlled_by: 'player',
+  };
+  const enemy = { id: 'e1', position: { x: 4, y: 0 }, hp: 10, controlled_by: 'sistema' };
+  const units = [actor, enemy];
+  const opts = {
+    terrainFeatures: [
+      { x: 2, y: 0, type: 'roccia' },
+      { x: 2, y: 1, type: 'roccia' },
+    ],
+    gridSize: 6,
+  };
+  const action = selectPlayerAction(actor, units, null, opts);
+  // Not an attack (LOS blocked) and not a plain step toward the enemy row (y stays 0);
+  // it should move to a tile that reopens LOS (y changes) rather than stepToward(nearest).
+  assert.equal(action.action_type, 'move');
+  assert.notEqual(action.target_position.y, 0);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag OFF: same setup is byte-identical (attacks or steps toward as before)', () => {
+  delete process.env.COMBAT_LOS_ENABLED;
+  const actor = {
+    id: 'p1',
+    position: { x: 0, y: 0 },
+    attack_range: 5,
+    ap_remaining: 2,
+    controlled_by: 'player',
+  };
+  const enemy = { id: 'e1', position: { x: 4, y: 0 }, hp: 10, controlled_by: 'sistema' };
+  const units = [actor, enemy];
+  const opts = { terrainFeatures: [{ x: 2, y: 0, type: 'roccia' }], gridSize: 6 };
+  const action = selectPlayerAction(actor, units, null, opts);
+  assert.equal(action.action_type, 'attack'); // flag OFF -> LOS ignored -> in-range attack
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /c/dev/Game && node --test tests/sim/combatPolicy.test.js`
+Expected: FAIL on the flag-ON case (currently returns a `stepToward` with `y===0`).
+
+- [ ] **Step 3: Add the require + wire the fallback.** At the top of `combat-policy.js` (near the losForGrid require):
+
+```javascript
+const { stepToRegainLos } = require('../../apps/backend/services/combat/losReposition');
+```
+
+In `selectPlayerAction`, the default branch currently ends:
+
+```javascript
+// None in range (or no AP): approach the nearest.
+const nearest = enemies
+  .slice()
+  .sort((a, b) => dist(actor.position, a.position) - dist(actor.position, b.position))[0];
+return stepToward(actor, nearest.position);
+```
+
+Replace that tail with (LOS-repositioning before the plain approach):
+
+```javascript
+// COMBAT_LOS_ENABLED (default OFF): if the reason nothing is attackable is that
+// in-range enemies are LOS-blocked, try a one-tile step that reopens a firing
+// line before falling back to a plain approach. Flag OFF -> losFn is a no-op so
+// no enemy is ever LOS-blocked -> this block is skipped (byte-identical).
+const gridForLos = {
+  terrain_features: (opts && opts.terrainFeatures) || [],
+  width: (opts && opts.gridSize) || 6,
+  height: (opts && opts.gridSize) || 6,
+};
+const losBlockedInRange = enemies.some(
+  (e) =>
+    dist(actor.position, e.position) <= (actor.attack_range || 1) &&
+    !losFn(actor.position, e.position),
+);
+if (losBlockedInRange) {
+  const repos = stepToRegainLos(actor, enemies, gridForLos, {
+    occupied: occupiedSet(units, actor.id),
+  });
+  if (repos) return { action_type: 'move', target_position: repos };
+}
+// None in range (or no AP): approach the nearest.
+const nearest = enemies
+  .slice()
+  .sort((a, b) => dist(actor.position, a.position) - dist(actor.position, b.position))[0];
+return stepToward(actor, nearest.position);
+```
+
+- [ ] **Step 4: Thread `gridSize` from the adapter.** In `tools/sim/combat-adapter.js:212` change
+      `selectPlayerAction(active, units, objective, { focusFire, terrainFeatures })` to
+      `selectPlayerAction(active, units, objective, { focusFire, terrainFeatures, gridSize })`.
+      Confirm `gridSize` is the in-scope identifier there (grep `gridSize` in the file; it is used in the start-body terrain block ~line 98).
+
+- [ ] **Step 5: Run tests + regression**
+
+Run: `cd /c/dev/Game && node --test tests/sim/combatPolicy.test.js tests/sim/combatAdapter.test.js` -> PASS (new cases + existing unchanged; flag OFF byte-identical).
+
+- [ ] **Step 6: Prettier + commit**
+
+```bash
+cd /c/dev/Game && npx prettier --write tools/sim/combat-policy.js tools/sim/combat-adapter.js tests/sim/combatPolicy.test.js
+cd /c/dev/Game && git add tools/sim/combat-policy.js tools/sim/combat-adapter.js tests/sim/combatPolicy.test.js && git commit  # "feat(sim): player-proxy repositions to regain LOS (flag-gated)"
+```
+
+---
+
+## Task 3: Wire the prod Sistema AI (`declareSistemaIntents.js`) + regression
+
+**Files:**
+
+- Modify: `apps/backend/services/ai/declareSistemaIntents.js` (downgrade site ~:472 + move resolution ~:527)
+- Test: `tests/services/aiLosDowngrade.test.js` (extend)
+
+- [ ] **Step 1: Write the failing test** -- append to `tests/services/aiLosDowngrade.test.js` (reuse its session builder). Assert that when the attack->approach downgrade fires under a wall, the emitted move goes to a LOS-reopening tile (off the straight line), not straight toward the target:
+
+```javascript
+test('flag ON: LOS-downgraded Sistema approaches a LOS-reopening tile, not straight at the target', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  // Build a session (reuse the file's helper): SIS attacker at (0,0) range 5,
+  // player target at (4,0), a roccia wall at (2,0)+(2,1) between them.
+  // Expect the emitted move for the SIS to have y !== 0 (stepped to reopen LOS),
+  // and its decision rule to carry the _LOS_BLOCKED suffix.
+  // ... construct via the same makeSession/buildDeclare helpers already in this file ...
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+```
+
+(Construct the scenario with the file's existing `makeSession`/`buildDeclare` DI helpers -- SIS `attack_range: 5`, player at (4,0), wall `roccia` at (2,0) and (2,1); grid width/height 6. Assert the SIS `move` intent's destination `y !== 0` and the decision `rule` matches `/_LOS_BLOCKED$/`. If the harness only exposes decisions not raw move coords, assert on the decision fields it does expose plus that no `attack` intent was emitted for the SIS.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /c/dev/Game && node --test tests/services/aiLosDowngrade.test.js`
+Expected: FAIL (today the downgrade approaches straight toward the target).
+
+- [ ] **Step 3: Add the require + compute the reposition at the downgrade + honor it at the move.**
+
+Add to the existing policy require or near the top of `declareSistemaIntents.js`:
+
+```javascript
+const { stepToRegainLos } = require('../combat/losReposition');
+```
+
+At the downgrade site (currently ~:470-472):
+
+```javascript
+if (
+  policy &&
+  policy.intent === 'attack' &&
+  !losClearForAi(session.grid, actor.position, target.position, session.units)
+) {
+  const foes = (session.units || []).filter(
+    (u) => u && u.position && (u.hp ?? 1) > 0 && u.controlled_by !== actor.controlled_by,
+  );
+  const occupied = new Set(
+    (session.units || [])
+      .filter((u) => u && u.position && (u.hp ?? 1) > 0 && u.id !== actor.id)
+      .map((u) => `${u.position.x},${u.position.y}`),
+  );
+  const reposition = stepToRegainLos(actor, foes, session.grid, { occupied });
+  policy = {
+    ...policy,
+    intent: 'approach',
+    rule: `${policy.rule || 'REGOLA'}_LOS_BLOCKED`,
+    reposition_to: reposition || undefined,
+  };
+}
+```
+
+At the approach/retreat move resolution (currently ~:527-530):
+
+```javascript
+// intent='approach' o 'retreat' -> move
+const positionFrom = { ...actor.position };
+const nextPos =
+  policy.intent === 'retreat'
+    ? stepAway(actor.position, target.position, effectiveGrid)
+    : policy.reposition_to || stepTowards(actor.position, target.position);
+```
+
+(Only the `approach` branch changes: when `reposition_to` is present it moves there; otherwise the current `stepTowards`. `retreat` is untouched.)
+
+- [ ] **Step 4: Run tests + regression**
+
+Run: `cd /c/dev/Game && node --test tests/services/aiLosDowngrade.test.js tests/services/aiLosFilter.test.js tests/ai/declareSistemaIntents.test.js tests/api/roundExecute.test.js` -> PASS (new case + existing unchanged; flag OFF byte-identical -> the downgrade branch never runs, so `reposition_to` is never set).
+
+- [ ] **Step 5: Prettier + commit**
+
+```bash
+cd /c/dev/Game && npx prettier --write apps/backend/services/ai/declareSistemaIntents.js tests/services/aiLosDowngrade.test.js
+cd /c/dev/Game && git add apps/backend/services/ai/declareSistemaIntents.js tests/services/aiLosDowngrade.test.js && git commit  # "feat(combat): Sistema AI repositions to regain LOS (flag-gated)"
+```
+
+---
+
+## Task 4: Re-probe validation + QUALITY.md + PR
+
+**Files:**
+
+- Create: `docs/quality/2026-07-04-ai-los-repositioning-QUALITY.md`
+
+- [ ] **Step 1: Full backend + sim gate**
+
+Run: `cd /c/dev/Game && npm run test:api` and `cd /c/dev/Game && node --test tests/sim/*.test.js`
+Expected: green (flag OFF everywhere -> band-neutral / byte-identical).
+
+- [ ] **Step 2: Re-run the LOS ratify direction probe (validation)**
+
+Run: `cd /c/dev/Game && node tools/sim/los-n-probe.js 10 2>&1 | tail -30`
+Record the new `wr_delta` and `avg_rounds_delta`. Compare to the pre-repositioning baseline (flag_on WR 0.70 vs OFF 1.00, wr_delta -0.30, +3 timeouts). Expected: the WR gap SHRINKS and timeouts drop (the player-proxy now sidesteps the wall). If the gap does NOT shrink, that is a finding (either the wiring is not engaging or the greedy one-tile step is insufficient for this wall) -- report it rather than hiding it. Paste both before/after numbers.
+
+- [ ] **Step 3: Write QUALITY.md**
+
+Document: (1) Smoke -- losReposition 5/5 + the two consumer integration tests + flag-OFF regression (paste outputs); (2) Ricerca -- edge cases (no-step-reopens -> null/fallback, occupied/off-board exclusion, determinism, both consumers); (3) Tuning -- the greedy 4-neighbor + graceful-fallback choice + the before/after re-probe delta. Then the SDMG governance note: the heuristic is self-designed -> external falsification (harsh-reviewer on the method + game-design-validator on the AI behavior) is REQUIRED before the production flip is ratified; the flip stays owner-gated post N=40.
+
+- [ ] **Step 4: Prettier + commit + push + PR (merge = Eduardo)**
+
+```bash
+cd /c/dev/Game && npx prettier --write docs/quality/2026-07-04-ai-los-repositioning-QUALITY.md
+cd /c/dev/Game && git add docs/quality/2026-07-04-ai-los-repositioning-QUALITY.md && git commit  # "docs(quality): ai los-repositioning gate + re-probe delta"
+cd /c/dev/Game && git push -u origin feat/combat-los-repositioning
+cd /c/dev/Game && gh pr create -R MasterDD-L34D/Game --base main --head feat/combat-los-repositioning --title "feat(combat): AI LOS-repositioning (greedy step-to-LOS, flag-dormant)" --body-file <PR body>
+```
+
+PR body: summary; the shared helper + both wired consumers; flag-OFF band-neutral; the before/after re-probe delta; the SDMG external-falsification requirement before any flip; forbidden-path note if applicable. Merge = Eduardo.
+
+---
+
+## Notes for the executor
+
+- **Flag discipline:** never set `COMBAT_LOS_ENABLED=true` outside a test (`delete` after). The merge ships with the flag OFF -- this slice only makes the (dormant) mechanic smarter.
+- **Parity:** the sim and prod consumers MUST call the same `stepToRegainLos` with the same semantics -- do not fork the heuristic.
+- **Determinism:** if you reach for `Math.random`/`Date` or a non-deterministic sort, stop -- the ratify depends on determinism.
+- **Never worse than today:** the fallback (no reopening step -> plain approach) is load-bearing; keep it.

--- a/docs/superpowers/specs/2026-07-04-ai-los-repositioning-design.md
+++ b/docs/superpowers/specs/2026-07-04-ai-los-repositioning-design.md
@@ -1,0 +1,175 @@
+---
+title: 'AI LOS-repositioning: passo per riaprire la linea di vista (flag-dormant) -- design spec'
+date: 2026-07-04
+doc_status: draft
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-07-04'
+source_of_truth: false
+language: it
+review_cycle_days: 90
+tags: [combat, ai, los, repositioning, ratify, sdmg, spec]
+---
+
+# AI LOS-repositioning: passo per riaprire la linea di vista (flag-dormant)
+
+> **Origine**: la ratify direzione N=10 di `COMBAT_LOS_ENABLED` (PR #3207,
+> `tools/sim/los-n-probe.js`) ha misurato WR flag-ON 0.70 vs OFF 1.00 (delta -0.30, +3 timeout)
+> su una mappa dove il positive-control conferma 5/5 linee di tiro LOS-bloccate. Il calo e' in
+> parte un GAP AI reale, non puro balance: quando tutti i target in-range sono LOS-bloccati, il
+> player-proxy sim (`combat-policy.selectPlayerAction`) ricade su `stepToward(nearest)` e il
+> Sistema AI prod (`declareSistemaIntents`, downgrade attack->approach) avanza verso il target --
+> **nessuno dei due si riposiziona per riaprire la linea**. Sotto un muro di blocker l'attaccante
+> cammina dritto e stalla -> timeout. Questo spec progetta il riposizionamento LOS-aware, cosi'
+> la ratify misuri il balance-terreno reale e non il pathing stupido.
+
+## 1. Contesto e obiettivo
+
+Il flip di `COMBAT_LOS_ENABLED` e' owner-gated post N=40 (SDMG). La ratify e' inaffidabile finche'
+l'AI resta cieca al riposizionamento: il delta WR e' confuso tra "il terreno cambia il balance"
+e "l'AI non sa aggirare il blocker". Obiettivo: un passo di riposizionamento **greedy, deterministico,
+condiviso** che, quando un'unita' vuole attaccare ma non ha LOS su nessun target in-range, muove
+verso una cella adiacente che riapre una linea di tiro -- altrimenti ricade sul comportamento
+attuale (mai peggio di oggi). Flag-dormant: raggiunto solo con `COMBAT_LOS_ENABLED` ON.
+
+## 2. Decisioni ratificate (brainstorming 2026-07-04)
+
+| Asse        | Scelta                                                                                                                                                                                                                                                                 |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scope       | **Player-proxy sim (`combat-policy`) + Sistema AI prod (`declareSistemaIntents`) insieme** -- stessa regola su entrambi = parita' AI preservata (il ratify misura la stessa AI della produzione). Cambio comportamentale di PRODUZIONE -> governance pesante (sez. 8). |
+| Euristica   | **Greedy one-tile step-to-LOS con fallback grazioso**: prova ad aprire la linea in un passo; se nessun passo la apre, avanza come oggi.                                                                                                                                |
+| Vicinato    | **4-neighbor ortogonale** (coerente col movimento reale: `moveCost.js` Dijkstra 4-neighbor + `stepToward` a singolo asse). Le diagonali NON sono mosse legali del combat.                                                                                              |
+| Flag        | Raggiunto solo sul branch LOS-bloccato -> `COMBAT_LOS_ENABLED` OFF = byte-identico. Nessun nuovo flag.                                                                                                                                                                 |
+| Blocker LOS | Terrain-only (3-arg `losClearOnGrid`, come lo slice-1). Unit-blocking (`units_block_los`) resta un asse separato/dormiente.                                                                                                                                            |
+
+## 3. Vincoli e non-scope
+
+**Vincoli:**
+
+- **Determinismo**: helper puro, nessun `Math.random`/`Date`, tie-break deterministico (x poi y).
+  Il ratify gira seedato; il riposizionamento non deve introdurre non-determinismo.
+- **Flag OFF byte-identico** su ENTRAMBI i consumer (regression dedicata): con flag OFF il branch
+  LOS-bloccato non esiste, quindi `stepToRegainLos` non e' mai chiamato.
+- **Mai peggio di oggi**: se nessun passo apre LOS, il fallback e' l'esatto comportamento attuale
+  (`stepToward(nearest)` sim / approach prod). Il riposizionamento non puo' far stallare un'unita'
+  che oggi avanzerebbe.
+- **Movimento 4-neighbor legale**: le celle candidate devono essere mosse valide (in-bounds, non
+  occupate da unita' viva) -- altrimenti il backend le rifiuta (`session.js` "casella occupata").
+- Zero nuove dipendenze prod. ASCII-first; Conventional Commits; trailer ADR-0011.
+
+**Non-scope**: unit-blocking repositioning (terrain-only qui); pathfinding multi-tile / A\* (one-tile
+greedy soltanto); diagonali; il flip del flag (owner-gated, post N=40 + falsificazione esterna);
+riposizionamento per intent non-attacco (retreat/kite restano invariati).
+
+## 4. Architettura
+
+### 4.1 Helper condiviso `apps/backend/services/combat/losReposition.js`
+
+```
+stepToRegainLos(actor, enemies, grid, opts) -> {x, y} | null
+```
+
+- `actor`: `{position:{x,y}, attack_range}`.
+- `enemies`: array di unita' nemiche vive `{position:{x,y}, hp}`.
+- `grid`: `{terrain_features, width, height}` (per `losClearOnGrid` + bounds).
+- `opts`: `{ occupied?: Set<"x,y"> }` (celle occupate da altre unita' vive, per escludere mosse illegali).
+
+Algoritmo (puro, integer, deterministico):
+
+1. Candidate = i 4 vicini ortogonali `(x+1,y),(x-1,y),(x,y+1),(x,y-1)` di `actor.position` che
+   sono in-bounds (0..width-1 / 0..height-1) e NON in `opts.occupied`.
+2. Per ogni candidate `c` (ordine deterministico: x crescente poi y crescente): trova gli enemy che
+   da `c` sarebbero (a) in `attack_range` (Manhattan) E (b) LOS-clear
+   (`losClearOnGrid(grid, c, enemy.position)` === true). Se >=1 -> `c` e' un candidate valido, con
+   metrica = distanza Manhattan al nemico LOS-clear piu' vicino.
+3. Ritorna il candidate valido con metrica minima (tie-break: x poi y). Nessun candidate valido -> `null`.
+
+Nota LOS: `stepToRegainLos` usa `losClearOnGrid` con `COMBAT_LOS_ENABLED` gia' ON (e' chiamato solo
+in quel branch), quindi il predicato riflette il terreno reale. Endpoints esclusi da `squareLos`.
+
+### 4.2 Wiring dei due consumer (flag-dormant)
+
+**(A) Sim player-proxy -- `tools/sim/combat-policy.js selectPlayerAction`.** Oggi: se
+`pickInRangeTarget(... losFn)` ritorna null (tutti i target LOS-bloccati o fuori range) -> `stepToward(nearest)`.
+Nuovo: PRIMA del fallback, se il flag e' ON e c'e' >=1 nemico in-range-ma-LOS-bloccato, prova
+`stepToRegainLos(actor, enemies, grid-da-opts, {occupied})`; se ritorna una tile -> `move` li';
+altrimenti `stepToward(nearest)` (invariato). Il `grid` arriva da `opts.terrainFeatures` (gia'
+threadato da `combat-adapter`). Flag OFF -> `losFn` no-op -> il target non e' mai LOS-bloccato ->
+branch mai raggiunto.
+
+**(B) Sistema AI prod -- `apps/backend/services/ai/declareSistemaIntents.js`.** Oggi: il downgrade
+`attack->approach` (LOS-bloccato, gia' shippato) produce `intent:'approach'` e il movimento risolve
+verso il target. Nuovo: quando il downgrade scatta, calcola la destinazione via
+`stepToRegainLos(actor, enemies, session.grid, {occupied})`; se apre LOS -> approach verso quella
+cella; altrimenti l'approach attuale (verso il target). Solo `attack->approach` LOS-bloccato; gli
+altri intent (retreat/kite/skip) invariati. Flag OFF -> nessun downgrade -> branch mai raggiunto.
+
+## 5. Data flow (path B, produzione)
+
+```
+declareSistemaIntents: policy.intent === 'attack' && !losClearForAi(...) (downgrade gia' shippato)
+   | flag ON + LOS-bloccato
+   dest = stepToRegainLos(actor, enemies, session.grid, {occupied})
+   | dest != null -> intent 'approach' verso dest (riapre la linea al prossimo turno)
+   | dest == null -> approach attuale verso il target (fallback invariato)
+```
+
+## 6. Testing e Definition of Done
+
+Casa test: `tests/services/losReposition.test.js` (helper puro) + estensione
+`tests/sim/combatPolicy.test.js` (path A) + `tests/services/aiLosDowngrade.test.js` o
+`declareSistemaIntents.test.js` (path B).
+
+- **Smoke**: `stepToRegainLos` apre LOS quando un passo laterale libera la linea (muro con un varco
+  a una cella); ritorna `null` quando nessun passo la apre (muro pieno); esclude celle occupate /
+  off-board; determinismo (stesso input -> stessa tile, tie-break x poi y).
+- **Ricerca (>=3 edge)**: nemico in-range-dopo-il-passo ma non prima; due candidate che aprono LOS
+  su nemici diversi (tie-break); tutti i candidate occupati -> null; nemico gia' LOS-clear -> il
+  branch non e' nemmeno raggiunto (no-op).
+- **Regression flag-OFF**: con `COMBAT_LOS_ENABLED` unset, `combat-policy` e `declareSistemaIntents`
+  byte-identici a oggi (il branch LOS-bloccato non esiste) -- suite sim + AI verdi, conteggi invariati.
+- **Validazione ratify**: ri-esegui `tools/sim/los-n-probe.js 10` -> atteso che il gap WR -0.30 si
+  **restringa** (il player-proxy ora aggira il muro). Registra il nuovo delta before/after.
+- **DoD**: `node --test` verde (output mostrato) + Prettier + zero TODO/stub + determinismo verificato
+  - spec/commit ADR-0011.
+
+## 7. Balance / ratify
+
+Il riposizionamento **non flippa nulla**: e' band-neutral con flag OFF. Il suo scopo e' rendere la
+ratify N=40 (owner-gated) misura del balance-terreno reale e non del pathing. Sequenza post-merge:
+re-probe N=10 (gap atteso in calo) -> se il delta residuo e' piccolo/accettabile -> N=40 su
+`full-loop-batch` + `los-n-probe` -> falsificazione esterna (sez. 8) -> decisione flip di Eduardo.
+
+## 8. SDMG / governance (load-bearing)
+
+L'euristica greedy step-to-LOS e la sua soglia (4-neighbor, metrica advance-mentre-apri) sono
+**self-designed = ipotesi ad alto errore**, e questo e' un cambio COMPORTAMENTALE di PRODUZIONE
+(il Sistema AI gioca diversamente). Pre-ratifica del rollout prod:
+
+- **Falsificazione esterna**: `harsh-reviewer` sul metodo (l'euristica e' misurabile/corretta? il
+  fallback e' davvero mai-peggio-di-oggi? il determinismo regge?) + `game-design-validator` sul
+  comportamento (un Sistema che flanka e' coerente col design / non degenera in kiting infinito?).
+- **Adozione narrow**: flag-dormant (nessun impatto finche' `COMBAT_LOS_ENABLED` OFF).
+- **Decider = Eduardo**, non l'euristica: il flip resta owner-gated post N=40.
+
+## 9. Rischi / caveat
+
+- **R1 one-tile miope**: un muro largo puo' richiedere piu' passi per aggirare; il greedy one-tile
+  apre solo se un singolo passo basta. Mitigazione: fallback grazioso (avanza comunque) -> nel giro
+  di piu' turni l'unita' progredisce; multi-tile pathfinding = non-scope (YAGNI finche' il re-probe
+  non lo richiede).
+- **R2 loop/oscillazione**: due unita' che si riposizionano potrebbero oscillare. Mitigazione:
+  determinismo + il commit-window guard esistente (`declareSistemaIntents` K4) gia' anti-flip;
+  verificare nel re-probe che i timeout calino (non aumentino).
+- **R3 parita' sim<->prod**: se i due consumer wirano l'helper in modo diverso, il ratify diverge.
+  Mitigazione: stessa `stepToRegainLos`, stessa semantica "apri-LOS-o-fallback"; test di parita'.
+- **R4 SDMG**: euristica ipotesi -> sez. 8 (falsificazione esterna pre-flip).
+
+## 10. Riferimenti
+
+- Ratify probe: `tools/sim/los-n-probe.js` (PR #3207); risultato N=10 nel report di sessione.
+- Regola LOS condivisa: `apps/backend/services/combat/losForGrid.js` (`losClearOnGrid`).
+- Downgrade AI gia' shippato: `apps/backend/services/ai/declareSistemaIntents.js` (attack->approach).
+- Sim player-proxy: `tools/sim/combat-policy.js` (`selectPlayerAction`, `stepToward`).
+- Movimento 4-neighbor: `apps/backend/services/combat/moveCost.js` (Dijkstra).
+- Slice-1 design + gap noti: `docs/superpowers/specs/2026-07-03-combat-los-slice1-design.md`.

--- a/tests/services/aiLosDowngrade.test.js
+++ b/tests/services/aiLosDowngrade.test.js
@@ -150,3 +150,111 @@ test('flag ON: LOS-blocked non-attack intent (retreat) passes through unchanged'
   assert.ok(!/_LOS_BLOCKED$/.test(decisions[0].rule));
   delete process.env.COMBAT_LOS_ENABLED;
 });
+
+// Task 3 (AI LOS-repositioning wiring): when the attack->approach downgrade
+// fires, the SIS must step to a LOS-reopening tile (stepToRegainLos) instead
+// of walking straight toward its chosen target -- and must keep engaging
+// THAT target (only [target] is passed to stepToRegainLos, not all foes).
+//
+// Geometry: SIS at (0,1) attack_range 5, player target at (4,1), roccia wall
+// at (2,0) and (2,1) blocking the row, grid 6x6. Verified via a direct
+// stepToRegainLos(actor, [target], grid, {}) call: the reopening tile is
+// (0,2) (matches the task's suggested geometry, no adjustment needed).
+// Straight stepTowards from (0,1) toward (4,1) would produce (1,1) (still on
+// the blocked row, y===1) -- the reposition must NOT match that.
+const LOS_REPOSITION_UNITS = [
+  {
+    id: 'p1',
+    hp: 10,
+    max_hp: 10,
+    ap: 2,
+    position: { x: 4, y: 1 },
+    controlled_by: 'player',
+    status: {},
+  },
+  {
+    id: 'sis',
+    hp: 10,
+    max_hp: 10,
+    ap: 2,
+    attack_range: 5,
+    position: { x: 0, y: 1 },
+    controlled_by: 'sistema',
+    status: {},
+  },
+];
+
+function makeLosRepositionSession(terrainFeatures) {
+  return {
+    session_id: 'los-reposition',
+    turn: 1,
+    units: LOS_REPOSITION_UNITS,
+    grid: { width: 6, height: 6, terrain_features: terrainFeatures },
+    sistema_pressure: 100,
+  };
+}
+
+test('flag ON: LOS-blocked target -> SIS repositions to regain LOS (not straight approach)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const declare = buildDeclare();
+  const session = makeLosRepositionSession([
+    { x: 2, y: 0, type: 'roccia' },
+    { x: 2, y: 1, type: 'roccia' },
+  ]);
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  assert.equal(intents[0].action.type, 'move');
+  // Repositioned off the blocked row -- NOT a straight step toward target
+  // (which would stay on y===1).
+  assert.notEqual(intents[0].action.move_to.y, 1);
+  assert.deepEqual(intents[0].action.move_to, { x: 0, y: 2 });
+  assert.equal(decisions[0].intent, 'approach');
+  assert.ok(/_LOS_BLOCKED$/.test(decisions[0].rule));
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag OFF: same LOS-blocked geometry -> byte-identical, no downgrade/reposition', () => {
+  delete process.env.COMBAT_LOS_ENABLED;
+  const declare = buildDeclare();
+  const session = makeLosRepositionSession([
+    { x: 2, y: 0, type: 'roccia' },
+    { x: 2, y: 1, type: 'roccia' },
+  ]);
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  // Flag OFF -> losClearForAi() always true -> no downgrade -> straight attack.
+  assert.equal(intents[0].action.type, 'attack');
+  assert.equal(decisions[0].intent, 'attack');
+  assert.ok(!/_LOS_BLOCKED$/.test(decisions[0].rule));
+});
+
+// Graceful fallback (mirrors the sim seam's "no reopening step" test): when the
+// downgrade fires but NO single 4-neighbor step reopens LOS, stepToRegainLos
+// returns null and the SIS falls back to a plain stepTowards approach toward its
+// target -- never worse than today. FULL vertical wall at x=2 (y=0..5) blocks the
+// whole column, so no perpendicular step regains sight. Verified via a direct
+// stepToRegainLos(actor, [target], grid, {}) call: returns null; the harness then
+// emits the stepTowards advance move_to={x:1,y:1} (y stays 1, x advances toward
+// the target at (4,1) -- NOT a perpendicular reposition).
+function makeLosFullWallSession() {
+  const wall = [];
+  for (let y = 0; y <= 5; y++) wall.push({ x: 2, y, type: 'roccia' });
+  return makeLosRepositionSession(wall);
+}
+
+test('flag ON: LOS-blocked with no reopening step -> graceful stepTowards fallback', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const declare = buildDeclare();
+  const session = makeLosFullWallSession();
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  assert.equal(intents[0].action.type, 'move');
+  // Fallback fired: stepTowards advance toward target (y stays on the row,
+  // x advances) -- NOT a perpendicular reposition.
+  assert.deepEqual(intents[0].action.move_to, { x: 1, y: 1 });
+  assert.equal(intents[0].action.move_to.y, 1);
+  assert.equal(decisions[0].intent, 'approach');
+  // Downgrade still fired (LOS was blocked); there was just no reopening tile.
+  assert.ok(/_LOS_BLOCKED$/.test(decisions[0].rule));
+  delete process.env.COMBAT_LOS_ENABLED;
+});

--- a/tests/services/losReposition.test.js
+++ b/tests/services/losReposition.test.js
@@ -1,0 +1,74 @@
+// tests/services/losReposition.test.js
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { stepToRegainLos } = require('../../apps/backend/services/combat/losReposition');
+
+// A vertical wall of roccia at x=2 (y=0..1) blocks a straight horizontal shot but
+// leaves the tile above the actor open to sidestep and shoot around it.
+function grid(features) {
+  return { terrain_features: features, width: 6, height: 6 };
+}
+const WALL = [
+  { x: 2, y: 0, type: 'roccia' },
+  { x: 2, y: 1, type: 'roccia' },
+];
+
+test('flag OFF: helper is a no-op (returns null even when a step would open LOS)', () => {
+  delete process.env.COMBAT_LOS_ENABLED;
+  const actor = { position: { x: 0, y: 0 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 0 }, hp: 5 }];
+  assert.equal(stepToRegainLos(actor, enemies, grid(WALL), {}), null);
+});
+
+test('flag ON: steps to a 4-neighbor tile that reopens LOS to an in-range enemy', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  // Actor/enemy share y=1, which the 2-tile wall (y=0..1) also blocks; stepping
+  // to (0,2) -- below the wall -- is the single 4-neighbor tile that reopens LOS.
+  const actor = { position: { x: 0, y: 1 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 1 }, hp: 5 }];
+  const dest = stepToRegainLos(actor, enemies, grid(WALL), {});
+  assert.ok(dest, 'expected a repositioning tile');
+  const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
+  assert.equal(losClearOnGrid(grid(WALL), dest, enemies[0].position), true);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON: returns null when no single 4-neighbor step reopens LOS (full wall)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const full = [
+    { x: 2, y: 0, type: 'roccia' },
+    { x: 2, y: 1, type: 'roccia' },
+    { x: 2, y: 2, type: 'roccia' },
+    { x: 2, y: 3, type: 'roccia' },
+    { x: 2, y: 4, type: 'roccia' },
+    { x: 2, y: 5, type: 'roccia' },
+  ];
+  const actor = { position: { x: 0, y: 0 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 0 }, hp: 5 }];
+  assert.equal(stepToRegainLos(actor, enemies, grid(full), {}), null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON: excludes occupied + off-board candidate tiles', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  // Same actor/enemy as the "reopens LOS" case, where (0,2) is the ONLY tile
+  // that reopens LOS; occupying it must force a null (no other step qualifies,
+  // and off-board neighbors x=-1/y=-1 are already excluded by the bounds check).
+  const actor = { position: { x: 0, y: 1 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 1 }, hp: 5 }];
+  const dest = stepToRegainLos(actor, enemies, grid(WALL), { occupied: new Set(['0,2']) });
+  assert.equal(dest, null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON: deterministic (same input -> same tile)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = { position: { x: 3, y: 3 }, attack_range: 5 };
+  const enemies = [{ position: { x: 5, y: 3 }, hp: 5 }];
+  const feats = [{ x: 4, y: 3, type: 'roccia' }];
+  const a = stepToRegainLos(actor, enemies, grid(feats), {});
+  const b = stepToRegainLos(actor, enemies, grid(feats), {});
+  assert.deepEqual(a, b);
+  delete process.env.COMBAT_LOS_ENABLED;
+});

--- a/tests/sim/combatPolicy.test.js
+++ b/tests/sim/combatPolicy.test.js
@@ -229,10 +229,14 @@ test('pickInRangeTarget: losFn blocking the only in-range enemy -> null', () => 
 // Task 6 integration: selectPlayerAction wires opts.terrainFeatures through the shared
 // production losClearForAi (apps/backend/services/ai/policy.js), so the sim measures the
 // SAME LOS rule as production. Flag ON + a roccia blocker strictly between actor and the
-// only enemy -> the in-range attack is filtered out and the default branch falls back to
-// approach (move). Flag OFF (unset) -> losClearForAi always returns true -> byte-identical
-// attack.
-test('selectPlayerAction: LOS-blocked in-range enemy falls back to approach (flag ON)', () => {
+// only enemy -> the in-range attack is filtered out.
+// Task 2 (AI LOS-repositioning): with the reposition wiring, this now takes the
+// stepToRegainLos path (a perpendicular one-tile step that reopens a firing line),
+// NOT the plain stepToward-approach. A single-tile wall at (2,0) leaves a legal
+// reopening step, so the destination lands OFF the enemy's row (y != 0) -- proving
+// the reposition path fired rather than a straight stepToward toward the enemy
+// (which would advance on x and stay on row 0).
+test('flag ON: LOS-blocked enemy triggers repositioning', () => {
   process.env.COMBAT_LOS_ENABLED = 'true';
   try {
     const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 5, ap_remaining: 1 };
@@ -240,6 +244,8 @@ test('selectPlayerAction: LOS-blocked in-range enemy falls back to approach (fla
     const terrainFeatures = [{ x: 2, y: 0, type: 'roccia' }];
     const a = selectPlayerAction(actor, units, { type: 'elimination' }, { terrainFeatures });
     assert.equal(a.action_type, 'move');
+    // reposition moved perpendicular (off row 0), not a stepToward along row 0 at the wall.
+    assert.notEqual(a.target_position.y, 0);
   } finally {
     delete process.env.COMBAT_LOS_ENABLED;
   }
@@ -252,4 +258,92 @@ test('selectPlayerAction: same LOS-blocking geometry, flag OFF -> byte-identical
   const terrainFeatures = [{ x: 2, y: 0, type: 'roccia' }];
   const a = selectPlayerAction(actor, units, { type: 'elimination' }, { terrainFeatures });
   assert.deepEqual(a, { action_type: 'attack', target_id: 'e' });
+});
+
+// Task 2 (AI LOS-repositioning): the sim player-proxy plays "shoot whoever is visible", so
+// it passes ALL enemies to stepToRegainLos. When the only in-range enemy is LOS-blocked, the
+// proxy should try a one-tile reposition that reopens a firing line BEFORE falling back to
+// the dumb stepToward-along-the-wall approach.
+test('flag ON: LOS-blocked ranged attacker repositions instead of walking at the wall', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = {
+    id: 'p1',
+    position: { x: 0, y: 1 },
+    attack_range: 5,
+    ap_remaining: 2,
+    controlled_by: 'player',
+  };
+  const enemy = { id: 'e1', position: { x: 4, y: 1 }, hp: 10, controlled_by: 'sistema' };
+  const units = [actor, enemy];
+  const opts = {
+    terrainFeatures: [
+      { x: 2, y: 0, type: 'roccia' },
+      { x: 2, y: 1, type: 'roccia' },
+    ],
+    gridSize: 6,
+  };
+  const action = selectPlayerAction(actor, units, null, opts);
+  // LOS blocked -> not an attack; should move to a tile that reopens LOS (y changes off row 1),
+  // not a plain stepToward along row 1.
+  assert.equal(action.action_type, 'move');
+  assert.notEqual(action.target_position.y, 1);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag OFF: same setup is byte-identical (in-range attack, LOS ignored)', () => {
+  delete process.env.COMBAT_LOS_ENABLED;
+  const actor = {
+    id: 'p1',
+    position: { x: 0, y: 1 },
+    attack_range: 5,
+    ap_remaining: 2,
+    controlled_by: 'player',
+  };
+  const enemy = { id: 'e1', position: { x: 4, y: 1 }, hp: 10, controlled_by: 'sistema' };
+  const units = [actor, enemy];
+  const opts = {
+    terrainFeatures: [
+      { x: 2, y: 0, type: 'roccia' },
+      { x: 2, y: 1, type: 'roccia' },
+    ],
+    gridSize: 6,
+  };
+  const action = selectPlayerAction(actor, units, null, opts);
+  assert.equal(action.action_type, 'attack');
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+// Task 2 graceful fallback ("never worse than today"): flag ON + LOS-blocked but NO single
+// 4-neighbor step reopens a firing line (a FULL vertical wall) -> stepToRegainLos returns null
+// -> the code must fall THROUGH to the plain stepToward approach (not reposition, not stall).
+test('flag ON: LOS-blocked but no reopening step -> graceful stepToward fallback (never worse than today)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = {
+    id: 'p1',
+    position: { x: 0, y: 1 },
+    attack_range: 5,
+    ap_remaining: 2,
+    controlled_by: 'player',
+  };
+  const enemy = { id: 'e1', position: { x: 4, y: 1 }, hp: 10, controlled_by: 'sistema' };
+  const units = [actor, enemy];
+  const opts = {
+    terrainFeatures: [
+      { x: 2, y: 0, type: 'roccia' },
+      { x: 2, y: 1, type: 'roccia' },
+      { x: 2, y: 2, type: 'roccia' },
+      { x: 2, y: 3, type: 'roccia' },
+      { x: 2, y: 4, type: 'roccia' },
+      { x: 2, y: 5, type: 'roccia' },
+    ],
+    gridSize: 6,
+  };
+  const action = selectPlayerAction(actor, units, null, opts);
+  // No 4-neighbor step clears the full wall -> stepToRegainLos returns null ->
+  // the code falls through to the plain approach (stepToward toward the enemy).
+  assert.equal(action.action_type, 'move');
+  // stepToward from (0,1) toward (4,1) advances on x (toward the enemy), NOT a perpendicular reposition.
+  assert.equal(action.target_position.x, 1);
+  assert.equal(action.target_position.y, 1);
+  delete process.env.COMBAT_LOS_ENABLED;
 });

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -209,7 +209,11 @@ async function runEncounter(
       });
       if (oc && oc.status >= 200 && oc.status < 300) overchargeUses += 1;
     }
-    const action = selectPlayerAction(active, units, objective, { focusFire, terrainFeatures });
+    const action = selectPlayerAction(active, units, objective, {
+      focusFire,
+      terrainFeatures,
+      gridSize,
+    });
     if (!action) {
       await http.post('/api/session/turn/end', { session_id: sessionId });
       continue;

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -20,6 +20,7 @@
 // COMBAT_LOS_ENABLED default OFF -> losClearOnGrid always returns true -> the
 // LOS filter keeps every in-range candidate (byte-identical to pre-Task-6).
 const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
+const { stepToRegainLos } = require('../../apps/backend/services/combat/losReposition');
 
 const ZONE_PURSUIT_OBJECTIVES = new Set(['capture_point', 'sabotage', 'escape', 'escort']);
 
@@ -172,6 +173,26 @@ function selectPlayerAction(actor, units, objective, opts = {}) {
   const tgt = pickInRangeTarget(actor, enemies, opts && opts.focusFire, losFn);
   if (tgt && (actor.ap_remaining ?? 0) >= 1) {
     return { action_type: 'attack', target_id: tgt.id };
+  }
+  // COMBAT_LOS_ENABLED (default OFF): if nothing is attackable because in-range
+  // enemies are LOS-blocked, try a one-tile step that reopens a firing line before
+  // the plain approach. Flag OFF -> losFn is a no-op so no enemy is ever LOS-blocked
+  // -> this block is skipped (byte-identical).
+  const gridForLos = {
+    terrain_features: (opts && opts.terrainFeatures) || [],
+    width: (opts && opts.gridSize) || 6,
+    height: (opts && opts.gridSize) || 6,
+  };
+  const losBlockedInRange = enemies.some(
+    (e) =>
+      dist(actor.position, e.position) <= (actor.attack_range || 1) &&
+      !losFn(actor.position, e.position),
+  );
+  if (losBlockedInRange) {
+    const repos = stepToRegainLos(actor, enemies, gridForLos, {
+      occupied: occupiedSet(units, actor.id),
+    });
+    if (repos) return { action_type: 'move', target_position: repos };
   }
   // None in range (or no AP): approach the nearest.
   const nearest = enemies


### PR DESCRIPTION
## Summary

Adds a shared `stepToRegainLos` greedy 4-neighbor step-to-LOS helper
(`apps/backend/services/combat/losReposition.js`), wired into two AI seams so
the LOS ratify (`COMBAT_LOS_ENABLED`) can measure terrain-balance instead of
"the AI can't route around a wall":

- **sim player-proxy** (`tools/sim/combat-policy.js`): considers ALL live
  enemies -- opens a shot on whoever becomes visible.
- **prod Sistema AI** (`apps/backend/services/ai/declareSistemaIntents.js`):
  repositions on the CHOSEN target only, so a flanking Sistema keeps
  engaging the same foe instead of switching prey mid-approach.

`COMBAT_LOS_ENABLED` stays OFF on this branch. The helper no-ops (`return
null`) when the flag is unset, and degrades gracefully (falls back to the
existing `stepToward`/`stepTowards` approach) whenever no single legal step
reopens a firing line -- never worse than today.

## Full gate (flag OFF, band-neutral)

- `npm run test:api`: `tests/api` 77/77, `tests/js` 5/5. Exit 0.
- `node --test tests/sim/*.test.js`: 225/225 pass (clean run). Two of five
  repeated runs during this gate hit a pre-existing `EADDRINUSE` port-flake
  in `metaNetworkDriver.test.js` / `fullLoopBatch.test.js` /
  `fullLoopRunner.test.js` -- files this branch does not touch (last
  modified in unrelated commit `495f855eb`). Confirmed not a regression.
- New/changed suites: `losReposition.test.js` 5/5, `combatPolicy.test.js`
  23/23, `aiLosDowngrade.test.js` 7/7.

## Re-probe: before / after (the validation)

Re-ran the LOS ratify direction probe (`tools/sim/los-n-probe.js`, owned by
the separate unmerged branch/PR #3207 -- materialized into the tree only to
run it, then removed; NOT part of this branch's diff) to check whether
repositioning shrinks the win-rate gap the slice-1 hard-block exposed.

**Baseline (pre-repositioning, PR #3207, N=10):** `wr_delta -0.30` (flag_on
0.70/3 timeouts vs flag_off 1.00/0 timeouts), `avg_rounds_delta +1.1`.

**This branch (post-repositioning, N=10, reproduced byte-identical twice):**
`wr_delta -0.30` (flag_on 0.70/3 timeouts vs flag_off 1.00/0 timeouts, same
split), `avg_rounds_delta -0.20`.

**Honest finding: the gap did NOT shrink.** Root-cause investigation (temporary
tracing, reverted -- `git diff HEAD` clean) showed the repositioning wiring
itself works correctly (the actor walks along the wall regaining LOS at each
step as designed). The unchanged gap traces to this probe fixture's turn
order: only one roster unit ever becomes `active_unit` across all 30 rounds
(reproduced with the flag OFF too), so the extra `move` actions
repositioning spends -- instead of `attack` -- are enough action-economy
cost in an already turn-starved fight to push 3/10 seeds past the round cap
(timeout with enemy HP down to 12-39%, i.e. near-kill, not stalemate). Full
trace + reasoning in the QUALITY.md.

## Governance (SDMG)

The greedy heuristic is self-designed -- before any production flip of
`COMBAT_LOS_ENABLED`, external falsification is required: harsh-reviewer on
the method (does the turn-starvation interaction call for a smarter step?)
and game-design-validator on the AI behavior (does a flanking Sistema stay
coherent, or degenerate into oscillation under other geometries?). The flip
stays owner-gated post N=40 (Eduardo), and this branch's non-improvement
finding should feed that N=40 review.

## Follow-up noted (not a merge blocker)

Occupancy-set construction (`{x,y} -> Set` of live units) is now duplicated
~4x: `combat-policy.js` (`occupiedSet`), `declareSistemaIntents.js` (inline),
`losForGrid.js` (`_unitBlocker`), `abilityExecutor.js` (inline). A shared
`services/combat/occupiedSetFromUnits` helper is a low-risk fast-follow,
same pattern as the `losForGrid.js` shared-rule extraction.

## Details

Full 3-step Quality Gate + evidence in
`docs/quality/2026-07-04-ai-los-repositioning-QUALITY.md`.

**Merge = Eduardo.** Flag OFF; do not merge without explicit approval.
