### PR TITLE
fix(scripts): lint-stack prettier spawn works on Windows

### DIFF
--- a/scripts/lint-stack.mjs
+++ b/scripts/lint-stack.mjs
@@ -83,7 +83,14 @@ if (files.length === 0) {
 }
 
 const prettierArgs = ['prettier', '--check', ...files];
-const result = spawnSync('npx', prettierArgs, { stdio: 'inherit' });
+// Windows: the npx launcher is npx.cmd and Node >=18.20 refuses to spawn .cmd
+// files without a shell (CVE-2024-27980) -> spawnSync('npx') dies with ENOENT.
+// Single-string shell form (not args + shell:true, deprecated DEP0190); stack
+// paths never contain spaces (STACK_PATTERNS), so no quoting is needed.
+const result =
+  process.platform === 'win32'
+    ? spawnSync(['npx', ...prettierArgs].join(' '), { stdio: 'inherit', shell: true })
+    : spawnSync('npx', prettierArgs, { stdio: 'inherit' });
 
 if (result.error) {
   console.error('Failed to execute prettier:', result.error.message);


### PR DESCRIPTION
## Problema
`node scripts/lint-stack.mjs` muore con `spawnSync npx ENOENT` su Windows: il launcher e' `npx.cmd` e Node >=18.20 blocca lo spawn di .cmd senza shell (CVE-2024-27980). Il gate locale era quindi non-eseguibile sulle dev machine Windows -- il prettier drift arrivava dritto in CI (#3215 e #3219 rossi su stack-quality per questa classe).

## Fix
Su win32: forma shell single-string (`['npx', ...args].join(' ')`) -- niente DEP0190 (args+shell:true e' deprecato). Path POSIX invariato. I path stack non contengono spazi (STACK_PATTERNS), quindi nessun quoting necessario.

## Verifica
- Ryzen (win32, Node 24): spawn ok, prettier 3.8.3, script exit 0, zero warning.
- `npx prettier --check scripts/lint-stack.mjs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)