### PR TITLE
fix(combat): authz on round routes + server-authoritative move AP cost

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -257,7 +257,10 @@ function createRoundBridge(deps) {
     if (actor.controlled_by !== 'player') {
       return {
         status: 403,
-        body: { error: `actor "${actorId}" non e' controllato dal player`, code: 'ACTOR_NOT_OWNED' },
+        body: {
+          error: `actor "${actorId}" non e' controllato dal player`,
+          code: 'ACTOR_NOT_OWNED',
+        },
       };
     }
     if (requireAlive && Number(actor.hp || 0) <= 0) {

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -243,6 +243,44 @@ function createRoundBridge(deps) {
     return null;
   }
 
+  // Authz precheck for the player-facing round routes (security fix 2026-07-05).
+  // The HTTP round endpoints (/declare-intent, /declare-reaction, /clear-intent,
+  // /undo-action) are the client surface; only player-controlled units may be
+  // driven from a client. SISTEMA (AI/enemy) intents are authored server-side by
+  // declareSistemaIntents, so a request naming a non-player actor is illegitimate
+  // (CWE-284 / CWE-639 IDOR). Returns null when allowed, else { status, body }.
+  function requirePlayerActor(session, actorId, { requireAlive = true } = {}) {
+    const actor = (session.units || []).find((u) => u.id === actorId);
+    if (!actor) {
+      return { status: 404, body: { error: `actor "${actorId}" non trovato`, code: 'NO_ACTOR' } };
+    }
+    if (actor.controlled_by !== 'player') {
+      return {
+        status: 403,
+        body: { error: `actor "${actorId}" non e' controllato dal player`, code: 'ACTOR_NOT_OWNED' },
+      };
+    }
+    if (requireAlive && Number(actor.hp || 0) <= 0) {
+      return {
+        status: 400,
+        body: { error: `actor "${actorId}" e' KO (hp ${actor.hp})`, code: 'ACTOR_DEAD' },
+      };
+    }
+    return null;
+  }
+
+  // Server-authoritative move AP cost (security fix 2026-07-05). The resolver
+  // must NOT trust action.ap_cost for moves: the shipped client posts ap_cost:1
+  // for any destination, so a raw request could move N tiles for 1 AP. Cost =
+  // max(1, Manhattan(from,to) - move_bonus), mirroring the legacy /session/action
+  // path (routes/session.js). Terrain-weighted cost stays on that legacy path;
+  // the round path uses the Manhattan basis by design (band-neutral).
+  function resolveMoveApCost(actor, from, to) {
+    const dist = typeof manhattanDistance === 'function' ? manhattanDistance(from, to) : 0;
+    const moveBonus = Math.max(0, Number((actor && actor.move_bonus_bonus) || 0));
+    return Math.max(1, dist - moveBonus);
+  }
+
   // ────────────────────────────────────────────────────────────────
   // Guards + adapters
   // ────────────────────────────────────────────────────────────────
@@ -1620,11 +1658,11 @@ function createRoundBridge(deps) {
           });
           turnLogEntry.skipped = 'blocked';
         } else {
+          // Server-authoritative move cost: ignore client action.ap_cost, charge
+          // real distance (minus move_bonus). Computed before the position write.
+          const moveApCost = resolveMoveApCost(actor, positionFrom, dest);
           actor.position = { x: dest.x, y: dest.y };
-          actor.ap_remaining = Math.max(
-            0,
-            (actor.ap_remaining ?? actor.ap) - Number(action.ap_cost || 1),
-          );
+          actor.ap_remaining = Math.max(0, (actor.ap_remaining ?? actor.ap) - moveApCost);
           const newFacing = facingFromMove(positionFrom, actor.position);
           if (newFacing) actor.facing = newFacing;
           const event = buildMoveEvent({ session, actor, positionFrom });
@@ -1923,11 +1961,11 @@ function createRoundBridge(deps) {
           });
           turnLogEntry.skipped = 'blocked';
         } else {
+          // Server-authoritative move cost (mirror of the unified path): charge
+          // real distance (minus move_bonus), not the intent's ap_cost field.
+          const moveApCost = resolveMoveApCost(actor, positionFrom, dest);
           actor.position = { x: dest.x, y: dest.y };
-          actor.ap_remaining = Math.max(
-            0,
-            (actor.ap_remaining ?? actor.ap) - Number(action.ap_cost || 1),
-          );
+          actor.ap_remaining = Math.max(0, (actor.ap_remaining ?? actor.ap) - moveApCost);
           const newFacing = facingFromMove(positionFrom, actor.position);
           if (newFacing) actor.facing = newFacing;
           const event = buildMoveEvent({ session, actor, positionFrom });
@@ -2290,17 +2328,22 @@ function createRoundBridge(deps) {
             .json({ error: "action richiesto (object con campi 'type', 'actor_id', ...)" });
         }
 
-        // Validate player intent against session state (range/AP/target/etc).
-        // SIS intents bypassano (generati da declareSistemaIntents già validato).
-        const actor = (session.units || []).find((u) => u.id === actorId);
-        if (actor && actor.controlled_by === 'player') {
-          const validationError = validatePlayerIntent(session, actorId, action);
-          if (validationError) {
-            return res.status(400).json({
-              error: validationError.message,
-              code: validationError.code,
-            });
-          }
+        // Actor-ownership authz (security fix): only a player-controlled, live unit
+        // may be driven from a client. SIS intents are authored server-side by
+        // declareSistemaIntents and never flow through this route, so a non-player
+        // actor here is illegitimate -- reject before any state mutation. This also
+        // guarantees validatePlayerIntent (range/AP/bounds) always runs for the
+        // actors the route accepts, closing the OUT_OF_GRID teleport bypass.
+        const ownershipError = requirePlayerActor(session, actorId, { requireAlive: true });
+        if (ownershipError) {
+          return res.status(ownershipError.status).json(ownershipError.body);
+        }
+        const validationError = validatePlayerIntent(session, actorId, action);
+        if (validationError) {
+          return res.status(400).json({
+            error: validationError.message,
+            code: validationError.code,
+          });
         }
 
         const state = ensureRoundState(session);
@@ -2353,6 +2396,13 @@ function createRoundBridge(deps) {
             .json({ error: "reaction_payload richiesto (object con campo 'type')" });
         }
 
+        // Actor-ownership authz (security fix): reactions may only be declared for
+        // player-controlled, live units. SIS reactions are engine-driven.
+        const ownershipError = requirePlayerActor(session, actorId, { requireAlive: true });
+        if (ownershipError) {
+          return res.status(ownershipError.status).json(ownershipError.body);
+        }
+
         const state = ensureRoundState(session);
         let current = state;
         if (current.round_phase !== PHASE_PLANNING) {
@@ -2394,6 +2444,13 @@ function createRoundBridge(deps) {
             .status(400)
             .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
         }
+        // Actor-ownership authz (security fix): a client may only clear intents for
+        // its own player units, never server-authored SIS intents. Alive not
+        // required -- a stale intent of a just-KO'd player unit stays clearable.
+        const ownershipError = requirePlayerActor(session, actorId, { requireAlive: false });
+        if (ownershipError) {
+          return res.status(ownershipError.status).json(ownershipError.body);
+        }
         const { nextState } = roundOrchestrator.clearIntent(session.roundState, actorId);
         session.roundState = nextState;
         res.json({
@@ -2424,6 +2481,12 @@ function createRoundBridge(deps) {
           return res
             .status(400)
             .json({ error: 'roundState non inizializzato (chiama prima /declare-intent)' });
+        }
+        // Actor-ownership authz (security fix): undo only a client's own player
+        // intents, never server-authored SIS intents.
+        const ownershipError = requirePlayerActor(session, actorId, { requireAlive: false });
+        if (ownershipError) {
+          return res.status(ownershipError.status).json(ownershipError.body);
         }
         const phase = session.roundState.round_phase;
         if (phase !== PHASE_PLANNING) {

--- a/tests/api/sessionDeclareIntentAuthz.test.js
+++ b/tests/api/sessionDeclareIntentAuthz.test.js
@@ -1,0 +1,159 @@
+// Actor-ownership authz on the player-facing round routes (security fix 2026-07-05).
+//
+// Threat model: co-op MVP, LAN, trust boundary = player-client vs server. The
+// HTTP round routes (/declare-intent, /declare-reaction, /clear-intent,
+// /undo-action) are the PLAYER surface. Only player-controlled units may be
+// driven by a client; SISTEMA (AI/enemy) intents are authored server-side by
+// declareSistemaIntents and must never be injected/mutated over HTTP.
+//
+// Regression guard for CWE-284/CWE-639 (IDOR): before the fix, /declare-intent
+// only ran validatePlayerIntent when actor.controlled_by === 'player', so a
+// client could declare an arbitrary intent for a SIS unit -- bypassing the
+// OUT_OF_GRID bounds check and teleporting an enemy off-grid.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { startSession, twoUnits } = require('./sessionTestHelpers');
+
+async function declare(app, sid, actorId, action) {
+  return request(app)
+    .post('/api/session/declare-intent')
+    .send({ session_id: sid, actor_id: actorId, action });
+}
+
+test('authz: declare-intent for a SIS actor is rejected 403 (not owned)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ sisPos: { x: 3, y: 2 } }));
+  const r = await declare(app, sid, 'sis', {
+    id: 'sis-mv',
+    type: 'move',
+    actor_id: 'sis',
+    ap_cost: 1,
+    move_to: { x: 3, y: 3 },
+  });
+  assert.equal(r.status, 403);
+  assert.equal(r.body.code, 'ACTOR_NOT_OWNED');
+});
+
+test('authz: declare-intent SIS off-grid move blocked (no teleport bypass)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ sisPos: { x: 3, y: 2 } }));
+  // Before the fix this returned 200 and stored an off-grid intent for 'sis'.
+  const r = await declare(app, sid, 'sis', {
+    id: 'sis-mv',
+    type: 'move',
+    actor_id: 'sis',
+    ap_cost: 1,
+    move_to: { x: 99, y: 99 },
+  });
+  assert.equal(r.status, 403);
+  assert.equal(r.body.code, 'ACTOR_NOT_OWNED');
+});
+
+test('authz: declare-intent for an unknown actor is rejected 404', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits());
+  const r = await declare(app, sid, 'ghost', {
+    id: 'ghost-mv',
+    type: 'move',
+    actor_id: 'ghost',
+    ap_cost: 1,
+    move_to: { x: 2, y: 3 },
+  });
+  assert.equal(r.status, 404);
+  assert.equal(r.body.code, 'NO_ACTOR');
+});
+
+test('authz: declare-intent for a dead player actor is rejected 400 (ACTOR_DEAD)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ p1Hp: 0 }));
+  const r = await declare(app, sid, 'p1', {
+    id: 'p1-mv',
+    type: 'move',
+    actor_id: 'p1',
+    ap_cost: 1,
+    move_to: { x: 2, y: 3 },
+  });
+  assert.equal(r.status, 400);
+  assert.equal(r.body.code, 'ACTOR_DEAD');
+});
+
+test('authz regression: declare-intent for a valid player actor still 200', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 } }));
+  const r = await declare(app, sid, 'p1', {
+    id: 'p1-mv',
+    type: 'move',
+    actor_id: 'p1',
+    ap_cost: 1,
+    move_to: { x: 2, y: 3 },
+  });
+  assert.equal(r.status, 200);
+  assert.equal(r.body.round_phase, 'planning');
+});
+
+test('authz: declare-reaction for a SIS actor is rejected 403', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ sisPos: { x: 3, y: 2 } }));
+  const r = await request(app)
+    .post('/api/session/declare-reaction')
+    .send({
+      session_id: sid,
+      actor_id: 'sis',
+      reaction_trigger: { event: 'on_hit' },
+      reaction_payload: { type: 'parry' },
+    });
+  assert.equal(r.status, 403);
+  assert.equal(r.body.code, 'ACTOR_NOT_OWNED');
+});
+
+test('authz: clear-intent for a SIS actor is rejected 403', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ sisPos: { x: 3, y: 2 } }));
+  // begin-planning populates a server-authored SIS intent we must not be able to drop.
+  await request(app).post('/api/session/round/begin-planning').send({ session_id: sid }).expect(200);
+  const r = await request(app)
+    .post('/api/session/clear-intent/sis')
+    .send({ session_id: sid });
+  assert.equal(r.status, 403);
+  assert.equal(r.body.code, 'ACTOR_NOT_OWNED');
+});
+
+test('authz: undo-action for a SIS actor is rejected 403', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ sisPos: { x: 3, y: 2 } }));
+  await request(app).post('/api/session/round/begin-planning').send({ session_id: sid }).expect(200);
+  const r = await request(app)
+    .post('/api/session/undo-action')
+    .send({ session_id: sid, actor_id: 'sis' });
+  assert.equal(r.status, 403);
+  assert.equal(r.body.code, 'ACTOR_NOT_OWNED');
+});

