### PR TITLE
feat(combat): flip COMBAT_LOS_ENABLED default ON + step prod default

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -323,7 +323,7 @@ const {
 // Constants + pure helpers extracted to sessionConstants.js + sessionHelpers.js
 // (imported above). Only createSessionRouter closure remains inline.
 
-// COMBAT_LOS_ENABLED (default OFF): true iff a terrain blocker sits strictly
+// COMBAT_LOS_ENABLED (default ON since the 2026-07-06 flip, opt-out 'false'): true iff a terrain blocker sits strictly
 // between attacker and target. Thin negation of the shared combat LOS rule
 // (services/combat/losForGrid.js). Optional `units` also gates a live
 // interposed unit (units_block_los config, default false -- dormant). Exported
@@ -3495,7 +3495,7 @@ function createSessionRouter(options = {}) {
             });
             continue;
           }
-          // Combat LOS slice-1 (COMBAT_LOS_ENABLED, default OFF): a human-declared
+          // Combat LOS slice-1 (COMBAT_LOS_ENABLED, default ON since the 2026-07-06 flip): a human-declared
           // ranged attack cannot pass through a terrain blocker. Symmetric with the
           // single-attack HTTP handler (losGateBlocks in the /action path). Scoped to
           // source 'player': the AI path is already LOS-gated upstream at target

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -460,7 +460,7 @@ function createDeclareSistemaIntents(deps) {
         }
       }
 
-      // COMBAT_LOS_ENABLED (default OFF): an AI cannot attack a target it cannot see.
+      // COMBAT_LOS_ENABLED (default ON since the 2026-07-06 flip, opt-out 'false'): an AI cannot attack a target it cannot see.
       // Downgrade attack -> approach so a blocked AI advances to gain line of sight
       // instead of shooting through a blocker. Flag OFF -> losClearForAi()===true -> no-op.
       // Placed AFTER the commit-window guard and the cornered retreat fallback so LOS
