### PR TITLE
fix(combat): server-authoritative move AP in over-declaration gate (A04 residual)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -259,7 +259,10 @@ function createRoundBridge(deps) {
     if (actor.controlled_by !== 'player') {
       return {
         status: 403,
-        body: { error: `actor "${actorId}" non e' controllato dal player`, code: 'ACTOR_NOT_OWNED' },
+        body: {
+          error: `actor "${actorId}" non e' controllato dal player`,
+          code: 'ACTOR_NOT_OWNED',
+        },
       };
     }
     if (requireAlive && Number(actor.hp || 0) <= 0) {
@@ -321,16 +324,36 @@ function createRoundBridge(deps) {
     return Number(action.ap_cost || 1);
   }
 
+  // True when a move destination is a valid, in-grid cell (mirrors the NO_DEST +
+  // OUT_OF_GRID checks in validatePlayerIntent). Used to decide whether the budget
+  // gate can trust a server-authoritative move cost: an off-grid / malformed dest
+  // keeps the advisory client value so its own OUT_OF_GRID / NO_DEST rejection
+  // fires first (clearer error, and no NaN from manhattanDistance on a bad dest).
+  function isValidGridDest(dest) {
+    if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') return false;
+    if (!Number.isFinite(dest.x) || !Number.isFinite(dest.y)) return false;
+    const size = gridSize || 6;
+    return dest.x >= 0 && dest.x < size && dest.y >= 0 && dest.y < size;
+  }
+
   // Declare-time budget cost of an intent, for validatePlayerIntent. Attack/ability
-  // use the server-authoritative resolveActionApCost so a client cannot pass the
-  // budget gate by declaring ap_cost:0/negative and over-declare free actions (the
-  // resolver charges the real cost per action but floors at 0, so an un-gated
-  // over-declaration still executes N actions while paying for fewer -- A04).
-  // move/skip/other keep the client value: moves are gated separately by dist /
-  // MOVE_TOO_FAR, and skip legitimately costs 0.
+  // use the server-authoritative resolveActionApCost, and a move to a valid in-grid
+  // cell uses resolveMoveApCost -- so a client cannot pass the budget gate by
+  // declaring ap_cost:0/negative and over-declare free actions. The resolver charges
+  // the real cost per action but floors ap_remaining at 0, so an un-gated
+  // over-declaration still executes N actions while paying for fewer (OWASP A04):
+  // for moves this means N short moves at ap_cost:0 all clear the pending-sum gate
+  // and the (N+1)th still resolves for free. Charging max(1, dist - move_bonus) per
+  // move in the pending sum closes that. AP_INSUFFICIENT now precedes MOVE_TOO_FAR
+  // for a single over-far in-grid move (both 400 rejections; the over-far move IS
+  // over-budget). skip/off-grid/other keep the client value: skip legitimately
+  // costs 0, and an off-grid dest is rejected by OUT_OF_GRID before this matters.
   function resolveIntentApCost(actor, act) {
     if (act && (act.type === 'attack' || act.ability_id)) {
       return resolveActionApCost(actor, act);
+    }
+    if (act && act.type === 'move' && isValidGridDest(act.move_to)) {
+      return resolveMoveApCost(actor, actor && actor.position, act.move_to);
     }
     return Number((act && act.ap_cost) || 0);
   }
@@ -502,7 +525,10 @@ function createRoundBridge(deps) {
     const targetId = action.target_id ? String(action.target_id) : null;
     const actor = next.units.find((u) => u.id === actorId);
     if (actor && actor.ap) {
-      actor.ap.current = Math.max(0, Number(actor.ap.current || 0) - resolveActionApCost(actor, action));
+      actor.ap.current = Math.max(
+        0,
+        Number(actor.ap.current || 0) - resolveActionApCost(actor, action),
+      );
     }
     let damageApplied = 0;
     let healingApplied = 0;

--- a/tests/api/sessionDeclareIntentValidation.test.js
+++ b/tests/api/sessionDeclareIntentValidation.test.js
@@ -125,14 +125,17 @@ test('validation: AP insufficienti rigettato (AP_INSUFFICIENT)', async (t) => {
   t.after(async () => {
     if (typeof close === 'function') await close().catch(() => {});
   });
-  // p1 ap=2, action ap_cost=5
+  // p1 ap=2 at (2,2); move 3 tiles to (2,5) -- empty (sis at default (3,2)), in-grid.
+  // The budget gate uses the SERVER move cost max(1, dist) = 3 > 2, so the client
+  // ap_cost:0 (claiming a free move) cannot bypass it. AP_INSUFFICIENT precedes
+  // MOVE_TOO_FAR here because the AP gate runs before the move-type checks.
   const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 } }));
   const r = await declare(app, sid, 'p1', {
     id: 'p1-mv',
     type: 'move',
     actor_id: 'p1',
-    ap_cost: 5,
-    move_to: { x: 3, y: 2 },
+    ap_cost: 0,
+    move_to: { x: 2, y: 5 },
   });
   assert.equal(r.status, 400);
   assert.equal(r.body.code, 'AP_INSUFFICIENT');

--- a/tests/api/sessionMoveApCharge.test.js
+++ b/tests/api/sessionMoveApCharge.test.js
@@ -23,7 +23,10 @@ const { createApp } = require('../../apps/backend/app');
 const { startSession, twoUnits } = require('./sessionTestHelpers');
 
 async function resolveSingleMove(app, sid, moveTo, apCost) {
-  await request(app).post('/api/session/round/begin-planning').send({ session_id: sid }).expect(200);
+  await request(app)
+    .post('/api/session/round/begin-planning')
+    .send({ session_id: sid })
+    .expect(200);
   await request(app)
     .post('/api/session/declare-intent')
     .send({
@@ -65,4 +68,39 @@ test('AP charge regression: a 1-tile move still costs 1 AP', async (t) => {
 
   assert.deepEqual(p1.position, { x: 2, y: 3 }, 'move actually resolved');
   assert.equal(p1.ap_remaining, 1, '1-tile move charges 1 AP (unchanged)');
+});
+
+test('AP budget gate: cannot over-declare more moves than real AP via ap_cost:0', async (t) => {
+  const { app, close } = createApp({ databasePath: null });
+  t.after(async () => {
+    if (typeof close === 'function') await close().catch(() => {});
+  });
+  // p1 ap=2 at (2,2); SIS parked far so it never occupies a destination cell.
+  // validatePlayerIntent must gate on the SERVER move cost (max(1, dist) >= 1 per
+  // move), not the client-declared ap_cost:0. Otherwise N move intents each
+  // ap_cost:0 all pass the pending-sum budget check and the resolver executes all
+  // N -- each deduction floored at ap_remaining 0 -- for free movement beyond the
+  // real AP (OWASP A04, same class as the move-undercharge fixed above; the
+  // attack analog lives in sessionActionApCharge.test.js).
+  const sid = await startSession(app, twoUnits({ p1Pos: { x: 2, y: 2 }, sisPos: { x: 5, y: 5 } }));
+  await request(app)
+    .post('/api/session/round/begin-planning')
+    .send({ session_id: sid })
+    .expect(200);
+  const declareMove = (n, moveTo) =>
+    request(app)
+      .post('/api/session/declare-intent')
+      .send({
+        session_id: sid,
+        actor_id: 'p1',
+        action: { id: `p1-mv-${n}`, type: 'move', actor_id: 'p1', ap_cost: 0, move_to: moveTo },
+      });
+
+  // Each destination is 1 tile from (2,2): server cost 1 apiece.
+  await declareMove(1, { x: 2, y: 3 }).expect(200); // running total 1 <= 2
+  await declareMove(2, { x: 2, y: 1 }).expect(200); // running total 2 <= 2
+  const third = await declareMove(3, { x: 1, y: 2 }); // running total 3 > 2 -> rejected
+
+  assert.equal(third.status, 400, '3rd move must be rejected (3 x server cost 1 exceeds 2 AP)');
+  assert.equal(third.body.code, 'AP_INSUFFICIENT', 'rejection must be an AP budget error');
 });


### PR DESCRIPTION
## Cosa

Follow-up a #3219. Chiude il **residuo A04** che #3219 ha lasciato aperto sui **move**: la budget-gate `validatePlayerIntent` sommava il `ap_cost` client-supplied per i move, quindi un client raw-HTTP poteva dichiarare N move corti a `ap_cost:0` -- ognuno passa `MOVE_TOO_FAR` singolarmente, la somma-pending resta 0, e il resolver esegue l'(N+1)-esimo **gratis** (deduzione `resolveMoveApCost` ma `ap_remaining` floored a 0).

## Fix

`resolveIntentApCost` (`apps/backend/routes/sessionRoundBridge.js`) ora calcola il costo move server-authoritative via `resolveMoveApCost(actor, actor.position, move_to)` = `max(1, dist - move_bonus)`, invece del valore client. Ogni move valido costa >=1 AP nella somma-pending -> l'over-declaration sfonda il budget -> `AP_INSUFFICIENT`.

- **Solo dest in-grid valide** usano il costo server: un `move_to` off-grid/malformato mantiene il valore client cosi' `OUT_OF_GRID`/`NO_DEST` scatta prima (error-taxonomy preservata, niente NaN da `manhattanDistance`).
- `AP_INSUFFICIENT` ora precede `MOVE_TOO_FAR` per un singolo move in-grid troppo lontano (entrambi 400; il move over-far **e'** over-budget).
- `skip`/altro invariati (skip costa 0 legittimamente).

## Test (TDD)

- **Nuovo** (`sessionMoveApCharge.test.js`): dichiara N move corti a `ap_cost:0`, l'(N+1)-esimo rigettato `AP_INSUFFICIENT` (mirror dell'analogo attack in `sessionActionApCharge.test.js`). RED verificato prima del fix (3o move 200), GREEN dopo.
- **Riscritto** (`sessionDeclareIntentValidation.test.js` test AP_INSUFFICIENT): la premessa dist-1 ora costa 1 AP -> colpiva `CELL_OCCUPIED`; riscritto a un move genuinamente over-budget (p1 ap=2 -> dist 3, cella vuota in-grid).

Per-file (full `npm run test:api` floods Windows ephemeral ports):
- sessionDeclareIntentValidation 8/8 · sessionMoveApCharge 3/3 · sessionActionApCharge 6/6 · apBudget 3/3 · sessionRoundEndpoints 11/11
- regressione: sessionDeclareIntentAuthz 8/8 · sessionEncounterWiringStep2 3/3 · sessionLegacyActionWrapper 6/6 · sessionUndo 6/6
- `prettier --check` (3.8.3, repo-pinned) clean.

## Rollback

Revert del commit: `resolveIntentApCost` torna al valore client per i move (ripristina il residuo A04). Nessuna migrazione, nessun contract, nessun flag; solo `apps/backend/` + test.

## Note

- Stacked su #3219 (`fix/round-attack-ability-ap-undercharge`, a sua volta su #3215). Rebase su main quando #3215/#3219 mergiano.
- Nessun forbidden-path (`sessionRoundBridge.js` in `apps/backend/`). Merge = Eduardo.