--- a/tests/api/sessionDeclareIntentAuthz.test.js
+++ b/tests/api/sessionDeclareIntentAuthz.test.js
@@ -136,10 +136,11 @@ test('authz: clear-intent for a SIS actor is rejected 403', async (t) => {
   });
   const sid = await startSession(app, twoUnits({ sisPos: { x: 3, y: 2 } }));
   // begin-planning populates a server-authored SIS intent we must not be able to drop.
-  await request(app).post('/api/session/round/begin-planning').send({ session_id: sid }).expect(200);
-  const r = await request(app)
-    .post('/api/session/clear-intent/sis')
-    .send({ session_id: sid });
+  await request(app)
+    .post('/api/session/round/begin-planning')
+    .send({ session_id: sid })
+    .expect(200);
+  const r = await request(app).post('/api/session/clear-intent/sis').send({ session_id: sid });
   assert.equal(r.status, 403);
   assert.equal(r.body.code, 'ACTOR_NOT_OWNED');
 });
@@ -150,7 +151,10 @@ test('authz: undo-action for a SIS actor is rejected 403', async (t) => {
     if (typeof close === 'function') await close().catch(() => {});
   });
   const sid = await startSession(app, twoUnits({ sisPos: { x: 3, y: 2 } }));
-  await request(app).post('/api/session/round/begin-planning').send({ session_id: sid }).expect(200);
+  await request(app)
+    .post('/api/session/round/begin-planning')
+    .send({ session_id: sid })
+    .expect(200);
   const r = await request(app)
     .post('/api/session/undo-action')
     .send({ session_id: sid, actor_id: 'sis' });

