### PR TITLE
refactor(combat): extract shared occupiedSetFromUnits occupancy helper

### DIFF
--- a/apps/backend/services/abilityExecutor.js
+++ b/apps/backend/services/abilityExecutor.js
@@ -35,6 +35,7 @@
 const { loadJobs, extractAbilities } = require('./jobsLoader');
 const { defaultRng } = require('./combat/pseudoRng');
 const { isAbilityInhibited } = require('./combat/abilitySuppression');
+const { occupiedSetFromUnits } = require('./combat/occupancy');
 
 let abilityIndex = null;
 
@@ -489,11 +490,7 @@ function createAbilityExecutor(deps) {
     const grid = session.grid || null;
     // Only LIVE units block a spawn tile (Codex #2544 P2): corpses don't occupy
     // cells, matching the codebase's live-unit movement/occupancy semantics.
-    const occupied = new Set(
-      (session.units || [])
-        .filter((u) => u && u.position && (u.hp ?? 0) > 0)
-        .map((u) => `${u.position.x},${u.position.y}`),
-    );
+    const occupied = occupiedSetFromUnits(session.units);
     const candidates = [
       { x: pos.x + 1, y: pos.y },
       { x: pos.x - 1, y: pos.y },

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -45,6 +45,7 @@ const {
 } = require('./policy');
 const { selectAiPolicyUtility } = require('./utilityBrain');
 const { stepToRegainLos } = require('../combat/losReposition');
+const { occupiedSetFromUnits } = require('../combat/occupancy');
 const { ARCHETYPE_VULN_CHANNEL } = require('../../routes/sessionConstants');
 // A2 (TKT-PRESSURE-TIER-ENCOUNTER): per-encounter pressure_tier_floor mirror.
 // sessionHelpers owns the single effectivePressure SoT (flag-gated, default OFF).
@@ -470,11 +471,7 @@ function createDeclareSistemaIntents(deps) {
         policy.intent === 'attack' &&
         !losClearForAi(session.grid, actor.position, target.position, session.units)
       ) {
-        const occupied = new Set(
-          (session.units || [])
-            .filter((u) => u && u.position && (u.hp ?? 0) > 0 && u.id !== actor.id)
-            .map((u) => `${u.position.x},${u.position.y}`),
-        );
+        const occupied = occupiedSetFromUnits(session.units, { excludeId: actor.id });
         // Reposition to regain LOS on the CHOSEN target specifically (keep engaging
         // it, do not switch enemies) -- pass only [target]. null -> plain approach.
         // Budget v2: an approach intent is a move-only round (one intent per unit),

--- a/apps/backend/services/combat/losForGrid.js
+++ b/apps/backend/services/combat/losForGrid.js
@@ -20,6 +20,7 @@
 const { lineOfSightClear } = require('../grid/squareLos');
 const { terrainAtFromFeatures } = require('./moveCost');
 const { terrainBlocksLos, unitsBlockLos } = require('./losBlockers');
+const { occupiedSetFromUnits } = require('./occupancy');
 
 // Pure occupancy predicate from live units, gated by `enabled` (the units_block_los
 // config). Disabled OR no units -> no-op (keeps terrain-only slice-1 behavior
@@ -27,18 +28,7 @@ const { terrainBlocksLos, unitsBlockLos } = require('./losBlockers');
 // attacker/target cell never self-blocks. Exported for testing.
 function _unitBlocker(units, enabled) {
   if (!enabled || !Array.isArray(units) || units.length === 0) return () => false;
-  const occ = new Set();
-  for (const u of units) {
-    if (
-      u &&
-      u.position &&
-      (u.hp ?? 0) > 0 &&
-      Number.isFinite(u.position.x) &&
-      Number.isFinite(u.position.y)
-    ) {
-      occ.add(`${u.position.x},${u.position.y}`);
-    }
-  }
+  const occ = occupiedSetFromUnits(units, { requireFinite: true });
   return (x, y) => occ.has(`${x},${y}`);
 }
 

--- a/apps/backend/services/combat/occupancy.js
+++ b/apps/backend/services/combat/occupancy.js
@@ -1,0 +1,31 @@
+// apps/backend/services/combat/occupancy.js
+'use strict';
+
+// Shared occupancy-set builder: the "x,y" tile keys of LIVE positioned units.
+// Extracted from 6 near-identical inline constructions (abilityExecutor spawn
+// tiles, declareSistemaIntents LOS reposition, losForGrid._unitBlocker,
+// tools/sim combat-policy occupiedSet + the los-repos / ultima-caccia probes)
+// so the key format stays in lockstep with the consumers' contracts
+// (stepToRegainLos opts.occupied, session.js "niente overlap" occupancy).
+//
+// Options mirror the original per-site semantics -- pure dedup, no new policy:
+// - excludeId: skip the unit with this id (self-exclusion when planning the
+//   actor's own move; the actor's current tile must not block its step).
+// - requireFinite: also require Number.isFinite on both coordinates
+//   (losForGrid._unitBlocker strictness; default off keeps the raw-key
+//   behavior of the other sites).
+function occupiedSetFromUnits(units, opts = {}) {
+  const { excludeId, requireFinite = false } = opts;
+  const occ = new Set();
+  for (const u of units || []) {
+    if (!u || !u.position || (u.hp ?? 0) <= 0) continue;
+    if (excludeId !== undefined && u.id === excludeId) continue;
+    if (requireFinite && !(Number.isFinite(u.position.x) && Number.isFinite(u.position.y))) {
+      continue;
+    }
+    occ.add(`${u.position.x},${u.position.y}`);
+  }
+  return occ;
+}
+
+module.exports = { occupiedSetFromUnits };

--- a/tests/services/occupancy.test.js
+++ b/tests/services/occupancy.test.js
@@ -1,0 +1,67 @@
+// tests/services/occupancy.test.js
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { occupiedSetFromUnits } = require('../../apps/backend/services/combat/occupancy');
+
+test('builds "x,y" keys from live positioned units', () => {
+  const units = [
+    { id: 'a', hp: 5, position: { x: 1, y: 2 } },
+    { id: 'b', hp: 1, position: { x: 0, y: 0 } },
+  ];
+  assert.deepEqual(occupiedSetFromUnits(units), new Set(['1,2', '0,0']));
+});
+
+test('skips dead, hp-less and negative-hp units ((hp ?? 0) > 0 gate)', () => {
+  const units = [
+    { id: 'dead', hp: 0, position: { x: 1, y: 1 } },
+    { id: 'nohp', position: { x: 2, y: 2 } },
+    { id: 'neg', hp: -3, position: { x: 3, y: 3 } },
+    { id: 'frac', hp: 0.5, position: { x: 4, y: 4 } },
+  ];
+  assert.deepEqual(occupiedSetFromUnits(units), new Set(['4,4']));
+});
+
+test('skips null entries and positionless units', () => {
+  const units = [
+    null,
+    undefined,
+    { id: 'nopos', hp: 5 },
+    { id: 'ok', hp: 5, position: { x: 5, y: 6 } },
+  ];
+  assert.deepEqual(occupiedSetFromUnits(units), new Set(['5,6']));
+});
+
+test('null/undefined units input -> empty set', () => {
+  assert.deepEqual(occupiedSetFromUnits(null), new Set());
+  assert.deepEqual(occupiedSetFromUnits(undefined), new Set());
+});
+
+test('excludeId skips exactly that unit (self-exclusion for move planning)', () => {
+  const units = [
+    { id: 'self', hp: 5, position: { x: 1, y: 1 } },
+    { id: 'other', hp: 5, position: { x: 2, y: 2 } },
+  ];
+  assert.deepEqual(occupiedSetFromUnits(units, { excludeId: 'self' }), new Set(['2,2']));
+  // no excludeId -> self included
+  assert.deepEqual(occupiedSetFromUnits(units), new Set(['1,1', '2,2']));
+});
+
+test('requireFinite drops non-finite coordinates; default keeps them raw', () => {
+  const units = [
+    { id: 'ok', hp: 5, position: { x: 1, y: 1 } },
+    { id: 'nan', hp: 5, position: { x: NaN, y: 2 } },
+    { id: 'str', hp: 5, position: { x: '3', y: 3 } },
+  ];
+  // losForGrid._unitBlocker semantics: strict finite gate.
+  assert.deepEqual(occupiedSetFromUnits(units, { requireFinite: true }), new Set(['1,1']));
+  // abilityExecutor/probe semantics: no finite gate, keys built as-is.
+  assert.deepEqual(occupiedSetFromUnits(units), new Set(['1,1', 'NaN,2', '3,3']));
+});
+
+test('returned Set is a plain mutable Set (probes delete/add on it)', () => {
+  const occ = occupiedSetFromUnits([{ id: 'a', hp: 5, position: { x: 1, y: 1 } }]);
+  occ.delete('1,1');
+  occ.add('9,9');
+  assert.deepEqual(occ, new Set(['9,9']));
+});

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -21,6 +21,7 @@
 // LOS filter keeps every in-range candidate (byte-identical to pre-Task-6).
 const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
 const { stepToRegainLos } = require('../../apps/backend/services/combat/losReposition');
+const { occupiedSetFromUnits } = require('../../apps/backend/services/combat/occupancy');
 
 const ZONE_PURSUIT_OBJECTIVES = new Set(['capture_point', 'sabotage', 'escape', 'escort']);
 
@@ -46,12 +47,7 @@ function stepToward(actor, dest) {
 // OA2 (item 7): tiles occupied by OTHER live units -- move targets the backend
 // rejects with 400 "casella occupata" (session.js "niente overlap").
 function occupiedSet(units, selfId) {
-  const occ = new Set();
-  for (const u of units || []) {
-    if (!u || u.id === selfId || !u.position || (u.hp ?? 0) <= 0) continue;
-    occ.add(`${u.position.x},${u.position.y}`);
-  }
-  return occ;
+  return occupiedSetFromUnits(units, { excludeId: selfId });
 }
 
 // Nearest (Manhattan) zone tile not occupied by a live unit. Deterministic

--- a/tools/sim/los-repos-probe.js
+++ b/tools/sim/los-repos-probe.js
@@ -253,6 +253,7 @@ function positiveControls(enemyRange = 2) {
   delete process.env.COMBAT_LOS_REPOSITION_MODE;
   const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
   const { stepToRegainLos } = require('../../apps/backend/services/combat/losReposition');
+  const { occupiedSetFromUnits } = require('../../apps/backend/services/combat/occupancy');
   const grid = { terrain_features: TERRAIN, width: GRID_SIZE, height: GRID_SIZE };
   const attackers = roster();
   const foes = enemies(1.0, enemyRange);
@@ -267,7 +268,7 @@ function positiveControls(enemyRange = 2) {
     }
   }
 
-  const occAll = new Set([...attackers, ...foes].map((u) => `${u.position.x},${u.position.y}`));
+  const occAll = occupiedSetFromUnits([...attackers, ...foes]);
   const reopensClearInRange = (a, tile) => {
     if (!tile) return false;
     for (const e of foes) {

--- a/tools/sim/ultima-caccia-wr-probe.js
+++ b/tools/sim/ultima-caccia-wr-probe.js
@@ -30,6 +30,7 @@ const {
   buildUltimaCacciaUnits01,
 } = require('../../apps/backend/services/worldgen/ultimaCacciaScenario');
 const { deriveCombatStats } = require('../../apps/backend/services/worldgen/ecologyCombatAdapter');
+const { occupiedSetFromUnits } = require('../../apps/backend/services/combat/occupancy');
 
 process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
 process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
@@ -88,9 +89,7 @@ function planPlayerIntents(state) {
   const enemies = units.filter((u) => u.controlled_by === 'sistema' && (u.hp || 0) > 0);
   if (!enemies.length) return [];
   const intents = [];
-  const reserved = new Set(
-    units.filter((u) => (u.hp || 0) > 0).map((u) => `${u.position.x},${u.position.y}`),
-  );
+  const reserved = occupiedSetFromUnits(units);
   for (const pl of players) {
     const ap = pl.ap_remaining != null ? pl.ap_remaining : pl.ap != null ? pl.ap : 2;
     if (ap <= 0) continue;


### PR DESCRIPTION
## Cosa

Fast-follow dall'arco combat-LOS (journal 2026-07-05, PR #3210): l'occupancy-set dei tile occupati (`Set` di chiavi `"x,y"` da unita' vive posizionate) era costruito inline in 6 punti quasi identici del combat stack. Estratto helper condiviso `occupiedSetFromUnits(units, opts)` in `apps/backend/services/combat/occupancy.js` + tutti i siti delegati.

## Siti sostituiti

| Sito | Chiamata |
|---|---|
| `abilityExecutor.js` (spawn tile minion) | `occupiedSetFromUnits(session.units)` |
| `declareSistemaIntents.js` (LOS reposition) | `{ excludeId: actor.id }` |
| `losForGrid.js` `_unitBlocker` | `{ requireFinite: true }` |
| `tools/sim/combat-policy.js` `occupiedSet` | delegate thin, stessa firma |
| `tools/sim/los-repos-probe.js` `occAll` | `occupiedSetFromUnits([...attackers, ...foes])` |
| `tools/sim/ultima-caccia-wr-probe.js` `reserved` | `occupiedSetFromUnits(units)` |

**Escluso (intenzionale)**: `routes/sessionRoundBridge.js` CELL_OCCUPIED -- e' un `.find` lineare che serve il `blocker.id` per il messaggio d'errore, non un Set; convertirlo cambierebbe la shape. Anche `reinforcementSpawner.isWalkable` resta com'e' (scan per-tile, non costruzione Set).

## Zero behavior-change

Le opts replicano ESATTAMENTE il filtro originale di ogni sito (`(hp ?? 0) > 0` + guard position; self-exclusion opzionale; gate `Number.isFinite` opzionale). Unica delta teorica: i 2 probe guadagnano il guard null/position su input degeneri -- le loro fixture hanno sempre `hp > 0` + `position`, output identico.

## Test / verifica

- Nuovo `tests/services/occupancy.test.js` (7 casi: chiavi, gate hp, null/positionless, excludeId, requireFinite, Set mutabile) -- TDD, RED verificato pre-implementazione; CI-wired dal glob esistente `tests/services/*.test.js`.
- Per-file (no full `test:api`, EADDRINUSE Ryzen): LOS suite 53 pass, declareSistemaIntents+combatPolicy 47 pass, api/abilityExecutor 41 pass, 0 fail.
- `node --check` sui 3 tools/sim + `prettier --check` pulito sugli 8 file.

Merge = Eduardo.