### PR TITLE
fix(session): honest active_unit semantics + co-op free-ordering regression pin

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -2100,6 +2100,18 @@ function createSessionRouter(options = {}) {
       applyStressWaveTick(session); // SPEC-I ER6 (flag-gated, default OFF)
     }
 
+    // Co-op hand-off (ADR-2026-04-16 §2, addendum 2026-07-05): active_unit e'
+    // significativo solo mentre la catena sistema sta risolvendo. I player
+    // agiscono in ordine libero dentro il round (vincolo = AP budget), quindi
+    // quando la catena si ferma su una unit non-sistema (o morta/assente) non
+    // esiste una singola unit attiva: null, non il pin permanente sul primo
+    // player di turn_order (display "chi sta risolvendo ora" stantio + sim
+    // AI-driven affamati sul solo pinned actor).
+    const handoff = session.units.find((u) => u.id === session.active_unit);
+    if (!handoff || handoff.controlled_by !== 'sistema' || handoff.hp <= 0) {
+      session.active_unit = null;
+    }
+
     return { iaActions, bleedingEvents };
   }
 

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -2135,6 +2135,12 @@ function createRoundBridge(deps) {
       });
     }
 
+    // Co-op hand-off (ADR-2026-04-16 §2, addendum 2026-07-05): il round
+    // sistema e' completamente risolto e inizia una nuova planning phase
+    // player (ordine libero, vincolo = AP budget). Nessuna singola unit
+    // attiva durante il planning: null, non l'id stantio ereditato da /start.
+    session.active_unit = null;
+
     return {
       session_id: session.session_id,
       turn: session.turn,

--- a/docs/adr/ADR-2026-04-16-session-engine-round-migration.md
+++ b/docs/adr/ADR-2026-04-16-session-engine-round-migration.md
@@ -3,7 +3,7 @@ title: 'ADR-2026-04-16: Migrazione Node session engine al round-based combat mod
 doc_status: active
 doc_owner: combat-team
 workstream: combat
-last_verified: 2026-06-06
+last_verified: 2026-07-05
 source_of_truth: true
 language: it-en
 review_cycle_days: 180
@@ -200,3 +200,29 @@ Feature flag come safety net durante la transizione: abilita il rollback senza r
 Questo ADR chiude il **disallineamento temporaneo** dichiarato in ADR-2026-04-15 Conseguenze/Negative. Recepisce la decisione del round-based model come vincolo architetturale anche per il Node session engine. Dopo la migrazione, i due layer (Python rules engine + Node session engine) implementano la **stessa semantica** con interfacce diverse — Python come reference pura, Node come API-backed runtime.
 
 Il [`Final Design Freeze v0.9 §7`](../core/90-FINAL-DESIGN-FREEZE.md) recepisce la convergenza dei due layer come parte del combat system finale shipping.
+
+## Addendum 2026-07-05 -- Semantica `active_unit` ground-truthed (co-op free ordering)
+
+Ground-truth emerso dalla review LOS probe-v2 (PR #3212): post-M17 `session.active_unit`
+veniva scritto SOLO dalla catena AI di /start (`advanceThroughAiTurns`) e restava pinnato
+al primo player di `turn_order` per l'intero fight; `POST /action` risolve l'actor per
+`actor_id` senza alcun check su `active_unit`. Verdict e fix:
+
+1. **Il free player ordering dentro il round E' il design co-op inteso.** `POST /action`
+   autorizza per `actor_id` + AP budget (`validatePlayerIntent` somma gli intent pendenti
+   vs `ap_remaining`; refill solo a fine round), NON per posizione in `turn_order`.
+   Un enforcement del turn order player contraddirebbe il round model (planning condiviso
+   -> commit -> resolution, ADR-2026-04-15), il batch endpoint `/round/execute` e il flusso
+   composer co-op Godot.
+2. **`active_unit` ora e' onesto** (coerente con §2 "advisory"): valorizzato solo mentre
+   la catena sistema sta risolvendo; `null` al hand-off alla planning phase player
+   (da /start) e dopo `/turn/end`. Prima il pin permanente rendeva stantio il display
+   "chi sta risolvendo ora" (ctBar web / phone Godot) e affamava gli harness AI-driven
+   che pilotavano solo il pinned actor (LOS probe v1 starved).
+3. **Consumer verificati null-tolerant**: web `ctBar.js` (fallback priority, test
+   dedicato), `ui.js` ("Active: --"), Godot `phone_coop_ids.gd` (fallback chain, ""
+   se assente), replay panel, client HTML legacy (fallback `turn % 2`). Il driver
+   `tests/smoke/ai-driven-sim.js` ora sceglie il primo player vivo con AP residuo
+   quando `active_unit` e' `null`.
+4. **Regression pin**: `tests/api/coopTurnSemantics.test.js` (ordering libero 3-player,
+   null in planning, null post `/action` e post `/turn/end`, hand-off sistema-first).

--- a/tests/api/coopTurnSemantics.test.js
+++ b/tests/api/coopTurnSemantics.test.js
@@ -1,0 +1,187 @@
+// Co-op turn semantics regression pin (2026-07-05, PR #3212 LOS probe-v2 follow-up).
+//
+// Ground-truthed verdict (ADR-2026-04-16 §2 + addendum 2026-07-05):
+//   1. Free player ordering within a round IS the intended co-op design.
+//      POST /action authorizes by actor_id + AP budget, NOT by turn_order
+//      position. Enforcing a player turn order would contradict the round
+//      model (shared planning -> commit -> resolution) and break the co-op
+//      composer flow.
+//   2. session.active_unit is honest: meaningful only while the sistema AI
+//      chain is resolving (advanceThroughAiTurns). During the player planning
+//      phase it is null. It used to stay pinned to turn_order's first player
+//      for the whole fight (misleading "chi sta risolvendo ora" display +
+//      starved AI-driven sim harnesses that acted only with the pinned unit).
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createFlaggedApp,
+  startSession,
+  playerAttack,
+  turnEnd,
+  getState,
+} = require('./sessionTestHelpers');
+
+// 3-player party + 1 sistema. Initiative: pA > pB > pC > sis, so turn_order
+// is [pA, pB, pC, sis] and /start does NOT run the AI pre-phase. Every player
+// is within attack_range 2 of the enemy at (3,3); no unit sits on another's
+// LOS segment. mod 99 = deterministic hit (d20 + 99 vs DC ~10).
+function coopParty(overrides = {}) {
+  return [
+    {
+      id: 'pA',
+      species: 'velox',
+      job: 'skirmisher',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      attack_range: 2,
+      initiative: overrides.pAInitiative != null ? overrides.pAInitiative : 20,
+      position: { x: 2, y: 2 },
+      controlled_by: 'player',
+      mod: 99,
+    },
+    {
+      id: 'pB',
+      species: 'velox',
+      job: 'skirmisher',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      attack_range: 2,
+      initiative: 18,
+      position: { x: 3, y: 1 },
+      controlled_by: 'player',
+      mod: 99,
+    },
+    {
+      id: 'pC',
+      species: 'velox',
+      job: 'skirmisher',
+      hp: 10,
+      max_hp: 10,
+      ap: 2,
+      attack_range: 2,
+      initiative: 16,
+      position: { x: 1, y: 3 },
+      controlled_by: 'player',
+      mod: 99,
+    },
+    {
+      id: 'sis',
+      species: 'carapax',
+      job: 'vanguard',
+      // mod 99 scala il danno con la MoS: hp alto cosi' 3 attacchi non uccidono.
+      hp: 500,
+      max_hp: 500,
+      ap: 2,
+      attack_range: 1,
+      initiative: overrides.sisInitiative != null ? overrides.sisInitiative : 5,
+      position: { x: 3, y: 3 },
+      controlled_by: 'sistema',
+    },
+  ];
+}
+
+test('free player ordering: any player acts in any order within the round', async (t) => {
+  const { app, close, restore } = createFlaggedApp('true');
+  t.after(async () => {
+    restore();
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app, coopParty());
+  const state0 = await getState(app, sid);
+  assert.equal(state0.turn_order[0], 'pA', 'pA atteso primo in turn_order (initiative 20)');
+
+  // pB (turn_order[1]) acts FIRST -- must be authorized (actor_id + AP, not
+  // turn_order position).
+  const rB = await playerAttack(app, sid, 'pB', 'sis');
+  assert.equal(rB.status, 200, `pB out-of-order attack deve passare: ${JSON.stringify(rB.body)}`);
+  assert.equal(rB.body.result, 'hit', 'mod 99 = hit deterministico');
+  assert.ok(rB.body.damage_dealt > 0, 'danno atteso > 0');
+
+  // Then pA and pC in arbitrary order: full party acts in the same round.
+  const rA = await playerAttack(app, sid, 'pA', 'sis');
+  assert.equal(rA.status, 200, `pA attack deve passare: ${JSON.stringify(rA.body)}`);
+  const rC = await playerAttack(app, sid, 'pC', 'sis');
+  assert.equal(rC.status, 200, `pC attack deve passare: ${JSON.stringify(rC.body)}`);
+
+  const state1 = await getState(app, sid);
+  const sis = state1.units.find((u) => u.id === 'sis');
+  assert.ok(sis.hp < 500, `enemy hp scalato dai 3 attacchi, actual=${sis.hp}`);
+  // Same round: turn not advanced by player actions.
+  assert.equal(state1.turn, state0.turn, 'player actions non avanzano il turn counter');
+});
+
+test('active_unit e\' null durante la planning phase (hand-off da /start)', async (t) => {
+  const { app, close, restore } = createFlaggedApp('true');
+  t.after(async () => {
+    restore();
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app, coopParty());
+  const state = await getState(app, sid);
+  // turn_order[0] is a player -> no sistema chain is resolving -> honest
+  // active_unit = null (NOT pinned to pA).
+  assert.equal(
+    state.active_unit,
+    null,
+    `active_unit atteso null in planning phase, actual=${JSON.stringify(state.active_unit)}`,
+  );
+});
+
+test('active_unit resta null dopo /action e dopo /turn/end', async (t) => {
+  const { app, close, restore } = createFlaggedApp('true');
+  t.after(async () => {
+    restore();
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  const sid = await startSession(app, coopParty());
+
+  const rB = await playerAttack(app, sid, 'pB', 'sis');
+  assert.equal(rB.status, 200);
+  const stateMid = await getState(app, sid);
+  assert.equal(stateMid.active_unit, null, '/action non deve ri-puntare active_unit');
+
+  const te = await turnEnd(app, sid);
+  assert.equal(te.status, 200, `/turn/end deve passare: ${JSON.stringify(te.body)}`);
+  // The sistema round is fully resolved inside /turn/end; the response hands
+  // back a NEW planning phase -> no single active unit.
+  assert.equal(
+    te.body.active_unit,
+    null,
+    `active_unit atteso null nella response /turn/end, actual=${JSON.stringify(te.body.active_unit)}`,
+  );
+  const stateAfter = await getState(app, sid);
+  assert.equal(stateAfter.active_unit, null, 'active_unit atteso null anche in /state');
+  assert.equal(stateAfter.turn, 2, '/turn/end avanza il turn counter');
+});
+
+test('sistema-first: la catena AI di /start gira e poi consegna active_unit=null', async (t) => {
+  const { app, close, restore } = createFlaggedApp('true');
+  t.after(async () => {
+    restore();
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+
+  // sis first in initiative -> /start runs advanceThroughAiTurns (AI pre-phase)
+  // before handing off to players.
+  const units = coopParty({ sisInitiative: 30 });
+  const sid = await startSession(app, units);
+  const state = await getState(app, sid);
+  assert.equal(state.turn_order[0], 'sis', 'sis atteso primo in turn_order (initiative 30)');
+  // AI pre-phase ran: turn advanced past 1 by the sistema chain.
+  assert.ok(state.turn >= 2, `AI pre-phase attesa (turn >= 2), actual=${state.turn}`);
+  // Chain handed off to players -> planning phase -> honest null.
+  assert.equal(
+    state.active_unit,
+    null,
+    `active_unit atteso null post hand-off, actual=${JSON.stringify(state.active_unit)}`,
+  );
+});

--- a/tests/api/coopTurnSemantics.test.js
+++ b/tests/api/coopTurnSemantics.test.js
@@ -117,7 +117,7 @@ test('free player ordering: any player acts in any order within the round', asyn
   assert.equal(state1.turn, state0.turn, 'player actions non avanzano il turn counter');
 });
 
-test('active_unit e\' null durante la planning phase (hand-off da /start)', async (t) => {
+test("active_unit e' null durante la planning phase (hand-off da /start)", async (t) => {
   const { app, close, restore } = createFlaggedApp('true');
   t.after(async () => {
     restore();

--- a/tests/smoke/ai-driven-sim.js
+++ b/tests/smoke/ai-driven-sim.js
@@ -679,15 +679,25 @@ function logSistemaDecisions(round, body) {
     }
 
     const activeId = st.active_unit;
-    const activeUnit = units.find((u) => u.id === activeId);
-    if (!activeUnit) {
-      console.warn(`round ${rounds}: no active_unit`);
-      break;
-    }
+    let activeUnit = units.find((u) => u.id === activeId);
 
-    if (activeUnit.controlled_by === 'sistema') {
+    if (activeUnit && activeUnit.controlled_by === 'sistema') {
       // Server-side sistemaTurnRunner should have advanced the turn already
       // (via /turn/end). Force /turn/end to nudge if stuck.
+      const teRes = await postJson('/api/session/turn/end', { session_id: sessionId });
+      logSistemaDecisions(rounds, teRes.body);
+      continue;
+    }
+
+    // Co-op semantics (ADR-2026-04-16 §2, addendum 2026-07-05): active_unit
+    // e' null durante la player planning phase (ordine libero, vincolo = AP
+    // budget). Il driver sceglie il primo player vivo con AP residuo; nessuno
+    // -> /turn/end. Prima il driver pilotava SOLO il player pinnato in
+    // active_unit (starvation: gli altri player non agivano mai).
+    if (!activeUnit) {
+      activeUnit = players.find((u) => Number(u.ap_remaining ?? u.ap ?? 0) > 0);
+    }
+    if (!activeUnit) {
       const teRes = await postJson('/api/session/turn/end', { session_id: sessionId });
       logSistemaDecisions(rounds, teRes.body);
       continue;


### PR DESCRIPTION
## Contesto

Due finding ground-truthed durante la review LOS probe-v2 (PR #3212, 2026-07-05):

1. `session.active_unit` scritto SOLO dalla catena AI di `/start` (`advanceThroughAiTurns`, session.js ~2083-2101): appena la unit attiva e' un player, resta pinnata per l'intero fight. Ne' `/action` ne' `/turn/end` la ri-puntavano.
2. `POST /action` risolve l'actor per `body.actor_id` senza check su `active_unit`: qualsiasi player agisce in qualsiasi momento.

## Verdict: free ordering = design inteso (non bug)

Evidenza (dettaglio nell'addendum ADR):

- **ADR-2026-04-16 sez. 2**: `turn_order`/`turn_index`/`active_unit` dichiarati **advisory** ("display UI, non guidano piu' il flusso") post-migrazione round model.
- **M17 shipped**: `/action` e `/turn/end` sono wrapper sul round flow (planning -> commit -> resolution); il path sequenziale legacy e' rimosso.
- **Vincolo reale = AP budget**: `validatePlayerIntent` somma gli intent pendenti vs `ap_remaining`, `/action` rigetta ad AP<1, refill solo a fine round (gia' pinnato in `apBudget.test.js`).
- **Nessun client gata su active_unit**: Godot `phone_coop_ids.gd` = fallback display-only; web `ctBar.js` ha il test "no active_unit -> priority"; il publisher TV non forwarda nemmeno la key (follow-up #2727).

Enforcement del turn order avrebbe contraddetto il round model e rotto il flusso composer co-op.

## Fix: active_unit onesto

`active_unit` ora e' valorizzato solo mentre la catena sistema risolve; `null` durante la player planning phase:

- `advanceThroughAiTurns`: null al hand-off ai player (prima: pin permanente su `turn_order[0]` player).
- `handleTurnEndViaRound`: null quando inizia la nuova planning phase (response + state).
- `tests/smoke/ai-driven-sim.js`: il driver sceglie il primo player vivo con AP quando `active_unit` e' null -- fix della starvation single-pinned-actor che ha affamato il probe LOS v1.
- Addendum ADR-2026-04-16 con la semantica ground-truthed.

## Regression pin

`tests/api/coopTurnSemantics.test.js` (4 test, RED pre-fix sui 3 assert semantici):
- ordering libero: `turn_order[1]` agisce prima di `turn_order[0]`, party intero nello stesso round;
- `active_unit === null` in planning (hand-off da `/start`);
- `active_unit === null` dopo `/action` e dopo `/turn/end`;
- sistema-first: catena AI di `/start` gira poi consegna null.

## Test

- Nuovo file: 4/4 verdi.
- Blast radius round-model (apBudget, sessionLegacy/TurnEnd wrapper, sessionRoundEndpoints/Equivalence/StatusSyncWire, sessionRewind, roundExecute x3): 60/60 verdi.
- Full `npm run test:api` (gate CI): exit 0.
- `node --check` sul sim driver: OK.

## Note consumer

Tutti i read-site verificati null-tolerant: web ctBar/ui/replay, Godot fallback chain, Playtest.html legacy (`turn % 2`). Il campo resta presente nelle response (nessun breaking di shape).

Protocolli applicati: Refresh-verify (ADR + codice + client Godot + QA doc prima del verdict) - ground-truth > report - TDD (RED->GREEN) - regression pin.