--- a/tests/api/sessionLegacyActionWrapper.test.js
+++ b/tests/api/sessionLegacyActionWrapper.test.js
@@ -155,12 +155,16 @@ test('with flag on, /action attack sets session.roundState to resolved phase', a
   // quindi auto-trigger beginRound (phase → planning).
   assert.equal(res.body.round_phase, 'resolved');
 
+  // This second declare-intent formerly named 'sis' (a SISTEMA unit) only as a
+  // shortcut -- SIS actors used to bypass validation. The route now rejects
+  // non-player actors (403), so drive the player unit p1 with a valid move; the
+  // assertion under test (auto beginRound: resolved -> planning) is unchanged.
   const declareRes = await request(app)
     .post('/api/session/declare-intent')
     .send({
       session_id: sessionId,
-      actor_id: 'sis',
-      action: { id: 'x', type: 'move', actor_id: 'sis', ap_cost: 1 },
+      actor_id: 'p1',
+      action: { id: 'x', type: 'move', actor_id: 'p1', ap_cost: 1, move_to: { x: 2, y: 3 } },
     })
     .expect(200);
   assert.equal(declareRes.body.round_phase, 'planning');

--- a/tests/api/sessionMoveApCharge.test.js
+++ b/tests/api/sessionMoveApCharge.test.js
@@ -1,0 +1,68 @@
+// Server-authoritative move AP cost on the round-model resolver (security fix
+// 2026-07-05).
+//
+// The round-model resolver deducted a flat Number(action.ap_cost || 1) for a
+// move, trusting a client-supplied field. The shipped playtest client posts
+// ap_cost:1 for ANY destination (public/Evo-Tactics -- Playtest.html), so a
+// player with N AP could move N tiles for 1 AP and keep N-1 AP for more actions.
+// validatePlayerIntent gates dist <= AP budget but never enforces ap_cost==dist.
+//
+// Fix: the resolver recomputes cost = max(1, Manhattan(from,to) - move_bonus),
+// ignoring the client value. buildMoveEvent already logged ap_spent = real
+// distance, so post-fix the deduction and the telemetry converge.
+//
+// AP reset happens at the NEXT begin-planning (applyEndOfRoundSideEffects), not
+// at commit-round, so post-commit state reflects the resolve-time deduction.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { startSession, twoUnits } = require('./sessionTestHelpers');
+
+async function resolveSingleMove(app, sid, moveTo, apCost) {
+  await request(app).post('/api/session/round/begin-planning').send({ session_id: sid }).expect(200);
+  await request(app)
+    .post('/api/session/declare-intent')
+    .send({
+      session_id: sid,
+      actor_id: 'p1',
+      action: { id: 'p1-mv', type: 'move', actor_id: 'p1', ap_cost: apCost, move_to: moveTo },
+    })
+    .expect(200);
+  await request(app)
+    .post('/api/session/commit-round')
+    .send({ session_id: sid, auto_resolve: true })
+    .expect(200);
+  const state = await request(app).get('/api/session/state').query({ session_id: sid });
+  return state.body.units.find((u) => u.id === 'p1');
+}
+
+test('AP charge: a 2-tile move with client ap_cost:1 costs 2 AP (real distance)', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  // p1 ap=2 at (2,2); SIS parked far away so it cannot interfere with the move.
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 }, sisPos: { x: 5, y: 5 } }));
+
+  const p1 = await resolveSingleMove(app, sid, { x: 2, y: 4 }, 1);
+
+  assert.deepEqual(p1.position, { x: 2, y: 4 }, 'move actually resolved (not skipped/blocked)');
+  assert.equal(p1.ap_remaining, 0, '2-tile move must charge 2 AP, not the client-declared 1');
+});
+
+test('AP charge regression: a 1-tile move still costs 1 AP', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 }, sisPos: { x: 5, y: 5 } }));
+
+  const p1 = await resolveSingleMove(app, sid, { x: 2, y: 3 }, 1);
+
+  assert.deepEqual(p1.position, { x: 2, y: 3 }, 'move actually resolved');
+  assert.equal(p1.ap_remaining, 1, '1-tile move charges 1 AP (unchanged)');
+});

