### PR TITLE
fix(sim): combat-adapter drives players by AP post honest active_unit

### DIFF
--- a/tests/sim/combatAdapter.test.js
+++ b/tests/sim/combatAdapter.test.js
@@ -304,8 +304,11 @@ test('combatAdapter.runEncounter: allPlayersActPerRound drives every live player
     seed: 'apr-1',
     maxRounds: 6,
   });
-  // Documented freeze: only turn_order[0] (camp_a, initiative 18) ever acts.
-  assert.deepEqual(acted(legacy), ['camp_a']);
+  // Post-#3214 (honest active_unit: null in the player phase) the M17 freeze
+  // is gone server-side; the legacy driver now selects by AP budget, so BOTH
+  // players act. The old pin (only turn_order[0] camp_a) documented an
+  // artifact of piloting via active_unit -- dead with the driver fix.
+  assert.deepEqual(acted(legacy), ['camp_a', 'camp_b']);
 
   const all = await runEncounter(http, {
     roster: roster(),

--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -239,8 +239,25 @@ async function runEncounter(
     }
 
     const activeId = st.body.active_unit;
-    const active = units.find((u) => u.id === activeId);
-    if (!active) break;
+    let active = units.find((u) => u.id === activeId);
+    // Co-op semantics (ADR-2026-04-16 addendum 2026-07-05, PR #3214): active_unit
+    // is null during the player planning phase (advisory only; the real
+    // constraint is the AP budget). Drive the first live player with AP left --
+    // same fix as tests/smoke/ai-driven-sim.js. The old `break` on a missing
+    // active_unit exited with nobody acting = guaranteed timeout (regression
+    // caught by tests/sim/combatAdapter.test.js, which no CI glob runs).
+    if (!active) {
+      active = units.find(
+        (u) =>
+          u.controlled_by === 'player' &&
+          (u.hp ?? 0) > 0 &&
+          Number(u.ap_remaining ?? u.ap ?? 0) > 0,
+      );
+    }
+    if (!active) {
+      await http.post('/api/session/turn/end', { session_id: sessionId });
+      continue;
+    }
     if (active.controlled_by === 'sistema') {
       await http.post('/api/session/turn/end', { session_id: sessionId });
       continue;


### PR DESCRIPTION
## Regressione (da #3214, invisibile in CI)
Il loop legacy dell'adapter pilotava via `session.active_unit` -- post-#3214 e' onestamente null in player phase -> `break` con nessuno che agisce -> timeout garantito. `tests/sim/combatAdapter.test.js` era 5/6 ROSSO su main ma **nessun glob CI esegue tests/sim** (blind-spot flaggato in chip separato).

Bisezione: `7b7b224cf` (#3216) verde -> `5bf7b652a` (#3214) rosso.

## Fix
Stessa semantica del fix #3214 in ai-driven-sim.js: primo player vivo con AP residuo, `/turn/end` se nessuno. Pin M17-freeze obsoleto aggiornato (il freeze era l'artefatto active_unit).

## Verifica
6/6 (era 1/6); prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)