### PR TITLE
feat(combat): budget-aware LOS repositioning + SDMG falsification + corrected-control matrix

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -477,7 +477,14 @@ function createDeclareSistemaIntents(deps) {
         );
         // Reposition to regain LOS on the CHOSEN target specifically (keep engaging
         // it, do not switch enemies) -- pass only [target]. null -> plain approach.
-        const reposition = stepToRegainLos(actor, [target], session.grid, { occupied });
+        // Budget v2: an approach intent is a move-only round (one intent per unit),
+        // so the SIS may spend its whole AP pool on the reposition -- a farther LOS
+        // tile strictly dominates the blind stepTowards, which also forfeits the
+        // attack. The cost-first metric still prefers the nearest reopening tile.
+        const reposition = stepToRegainLos(actor, [target], session.grid, {
+          occupied,
+          budget: actor.ap_remaining ?? actor.ap ?? 1,
+        });
         policy = {
           ...policy,
           intent: 'approach',
@@ -586,7 +593,12 @@ function createDeclareSistemaIntents(deps) {
         actor_id: actor.id,
         target_id: null,
         ability_id: null,
-        ap_cost: 1,
+        // Real move distance (was hardcoded 1): stepTowards/stepAway still cost 1,
+        // but a budget-v2 multi-tile reposition costs its full Manhattan distance.
+        // The WEGO resolver deducts this FIELD without recomputing (bridge :1927),
+        // so it must carry the true cost -- and buildMoveEvent's ap_spent (= real
+        // distance) stays in sync with what is actually charged.
+        ap_cost: manhattanDistance(positionFrom, nextPos),
         channel: null,
         move_to: { x: nextPos.x, y: nextPos.y },
         position_from: positionFrom,

--- a/apps/backend/services/combat/losReposition.js
+++ b/apps/backend/services/combat/losReposition.js
@@ -29,6 +29,8 @@
 // LOS is checked TERRAIN-ONLY here (losClearOnGrid without a units list); unit-body
 // occlusion (units_block_los) is a separate dormant axis, not modeled by this step.
 const { losClearOnGrid } = require('./losForGrid');
+const { terrainBlocksLos } = require('./losBlockers');
+const { isMoveTerrainCostEnabled } = require('./moveCost');
 
 function _manhattan(a, b) {
   return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
@@ -43,10 +45,30 @@ function stepToRegainLos(actor, enemies, grid, opts) {
   const width = (grid && grid.width) || 6;
   const height = (grid && grid.height) || 6;
   const occupied = (opts && opts.occupied) || new Set();
+  // range defaults to melee (1): such an actor repositions INTO range-1 of the
+  // enemy by construction -- consistent with intent, and the metric carries no
+  // threat term (AP-only economy; see the QUALITY doc's honesty section).
   const range = actor.attack_range ?? 1;
   const rawBudget = Number.isFinite(opts && opts.budget) ? opts.budget : 1;
-  const budget = mode === 'step' ? Math.min(1, rawBudget) : rawBudget;
+  // Guard (harsh-review P1): with MOVE_TERRAIN_COST_ENABLED the engine's real
+  // move cost is the terrain-weighted path, not Manhattan -- and the WEGO
+  // bridge resolver deducts the intent's ap_cost FIELD without recomputing, so
+  // a multi-tile reposition priced by Manhattan would silently under-charge
+  // AP. Both flags ON -> clamp to the shipped 1-step greedy (whose flat cost
+  // predates this budget and matches the pre-v2 behavior).
+  const terrainCostOn = isMoveTerrainCostEnabled();
+  const budget = mode === 'step' || terrainCostOn ? Math.min(1, rawBudget) : rawBudget;
   if (budget < 1) return null;
+  // Design-validation knob (default OFF = unchanged): exclude candidates that
+  // stand ON a LOS-blocker tile (perched-on-roccia reads bimodally -- the
+  // eventual ratify should A/B it rather than hard-code either answer).
+  const avoidBlockers = !!(opts && opts.avoidBlockerTiles);
+  const blockerAt = new Set();
+  if (avoidBlockers) {
+    for (const f of (grid && grid.terrain_features) || []) {
+      if (f && terrainBlocksLos(f.type)) blockerAt.add(`${f.x},${f.y}`);
+    }
+  }
   const live = enemies.filter((e) => e && e.position && (e.hp ?? 0) > 0);
   if (live.length === 0) return null;
 
@@ -67,6 +89,7 @@ function stepToRegainLos(actor, enemies, grid, opts) {
       if (cost < 1 || cost > budget) continue;
       if (cost > bestCost) continue;
       if (occupied.has(`${cx},${cy}`)) continue;
+      if (avoidBlockers && blockerAt.has(`${cx},${cy}`)) continue;
       const c = { x: cx, y: cy };
       let nearest = Infinity;
       for (const e of live) {

--- a/apps/backend/services/combat/losReposition.js
+++ b/apps/backend/services/combat/losReposition.js
@@ -1,13 +1,25 @@
 // apps/backend/services/combat/losReposition.js
 'use strict';
 
-// Greedy one-tile LOS-repositioning (COMBAT_LOS_ENABLED, default OFF).
+// Budget-aware LOS-repositioning (COMBAT_LOS_ENABLED, default OFF).
 // When a unit wants to attack but has no line of sight to any in-range enemy,
-// stepToRegainLos returns a 4-neighbor tile that reopens a clear firing line to
-// an enemy that would be in attack_range from that tile -- or null if no single
-// legal step reopens LOS (caller then falls back to its normal approach: never
-// worse than today). Pure + deterministic (tie-break: x then y). Shared by the
-// sim player-proxy and the prod Sistema AI so the ratify measures one AI.
+// stepToRegainLos returns a tile within `opts.budget` Manhattan steps (default
+// 1 = the original greedy 4-neighbor behavior) that reopens a clear firing
+// line to an enemy that would be in attack_range from that tile -- or null if
+// no legal tile within budget reopens LOS (caller then falls back to its
+// normal approach: never worse than today). Movement is a single AP-charged
+// action (AP cost = Manhattan distance, session.js SPRINT_008), so a budget-N
+// tile is reachable in ONE move; the metric prefers the CHEAPEST tile first
+// (preserve AP for attacks), then the nearest LOS-clear enemy, then x-then-y.
+// Pure + deterministic. Shared by the sim player-proxy and the prod Sistema
+// AI so the ratify measures one AI.
+//
+// COMBAT_LOS_REPOSITION_MODE (probe-only knob, read per-call, default unset):
+//   'off'  -> repositioning disabled (null) on both seams, LOS gate untouched
+//             (the repos-OFF control arm: LOS ON, no repositioning).
+//   'step' -> budget clamped to 1 (the shipped greedy arm, for step-vs-budget
+//             A/B probes).
+// Neither value is set in production; unset -> opts.budget honored.
 //
 // The caller controls WHICH enemies are considered: stepToRegainLos opens LOS to
 // the NEAREST in-range enemy present in `enemies` and may favor a different enemy
@@ -24,40 +36,49 @@ function _manhattan(a, b) {
 
 function stepToRegainLos(actor, enemies, grid, opts) {
   if (process.env.COMBAT_LOS_ENABLED !== 'true') return null;
+  const mode = process.env.COMBAT_LOS_REPOSITION_MODE;
+  if (mode === 'off') return null;
   if (!actor || !actor.position || !Array.isArray(enemies) || enemies.length === 0) return null;
 
   const width = (grid && grid.width) || 6;
   const height = (grid && grid.height) || 6;
   const occupied = (opts && opts.occupied) || new Set();
   const range = actor.attack_range ?? 1;
+  const rawBudget = Number.isFinite(opts && opts.budget) ? opts.budget : 1;
+  const budget = mode === 'step' ? Math.min(1, rawBudget) : rawBudget;
+  if (budget < 1) return null;
   const live = enemies.filter((e) => e && e.position && (e.hp ?? 0) > 0);
   if (live.length === 0) return null;
 
+  // Candidates: every in-bounds, non-occupied tile within `budget` Manhattan
+  // steps of the actor (the engine charges AP = distance in one move action;
+  // only the DESTINATION is occupancy-checked -- session.js move handler).
+  // Deterministic scan order: x asc then y asc; strict `<` comparisons keep
+  // the first tile on ties, so the metric is (cost, nearest-clear-enemy, x, y)
+  // lexicographic. With budget=1 this reduces to the original 4-neighbor
+  // greedy step (same candidates, same winner).
   const { x, y } = actor.position;
-  const candidates = [
-    { x: x - 1, y },
-    { x: x + 1, y },
-    { x, y: y - 1 },
-    { x, y: y + 1 },
-  ]
-    .filter(
-      (c) => c.x >= 0 && c.y >= 0 && c.x < width && c.y < height && !occupied.has(`${c.x},${c.y}`),
-    )
-    .sort((a, b) => a.x - b.x || a.y - b.y);
-
   let best = null;
-  let bestMetric = Infinity;
-  for (const c of candidates) {
-    let nearest = Infinity;
-    for (const e of live) {
-      if (_manhattan(c, e.position) <= range && losClearOnGrid(grid, c, e.position)) {
+  let bestCost = Infinity;
+  let bestDist = Infinity;
+  for (let cx = Math.max(0, x - budget); cx <= Math.min(width - 1, x + budget); cx += 1) {
+    for (let cy = Math.max(0, y - budget); cy <= Math.min(height - 1, y + budget); cy += 1) {
+      const cost = Math.abs(cx - x) + Math.abs(cy - y);
+      if (cost < 1 || cost > budget) continue;
+      if (cost > bestCost) continue;
+      if (occupied.has(`${cx},${cy}`)) continue;
+      const c = { x: cx, y: cy };
+      let nearest = Infinity;
+      for (const e of live) {
         const d = _manhattan(c, e.position);
-        if (d < nearest) nearest = d;
+        if (d <= range && d < nearest && losClearOnGrid(grid, c, e.position)) nearest = d;
       }
-    }
-    if (nearest < bestMetric) {
-      bestMetric = nearest;
-      best = c;
+      if (nearest === Infinity) continue;
+      if (cost < bestCost || nearest < bestDist) {
+        best = c;
+        bestCost = cost;
+        bestDist = nearest;
+      }
     }
   }
   return best;

--- a/docs/quality/2026-07-06-los-reposition-budget-QUALITY.md
+++ b/docs/quality/2026-07-06-los-reposition-budget-QUALITY.md
@@ -1,0 +1,151 @@
+# QUALITY -- Budget-aware LOS repositioning + corrected-control measurements
+
+Slice follow-up to `docs/quality/2026-07-04-ai-los-repositioning-QUALITY.md`
+(PR #3210, merged) and to the corrected-control probe (PR #3212/#3213, merged).
+Branch: `feat/combat-los-repos-budget`. Flag-dormant end to end:
+`COMBAT_LOS_ENABLED` stays OFF; `COMBAT_LOS_REPOSITION_MODE` is a probe-only
+knob nothing sets in production.
+
+## Summary
+
+Extends `stepToRegainLos` from the shipped greedy 1-tile step to a
+budget-aware lookahead: any tile within `opts.budget` Manhattan steps (default
+1 = byte-identical shipped behavior), metric = (move cost asc, distance to
+nearest LOS-clear enemy asc, x, y) lexicographic -- the engine charges a move
+AP = Manhattan distance in ONE action, so a budget-N tile is reachable in a
+single move. Seams: sim player-proxy uses a two-phase budget (reserve 1 AP to
+still shoot this turn, else full pool); prod Sistema uses its full pool (an
+approach intent is a move-only round) and the move intent now carries
+`ap_cost` = real distance (was hardcoded 1; the WEGO bridge resolver deducts
+the field without recomputing). `combat-adapter` gains an opt-in
+`allPlayersActPerRound` driver + `playerActionsByUnit` metric (the M17
+active_unit freeze starves every roster unit but turn_order[0], so the old
+probe could never measure multi-unit repositioning payoff). The isolation
+probe gains a `wide` geometry (3-tile blocker segments: no 1-step reopening
+exists, only a budget>=2 tile) to separate step-vs-budget.
+
+## Step 1 -- Smoke (happy-path green + verifiable output)
+
+| Suite | File | Pass |
+| --- | --- | --- |
+| repositioning helper (budget/mode/guard/knob) | `tests/services/losReposition.test.js` | 18/18 |
+| prod Sistema AI seam | `tests/services/aiLosDowngrade.test.js` | 8/8 |
+| declareSistemaIntents regression | `tests/ai/declareSistemaIntents.test.js` | green |
+| sim player-proxy seam | `tests/sim/combatPolicy.test.js` | 24/24 |
+| adapter multi-unit driver | `tests/sim/combatAdapter.test.js` | 6/6 |
+
+TDD red-green per cycle; the two SDMG-fix tests (terrain guard, blocker knob)
+were additionally verified RED retroactively (stash impl -> 2 fail -> pop ->
+18/18). Prettier clean. Full flag-OFF regression on this worktree: `npm run
+test:api` 77/77 + 5/5 pass, `node --test tests/sim` 227/227 pass, 0 fail. A
+first regression attempt hit the documented EADDRINUSE ephemeral-port flake
+family (fullLoopBatch/woundCutoverWire, files this branch never touches) while
+~5k TIME_WAIT sockets drained from a concurrent sim batch; the recorded run
+above is clean end-to-end, matching the alternate clean/flaky pattern already
+documented in the 2026-07-04 QUALITY doc.
+
+## Step 2 -- Ricerca (edge cases + SDMG falsification)
+
+Edge cases covered by tests: default budget 1 byte-identical; budget <= 0
+null (turn-starved guard); occupied multi-tile destination excluded;
+attack_range re-checked from the candidate tile; deterministic at budget 3;
+mode 'off'/'step' knob semantics; terrain-cost flag clamps budget to 1;
+avoidBlockerTiles filters blocker-tile reopeners but keeps open-ground ones.
+
+SDMG external falsification (both run on this branch's real code):
+
+- **harsh-reviewer -- verdict: SOUND WITH FIXES.** P1 found and FIXED in this
+  slice: with `MOVE_TERRAIN_COST_ENABLED` the engine's real move cost is the
+  terrain-weighted path while the helper budgets by Manhattan, and the WEGO
+  bridge resolver (`sessionRoundBridge.js:1926-1930`) deducts the intent's
+  `ap_cost` field without recomputing -> a multi-tile reposition would
+  silently under-charge AP. Guard shipped: both flags ON -> budget clamps to
+  1 (test-locked). P2s: the metric is AP-only / THREAT-BLIND (no
+  enemy-adjacency term -- a reposition may legally stand in melee reach; the
+  ratify must stay scoped to ranged-LOS scenarios or add a safety term); K4
+  commit-window does NOT recognize `_LOS_BLOCKED` moves (bridge
+  `last_action_type` recognizer), so cross-round reposition oscillation is
+  bounded-deterministic but NOT commit-window-damped -- open decision below.
+- **game-design-validator -- verdict: BEHAVIOR COHERENT WITH CHANGES.**
+  Flanking reads on-pillar (WEGO resolves the multi-tile reposition as one
+  continuous move; cost-first hugs cover). Wall-standing (perched on roccia
+  shooting over it -- mechanically legal, endpoints excluded) reads bimodal ->
+  shipped as an A/B knob (`opts.avoidBlockerTiles`, default off), decide with
+  the ratify, don't hard-code. Oscillation: deterministic metric + pressure
+  cap bound it, but the sim seam has no K4 equivalent (parity risk R3);
+  suggested mirror-wall probe boards recorded below. Prod full-pool budget =
+  the speculative arm: hold it behind a demonstrated N=40 win.
+
+## Step 3 -- Tuning + VALIDATION (corrected-control matrix, N=10 direction)
+
+Instrument: `tools/sim/los-repos-probe.js` (merged #3212/#3213) + this
+slice's `wide` geometry + `COMBAT_LOS_REPOSITION_MODE` env knob (children
+inherit it; 'step' clamps the real helper to the shipped greedy). LOS ON in
+BOTH arms of every measured pair (the v1 wrong-control defect is closed);
+multi-unit coverage gate >= 2 acting units enforced per run (the v1
+turn-starved defect is closed -- all runs drove 3/3 roster units).
+
+| Geometry / scale | Arm pair | wr_delta | rounds_delta | Note |
+| --- | --- | --- | --- | --- |
+| lane 1.0 | budget vs off | 0 | -0.8 | wins 12% faster |
+| lane 1.0 | step vs off | 0 | -0.8 | identical to budget (parity) |
+| wide 1.0 | budget vs off | 0 | 0 | WR ceiling 1.00 everywhere |
+| wide 1.0 | step vs off | 0 | 0 | greedy finds tiles mid-fight |
+| lane 1.8 | budget vs off | 0 | **-3.0** | 9.6 vs 12.6 rounds, 24% faster |
+| lane 1.8 | step vs off | 0 | **-3.0** | identical to budget |
+| wide 1.8 | budget vs off | 0 | -0.1 | fire-rate 48% (56/117 calls) |
+| wide 1.8 | step vs off | 0 | -0.2 | fire-rate 26% (53/207 calls) |
+
+Timeouts: ZERO in all 16 arms (v1's 3/10 timeouts confirmed as fixture
+artifact). Defeats only at scale 1.8 (1/10, both arms, wide) -- repositioning
+never changed a win to a loss or vice versa.
+
+**Honest findings:**
+
+1. **Repositioning (any flavor) vs the CORRECT control: real, coherent PACE
+   value, WR-neutral.** Up to -3.0 avg rounds on lane@1.8 with zero timeouts
+   and zero WR cost. The v1 "-0.30 WR gap" is fully explained: wrong control
+   (LOS-off ceiling) + turn-starved fixture. The mechanism (already merged as
+   greedy) earns its owner-gated N=40 flip ratify.
+2. **Budget vs step: NO outcome separation at N=10.** On lane they are
+   literally identical (cost-first picks the same 1-step tiles -- a parity
+   proof). On wide, budget fires ~2x more efficiently per call (48% vs 26%
+   non-null) and solves the shadow in one move (unit-proven), but mid-fight
+   mobility gives the greedy equivalent chances a round later and enemies
+   crossing the wall reopen LOS anyway -- no wr/pace conversion on these
+   boards. Per the design-validator cut-order: if N=40 confirms no
+   separation, ship greedy and cut the budget arm; the pillar is served
+   either way.
+
+N=10 = direction probe only (paired-seed). N=40 ratify (owner-gated, Eduardo)
+should run THREE arms (off / step / budget) on both geometries, crossed with
+`avoidBlockerTiles` on/off, plus the validator's mirror-wall oscillation
+boards (thin wall, two symmetric gaps, ranged units on opposite sides).
+
+## Open decisions (Eduardo, pre-flip -- none block this merge)
+
+1. **Prod default at flip time**: budget (as committed) vs step-clamped until
+   N=40 proves the full-pool arm. Data so far: budget never worse, no
+   measured gain.
+2. **K4 recognizer**: add `_LOS_BLOCKED` to the bridge `last_action_type`
+   recognizer (commit-window can lock repositions) vs accept documented
+   bounded-deterministic oscillation for the first ratify.
+3. **avoidBlockerTiles**: A/B in the ratify (knob shipped, default off).
+
+## Environment caveat
+
+All measurements ran on Ryzen (DESKTOP-T77TMKT), Node v24.11.0 (the only
+runtime on this machine; nvm/Node-22 is the Lenovo setup). Arm-vs-arm
+comparisons are same-node and internally valid; do not numerically compare
+against Lenovo-run probe outputs without a same-node re-run. A concurrent
+sim batch on the same machine can transiently exhaust the Windows ephemeral
+port range (49152+): the probe's supertest wrapper retries EADDRINUSE /
+ECONNRESET / EADDRNOTAVAIL up to ~4s cumulative.
+
+## Flag / merge discipline
+
+`COMBAT_LOS_ENABLED` ships OFF on every seam; the default `opts.budget` is 1,
+so even a flag-ON deployment without seam changes behaves byte-identically to
+the merged greedy. `COMBAT_LOS_REPOSITION_MODE` and `avoidBlockerTiles` are
+measurement knobs, never set in production. The flip remains owner-gated
+post-N=40 (Eduardo) per the SDMG governance in the 2026-07-04 QUALITY doc.

--- a/tests/services/aiLosDowngrade.test.js
+++ b/tests/services/aiLosDowngrade.test.js
@@ -205,9 +205,12 @@ test('flag ON: LOS-blocked target -> SIS repositions to regain LOS (not straight
   assert.equal(intents.length, 1);
   assert.equal(intents[0].action.type, 'move');
   // Repositioned off the blocked row -- NOT a straight step toward target
-  // (which would stay on y===1).
+  // (which would stay on y===1). Budget v2: the cost-first metric still picks
+  // the 1-step tile (0,2) over any farther candidate, and the intent charges
+  // the real move distance (1).
   assert.notEqual(intents[0].action.move_to.y, 1);
   assert.deepEqual(intents[0].action.move_to, { x: 0, y: 2 });
+  assert.equal(intents[0].action.ap_cost, 1);
   assert.equal(decisions[0].intent, 'approach');
   assert.ok(/_LOS_BLOCKED$/.test(decisions[0].rule));
   delete process.env.COMBAT_LOS_ENABLED;
@@ -242,19 +245,48 @@ function makeLosFullWallSession() {
   return makeLosRepositionSession(wall);
 }
 
-test('flag ON: LOS-blocked with no reopening step -> graceful stepTowards fallback', () => {
+// Budget lookahead (v2): the SIS spends its whole AP pool on the reposition when no
+// 1-step tile reopens LOS -- an approach intent is a move-only round anyway, so a
+// farther LOS tile strictly dominates the blind stepTowards. With ap:2 the full wall
+// at x=2 is beaten by standing ON the wall column at (2,1) (terrain blocks LOS, not
+// movement; endpoints excluded -> (2,1) sees (4,1) across the free (3,1)). The intent
+// must charge the REAL move distance (ap_cost 2, not the legacy hardcoded 1) so the
+// WEGO resolver -- which deducts the ap_cost field without recomputing -- stays honest.
+test('flag ON: no one-step reopening -> SIS spends full AP budget on a multi-tile reposition', () => {
   process.env.COMBAT_LOS_ENABLED = 'true';
   const declare = buildDeclare();
   const session = makeLosFullWallSession();
   const { intents, decisions } = declare(session);
   assert.equal(intents.length, 1);
   assert.equal(intents[0].action.type, 'move');
-  // Fallback fired: stepTowards advance toward target (y stays on the row,
-  // x advances) -- NOT a perpendicular reposition.
-  assert.deepEqual(intents[0].action.move_to, { x: 1, y: 1 });
-  assert.equal(intents[0].action.move_to.y, 1);
+  assert.deepEqual(intents[0].action.move_to, { x: 2, y: 1 });
+  assert.equal(intents[0].action.ap_cost, 2);
   assert.equal(decisions[0].intent, 'approach');
-  // Downgrade still fired (LOS was blocked); there was just no reopening tile.
+  assert.ok(/_LOS_BLOCKED$/.test(decisions[0].rule));
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+// Turn-starved guard: with only 1 AP the budget cannot reach past the 4-neighbors,
+// the full wall defeats the greedy step, and the SIS falls back to the plain
+// stepTowards approach -- never worse than today.
+test('flag ON: turn-starved SIS (1 AP) + full wall -> graceful stepTowards fallback', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const declare = buildDeclare();
+  const session = makeLosFullWallSession();
+  // LOS_REPOSITION_UNITS is a shared module-level fixture: clone before mutating.
+  session.units = session.units.map((u) => ({ ...u }));
+  const sis = session.units.find((u) => u.id === 'sis');
+  sis.ap = 1;
+  sis.ap_remaining = 1;
+  const { intents, decisions } = declare(session);
+  assert.equal(intents.length, 1);
+  assert.equal(intents[0].action.type, 'move');
+  // Fallback fired: stepTowards advance toward target (y stays on the row,
+  // x advances) -- NOT a reposition the unit cannot afford.
+  assert.deepEqual(intents[0].action.move_to, { x: 1, y: 1 });
+  assert.equal(intents[0].action.ap_cost, 1);
+  assert.equal(decisions[0].intent, 'approach');
+  // Downgrade still fired (LOS was blocked); there was just no affordable tile.
   assert.ok(/_LOS_BLOCKED$/.test(decisions[0].rule));
   delete process.env.COMBAT_LOS_ENABLED;
 });

--- a/tests/services/losReposition.test.js
+++ b/tests/services/losReposition.test.js
@@ -162,3 +162,54 @@ test("mode 'step': clamps the budget to 1 (multi-tile candidates excluded)", () 
   delete process.env.COMBAT_LOS_REPOSITION_MODE;
   delete process.env.COMBAT_LOS_ENABLED;
 });
+
+// --- MOVE_TERRAIN_COST_ENABLED guard (harsh-review P1) ---
+// The helper budgets and the prod seam prices moves by MANHATTAN distance, but
+// with the terrain-cost flag ON the engine's real cost is the terrain-weighted
+// path (moveApDistance) -- and the WEGO bridge resolver deducts the intent's
+// ap_cost FIELD without recomputing, so a multi-tile reposition would silently
+// under-charge AP. Guard: both flags ON -> clamp the budget to 1 (the shipped
+// greedy step), never a multi-tile candidate.
+
+test('terrain-cost flag ON: budget clamped to 1 (no multi-tile candidate, no AP desync)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  process.env.MOVE_TERRAIN_COST_ENABLED = 'true';
+  assert.equal(stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, { budget: 3 }), null);
+  delete process.env.MOVE_TERRAIN_COST_ENABLED;
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('terrain-cost flag ON: the 1-step greedy path still works', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  process.env.MOVE_TERRAIN_COST_ENABLED = 'true';
+  const actor = { position: { x: 0, y: 1 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 1 }, hp: 5 }];
+  assert.deepEqual(stepToRegainLos(actor, enemies, grid(WALL), { budget: 2 }), { x: 0, y: 2 });
+  delete process.env.MOVE_TERRAIN_COST_ENABLED;
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+// --- opts.avoidBlockerTiles (design-validation knob, default OFF) ---
+// Standing ON a LOS-blocker tile (perched on roccia, shooting over it) is
+// mechanically legal and often the cheapest reopener; whether it READS as
+// coherent is a design question the eventual A/B ratify should answer. The
+// knob filters blocker tiles from the candidate set; default off = unchanged.
+
+test('avoidBlockerTiles: excludes a blocker-tile reopener (corridor -> null)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const dest = stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, {
+    budget: 2,
+    avoidBlockerTiles: true,
+  });
+  assert.equal(dest, null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('avoidBlockerTiles: still picks a non-blocker reopener (WALL fixture)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = { position: { x: 0, y: 1 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 1 }, hp: 5 }];
+  const dest = stepToRegainLos(actor, enemies, grid(WALL), { budget: 2, avoidBlockerTiles: true });
+  assert.deepEqual(dest, { x: 0, y: 2 });
+  delete process.env.COMBAT_LOS_ENABLED;
+});

--- a/tests/services/losReposition.test.js
+++ b/tests/services/losReposition.test.js
@@ -72,3 +72,93 @@ test('flag ON: deterministic (same input -> same tile)', () => {
   assert.deepEqual(a, b);
   delete process.env.COMBAT_LOS_ENABLED;
 });
+
+// --- opts.budget (multi-tile lookahead within the AP move budget) ---
+//
+// 1-row corridor fixture (6x1): actor (0,0), enemy (4,0), single roccia at
+// (2,0). No 4-neighbor step reopens LOS ((1,0) is still behind the blocker),
+// but standing ON the blocker tile (2,0) -- legal: terrain blocks LOS, not
+// movement -- reopens the line (endpoints excluded, only (3,0) between).
+const CORRIDOR = { terrain_features: [{ x: 2, y: 0, type: 'roccia' }], width: 6, height: 1 };
+const corridorActor = () => ({ position: { x: 0, y: 0 }, attack_range: 5 });
+const corridorEnemies = () => [{ position: { x: 4, y: 0 }, hp: 5 }];
+
+test('flag ON, budget 2: reaches a firing tile two tiles away when no single step reopens LOS', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const dest = stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, { budget: 2 });
+  assert.deepEqual(dest, { x: 2, y: 0 });
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON, default budget stays 1: same corridor -> null (byte-identical greedy)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  assert.equal(stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, {}), null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON, budget 2: prefers the cheaper tile when a 1-step tile already reopens LOS', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  // WALL (x=2, y=0..1) fixture: (0,2) reopens at cost 1; a bigger budget must
+  // not pick a farther tile (cost-first metric preserves AP for attacks).
+  const actor = { position: { x: 0, y: 1 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 1 }, hp: 5 }];
+  const dest = stepToRegainLos(actor, enemies, grid(WALL), { budget: 2 });
+  assert.deepEqual(dest, { x: 0, y: 2 });
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON, budget 2: excludes an occupied multi-tile destination', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const dest = stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, {
+    budget: 2,
+    occupied: new Set(['2,0']),
+  });
+  assert.equal(dest, null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON, budget 2: candidate must still put the enemy in attack_range', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = { ...corridorActor(), attack_range: 1 };
+  // From (2,0) the enemy at (4,0) is at distance 2 > range 1 -> no valid tile.
+  assert.equal(stepToRegainLos(actor, corridorEnemies(), CORRIDOR, { budget: 2 }), null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON, budget <= 0: returns null (turn-starved guard)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  assert.equal(stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, { budget: 0 }), null);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test('flag ON, budget 3: deterministic (same input -> same tile)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const a = stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, { budget: 3 });
+  const b = stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, { budget: 3 });
+  assert.deepEqual(a, b);
+  assert.ok(a);
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+// --- COMBAT_LOS_REPOSITION_MODE (probe-only knob, read per-call) ---
+// 'off'  -> repositioning disabled on BOTH seams (null), LOS gate untouched.
+// 'step' -> budget clamped to 1 (shipped greedy), for step-vs-budget probe arms.
+// unset  -> opts.budget honored (default 1).
+
+test("mode 'off': returns null even when a reopening tile exists (LOS still ON)", () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  process.env.COMBAT_LOS_REPOSITION_MODE = 'off';
+  const actor = { position: { x: 0, y: 1 }, attack_range: 5 };
+  const enemies = [{ position: { x: 4, y: 1 }, hp: 5 }];
+  assert.equal(stepToRegainLos(actor, enemies, grid(WALL), {}), null);
+  delete process.env.COMBAT_LOS_REPOSITION_MODE;
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+test("mode 'step': clamps the budget to 1 (multi-tile candidates excluded)", () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  process.env.COMBAT_LOS_REPOSITION_MODE = 'step';
+  assert.equal(stepToRegainLos(corridorActor(), corridorEnemies(), CORRIDOR, { budget: 3 }), null);
+  delete process.env.COMBAT_LOS_REPOSITION_MODE;
+  delete process.env.COMBAT_LOS_ENABLED;
+});

--- a/tests/sim/combatAdapter.test.js
+++ b/tests/sim/combatAdapter.test.js
@@ -260,3 +260,59 @@ test('combatAdapter.runEncounter: OA2 -- sabotage objective completes (not elimi
   });
   assert.equal(res.outcome, 'victory', `expected objective victory, got ${res.outcome}`);
 });
+
+// LOS-repos v2 (multi-unit control probe): the M17 round model freezes
+// session.active_unit on turn_order[0] forever (assigned only at POST /start;
+// /turn/end never reassigns it), so the state-driven legacy loop can only ever
+// act ONE player unit -- multi-turn repositioning payoffs are unmeasurable.
+// allPlayersActPerRound (default OFF = byte-identical legacy loop) drives EVERY
+// live player unit each iteration (act until AP/policy exhaustion), then ends
+// the round once. playerActionsByUnit (successful /action posts per unit id)
+// proves the coverage either way. The assertion is WHO ACTED, not the outcome,
+// so the test has no damage-RNG coupling (huge foe HP -> timeout both arms).
+test('combatAdapter.runEncounter: allPlayersActPerRound drives every live player unit each round', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  const http = supertestHttp(app);
+  const bigFoe = () => [
+    {
+      id: 'tank',
+      species: 'tank',
+      hp: 500,
+      max_hp: 500,
+      ap: 1,
+      mod: 0,
+      dc: 20,
+      attack_range: 1,
+      initiative: 1,
+      position: { x: 1, y: 3 },
+      controlled_by: 'sistema',
+      status: {},
+    },
+  ];
+  const acted = (r) =>
+    Object.entries(r.playerActionsByUnit || {})
+      .filter(([, n]) => n > 0)
+      .map(([id]) => id)
+      .sort();
+
+  const legacy = await runEncounter(http, {
+    roster: roster(),
+    enemies: bigFoe(),
+    seed: 'apr-1',
+    maxRounds: 6,
+  });
+  // Documented freeze: only turn_order[0] (camp_a, initiative 18) ever acts.
+  assert.deepEqual(acted(legacy), ['camp_a']);
+
+  const all = await runEncounter(http, {
+    roster: roster(),
+    enemies: bigFoe(),
+    seed: 'apr-1',
+    maxRounds: 6,
+    allPlayersActPerRound: true,
+  });
+  assert.deepEqual(acted(all), ['camp_a', 'camp_b']);
+});

--- a/tests/sim/combatPolicy.test.js
+++ b/tests/sim/combatPolicy.test.js
@@ -313,10 +313,13 @@ test('flag OFF: same setup is byte-identical (in-range attack, LOS ignored)', ()
   delete process.env.COMBAT_LOS_ENABLED;
 });
 
-// Task 2 graceful fallback ("never worse than today"): flag ON + LOS-blocked but NO single
-// 4-neighbor step reopens a firing line (a FULL vertical wall) -> stepToRegainLos returns null
-// -> the code must fall THROUGH to the plain stepToward approach (not reposition, not stall).
-test('flag ON: LOS-blocked but no reopening step -> graceful stepToward fallback (never worse than today)', () => {
+// Budget lookahead (v2): flag ON + LOS-blocked and NO single 4-neighbor step reopens a
+// firing line (a FULL vertical wall), but the actor's AP budget reaches a reopening tile
+// two steps away -- standing ON the wall column (terrain blocks LOS, not movement;
+// endpoints are excluded by squareLos, so (2,1) sees the enemy at (4,1) across the free
+// (3,1)). Reserve phase (budget ap-1 = 1) finds nothing; the full-budget phase (2) must
+// spend the whole pool to set up next turn's shot instead of the dumb stepToward.
+test('flag ON: no one-step reopening but a full-budget tile exists -> multi-tile reposition', () => {
   process.env.COMBAT_LOS_ENABLED = 'true';
   const actor = {
     id: 'p1',
@@ -339,10 +342,40 @@ test('flag ON: LOS-blocked but no reopening step -> graceful stepToward fallback
     gridSize: 6,
   };
   const action = selectPlayerAction(actor, units, null, opts);
-  // No 4-neighbor step clears the full wall -> stepToRegainLos returns null ->
-  // the code falls through to the plain approach (stepToward toward the enemy).
   assert.equal(action.action_type, 'move');
-  // stepToward from (0,1) toward (4,1) advances on x (toward the enemy), NOT a perpendicular reposition.
+  assert.deepEqual(action.target_position, { x: 2, y: 1 });
+  delete process.env.COMBAT_LOS_ENABLED;
+});
+
+// Turn-starved guard ("never worse than today"): with 1 AP left the budget lookahead
+// cannot reach past the 4-neighbors (reserve phase budget 0 -> null; full phase budget 1
+// = the shipped greedy step, which the FULL wall defeats) -> graceful stepToward fallback.
+// Pins that the heuristic NEVER returns a tile costing more than ap_remaining.
+test('flag ON: turn-starved (1 AP) + full wall -> graceful stepToward fallback (never worse than today)', () => {
+  process.env.COMBAT_LOS_ENABLED = 'true';
+  const actor = {
+    id: 'p1',
+    position: { x: 0, y: 1 },
+    attack_range: 5,
+    ap_remaining: 1,
+    controlled_by: 'player',
+  };
+  const enemy = { id: 'e1', position: { x: 4, y: 1 }, hp: 10, controlled_by: 'sistema' };
+  const units = [actor, enemy];
+  const opts = {
+    terrainFeatures: [
+      { x: 2, y: 0, type: 'roccia' },
+      { x: 2, y: 1, type: 'roccia' },
+      { x: 2, y: 2, type: 'roccia' },
+      { x: 2, y: 3, type: 'roccia' },
+      { x: 2, y: 4, type: 'roccia' },
+      { x: 2, y: 5, type: 'roccia' },
+    ],
+    gridSize: 6,
+  };
+  const action = selectPlayerAction(actor, units, null, opts);
+  // Full wall defeats budget 1 -> fall through to the plain approach (stepToward).
+  assert.equal(action.action_type, 'move');
   assert.equal(action.target_position.x, 1);
   assert.equal(action.target_position.y, 1);
   delete process.env.COMBAT_LOS_ENABLED;

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -59,6 +59,15 @@ async function runEncounter(
     // false = byte-identical closest-attack. The N=40 A/B harness sets it to measure the AI
     // upgrade against the same seeds.
     focusFire = false,
+    // LOS-repos v2: opt-in multi-unit driver. The M17 round model freezes
+    // session.active_unit on turn_order[0] (assigned only at POST /start;
+    // /turn/end never reassigns it), so the state-driven loop below can only
+    // ever act ONE player unit. /api/session/action has no active-unit gate:
+    // with this opt each loop iteration acts EVERY live player unit (until AP/
+    // policy exhaustion, safety-capped) and then ends the round once, so a
+    // probe can measure multi-unit turn economy (>=2 units really act).
+    // Default false = byte-identical legacy loop. No overcharge in this mode.
+    allPlayersActPerRound = false,
   } = {},
 ) {
   if (Array.isArray(terrainFeatures) && terrainFeatures.length && scenarioId) {
@@ -115,6 +124,9 @@ async function runEncounter(
   // OD-058 D1 action-economy counters (always returned, 0 when the opt is off).
   let overchargeUses = 0;
   let playerAttacks = 0;
+  // LOS-repos v2: successful /action posts per player unit id (both driver modes).
+  // Lets a probe PROVE its coverage claim (e.g. ">=2 player units actually act").
+  const playerActionsByUnit = {};
   // A13 PA3 telegraph: /session/state exposes biome_wounded (session-static, set at
   // /start from the campaign's woundedBiomes). Captured for the wound-exposure metric.
   let biomeWounded = false;
@@ -188,6 +200,44 @@ async function runEncounter(
       break;
     }
 
+    // LOS-repos v2 multi-unit driver: act EVERY live player unit this round
+    // (fresh state before each action so occupancy/AP/target liveness are
+    // current), then end the round once. The 12-action safety cap bounds the
+    // inner loop even if a policy keeps emitting actions the backend accepts.
+    if (allPlayersActPerRound) {
+      for (const pid of players.map((u) => u.id)) {
+        for (let guard = 0; guard < 12; guard += 1) {
+          const cur = await http.get('/api/session/state', { session_id: sessionId });
+          const curUnits = (cur.body && cur.body.units) || [];
+          sweepEvents(cur.body);
+          lastUnits = curUnits.length ? curUnits : lastUnits;
+          const u = curUnits.find((x) => x.id === pid);
+          if (!u || (u.hp ?? 0) <= 0) break;
+          if (!curUnits.some((x) => x.controlled_by === 'sistema' && (x.hp ?? 0) > 0)) break;
+          const action = selectPlayerAction(u, curUnits, objective, {
+            focusFire,
+            terrainFeatures,
+            gridSize,
+          });
+          if (!action) break;
+          const wire =
+            action.action_type === 'move'
+              ? { action_type: 'move', position: action.target_position }
+              : action;
+          const act = await http.post('/api/session/action', {
+            session_id: sessionId,
+            actor_id: u.id,
+            ...wire,
+          });
+          if (!act || act.status < 200 || act.status >= 300) break;
+          playerActionsByUnit[u.id] = (playerActionsByUnit[u.id] || 0) + 1;
+          if (wire.action_type === 'attack') playerAttacks += 1;
+        }
+      }
+      await http.post('/api/session/turn/end', { session_id: sessionId });
+      continue;
+    }
+
     const activeId = st.body.active_unit;
     const active = units.find((u) => u.id === activeId);
     if (!active) break;
@@ -235,8 +285,9 @@ async function runEncounter(
     // forever (a move that can't complete would otherwise stick until maxRounds).
     if (!act || act.status < 200 || act.status >= 300) {
       await http.post('/api/session/turn/end', { session_id: sessionId });
-    } else if (wire.action_type === 'attack') {
-      playerAttacks += 1;
+    } else {
+      playerActionsByUnit[active.id] = (playerActionsByUnit[active.id] || 0) + 1;
+      if (wire.action_type === 'attack') playerAttacks += 1;
     }
   }
 
@@ -344,6 +395,7 @@ async function runEncounter(
     ended,
     overchargeUses,
     playerAttacks,
+    playerActionsByUnit,
     collectedEvents,
     firstStateUnits,
   };

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -175,9 +175,13 @@ function selectPlayerAction(actor, units, objective, opts = {}) {
     return { action_type: 'attack', target_id: tgt.id };
   }
   // COMBAT_LOS_ENABLED (default OFF): if nothing is attackable because in-range
-  // enemies are LOS-blocked, try a one-tile step that reopens a firing line before
-  // the plain approach. Flag OFF -> losFn is a no-op so no enemy is ever LOS-blocked
-  // -> this block is skipped (byte-identical).
+  // enemies are LOS-blocked, try a budget-aware reposition that reopens a firing
+  // line before the plain approach. Two-phase budget (v2): first reserve 1 AP so
+  // the unit can still shoot THIS turn (budget = ap_remaining - 1); if no such
+  // tile exists, spend the full pool to set up next turn's shot (budget =
+  // ap_remaining) -- a LOS tile strictly dominates the blind stepToward, which
+  // also forfeits this turn's attack. Flag OFF -> losFn is a no-op so no enemy
+  // is ever LOS-blocked -> this block is skipped (byte-identical).
   const gridForLos = {
     terrain_features: (opts && opts.terrainFeatures) || [],
     width: (opts && opts.gridSize) || 6,
@@ -189,9 +193,11 @@ function selectPlayerAction(actor, units, objective, opts = {}) {
       !losFn(actor.position, e.position),
   );
   if (losBlockedInRange) {
-    const repos = stepToRegainLos(actor, enemies, gridForLos, {
-      occupied: occupiedSet(units, actor.id),
-    });
+    const occupied = occupiedSet(units, actor.id);
+    const apBudget = actor.ap_remaining ?? 1;
+    const repos =
+      stepToRegainLos(actor, enemies, gridForLos, { occupied, budget: apBudget - 1 }) ||
+      stepToRegainLos(actor, enemies, gridForLos, { occupied, budget: apBudget });
     if (repos) return { action_type: 'move', target_position: repos };
   }
   // None in range (or no AP): approach the nearest.

--- a/tools/sim/los-repos-probe.js
+++ b/tools/sim/los-repos-probe.js
@@ -57,11 +57,29 @@
 // to change balance (it is a mechanic); the ratify measures the SIZE and SHAPE
 // of that shift for the owner.
 //
+// GEOMETRY (probe v2.2 -- step-vs-budget differentiation). The default 'lane'
+// fixture has a SINGLE blocker tile per lane, so a 1-tile lateral step already
+// reopens LOS -- it can measure "does repositioning help at all" but CANNOT
+// separate the shipped greedy step from the budget-aware lookahead (both solve
+// it). 'wide' widens each lane's blocker to a 3-tile vertical segment: no
+// single lateral step reopens LOS (every 1-step tile stays in the segment's
+// shadow); the cheapest reopening tile sits ON the segment's center (cost 2,
+// terrain blocks sight not movement, endpoints excluded) -- reachable only by
+// the budget lookahead. Combine with COMBAT_LOS_REPOSITION_MODE=step (clamps
+// the budget to 1) to run the shipped-greedy arm on the same geometry:
+//   repos + wide + MODE unset  -> budget lookahead vs no-repositioning
+//   repos + wide + MODE=step   -> shipped greedy   vs no-repositioning
+// The wide positive control INVERTS the reopening check: budget-1 must find
+// NOTHING (else the fixture is not wide) and budget-2 must reopen (else the
+// lookahead could never help and the probe would measure nothing).
+//
 // Usage:
-//   node tools/sim/los-repos-probe.js [N] [repos|flip]      (parent: both arms)
+//   node tools/sim/los-repos-probe.js [N] [repos|flip] [lane|wide]   (parent)
 //     repos (default) -- LOS ON both, toggle stepToRegainLos (heuristic isolation)
 //     flip            -- flag ON+real-repos vs flag OFF (true balance cost of LOS)
-//   node tools/sim/los-repos-probe.js --child <arm> <N> <scale> <mode>  (internal)
+//     lane  (default) -- 1-tile blocker per lane (1-step reopening exists)
+//     wide            -- 3-tile blocker segment per lane (budget>=2 required)
+//   node tools/sim/los-repos-probe.js --child <arm> <N> <scale> <mode> <geometry>
 
 const path = require('path');
 const { execFileSync } = require('child_process');
@@ -84,17 +102,28 @@ const { execFileSync } = require('child_process');
 // isolation, which is precisely what the LOS heuristic operates on. All three
 // los.yaml blocker_terrain_types appear across the lanes.
 const GRID_SIZE = 12;
-const TERRAIN = (() => {
+const LANE_TYPES = { 1: 'roccia', 5: 'vegetazione_densa', 9: 'obstacle' };
+function terrainFor(geometry) {
   const t = [];
   for (let x = 0; x < GRID_SIZE; x += 1) {
     t.push({ x, y: 3, type: 'roccia' });
     t.push({ x, y: 7, type: 'roccia' });
   }
-  t.push({ x: 3, y: 1, type: 'roccia' });
-  t.push({ x: 3, y: 5, type: 'vegetazione_densa' });
-  t.push({ x: 3, y: 9, type: 'obstacle' });
+  for (const laneY of [1, 5, 9]) {
+    t.push({ x: 3, y: laneY, type: LANE_TYPES[laneY] });
+    if (geometry === 'wide') {
+      // wide-shadow: widen the blocker to a 3-tile vertical segment. Every
+      // 1-step lateral tile stays in its shadow; the cheapest reopening tile
+      // is the segment's center itself (cost 2, standing ON blocker terrain --
+      // it blocks sight, not movement; squareLos excludes endpoints).
+      t.push({ x: 3, y: laneY - 1, type: LANE_TYPES[laneY] });
+      t.push({ x: 3, y: laneY + 1, type: LANE_TYPES[laneY] });
+    }
+  }
   return t;
-})();
+}
+// Set once per process from the parsed geometry (parent main + child entry).
+let TERRAIN = terrainFor('lane');
 
 function roster() {
   // attack_range 5: reaches the lane enemy at x=5 AND, from the lateral reopening
@@ -153,17 +182,44 @@ function supertestHttp(app) {
   // Lazy-require supertest so the parent (which never touches the app) does not
   // need it resolvable before a child run.
   const request = require('supertest');
+  // Windows ephemeral-port retry: supertest binds a fresh listener per request,
+  // and under concurrent sim storms (parallel probe sessions / the documented
+  // 4915x EADDRINUSE flake family) the dynamic-port range (49152+) can collide
+  // TRANSIENTLY on connect. Retry the identical request a few times with a tiny
+  // backoff -- the request itself is idempotent at the socket level (it never
+  // reached the app), so determinism is unaffected.
+  const RETRYABLE = new Set(['EADDRINUSE', 'ECONNRESET', 'EADDRNOTAVAIL']);
+  const withRetry = async (mk) => {
+    let lastErr;
+    for (let attempt = 0; attempt < 12; attempt += 1) {
+      try {
+        return await mk();
+      } catch (e) {
+        lastErr = e;
+        if (!RETRYABLE.has(e && e.code)) throw e;
+        // Up to ~4s cumulative: enough to ride out a TIME_WAIT-saturated
+        // ephemeral range under a concurrent sim batch, still fail-fast on a
+        // genuinely stuck host.
+        await new Promise((r) => setTimeout(r, Math.min(700, 50 * (attempt + 1))));
+      }
+    }
+    throw lastErr;
+  };
   return {
     post: (p, body) =>
-      request(app)
-        .post(p)
-        .send(body)
-        .then((r) => ({ status: r.status, body: r.body })),
+      withRetry(() =>
+        request(app)
+          .post(p)
+          .send(body)
+          .then((r) => ({ status: r.status, body: r.body })),
+      ),
     get: (p, query) =>
-      request(app)
-        .get(p)
-        .query(query || {})
-        .then((r) => ({ status: r.status, body: r.body })),
+      withRetry(() =>
+        request(app)
+          .get(p)
+          .query(query || {})
+          .then((r) => ({ status: r.status, body: r.body })),
+      ),
   };
 }
 
@@ -181,6 +237,13 @@ function dist(a, b) {
 //     never help even if wired). Uses the production helpers, not a re-impl.
 function positiveControls() {
   process.env.COMBAT_LOS_ENABLED = 'true';
+  // The fixture-validity controls ask about the GEOMETRY (does a budget-1 /
+  // budget-2 reopening tile exist?), not about the arm under test -- so they
+  // must run with the repositioning MODE knob cleared even when the parent was
+  // invoked with COMBAT_LOS_REPOSITION_MODE=step for the shipped-greedy arm
+  // (the clamp would blank the budget-2 probe and fail the wide gate).
+  const savedMode = process.env.COMBAT_LOS_REPOSITION_MODE;
+  delete process.env.COMBAT_LOS_REPOSITION_MODE;
   const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
   const { stepToRegainLos } = require('../../apps/backend/services/combat/losReposition');
   const grid = { terrain_features: TERRAIN, width: GRID_SIZE, height: GRID_SIZE };
@@ -198,34 +261,75 @@ function positiveControls() {
   }
 
   const occAll = new Set([...attackers, ...foes].map((u) => `${u.position.x},${u.position.y}`));
+  const reopensClearInRange = (a, tile) => {
+    if (!tile) return false;
+    for (const e of foes) {
+      if (
+        dist(tile, e.position) <= (a.attack_range || 1) &&
+        losClearOnGrid(grid, tile, e.position)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  };
   const reopening = [];
   for (const a of attackers) {
     const occ = new Set(occAll);
     occ.delete(`${a.position.x},${a.position.y}`);
-    const tile = stepToRegainLos(a, foes, grid, { occupied: occ });
-    let clearInRange = false;
-    if (tile) {
-      for (const e of foes) {
-        if (
-          dist(tile, e.position) <= (a.attack_range || 1) &&
-          losClearOnGrid(grid, tile, e.position)
-        ) {
-          clearInRange = true;
-          break;
-        }
-      }
-    }
-    reopening.push({ attacker: a.id, repos_tile: tile, reopens_clear_in_range: clearInRange });
+    // budget 1 = the shipped greedy step; budget 2 = the lookahead's cheapest
+    // wide-shadow solve. On 'lane' the budget-1 tile must exist; on 'wide' it
+    // must NOT (else the fixture is not wide) while budget-2 must reopen.
+    const tile1 = stepToRegainLos(a, foes, grid, { occupied: occ, budget: 1 });
+    const tile2 = stepToRegainLos(a, foes, grid, { occupied: occ, budget: 2 });
+    reopening.push({
+      attacker: a.id,
+      budget1_tile: tile1,
+      budget1_reopens: reopensClearInRange(a, tile1),
+      budget2_tile: tile2,
+      budget2_reopens: reopensClearInRange(a, tile2),
+    });
   }
   delete process.env.COMBAT_LOS_ENABLED;
+  if (savedMode !== undefined) process.env.COMBAT_LOS_REPOSITION_MODE = savedMode;
 
-  const reopeningOk = reopening.filter((r) => r.reopens_clear_in_range).length;
   return {
     blocked_pairs: blockedPairs,
     blocked_pairs_count: blockedPairs.length,
     reopening_steps: reopening,
-    reopening_steps_ok: reopeningOk,
+    reopening_budget1_ok: reopening.filter((r) => r.budget1_reopens).length,
+    reopening_budget2_ok: reopening.filter((r) => r.budget2_reopens).length,
   };
+}
+
+// Fail-fast fixture-validity gates (a ~0 delta is only evidence on a fixture
+// where the mechanic actually bites):
+//   lane -> the greedy 1-step reopening must exist for all 3 attackers.
+//   wide -> NO attacker may have a 1-step reopening (else the fixture is not
+//           wide and step-vs-budget cannot be separated), while the budget-2
+//           reopening must exist for all 3.
+function assertFixtureValidity(geometry, controls) {
+  if (controls.blocked_pairs_count < 2) {
+    throw new Error(
+      `positive control FAILED (${geometry}): only ${controls.blocked_pairs_count} blocked pairs -- LOS never engages`,
+    );
+  }
+  if (geometry === 'wide') {
+    if (controls.reopening_budget1_ok !== 0) {
+      throw new Error(
+        `positive control FAILED (wide): ${controls.reopening_budget1_ok} attackers still have a 1-step reopening -- fixture not wide`,
+      );
+    }
+    if (controls.reopening_budget2_ok !== 3) {
+      throw new Error(
+        `positive control FAILED (wide): budget-2 reopening exists for ${controls.reopening_budget2_ok}/3 attackers`,
+      );
+    }
+  } else if (controls.reopening_budget1_ok !== 3) {
+    throw new Error(
+      `positive control FAILED (lane): 1-step reopening exists for ${controls.reopening_budget1_ok}/3 attackers`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -416,10 +520,10 @@ function summarize(arr) {
 // ---------------------------------------------------------------------------
 // Parent: spawn one child per arm (fresh module graph each), print the report.
 // ---------------------------------------------------------------------------
-function runArmChild(arm, N, scale, mode) {
+function runArmChild(arm, N, scale, mode, geometry) {
   const out = execFileSync(
     process.execPath,
-    [__filename, '--child', arm, String(N), String(scale), mode],
+    [__filename, '--child', arm, String(N), String(scale), mode, geometry],
     { cwd: path.resolve(__dirname, '..', '..'), encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
   );
   const line = out.split('\n').find((l) => l.startsWith('__ARM_RESULT__'));
@@ -430,21 +534,25 @@ function runArmChild(arm, N, scale, mode) {
 }
 
 function main() {
-  const N = Number(process.argv[2]) || 10;
-  // argv[3] is the mode token (repos|flip) when non-numeric; otherwise it is the
-  // legacy enemy-scale arg (keeps `node ... <N> <scale>` working). Default mode
-  // 'repos' -> the repos path is byte-identical to before this control existed.
-  const modeArg = process.argv[3];
+  // Geometry token first (position-independent), then the legacy positional
+  // args over what remains: N, then mode (repos|flip) or enemy-scale.
+  const args = process.argv.slice(2);
+  const geometry = args.includes('wide') ? 'wide' : 'lane';
+  const rest = args.filter((a) => a !== 'wide' && a !== 'lane');
+  const N = Number(rest[0]) || 10;
+  const modeArg = rest[1];
   const mode = modeArg === 'flip' ? 'flip' : 'repos';
   const scale = mode === 'repos' && modeArg ? Number(modeArg) || 1.0 : 1.0;
+  TERRAIN = terrainFor(geometry);
 
   const controls = positiveControls();
-  console.log('=== POSITIVE CONTROL: fixture validity (LOS ON) ===');
+  console.log(`=== POSITIVE CONTROL: fixture validity (LOS ON, geometry=${geometry}) ===`);
   console.log(JSON.stringify(controls, null, 2));
   console.log('=== END fixture-validity control ===');
+  assertFixtureValidity(geometry, controls);
 
-  const on = runArmChild('on', N, scale, mode);
-  const off = runArmChild('off', N, scale, mode);
+  const on = runArmChild('on', N, scale, mode, geometry);
+  const off = runArmChild('off', N, scale, mode, geometry);
 
   // Arm labels reflect the semantic per mode:
   //   repos -> on = real repositioning,  off = stubbed repositioning (LOS ON both)
@@ -452,6 +560,11 @@ function main() {
   const out = {
     N,
     mode,
+    geometry,
+    // The repositioning heuristic the 'on' arm ran: COMBAT_LOS_REPOSITION_MODE
+    // is inherited by the child processes ('step' clamps the budget to 1 =
+    // shipped greedy; unset = budget-aware lookahead).
+    reposition_mode: process.env.COMBAT_LOS_REPOSITION_MODE || 'budget',
     enemyScale: scale,
     positive_control: controls,
     // In flip mode the 'off' arm ran with LOS disabled: no shot is ever blocked,
@@ -487,6 +600,7 @@ if (process.argv[2] === '--child') {
   const N = Number(process.argv[4]) || 10;
   const scale = Number(process.argv[5]) || 1.0;
   const mode = process.argv[6] === 'flip' ? 'flip' : 'repos';
+  TERRAIN = terrainFor(process.argv[7] === 'wide' ? 'wide' : 'lane');
   childMain(arm, N, scale, mode).catch((e) => {
     console.error(e);
     process.exit(1);


### PR DESCRIPTION
Follow-up to #3210 (greedy LOS-repositioning, merged) and #3212/#3213 (corrected-control probe, merged). Implements the STRONGER HEURISTIC half of the SDMG follow-up: budget-aware multi-tile lookahead with the AP-guard built in, plus the post-falsification fixes and the wide-geometry probe arm. Flag-dormant end to end (`COMBAT_LOS_ENABLED` OFF; `COMBAT_LOS_REPOSITION_MODE` is probe-only).

## What

- `stepToRegainLos(actor, enemies, grid, opts)` now honors `opts.budget` (default 1 = shipped greedy, byte-identical): any in-bounds, non-occupied tile within budget Manhattan steps; metric = (move cost, nearest LOS-clear enemy, x, y) lexicographic. One move action reaches a budget-N tile (engine charges AP = Manhattan distance).
- Sim player-proxy seam: two-phase budget -- reserve 1 AP to still shoot this turn, else full pool to set up next turn's shot; turn-starved units never overspend.
- Prod Sistema seam: full-pool budget (approach intent = move-only round) + the move intent now carries `ap_cost` = real distance (was hardcoded 1; the WEGO bridge resolver deducts the field without recomputing).
- `combat-adapter`: opt-in `allPlayersActPerRound` driver + `playerActionsByUnit` metric (works around the M17 `active_unit` freeze so probes can PROVE >=2 roster units act). Default OFF = byte-identical.
- SDMG fixes: `MOVE_TERRAIN_COST_ENABLED` guard (both flags ON -> budget clamps to 1; prevents silent AP under-charge on the WEGO seam -- harsh-reviewer P1), `opts.avoidBlockerTiles` A/B knob (wall-standing bimodality -- design-validator).
- `los-repos-probe`: `wide` geometry (3-tile blocker segments; no 1-step reopening exists) with inverted fixture-validity gates, MODE-independent positive controls, ephemeral-port retry wrapper.

## Corrected-control measurements (N=10 direction, paired seeds, LOS ON both arms, 3/3 units acting)

| Geometry/scale | wr_delta (repos vs off) | rounds_delta | Note |
| --- | --- | --- | --- |
| lane 1.0 | 0 | -0.8 | budget == step (parity) |
| wide 1.0 | 0 | ~0 | WR ceiling 1.00 |
| lane 1.8 | 0 | **-3.0** | wins 24% faster, both flavors |
| wide 1.8 | 0 | -0.1/-0.2 | budget fire-rate 48% vs step 26% |

Zero timeouts in all 16 arms (v1's 3/10 timeouts = fixture artifact, confirmed). Honest finding: repositioning per se is real pace value at zero WR cost against the CORRECT control -- but budget vs step shows NO outcome separation at N=10 on these boards. Full analysis + open pre-flip decisions in `docs/quality/2026-07-06-los-reposition-budget-QUALITY.md`.

## SDMG falsification (external, pre-production per ADR-0026)

- harsh-reviewer: **SOUND WITH FIXES** (P1 terrain-cost guard shipped in this PR; threat-blind metric documented; K4 oscillation coverage = open decision).
- game-design-validator: **BEHAVIOR COHERENT WITH CHANGES** (flanking on-pillar; wall-standing -> A/B knob; prod full-pool held behind N=40 proof).

## Open decisions (Eduardo, pre-flip -- none block this merge)

1. Prod default at flip: budget (as committed) vs step-clamped until N=40 proves full-pool.
2. K4 recognizer: add `_LOS_BLOCKED` moves vs accept documented bounded-deterministic oscillation.
3. `avoidBlockerTiles`: A/B arm in the N=40 ratify.

## Verification

- TDD red-green per cycle (retro-RED verified for the 2 SDMG-fix tests: stash impl -> 2 fail -> pop -> 18/18).
- Suites: losReposition 18/18, aiLosDowngrade 8/8, combatPolicy 24/24, combatAdapter 6/6, declareSistemaIntents green.
- Full regression: `npm run test:api` 77/77 + 5/5, `node --test tests/sim` 227/227, prettier clean.
- Ran on Ryzen / Node v24.11.0 (only runtime there); arm-vs-arm same-node valid, cross-machine numeric comparison needs a same-node re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)