### PR TITLE
chore(verify): stopwords for LOS method/engineering jargon

### DIFF
--- a/scripts/data/verify_stopwords.txt
+++ b/scripts/data/verify_stopwords.txt
@@ -91,3 +91,29 @@ swarm-loop
 swarm_loop
 swarm-controls
 swarm_controls
+
+# LOS/combat method + engineering jargon (advisory FP su docs/research
+# 2026-07-06-los-flip-ratify-n40.md -- 20/21 flagged, tutti identificatori di
+# codice reali o vocabolario di metodo, zero entity di canon)
+action-economy
+active_unit
+anti-oscillazione
+budget-vs-step
+by-design
+combat_los_enabled
+combat_los_reposition_mode
+cross-run
+de-ceiling
+de-ceilinged
+game-design-validator
+los-repos-probe
+los_repos_probe
+mirror-wall
+multi-tile
+on-vs-off
+positive-control
+positive_control
+pre-godot
+step-vs-budget
+time_wait
+un-losable


### PR DESCRIPTION
Tuning advisory canon-grounding: i 20 termini flaggati su #3223 sono identificatori di codice reali + vocabolario di metodo, zero entity canon. Aggiunti a `verify_stopwords.txt` (kebab+snake dove sensato) come da rollout path.

Merge = Eduardo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)