@@ -474,13 +474,13 @@ function createDeclareSistemaIntents(deps) {
         const occupied = occupiedSetFromUnits(session.units, { excludeId: actor.id });
         // Reposition to regain LOS on the CHOSEN target specifically (keep engaging
         // it, do not switch enemies) -- pass only [target]. null -> plain approach.
-        // Budget v2: an approach intent is a move-only round (one intent per unit),
-        // so the SIS may spend its whole AP pool on the reposition -- a farther LOS
-        // tile strictly dominates the blind stepTowards, which also forfeits the
-        // attack. The cost-first metric still prefers the nearest reopening tile.
+        // Owner default 2026-07-06 (ratify N=40, docs/research/2026-07-06-los-flip-
+        // ratify-n40.md: step-vs-budget = NO outcome separation, budget pays pace
+        // only): prod runs the shipped greedy step (budget 1). The multi-tile
+        // lookahead stays available to probes via opts.budget / REPOSITION_MODE.
         const reposition = stepToRegainLos(actor, [target], session.grid, {
           occupied,
-          budget: actor.ap_remaining ?? actor.ap ?? 1,
+          budget: 1,
         });
         policy = {
           ...policy,

--- a/apps/backend/services/ai/policy.js
+++ b/apps/backend/services/ai/policy.js
@@ -293,7 +293,7 @@ function scoreObjectives(actor, target, objectives = DEFAULT_OBJECTIVES) {
   return { totalScore, matchedObjectives: matched };
 }
 
-// COMBAT_LOS_ENABLED (default OFF): true when target is visible to actor.
+// COMBAT_LOS_ENABLED (default ON since the 2026-07-06 flip, opt-out 'false'): true when target is visible to actor.
 // Thin alias over the shared combat LOS rule (services/combat/losForGrid.js);
 // kept so declareSistemaIntents.js and the AI LOS tests keep importing it here.
 // Optional `units` also gates a live interposed unit (units_block_los config,

--- a/apps/backend/services/combat/bondReactionTrigger.js
+++ b/apps/backend/services/combat/bondReactionTrigger.js
@@ -160,7 +160,7 @@ function fireCounterAttack(session, ally, attacker, bond, performAttack) {
   const range = Number(ally.attack_range) || 1;
   if (manhattan(ally.position, attacker.position) > range) return null;
 
-  // COMBAT_LOS_ENABLED (default OFF): the bonded ally cannot counter-strike an
+  // COMBAT_LOS_ENABLED (default ON since the 2026-07-06 flip, opt-out 'false'): the bonded ally cannot counter-strike an
   // attacker it has no line of sight to. Flag OFF -> no-op (byte-identical).
   if (!losClearOnGrid(session.grid, ally.position, attacker.position)) return null;
 

--- a/apps/backend/services/combat/losForGrid.js
+++ b/apps/backend/services/combat/losForGrid.js
@@ -1,7 +1,9 @@
 // apps/backend/services/combat/losForGrid.js
 'use strict';
 
-// Combat LOS slice-1 shared rule (COMBAT_LOS_ENABLED, default OFF).
+// Combat LOS shared rule (COMBAT_LOS_ENABLED, default ON since the 2026-07-06
+// owner flip -- ratify N=40 in docs/research/2026-07-06-los-flip-ratify-n40.md;
+// explicit opt-out via COMBAT_LOS_ENABLED=false for probes/A-B).
 // Single source of truth for "can the attacker at `from` see the target at `to`
 // on this grid" -- consumed by the human attack path (routes/session.js
 // losGateBlocks), the AI target seam (services/ai/policy.js losClearForAi) and
@@ -9,8 +11,8 @@
 // predicate. Extracted at the 3rd consumer (slice-1 QUALITY.md fast-follow) to
 // drop the duplicated 2-line body and the implicit sim -> ai/policy.js coupling.
 //
-// Returns true when the target is VISIBLE. Flag OFF -> always true
-// (band-neutral, byte-identical to pre-LOS behavior). Pure + exported for tests.
+// Returns true when the target is VISIBLE. Flag opted-out ('false') -> always
+// true (byte-identical to pre-LOS behavior). Pure + exported for tests.
 //
 // unit-blocking fast-follow (closes the slice-1 "shoot-through-allies" known
 // gap): takes an optional `units` arg (live units on this grid). A strictly-
@@ -33,7 +35,7 @@ function _unitBlocker(units, enabled) {
 }
 
 function losClearOnGrid(grid, fromPos, toPos, units) {
-  if (process.env.COMBAT_LOS_ENABLED !== 'true') return true;
+  if (process.env.COMBAT_LOS_ENABLED === 'false') return true;
   const terrainAt = terrainAtFromFeatures((grid && grid.terrain_features) || []);
   const unitBlocks = _unitBlocker(units, unitsBlockLos());
   return lineOfSightClear(

--- a/apps/backend/services/combat/losReposition.js
+++ b/apps/backend/services/combat/losReposition.js
@@ -1,7 +1,7 @@
 // apps/backend/services/combat/losReposition.js
 'use strict';
 
-// Budget-aware LOS-repositioning (COMBAT_LOS_ENABLED, default OFF).
+// Budget-aware LOS-repositioning (COMBAT_LOS_ENABLED, default ON since the 2026-07-06 flip).
 // When a unit wants to attack but has no line of sight to any in-range enemy,
 // stepToRegainLos returns a tile within `opts.budget` Manhattan steps (default
 // 1 = the original greedy 4-neighbor behavior) that reopens a clear firing
@@ -37,7 +37,7 @@ function _manhattan(a, b) {
 }
 
 function stepToRegainLos(actor, enemies, grid, opts) {
-  if (process.env.COMBAT_LOS_ENABLED !== 'true') return null;
+  if (process.env.COMBAT_LOS_ENABLED === 'false') return null;
   const mode = process.env.COMBAT_LOS_REPOSITION_MODE;
   if (mode === 'off') return null;
   if (!actor || !actor.position || !Array.isArray(enemies) || enemies.length === 0) return null;

--- a/apps/backend/services/reactionEngine.js
+++ b/apps/backend/services/reactionEngine.js
@@ -138,7 +138,7 @@ function triggerOnMove(session, mover, fromPos, performAttack) {
     const found = findReaction(unit, 'enemy_moves_in_range');
     if (!found) continue;
 
-    // COMBAT_LOS_ENABLED (default OFF): a watcher cannot overwatch-shoot a mover
+    // COMBAT_LOS_ENABLED (default ON since the 2026-07-06 flip, opt-out 'false'): a watcher cannot overwatch-shoot a mover
     // it has no line of sight to. Flag OFF -> losClearOnGrid()===true -> no-op
     // (the reaction is neither skipped nor consumed). Watcher fires at the mover's
     // destination cell (mover.position is already the post-move cell here).

--- a/docs/quality/2026-07-06-los-reposition-budget-QUALITY.md
+++ b/docs/quality/2026-07-06-los-reposition-budget-QUALITY.md
@@ -149,3 +149,30 @@ so even a flag-ON deployment without seam changes behaves byte-identically to
 the merged greedy. `COMBAT_LOS_REPOSITION_MODE` and `avoidBlockerTiles` are
 measurement knobs, never set in production. The flip remains owner-gated
 post-N=40 (Eduardo) per the SDMG governance in the 2026-07-04 QUALITY doc.
+
+## Addendum 2026-07-06 (sera) -- decisioni owner ratificate POST N=40
+
+Ratify N=40 completa: docs/research/2026-07-06-los-flip-ratify-n40.md (PR #3223).
+Eduardo ha ratificato in-session (AskUserQuestion strutturata, 4 decisioni):
+
+1. **FLIP `COMBAT_LOS_ENABLED` -> default ON** (opt-out esplicito `='false'`).
+   Applicato in questo PR su losForGrid.js + losReposition.js; il gemello
+   client-side (gate nel resolver locale Godot, stesso env-name/default) e'
+   Game-Godot-v2 PR #589 (il tell visivo era gia' in #588).
+2. **Default prod repositioning = STEP** (budget clampato a 1 in
+   declareSistemaIntents): la matrice N=40 non mostra separazione outcome
+   step-vs-budget nemmeno su geometria wide; budget paga solo pace. Il
+   lookahead resta raggiungibile via opts.budget / COMBAT_LOS_REPOSITION_MODE.
+3. **units_block_los resta OFF al flip**: la fixture lane/wide e'
+   strutturalmente cieca all'asse (nessun terzo corpo sulle linee, delta 0 per
+   costruzione -- misura vacua evitata). Misura reale = geometria `crowd`
+   (chip dedicato, post-flip).
+4. **K4 recognizer + avoidBlockerTiles: chiusi YAGNI** (0 timeout su 240
+   encounter = nessuna oscillazione osservata; nessuna evidenza wall-standing
+   dannoso). Riapribili a evidenza playtest.
+
+Blast-radius del flip sui test: i test "flag OFF" passano da `delete env` a
+`env='false'` (il delete ora significa default=ON); il pin full-AP budget e'
+ri-pinnato alla decisione step. Regressione PRE-esistente scoperta durante la
+verifica (adapter sim pilotava via active_unit post-#3214, timeout garantito,
+invisibile ai glob CI): fix separato PR #3225 + chip CI-gap.

--- a/tests/ai/bondReactionTrigger.test.js
+++ b/tests/ai/bondReactionTrigger.test.js
@@ -356,7 +356,7 @@ function makeCounterFixture(gridOverride) {
 }
 
 test('LOS flag OFF: counter fires even with a roccia blocker between ally and attacker (byte-identical)', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const { target, ally, attacker, session } = makeCounterFixture({
     terrain_features: [{ x: 7, y: 1, type: 'roccia' }], // strictly between ally(5,1) and attacker(9,1)
   });

--- a/tests/api/losAttackGate.test.js
+++ b/tests/api/losAttackGate.test.js
@@ -6,7 +6,7 @@ const { losGateBlocks } = require('../../apps/backend/routes/session');
 
 // Pure exported helper (added in Step 3) so we can unit-test the gate without a full HTTP session.
 test('flag OFF: gate never blocks (band-neutral)', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const grid = { terrain_features: [{ x: 2, y: 0, type: 'roccia' }] };
   assert.equal(losGateBlocks(grid, { x: 0, y: 0 }, { x: 4, y: 0 }), false);
 });

--- a/tests/api/losRoundDispatchGate.test.js
+++ b/tests/api/losRoundDispatchGate.test.js
@@ -94,7 +94,7 @@ test('round/execute LOS gate — flag OFF: shot through a rock still resolves (b
     if (typeof close === 'function') await close().catch(() => {});
   });
 
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const sid = await startSession(app, [{ x: 2, y: 0, type: 'roccia' }]);
   const res = await shoot(app, sid);
 

--- a/tests/services/aiLosDowngrade.test.js
+++ b/tests/services/aiLosDowngrade.test.js
@@ -127,7 +127,7 @@ test('flag ON: in-range with clear line -> attack', () => {
 });
 
 test('flag OFF: LOS-blocked target still attacks (no-op)', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const declare = buildDeclare();
   const session = makeSession([{ x: 3, y: 0, type: 'roccia' }]);
   const { intents, decisions } = declare(session);
@@ -217,7 +217,7 @@ test('flag ON: LOS-blocked target -> SIS repositions to regain LOS (not straight
 });
 
 test('flag OFF: same LOS-blocked geometry -> byte-identical, no downgrade/reposition', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const declare = buildDeclare();
   const session = makeLosRepositionSession([
     { x: 2, y: 0, type: 'roccia' },
@@ -245,22 +245,21 @@ function makeLosFullWallSession() {
   return makeLosRepositionSession(wall);
 }
 
-// Budget lookahead (v2): the SIS spends its whole AP pool on the reposition when no
-// 1-step tile reopens LOS -- an approach intent is a move-only round anyway, so a
-// farther LOS tile strictly dominates the blind stepTowards. With ap:2 the full wall
-// at x=2 is beaten by standing ON the wall column at (2,1) (terrain blocks LOS, not
-// movement; endpoints excluded -> (2,1) sees (4,1) across the free (3,1)). The intent
-// must charge the REAL move distance (ap_cost 2, not the legacy hardcoded 1) so the
-// WEGO resolver -- which deducts the ap_cost field without recomputing -- stays honest.
-test('flag ON: no one-step reopening -> SIS spends full AP budget on a multi-tile reposition', () => {
+// Owner default 2026-07-06 (ratify N=40: step-vs-budget = no outcome separation,
+// budget pays pace only): prod clamps the reposition budget to 1 (shipped greedy
+// step). On the full wall no 1-step tile reopens LOS -> stepToRegainLos returns
+// null and the SIS falls back to the plain stepTowards approach (never worse
+// than pre-LOS). The multi-tile (2,1) reposition stays reachable via
+// opts.budget (losReposition unit tests) and the probes' REPOSITION_MODE.
+test('flag ON: no one-step reopening -> step default falls back to plain approach', () => {
   process.env.COMBAT_LOS_ENABLED = 'true';
   const declare = buildDeclare();
   const session = makeLosFullWallSession();
   const { intents, decisions } = declare(session);
   assert.equal(intents.length, 1);
   assert.equal(intents[0].action.type, 'move');
-  assert.deepEqual(intents[0].action.move_to, { x: 2, y: 1 });
-  assert.equal(intents[0].action.ap_cost, 2);
+  assert.notDeepEqual(intents[0].action.move_to, { x: 2, y: 1 });
+  assert.equal(intents[0].action.ap_cost, 1);
   assert.equal(decisions[0].intent, 'approach');
   assert.ok(/_LOS_BLOCKED$/.test(decisions[0].rule));
   delete process.env.COMBAT_LOS_ENABLED;

--- a/tests/services/aiLosFilter.test.js
+++ b/tests/services/aiLosFilter.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict');
 const { losClearForAi } = require('../../apps/backend/services/ai/policy');
 
 test('flag OFF: AI LOS filter is a no-op (allows all)', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const grid = { terrain_features: [{ x: 2, y: 0, type: 'roccia' }] };
   assert.equal(losClearForAi(grid, { x: 0, y: 0 }, { x: 4, y: 0 }), true);
 });

--- a/tests/services/losForGrid.test.js
+++ b/tests/services/losForGrid.test.js
@@ -6,7 +6,7 @@ const { losClearOnGrid, _unitBlocker } = require('../../apps/backend/services/co
 const { lineOfSightClear } = require('../../apps/backend/services/grid/squareLos');
 
 test('flag OFF: always visible (band-neutral) even with a blocker', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const grid = { terrain_features: [{ x: 2, y: 0, type: 'roccia' }] };
   assert.equal(losClearOnGrid(grid, { x: 0, y: 0 }, { x: 4, y: 0 }), true);
 });

--- a/tests/services/reactionEngine.test.js
+++ b/tests/services/reactionEngine.test.js
@@ -292,7 +292,7 @@ test('triggerOnMove respects single-actor reaction cap (consumed not refireable)
 // ─────────────────────────────────────────────────────────────────
 
 test('triggerOnMove LOS flag OFF: overwatch fires even with a roccia blocker between (byte-identical)', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const overwatcher = makeUnit({
     id: 'ranger',
     position: { x: 0, y: 0 },

--- a/tests/sim/combatPolicy.test.js
+++ b/tests/sim/combatPolicy.test.js
@@ -252,7 +252,7 @@ test('flag ON: LOS-blocked enemy triggers repositioning', () => {
 });
 
 test('selectPlayerAction: same LOS-blocking geometry, flag OFF -> byte-identical attack', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 5, ap_remaining: 1 };
   const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 4, y: 0 } }];
   const terrainFeatures = [{ x: 2, y: 0, type: 'roccia' }];
@@ -291,7 +291,7 @@ test('flag ON: LOS-blocked ranged attacker repositions instead of walking at the
 });
 
 test('flag OFF: same setup is byte-identical (in-range attack, LOS ignored)', () => {
-  delete process.env.COMBAT_LOS_ENABLED;
+  process.env.COMBAT_LOS_ENABLED = 'false';
   const actor = {
     id: 'p1',
     position: { x: 0, y: 1 },

--- a/tools/sim/los-repos-probe.js
+++ b/tools/sim/los-repos-probe.js
@@ -350,7 +350,8 @@ async function childMain(arm, N, scale, mode, enemyRange) {
   // that reads the flag.
   const losOff = mode === 'flip' && arm === 'off';
   if (losOff) {
-    delete process.env.COMBAT_LOS_ENABLED;
+    // Post-flip (default ON): the no-LOS arm must OPT OUT explicitly.
+    process.env.COMBAT_LOS_ENABLED = 'false';
   } else {
     process.env.COMBAT_LOS_ENABLED = 'true';
   }


### PR DESCRIPTION
## Decisioni owner 2026-07-06 (ratificate in-session su evidenza N=40, #3223)
1. **LOS default ON** (`COMBAT_LOS_ENABLED === 'false'` = opt-out esplicito) su entrambe le letture flag (losForGrid, losReposition).
2. **Step = default prod** (budget repositioning clampato a 1 in declareSistemaIntents): N=40 = zero separazione outcome step-vs-budget, budget paga solo pace. Lookahead resta via `opts.budget`/`COMBAT_LOS_REPOSITION_MODE`.
3. **units_block_los resta OFF**: fixture attuale cieca all'asse (misura vacua evitata); geometria crowd = chip dedicato.
4. **K4 + avoidBlockerTiles chiusi YAGNI** (0 timeout/240 encounter). Riapribili a evidenza playtest.

Addendum completo nel QUALITY doc (incluso in questo PR).

## Blast radius gestito
- Test "flag OFF" -> opt-out esplicito `='false'` (il `delete` ora significa default ON).
- Pin full-AP budget ri-pinnato alla decisione step.
- Probe: arm flip-off fa opt-out esplicito.
- Verifica per-file: LOS+adiacenti **103/103**, api gates **7/7**, spread round/coop/AP **50/50**, prettier clean.

## Dipendenze
- Gemello client: GGv2 #588 (tell, MERGED) + **#589** (gate locale, stesso env/default).
- **#3225 prima** (fix regressione adapter pre-esistente da #3214, scoperta in questa verifica): i test tests/sim vanno verdi solo con entrambi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)