### PR TITLE
test(sim): crowd geometry + units_block_los ratify N=40 (C2)

### DIFF
--- a/docs/research/2026-07-06-los-units-block-crowd-n40.md
+++ b/docs/research/2026-07-06-los-units-block-crowd-n40.md
@@ -1,0 +1,95 @@
+# LOS units_block_los ratify N=40 -- geometria crowd (corpo alleato sulla linea)
+
+Data: 2026-07-06 | Macchina: Ryzen (Node v24.11.0) | Probe: `tools/sim/los-repos-probe.js` @ `c7805844e`
+Stato: RATIFY asse C2 (N=40, seed appaiati). Chiude il gap "units_block_los non-misurato" del report
+`2026-07-06-los-flip-ratify-n40.md` (PR #3223): la fixture lane/wide e' strutturalmente CIECA
+all'asse (1 attaccante + 1 nemico per corsia, endpoint esclusi da squareLos -> nessun terzo corpo
+sta mai sulla linea di tiro; delta 0 garantito per costruzione).
+
+## Fixture `crowd` (probe v2.3)
+
+Per corsia: attaccante x=1, corpo ALLEATO x=3 sulla linea di tiro, nemico x=5; NESSUN blocker
+terrain in-lane (i muri separatori y=3/y=7 restano). L'alleato e' un prop di fixture:
+player-controlled ma MAI pilotato dal loop del probe (non in rosterIds); hp 24 / dc 12 per reggere
+la linea nei primi round a enemyScale 2.0. Con `units_block_los: true` il corpo blocca il tiro
+dritto in ENTRAMBE le direzioni; con `false` linea libera.
+
+## Configurazione
+
+- Asse: `data/core/balance/los.yaml units_block_los` (letto da losBlockers.js, cache fredda per
+  processo). 2 varianti worktree (true / false); la variante true NON e' mai stata committata.
+- Modo `flip`: arm ON = `COMBAT_LOS_ENABLED=true` + repositioning reale; arm OFF = flag PINNATO a
+  `'false'` (non delete: un delete verrebbe ri-popolato se il default flippasse ON; entrambi i
+  reader gate-ano su `!== 'true'`). Provenienza per-arm nel JSON: `los_flag_env` on='true' /
+  off='false' verificato in entrambi i run.
+- Banda: `enemyScale 2.0`, `enemyRange 4` (stessa banda de-ceilinged del ratify #3223).
+- N=40 per run, seed appaiati 1..40, child process per arm (module graph fresco).
+- Positive-control nuovo (fallibile in entrambe le direzioni): il predicato units-aware di
+  produzione (`losClearOnGrid(grid, from, to, units)`) DEVE body-bloccare 3/3 coppie lane con
+  config true e lasciarle libere 3/3 con false; gate terrain invertito (0 coppie terrain-blocked).
+  Esito: true -> body_blocked 3/3, terrain 0; false -> body_blocked 0, terrain 0. PASS.
+- Gate operativo: drain porte effimere tra i run (TIME_WAIT < 3000, poll 45s; il run true ha
+  lasciato ~16.3k TIME_WAIT) + checkpoint per-file (resume idempotente).
+
+## Risultati
+
+| units_block | arm | WR    | CI95 Wilson   | W/D/T   | avg round |
+| ----------- | --- | ----- | ------------- | ------- | --------- |
+| true        | ON  | 0.150 | [0.071,0.291] | 6/0/34  | 36.88     |
+| true        | OFF | 0.800 | [0.652,0.895] | 32/0/8  | 19.00     |
+| false       | ON  | 0.525 | [0.375,0.671] | 21/11/8 | 25.10     |
+| false       | OFF | 0.800 | [0.652,0.895] | 32/0/8  | 19.00     |
+
+**Asse units_block (arm ON, true vs false, seed appaiati): dWR = -0.375** (0.525 -> 0.150, CI95
+non sovrapposti), **dRound = +11.78** (25.10 -> 36.88), timeout 8 -> 34, sconfitte 11 -> 0.
+Repositioning counters arm ON: real_calls 10970 / nonnull 8257 (true) vs 152 / 109 (false).
+
+Consistenza interna: arm OFF IDENTICO nei due run (32/0/8, WR 0.800, 19.00 round) -- a LOS spento
+la config non viene mai letta e i seed sono appaiati, quindi il controllo replica byte-identico.
+Conferma che il confronto e' pulito (zero rumore cross-run).
+
+## Meccanismo (replay seed 1, arm ON, config true)
+
+Stallo BILATERALE, ground-truthed con replay loggato round-per-round:
+
+1. **Oscillazione attaccanti**: la policy player gate-a l'attacco units-aware
+   (`combat-policy.js` threada `units`) ma `stepToRegainLos` e' TERRAIN-ONLY by-design
+   (`losReposition.js:29-30`): da (1,y) propone (2,y) (terrain-clear), il corpo resta interposto,
+   da (2,y) ripropone (1,y) -- mirror-dance infinito, zero attacchi. ranged_2/ranged_3: 120 azioni
+   (cap del guard) nel seed 1, quasi tutte move.
+2. **Sistema idle / no-retarget**: il sistema AI sceglie il target PRIMA (selezione LOS-blind),
+   poi il gate LOS declassa attack -> approach con reposition pinnato SUL target scelto
+   (`declareSistemaIntents.js` passa `[target]`, "do not switch enemies" by-design): foe_2/foe_3
+   restano fermi a (5,y) senza mai ritargettare il corpo alleato VISIBILE a 2 tile.
+3. **Asimmetria edge-row** (pre-esistente, vale per tutte le geometrie): la corsia y=1 ha la riga
+   di bordo y=0 come scappatoia diagonale -- foe_1 la usa e risolve (colpisce ranged_1 aggirando
+   il corpo); le corsie y=5 (boxed piena) e y=9 no. Da cui i 6 win residui a config true.
+
+Nota difensiva: a config true le sconfitte AZZERANO (11 -> 0) -- il corpo scherma anche i tiri
+nemici. L'asse alza la difesa e ammazza l'offesa: il collasso WR e' interamente da timeout.
+
+## Verdetti
+
+1. **L'asse ora e' misurato e NON e' neutro**: units_block ON su una linea affollata costa
+   dWR -0.375 e +11.78 round, con l'85% degli incontri in stallo (34/40 timeout). Il verdetto
+   "flip LOS" del 2026-07-06 resta valido SOLO a units_block_los=false.
+2. **Il collasso e' comportamentale, non geometrico**: entrambe le AI trattano l'occlusione da
+   corpo come un blocco che il loro strumento di sblocco non vede (reposition terrain-only) e
+   che la loro selezione target non aggira (no-retarget). Flippare units_block_los senza (a)
+   reposition body-aware e (b) retarget su target visibile = stallo patologico.
+3. **Costo flip combinato su questa fixture**: config true, flip ON-vs-OFF = dWR -0.65 (vs -0.275
+   a config false). Ordine di flip obbligato: COMBAT_LOS_ENABLED prima, units_block_los solo dopo
+   le due fix AI.
+4. Baseline OFF crowd (0.800) non confrontabile con OFF lane #3223 (0.850): fixture diversa
+   (3 corpi in piu' cambiano occupancy/aggro). I confronti validi sono within-fixture.
+
+## Gap dichiarati
+
+- `stepToRegainLos` body-blind: documentato by-design in `losReposition.js`; la fix e' fuori
+  scope di questo probe (misura, non patch).
+- Sistema no-retarget su target LOS-bloccato: by-design (commit-window/stickiness); asse di fix
+  separato.
+- Ally prop hp 24 / dc 12 non balance-representative: fixture worst-case (corpo perfettamente
+  interposto in corridoio isolato), non stima dell'impatto medio in partita reale.
+- Timeout baseline 8/40 anche a LOS OFF: proprieta' della banda scale 2.0 / range 4 su questa
+  fixture, simmetrica su tutti gli arm.

--- a/docs/research/2026-07-06-los-units-block-crowd-n40.md
+++ b/docs/research/2026-07-06-los-units-block-crowd-n40.md
@@ -1,10 +1,12 @@
 # LOS units_block_los ratify N=40 -- geometria crowd (corpo alleato sulla linea)
 
-Data: 2026-07-06 | Macchina: Ryzen (Node v24.11.0) | Probe: `tools/sim/los-repos-probe.js` @ `c7805844e`
-Stato: RATIFY asse C2 (N=40, seed appaiati). Chiude il gap "units_block_los non-misurato" del report
-`2026-07-06-los-flip-ratify-n40.md` (PR #3223): la fixture lane/wide e' strutturalmente CIECA
-all'asse (1 attaccante + 1 nemico per corsia, endpoint esclusi da squareLos -> nessun terzo corpo
-sta mai sulla linea di tiro; delta 0 garantito per costruzione).
+Data: 2026-07-06 | Macchina: Ryzen (Node v24.11.0) | Probe: `tools/sim/los-repos-probe.js` @ `0feab14c4`
+Base: main POST-FLIP `51e551266` (#3226: `COMBAT_LOS_ENABLED` default ON, sistema reposition
+pinnato a budget 1 = step). Stato: RATIFY asse C2 (N=40, seed appaiati). Chiude il gap
+"units_block_los non-misurato" del report `2026-07-06-los-flip-ratify-n40.md` (PR #3223): la
+fixture lane/wide e' strutturalmente CIECA all'asse (1 attaccante + 1 nemico per corsia, endpoint
+esclusi da squareLos -> nessun terzo corpo sta mai sulla linea di tiro; delta 0 garantito per
+costruzione).
 
 ## Fixture `crowd` (probe v2.3)
 
@@ -19,9 +21,11 @@ dritto in ENTRAMBE le direzioni; con `false` linea libera.
 - Asse: `data/core/balance/los.yaml units_block_los` (letto da losBlockers.js, cache fredda per
   processo). 2 varianti worktree (true / false); la variante true NON e' mai stata committata.
 - Modo `flip`: arm ON = `COMBAT_LOS_ENABLED=true` + repositioning reale; arm OFF = flag PINNATO a
-  `'false'` (non delete: un delete verrebbe ri-popolato se il default flippasse ON; entrambi i
-  reader gate-ano su `!== 'true'`). Provenienza per-arm nel JSON: `los_flag_env` on='true' /
-  off='false' verificato in entrambi i run.
+  `'false'` = l'opt-out esplicito post-flip (#3226: i reader gate-ano su `=== 'false'`, un delete
+  lascerebbe la LOS ATTIVA -- il gotcha "default cambiato" e' gestito e verificato). Provenienza
+  per-arm nel JSON: `los_flag_env` on='true' / off='false' verificato in entrambi i run.
+- Sistema reposition = step (budget pinnato a 1 in `declareSistemaIntents.js`, #3226); il seam
+  player del probe resta budget two-phase (knob `COMBAT_LOS_REPOSITION_MODE` non settato).
 - Banda: `enemyScale 2.0`, `enemyRange 4` (stessa banda de-ceilinged del ratify #3223).
 - N=40 per run, seed appaiati 1..40, child process per arm (module graph fresco).
 - Positive-control nuovo (fallibile in entrambe le direzioni): il predicato units-aware di
@@ -37,16 +41,23 @@ dritto in ENTRAMBE le direzioni; con `false` linea libera.
 | ----------- | --- | ----- | ------------- | ------- | --------- |
 | true        | ON  | 0.150 | [0.071,0.291] | 6/0/34  | 36.88     |
 | true        | OFF | 0.800 | [0.652,0.895] | 32/0/8  | 19.00     |
-| false       | ON  | 0.525 | [0.375,0.671] | 21/11/8 | 25.10     |
+| false       | ON  | 0.525 | [0.375,0.671] | 21/0/19 | 25.60     |
 | false       | OFF | 0.800 | [0.652,0.895] | 32/0/8  | 19.00     |
 
 **Asse units_block (arm ON, true vs false, seed appaiati): dWR = -0.375** (0.525 -> 0.150, CI95
-non sovrapposti), **dRound = +11.78** (25.10 -> 36.88), timeout 8 -> 34, sconfitte 11 -> 0.
-Repositioning counters arm ON: real_calls 10970 / nonnull 8257 (true) vs 152 / 109 (false).
+non sovrapposti), **dRound = +11.28** (25.60 -> 36.88), timeout 19 -> 34.
+Repositioning counters arm ON: real_calls 10970 / nonnull 8257 (true) vs 262 / 96 (false).
 
 Consistenza interna: arm OFF IDENTICO nei due run (32/0/8, WR 0.800, 19.00 round) -- a LOS spento
 la config non viene mai letta e i seed sono appaiati, quindi il controllo replica byte-identico.
 Conferma che il confronto e' pulito (zero rumore cross-run).
+
+Robustezza pre/post-flip: la coppia di run era stata eseguita ANCHE su main pre-#3226 (sistema
+reposition budget full-AP): run true BYTE-IDENTICO (stessi 40 esiti, stessi counter -- in crowd
+il tile 1-step terrain-clear esiste sempre e la metrica cost-first lo sceglieva gia', quindi il
+clamp budget-1 e' un no-op); run false stesso WR 0.525 ma mix esiti diverso (21/11/8 -> 21/0/19:
+il sistema step insegue meno -> le sconfitte diventano timeout). L'asse dWR -0.375 e' identico
+nelle due misure.
 
 ## Meccanismo (replay seed 1, arm ON, config true)
 
@@ -65,21 +76,23 @@ Stallo BILATERALE, ground-truthed con replay loggato round-per-round:
    di bordo y=0 come scappatoia diagonale -- foe_1 la usa e risolve (colpisce ranged_1 aggirando
    il corpo); le corsie y=5 (boxed piena) e y=9 no. Da cui i 6 win residui a config true.
 
-Nota difensiva: a config true le sconfitte AZZERANO (11 -> 0) -- il corpo scherma anche i tiri
-nemici. L'asse alza la difesa e ammazza l'offesa: il collasso WR e' interamente da timeout.
+Nota difensiva: zero sconfitte in ogni arm ON post-flip -- a config true il corpo scherma anche
+i tiri nemici (e pre-flip azzerava le 11 sconfitte del run false). L'asse alza la difesa e
+ammazza l'offesa: il collasso WR e' interamente da timeout.
 
 ## Verdetti
 
 1. **L'asse ora e' misurato e NON e' neutro**: units_block ON su una linea affollata costa
-   dWR -0.375 e +11.78 round, con l'85% degli incontri in stallo (34/40 timeout). Il verdetto
-   "flip LOS" del 2026-07-06 resta valido SOLO a units_block_los=false.
+   dWR -0.375 e +11.28 round, con l'85% degli incontri in stallo (34/40 timeout). Il flip
+   eseguito oggi (#3226) a `units_block_los=false` e' COERENTE col dato: la config deve restare
+   false.
 2. **Il collasso e' comportamentale, non geometrico**: entrambe le AI trattano l'occlusione da
    corpo come un blocco che il loro strumento di sblocco non vede (reposition terrain-only) e
    che la loro selezione target non aggira (no-retarget). Flippare units_block_los senza (a)
    reposition body-aware e (b) retarget su target visibile = stallo patologico.
-3. **Costo flip combinato su questa fixture**: config true, flip ON-vs-OFF = dWR -0.65 (vs -0.275
-   a config false). Ordine di flip obbligato: COMBAT_LOS_ENABLED prima, units_block_los solo dopo
-   le due fix AI.
+3. **Costo combinato su questa fixture**: a config true, LOS ON-vs-OFF = dWR -0.65 (vs -0.275 a
+   config false). Prerequisito per accendere l'asse corpo: le due fix AI del punto 2, POI
+   ri-misura su crowd.
 4. Baseline OFF crowd (0.800) non confrontabile con OFF lane #3223 (0.850): fixture diversa
    (3 corpi in piu' cambiano occupancy/aggro). I confronti validi sono within-fixture.
 

--- a/tools/sim/los-repos-probe.js
+++ b/tools/sim/los-repos-probe.js
@@ -50,8 +50,9 @@
 // cost the balance, on a FAIR fixture?" So `flip` mode compares:
 //   arm on  = COMBAT_LOS_ENABLED='true' + REAL stepToRegainLos (production
 //             behavior IF the flag is flipped on).
-//   arm off = flag DELETED entirely -> losClearOnGrid always returns true, no
-//             LOS constraint at all (today's live behavior, flag defaults OFF).
+//   arm off = flag PINNED to 'false' (the explicit opt-out; default is ON since
+//             the 2026-07-06 flip) -> losClearOnGrid always returns true, no
+//             LOS constraint at all (pre-flip behavior).
 // Same fixture, same paired seeds, same child isolation. This is the honest
 // flip-vs-nothing delta -- NOT v1's turn-starved -0.30 artifact. LOS is SUPPOSED
 // to change balance (it is a mechanic); the ratify measures the SIZE and SHAPE
@@ -73,14 +74,35 @@
 // NOTHING (else the fixture is not wide) and budget-2 must reopen (else the
 // lookahead could never help and the probe would measure nothing).
 //
+// CROWD (probe v2.3 -- the units_block_los axis). lane/wide are structurally
+// BLIND to unit-body occlusion: one attacker + one enemy per lane and
+// squareLos excludes endpoints, so no third body ever sits on a firing line --
+// units_block_los true-vs-false is delta-0 BY CONSTRUCTION there (do not
+// measure the axis with them). 'crowd' removes the in-lane terrain blocker
+// entirely (separator walls y=3/y=7 stay) and parks an allied BODY at x=3 on
+// each lane's firing line (attacker x=1, ally x=3, enemy x=5): with
+// units_block_los=true (data/core/balance/los.yaml, read by losBlockers.js)
+// the ally body blocks the straight shot BOTH ways; false -> free line. The
+// ally is a fixture prop: player-controlled but NEVER driven by the probe loop
+// (not in rosterIds), so the body holds the line until shot down. The axis is
+// a CONFIG, not an env flag: the probe reads whatever the worktree los.yaml
+// says (fresh process per invocation -> losBlockers' cache is always cold).
+// Run the probe twice -- yaml variant true, then false -- to measure the axis;
+// the probe itself never edits the file. Crowd positive control: the
+// units-aware production predicate (losClearOnGrid WITH units) must see the
+// body when the config is true and a free line when it is false -- asserted in
+// BOTH directions, so the control can fail.
+//
 // Usage:
-//   node tools/sim/los-repos-probe.js [N] [repos|flip] [lane|wide] [enemyScale] [enemyRange]
+//   node tools/sim/los-repos-probe.js [N] [repos|flip] [lane|wide|crowd] [enemyScale] [enemyRange]
 //     repos (default) -- LOS ON both, toggle stepToRegainLos (heuristic isolation)
 //     flip            -- flag ON+real-repos vs flag OFF (true balance cost of LOS)
 //     lane  (default) -- 1-tile blocker per lane (1-step reopening exists); the
 //                        geometry token is position-independent (parsed then
 //                        filtered out before the positional args).
 //     wide            -- 3-tile blocker segment per lane (budget>=2 required)
+//     crowd           -- allied body on the firing line, NO in-lane terrain
+//                        (the units_block_los axis; see CROWD above)
 //     enemyScale      -- optional, default 1.0, applies to BOTH modes (de-ceiling
 //                        the flip-mode fixture: at scale 1.0 the fixture is
 //                        structurally un-losable -- players range 5 vs enemy
@@ -117,6 +139,7 @@ function terrainFor(geometry) {
     t.push({ x, y: 7, type: 'roccia' });
   }
   for (const laneY of [1, 5, 9]) {
+    if (geometry === 'crowd') break; // crowd: the in-lane blocker is a BODY, not terrain
     t.push({ x: 3, y: laneY, type: LANE_TYPES[laneY] });
     if (geometry === 'wide') {
       // wide-shadow: widen the blocker to a 3-tile vertical segment. Every
@@ -152,6 +175,39 @@ function roster() {
     dc: 10,
     attack_range: range,
     initiative: 12,
+    position,
+    controlled_by: 'player',
+    traits: [],
+    status: {},
+  }));
+}
+
+// Crowd geometry: one allied BODY per lane, parked ON the firing line (x=3,
+// strictly between attacker x=1 and enemy x=5 -- squareLos excludes endpoints,
+// so only a STRICTLY interposed body can block). controlled_by 'player' so it
+// is an ally, but it is NOT in the probe's driven roster (rosterIds): it never
+// acts, it just stands there. The sistema AI will shoot it (nearest visible
+// target) -- symmetric across arms and config variants, so it is fixture, not
+// rigging. hp 24 / dc 12: tanky enough to hold the line for the opening rounds
+// at enemyScale 2.0 (a 1-hit body would blank the axis after round 1); offense
+// fields are inert since it is never driven.
+function crowdAllies() {
+  const defs = [
+    ['ally_1', { x: 3, y: 1 }],
+    ['ally_2', { x: 3, y: 5 }],
+    ['ally_3', { x: 3, y: 9 }],
+  ];
+  return defs.map(([id, position]) => ({
+    id,
+    species: id,
+    job: 'ranged',
+    hp: 24,
+    max_hp: 24,
+    ap: 3,
+    mod: 0,
+    dc: 12,
+    attack_range: 1,
+    initiative: 8,
     position,
     controlled_by: 'player',
     traits: [],
@@ -242,7 +298,12 @@ function dist(a, b) {
 // (2) Reopening-steps-exist: the REAL stepToRegainLos returns a non-null,
 //     clear, in-range tile for each blocked attacker (else repositioning could
 //     never help even if wired). Uses the production helpers, not a re-impl.
-function positiveControls(enemyRange = 2) {
+// (3) Crowd body-block: the units-aware predicate -- the exact production
+//     attack-gate call shape, losClearOnGrid(grid, from, to, units) -- must
+//     see each lane's attacker->foe line blocked by the ALLY BODY when
+//     units_block_los=true, and free when false. Config read from the worktree
+//     los.yaml via losBlockers (cold cache: fresh process per invocation).
+function positiveControls(geometry, enemyRange = 2) {
   process.env.COMBAT_LOS_ENABLED = 'true';
   // The fixture-validity controls ask about the GEOMETRY (does a budget-1 /
   // budget-2 reopening tile exist?), not about the arm under test -- so they
@@ -254,9 +315,12 @@ function positiveControls(enemyRange = 2) {
   const { losClearOnGrid } = require('../../apps/backend/services/combat/losForGrid');
   const { stepToRegainLos } = require('../../apps/backend/services/combat/losReposition');
   const { occupiedSetFromUnits } = require('../../apps/backend/services/combat/occupancy');
+  const { unitsBlockLos } = require('../../apps/backend/services/combat/losBlockers');
   const grid = { terrain_features: TERRAIN, width: GRID_SIZE, height: GRID_SIZE };
   const attackers = roster();
+  const allies = geometry === 'crowd' ? crowdAllies() : [];
   const foes = enemies(1.0, enemyRange);
+  const unitsAll = [...attackers, ...allies, ...foes];
 
   const blockedPairs = [];
   for (const a of attackers) {
@@ -268,7 +332,24 @@ function positiveControls(enemyRange = 2) {
     }
   }
 
-  const occAll = occupiedSetFromUnits([...attackers, ...foes]);
+  // Crowd body-block control (units-aware predicate; empty for lane/wide). The
+  // same pairs as the terrain control above, but WITH the live units threaded --
+  // so the result tracks the worktree units_block_los config and can diverge
+  // from the terrain-only read in exactly one way: body occlusion.
+  const bodyBlockedPairs = [];
+  if (geometry === 'crowd') {
+    for (const a of attackers) {
+      for (const e of foes) {
+        const d = dist(a.position, e.position);
+        if (d > (a.attack_range || 1)) continue;
+        if (!losClearOnGrid(grid, a.position, e.position, unitsAll)) {
+          bodyBlockedPairs.push({ attacker: a.id, enemy: e.id, dist: d });
+        }
+      }
+    }
+  }
+
+  const occAll = occupiedSetFromUnits(unitsAll);
   const reopensClearInRange = (a, tile) => {
     if (!tile) return false;
     for (const e of foes) {
@@ -307,6 +388,9 @@ function positiveControls(enemyRange = 2) {
     reopening_steps: reopening,
     reopening_budget1_ok: reopening.filter((r) => r.budget1_reopens).length,
     reopening_budget2_ok: reopening.filter((r) => r.budget2_reopens).length,
+    units_block_los_config: unitsBlockLos(),
+    body_blocked_pairs: bodyBlockedPairs,
+    body_blocked_pairs_count: bodyBlockedPairs.length,
   };
 }
 
@@ -316,7 +400,30 @@ function positiveControls(enemyRange = 2) {
 //   wide -> NO attacker may have a 1-step reopening (else the fixture is not
 //           wide and step-vs-budget cannot be separated), while the budget-2
 //           reopening must exist for all 3.
+//   crowd -> terrain gate INVERTS (0 terrain-blocked pairs: the blocker is a
+//            body), and the body gate follows the worktree config in BOTH
+//            directions: units_block_los=true MUST body-block all 3 lane
+//            pairs (axis engages), false MUST leave all 3 free (axis truly
+//            dormant). Either direction failing = fixture or predicate broken.
 function assertFixtureValidity(geometry, controls) {
+  if (geometry === 'crowd') {
+    if (controls.blocked_pairs_count !== 0) {
+      throw new Error(
+        `positive control FAILED (crowd): ${controls.blocked_pairs_count} terrain-blocked pairs -- crowd lanes must have NO in-lane terrain`,
+      );
+    }
+    if (controls.units_block_los_config === true && controls.body_blocked_pairs_count !== 3) {
+      throw new Error(
+        `positive control FAILED (crowd): units_block_los=true but the ally body blocks ${controls.body_blocked_pairs_count}/3 lane pairs`,
+      );
+    }
+    if (controls.units_block_los_config !== true && controls.body_blocked_pairs_count !== 0) {
+      throw new Error(
+        `positive control FAILED (crowd): units_block_los=false but ${controls.body_blocked_pairs_count} pairs are body-blocked`,
+      );
+    }
+    return;
+  }
   if (controls.blocked_pairs_count < 2) {
     throw new Error(
       `positive control FAILED (${geometry}): only ${controls.blocked_pairs_count} blocked pairs -- LOS never engages`,
@@ -343,11 +450,13 @@ function assertFixtureValidity(geometry, controls) {
 // ---------------------------------------------------------------------------
 // Child arm: run N seeds for one arm, print a JSON line the parent parses.
 // ---------------------------------------------------------------------------
-async function childMain(arm, N, scale, mode, enemyRange) {
+async function childMain(arm, N, scale, mode, geometry, enemyRange) {
   // LOS flag: in repos mode BOTH arms hold LOS ON (the heuristic-isolation
-  // control). In flip mode arm 'off' DELETES the flag entirely -> no LOS
-  // constraint at all (today's live behavior). Set BEFORE requiring anything
-  // that reads the flag.
+  // control). In flip mode arm 'off' PINS the flag to 'false' -- the explicit
+  // opt-out (post-flip default is ON: both readers gate on === 'false', so a
+  // deleted var would leave LOS ACTIVE). The child echoes the effective value
+  // in its result line so the report can PROVE the off arm really ran
+  // disabled. Set BEFORE requiring anything that reads the flag.
   const losOff = mode === 'flip' && arm === 'off';
   if (losOff) {
     // Post-flip (default ON): the no-LOS arm must OPT OUT explicitly.
@@ -389,13 +498,20 @@ async function childMain(arm, N, scale, mode, enemyRange) {
   // up the instrumented stepToRegainLos.
   const { createApp } = require('../../apps/backend/app');
   const { selectPlayerAction } = require('./combat-policy');
+  const { unitsBlockLos } = require('../../apps/backend/services/combat/losBlockers');
 
   // Drive ONE encounter, acting on EVERY live player unit each round (not just
   // active_unit -- the /action handler does not gate on active_unit). Returns
   // { outcome, rounds, actionsByUnit }.
   async function runOne(http, seed) {
     const start = await http.post('/api/session/start', {
-      units: [...roster(), ...enemies(scale, enemyRange)],
+      // crowd: the allied bodies join the session units (they hold the firing
+      // lines) but NOT rosterIds below -- the probe never drives them.
+      units: [
+        ...roster(),
+        ...(geometry === 'crowd' ? crowdAllies() : []),
+        ...enemies(scale, enemyRange),
+      ],
       seed,
       // board_scale:'grid_sized' + grid_size (ADR-2026-07-03) so the board is the
       // authored 12x12 -- WITHOUT it, resolveBoardSize auto-scales a 3-player
@@ -508,6 +624,11 @@ async function childMain(arm, N, scale, mode, enemyRange) {
       summary,
       counters,
       first_seed_actions: firstSeedActions,
+      // Axis + flag provenance, read in THIS child's process (module graph and
+      // env actually used by the run): the report can prove which config each
+      // arm saw and that the flip-off arm really ran disabled.
+      units_block_los: unitsBlockLos(),
+      los_flag_env: process.env.COMBAT_LOS_ENABLED ?? null,
     })}\n`,
   );
 }
@@ -546,8 +667,8 @@ function main() {
   // Geometry token first (position-independent), then the legacy positional
   // args over what remains: N, then mode (repos|flip) or enemy-scale.
   const args = process.argv.slice(2);
-  const geometry = args.includes('wide') ? 'wide' : 'lane';
-  const rest = args.filter((a) => a !== 'wide' && a !== 'lane');
+  const geometry = args.find((a) => a === 'wide' || a === 'crowd') || 'lane';
+  const rest = args.filter((a) => a !== 'wide' && a !== 'lane' && a !== 'crowd');
   const N = Number(rest[0]) || 10;
   const modeArg = rest[1];
   const mode = modeArg === 'flip' ? 'flip' : 'repos';
@@ -564,7 +685,7 @@ function main() {
   const enemyRange = Number(rest[3]) || 2;
   TERRAIN = terrainFor(geometry);
 
-  const controls = positiveControls(enemyRange);
+  const controls = positiveControls(geometry, enemyRange);
   console.log(`=== POSITIVE CONTROL: fixture validity (LOS ON, geometry=${geometry}) ===`);
   console.log(JSON.stringify(controls, null, 2));
   console.log('=== END fixture-validity control ===');
@@ -586,6 +707,17 @@ function main() {
     reposition_mode: process.env.COMBAT_LOS_REPOSITION_MODE || 'budget',
     enemyScale: scale,
     enemyRange,
+    // The units_block_los axis as each process actually saw it (parent control
+    // + both children read the same worktree los.yaml; a mismatch here means
+    // the config changed mid-run -> the run is invalid). los_flag_env proves
+    // the flip-off arm really ran with the flag disabled (pinned 'false'), not
+    // merely deleted-then-repopulated by some future default.
+    units_block_los: {
+      parent_config: controls.units_block_los_config,
+      arm_on: on.units_block_los,
+      arm_off: off.units_block_los,
+    },
+    los_flag_env: { arm_on: on.los_flag_env, arm_off: off.los_flag_env },
     positive_control: controls,
     // In flip mode the 'off' arm ran with LOS disabled: no shot is ever blocked,
     // so blocked-pair enforcement is 0 by construction (the control above still
@@ -593,7 +725,7 @@ function main() {
     // with). In repos mode both arms hold LOS ON.
     los_off_arm_note:
       mode === 'flip'
-        ? 'flip/off arm ran with COMBAT_LOS_ENABLED unset -> losClearOnGrid always true, 0 blocked-pair enforcement (free shots through walls, = live behavior)'
+        ? "flip/off arm ran with COMBAT_LOS_ENABLED pinned to 'false' (explicit opt-out, default ON post-flip) -> losClearOnGrid always true, 0 blocked-pair enforcement (free shots through walls, = pre-flip behavior)"
         : 'both arms LOS ON',
     // Turn-participation control: per-unit action counts for seed 1 of each arm.
     // Fixture is VALID only if >=2 player units have >0 actions.
@@ -620,9 +752,10 @@ if (process.argv[2] === '--child') {
   const N = Number(process.argv[4]) || 10;
   const scale = Number(process.argv[5]) || 1.0;
   const mode = process.argv[6] === 'flip' ? 'flip' : 'repos';
-  TERRAIN = terrainFor(process.argv[7] === 'wide' ? 'wide' : 'lane');
+  const geometry = ['wide', 'crowd'].includes(process.argv[7]) ? process.argv[7] : 'lane';
+  TERRAIN = terrainFor(geometry);
   const enemyRange = Number(process.argv[8]) || 2;
-  childMain(arm, N, scale, mode, enemyRange).catch((e) => {
+  childMain(arm, N, scale, mode, geometry, enemyRange).catch((e) => {
     console.error(e);
     process.exit(1);
   });


### PR DESCRIPTION
## Cosa

Misura l'asse `units_block_los` del combat LOS (condizione C2), rimasto non-misurato: la fixture lane/wide del probe e' strutturalmente cieca all'asse (1 attaccante + 1 nemico per corsia, endpoint esclusi -> nessun terzo corpo sulla linea; delta 0 per costruzione).

1. **`test(sim)`: geometria `crowd`** in `tools/sim/los-repos-probe.js` -- per corsia: attaccante x=1, corpo ALLEATO x=3 sulla linea (prop mai pilotato, hp 24/dc 12), nemico x=5, zero terrain in-lane (separatori y=3/y=7 restano). Positive-control nuovo fallibile in entrambe le direzioni sul predicato units-aware di produzione (`losClearOnGrid` con `units`). Arm flip-off PINNA `COMBAT_LOS_ENABLED='false'` = opt-out esplicito post-#3226 + eco provenienza per-arm (`los_flag_env`, `units_block_los`) nel JSON.
2. **`docs(research)`: ratify N=40** (`docs/research/2026-07-06-los-units-block-crowd-n40.md`) -- 2 run flip mode, banda scale 2.0 / enemyRange 4, varianti worktree di `los.yaml` (true MAI committata), drain-gate porte + checkpoint resume.

**Rebased su main post-flip (#3226) e RI-MISURATO**: run true byte-identico (clamp budget-1 no-op su crowd); run false stesso WR, mix esiti 21/11/8 -> 21/0/19 (sistema step insegue meno). Asse identico nelle due misure.

## Risultato chiave (main post-flip `51e551266`)

| units_block | arm ON WR | W/D/T | avg round |
|---|---|---|---|
| true | 0.150 [0.071,0.291] | 6/0/34 | 36.88 |
| false | 0.525 [0.375,0.671] | 21/0/19 | 25.60 |

**Asse: dWR -0.375 (CI95 disgiunti), dRound +11.28, timeout 19 -> 34, zero sconfitte** (il corpo scherma anche i nemici: difesa su, offesa morta -- collasso interamente da stallo). Arm OFF byte-identico nei 2 run (0.800, 32/0/8) = controllo di consistenza pulito.

Meccanismo (replay seed 1 loggato): stallo bilaterale -- policy player gate-a units-aware ma `stepToRegainLos` e' terrain-only by-design (oscillazione infinita); sistema AI non ritargetta mai il corpo visibile (idle). Verdetto: il flip #3226 a `units_block_los=false` e' coerente col dato; accendere l'asse richiede prima (a) reposition body-aware + (b) retarget su target visibile, poi ri-misura.

## Verifica

- Unit test LOS: `node --test tests/services/losForGrid.test.js tests/services/losReposition.test.js tests/services/occupancy.test.js` -> 35/35 pass (post-rebase).
- `node --check` sul probe; smoke N=1 su entrambe le varianti yaml (positive-control PASS nelle due direzioni).
- Nessuna variante true di `los.yaml` nel diff.

Metodi applicati: ground-truth > surface (replay loggato prima del verdetto), N=40 ratify, positive-control fallibile, Currency Gate (re-run post-#3226, non numeri stale), drain-gate EADDRINUSE, ADR-0011 trailers.

Merge = Eduardo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