--- a/tests/api/sessionMoveApCharge.test.js
+++ b/tests/api/sessionMoveApCharge.test.js
@@ -23,7 +23,10 @@ const { createApp } = require('../../apps/backend/app');
 const { startSession, twoUnits } = require('./sessionTestHelpers');
 
 async function resolveSingleMove(app, sid, moveTo, apCost) {
-  await request(app).post('/api/session/round/begin-planning').send({ session_id: sid }).expect(200);
+  await request(app)
+    .post('/api/session/round/begin-planning')
+    .send({ session_id: sid })
+    .expect(200);
   await request(app)
     .post('/api/session/declare-intent')
     .send({

--- a/tests/api/sessionRoundEndpoints.test.js
+++ b/tests/api/sessionRoundEndpoints.test.js
@@ -233,19 +233,20 @@ test('resolve-round priority order: higher initiative resolves first', async (t)
   });
   const sessionId = await startSession(app);
 
+  // begin-planning authors the SIS intent server-side. The /declare-intent route
+  // now rejects client-supplied SIS intents (403), so the enemy intent must enter
+  // the round the legitimate way; p1's intent is still declared explicitly. The
+  // test asserts resolution ORDER by initiative (p1 14 > sis 10), unchanged.
+  await request(app)
+    .post('/api/session/round/begin-planning')
+    .send({ session_id: sessionId })
+    .expect(200);
   await request(app)
     .post('/api/session/declare-intent')
     .send({
       session_id: sessionId,
       actor_id: 'p1',
       action: { id: 'p', type: 'attack', actor_id: 'p1', target_id: 'sis', ap_cost: 1 },
-    });
-  await request(app)
-    .post('/api/session/declare-intent')
-    .send({
-      session_id: sessionId,
-      actor_id: 'sis',
-      action: { id: 's', type: 'attack', actor_id: 'sis', target_id: 'p1', ap_cost: 1 },
     });
   await request(app).post('/api/session/commit-round').send({ session_id: sessionId });
   const resolveRes = await request(app)


### PR DESCRIPTION
## What

Closes two access-control / integrity defects on the round-model combat routes,
found via adversarial recon (2026-07-05, LOS-repositioning follow-up). Co-op MVP
threat model: LAN, trust boundary = player-client vs server; role auth exists but
is not per-unit-seat ownership.

### Finding 1 -- missing actor-ownership authz on the player-facing round routes (HIGH)
`POST /declare-intent` only ran `validatePlayerIntent` when
`actor.controlled_by === 'player'`. A raw client could therefore name a SISTEMA
(AI/enemy) unit and have its intent accepted with **zero** validation -- driving
the enemy team (declare `skip`/suicidal moves = auto-win) and, because the
`OUT_OF_GRID`/coordinate-type checks live *inside* `validatePlayerIntent`,
teleporting a SIS unit to arbitrary/off-grid/NaN coordinates (state corruption /
uncaught-500 vector). OWASP A01 (Broken Access Control), CWE-284 / CWE-639 (IDOR),
ASI03.

Fix: a `requirePlayerActor(session, actorId, {requireAlive})` precheck that
rejects any actor that is missing (404 `NO_ACTOR`), not player-controlled (403
`ACTOR_NOT_OWNED`), or KO'd (400 `ACTOR_DEAD`). Applied to all four player-facing
routes that name an actor: `/declare-intent`, `/declare-reaction`,
`/clear-intent/:actorId`, `/undo-action`. SIS intents are unaffected -- they are
authored server-side by `declareSistemaIntents` and never traversed these HTTP
handlers.

### Finding 2 -- AP undercharge: resolver trusted client `ap_cost` for moves (MEDIUM)
The round-model resolver deducted a flat `Number(action.ap_cost || 1)` for a move.
The shipped playtest client posts `ap_cost:1` for **any** destination
(`public/Evo-Tactics -- Playtest.html`), and `validatePlayerIntent` gates
`dist <= AP budget` but never `ap_cost == dist`. So a player with N AP could move
N tiles for 1 AP and keep N-1 AP for further actions. `buildMoveEvent` already
logged `ap_spent = real distance`, so the deduction and telemetry were desynced.
OWASP A04 (Insecure Design).

Fix: `resolveMoveApCost(actor, from, to) = max(1, Manhattan(from,to) - move_bonus)`,
computed at resolve, ignoring the client field. Mirrors the already-authoritative
legacy `/session/action` path (`routes/session.js:3031`). Applied in **both**
resolver move branches (unified + legacy SIS). The `move_bonus` (Ennea Esploratore)
free-tile semantics are preserved; the floor of 1 matches the legacy path.

## Tests (TDD -- red first, then green)
- New `tests/api/sessionDeclareIntentAuthz.test.js` (8 cases): SIS-actor
  declare-intent/reaction/clear/undo -> 403; off-grid SIS move blocked (no
  teleport); unknown actor -> 404; dead player -> 400; valid player -> 200.
- New `tests/api/sessionMoveApCharge.test.js` (2 cases): 2-tile move with client
  `ap_cost:1` charges 2 AP; 1-tile move still charges 1 AP (regression).
- Updated two pre-existing tests that declared **SIS** intents via `/declare-intent`
  purely as scaffolding (the behavior this PR forbids): `sessionRoundEndpoints`
  priority-order now seeds the enemy intent via `begin-planning`;
  `sessionLegacyActionWrapper` phase-transition now drives player `p1`. Assertions
  unchanged.

## Scope / deferred (explicit)
- **Attack and ability (`else`-branch) AP costs are still client-declared.** There
  is no server-side action-cost table for those here, so `max(ap_cost, ...)` has
  nothing to clamp against. Same class as Finding 2, deferred -- follow-up: a
  server-side action-cost table.
- Terrain-weighted move cost stays on the legacy `/session/action` path; the round
  path charges the Manhattan basis (band-neutral, flag OFF by default) -- unchanged
  by this PR, noted for a future round-path terrain wire.

## Methods applied (ADR-0026 / Quality Gate)
- Ground-truth verify (source-read, not report) before and after; owasp-security-auditor
  subagent for independent severity + completeness (surfaced the 3 sibling routes).
- Adversarial re-verify of the auditor's claims against live source.
- TDD (red -> green); full `test:api` regression run.
