### PR TITLE
ci: wire tests/sim glob into test:api + fix the residual #3214-family red it hid

### DIFF
--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -68,6 +68,19 @@ const steps = [
   // logic (unit-level), not a CI-blocking gate. Wired anyway so a future refactor
   // that breaks the guard's behavior does not silently rot (anti-pattern #10).
   'node --test tests/js/*.test.js',
+  // tests/sim/** was CI-orphaned (anti-pattern #10): 32 files / ~229 tests over
+  // the sim driver stack (combat-adapter, combat-policy, full-loop runner/batch/
+  // routing, aggregators, probes) never matched a glob above, so the #3214
+  // active_unit regression left combatAdapter.test.js 5/6 red ON MAIN with CI
+  // green (caught + fixed in #3225) and fullLoopRouting rotted red behind it --
+  // no gate ever ran them. Flat subtree -> single-* glob. --test-concurrency=1
+  // because these tests spawn REAL encounters through supertest (one ephemeral
+  // port per request): the parallel default floods Windows ports (EADDRINUSE
+  // cascade) and flaked the seed-replay determinism test under contention,
+  // while the serial run is 3/3 stable at ~16s -- the same command works on dev
+  // Windows and CI Linux. Verified red-on-regression: restoring the pre-#3225
+  // adapter makes this step fail (combatAdapter.test.js 5/6), so the gate gates.
+  'node --test --test-concurrency=1 tests/sim/*.test.js',
 ];
 
 const baseEnv = {

--- a/tests/sim/combatPolicy.test.js
+++ b/tests/sim/combatPolicy.test.js
@@ -25,6 +25,38 @@ test('selectPlayerAction: steps one tile toward the target when out of range', (
   assert.deepEqual(a.target_position, { x: 1, y: 0 });
 });
 
+// Post-#3214 free ordering, the AP-driven drivers act units in a FIXED order, so a
+// blind primary-axis approach step deterministically funnels a unit onto a tile an
+// ally already took -> 400 "casella occupata" EVERY round -> guaranteed timeout
+// (fullLoopRouting enc_tutorial_05 red on main). The approach must route around
+// occupied tiles like the OA2 zone-pursuit branch (item 7) already does.
+test('approach: ally on the primary-axis tile -> sidesteps around it', () => {
+  const actor = { id: 'p', position: { x: 1, y: 2 }, attack_range: 1, ap_remaining: 3 };
+  const units = [
+    actor,
+    { id: 'ally', controlled_by: 'player', hp: 10, position: { x: 2, y: 2 } },
+    { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 5, y: 2 } },
+  ];
+  const a = selectPlayerAction(actor, units);
+  assert.equal(a.action_type, 'move');
+  // primary axis (x+1,y) is taken by the ally; same row -> secondary axis is a
+  // no-op -> perpendicular sidestep (y+1) is the first free candidate.
+  assert.deepEqual(a.target_position, { x: 1, y: 3 });
+});
+
+test('approach: fully boxed in -> null (hold the tick, no 400-spam)', () => {
+  const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 1, ap_remaining: 3 };
+  const units = [
+    actor,
+    { id: 'a1', controlled_by: 'player', hp: 10, position: { x: 1, y: 0 } },
+    { id: 'a2', controlled_by: 'player', hp: 10, position: { x: 0, y: 1 } },
+    { id: 'e', controlled_by: 'sistema', hp: 5, position: { x: 3, y: 0 } },
+  ];
+  // (1,0) and (0,1) occupied, (0,-1) off-board, secondary axis is a no-op ->
+  // every candidate is exhausted -> hold instead of emitting a rejected move.
+  assert.equal(selectPlayerAction(actor, units), null);
+});
+
 test('selectPlayerAction: returns null when no alive enemy', () => {
   const actor = { id: 'p', position: { x: 0, y: 0 }, attack_range: 1, ap_remaining: 3 };
   const units = [actor, { id: 'e', controlled_by: 'sistema', hp: 0, position: { x: 1, y: 0 } }];

--- a/tools/sim/combat-policy.js
+++ b/tools/sim/combat-policy.js
@@ -33,15 +33,37 @@ function inZone(pos, zone) {
   return pos.x >= zone[0] && pos.x <= zone[2] && pos.y >= zone[1] && pos.y <= zone[3];
 }
 
-// One-tile greedy step toward a destination (Manhattan, x-axis tie-break).
-function stepToward(actor, dest) {
-  const dx = Math.sign(dest.x - actor.position.x);
-  const dy = Math.sign(dest.y - actor.position.y);
-  const stepX = Math.abs(dest.x - actor.position.x) >= Math.abs(dest.y - actor.position.y);
-  const target_position = stepX
-    ? { x: actor.position.x + dx, y: actor.position.y }
-    : { x: actor.position.x, y: actor.position.y + dy };
-  return { action_type: 'move', target_position };
+// One-tile greedy step toward a destination (Manhattan, x-axis tie-break),
+// routing around occupied tiles: primary axis, then secondary axis, then a
+// perpendicular sidestep -- the same candidate walk the OA2 zone-pursuit uses
+// (item 7). A free primary tile keeps the legacy blind-stepToward move, so the
+// happy path is byte-identical. Null when boxed in (caller holds the tick
+// rather than spamming a move the backend rejects with 400 "casella occupata").
+function stepAroundOccupied(actor, dest, occ) {
+  const { x, y } = actor.position;
+  const dx = Math.sign(dest.x - x);
+  const dy = Math.sign(dest.y - y);
+  const primaryX = Math.abs(dest.x - x) >= Math.abs(dest.y - y);
+  const ordered = primaryX
+    ? [
+        { x: x + dx, y },
+        { x, y: y + dy },
+        { x, y: y + 1 },
+        { x, y: y - 1 },
+      ]
+    : [
+        { x, y: y + dy },
+        { x: x + dx, y },
+        { x: x + 1, y },
+        { x: x - 1, y },
+      ];
+  for (const c of ordered) {
+    if (c.x === x && c.y === y) continue; // no-op (axis delta 0)
+    if (c.x < 0 || c.y < 0) continue; // off-board lower bound
+    if (occ.has(`${c.x},${c.y}`)) continue; // would be rejected by occupancy
+    return { action_type: 'move', target_position: c };
+  }
+  return null; // boxed in -> hold this tick
 }
 
 // OA2 (item 7): tiles occupied by OTHER live units -- move targets the backend
@@ -79,30 +101,7 @@ function stepTowardZone(actor, zone, units) {
     x: Math.round((zone[0] + zone[2]) / 2),
     y: Math.round((zone[1] + zone[3]) / 2),
   };
-  const { x, y } = actor.position;
-  const dx = Math.sign(dest.x - x);
-  const dy = Math.sign(dest.y - y);
-  const primaryX = Math.abs(dest.x - x) >= Math.abs(dest.y - y);
-  const ordered = primaryX
-    ? [
-        { x: x + dx, y },
-        { x, y: y + dy },
-        { x, y: y + 1 },
-        { x, y: y - 1 },
-      ]
-    : [
-        { x, y: y + dy },
-        { x: x + dx, y },
-        { x: x + 1, y },
-        { x: x - 1, y },
-      ];
-  for (const c of ordered) {
-    if (c.x === x && c.y === y) continue; // no-op (axis delta 0)
-    if (c.x < 0 || c.y < 0) continue; // off-board lower bound
-    if (occ.has(`${c.x},${c.y}`)) continue; // would be rejected by occupancy
-    return { action_type: 'move', target_position: c };
-  }
-  return null; // boxed in -> hold this tick
+  return stepAroundOccupied(actor, dest, occ);
 }
 
 // Pick the attack target among IN-RANGE enemies. focusFire -> the lowest-HP (finish-off),
@@ -175,7 +174,7 @@ function selectPlayerAction(actor, units, objective, opts = {}) {
   // line before the plain approach. Two-phase budget (v2): first reserve 1 AP so
   // the unit can still shoot THIS turn (budget = ap_remaining - 1); if no such
   // tile exists, spend the full pool to set up next turn's shot (budget =
-  // ap_remaining) -- a LOS tile strictly dominates the blind stepToward, which
+  // ap_remaining) -- a LOS tile strictly dominates the plain approach step, which
   // also forfeits this turn's attack. Flag OFF -> losFn is a no-op so no enemy
   // is ever LOS-blocked -> this block is skipped (byte-identical).
   const gridForLos = {
@@ -196,11 +195,16 @@ function selectPlayerAction(actor, units, objective, opts = {}) {
       stepToRegainLos(actor, enemies, gridForLos, { occupied, budget: apBudget });
     if (repos) return { action_type: 'move', target_position: repos };
   }
-  // None in range (or no AP): approach the nearest.
+  // None in range (or no AP): approach the nearest, routing around occupied
+  // tiles. Post-#3214 free ordering, the AP-driven drivers act units in a FIXED
+  // order, so a blind primary-axis step deterministically funnels a unit onto a
+  // tile an ally already took -> 400 "casella occupata" every round ->
+  // guaranteed timeout (fullLoopRouting enc_tutorial_05). Same routing the
+  // zone-pursuit branch already uses.
   const nearest = enemies
     .slice()
     .sort((a, b) => dist(actor.position, a.position) - dist(actor.position, b.position))[0];
-  return stepToward(actor, nearest.position);
+  return stepAroundOccupied(actor, nearest.position, occupiedSet(units, actor.id));
 }
 
 module.exports = {

--- a/tools/sim/full-loop-runner.js
+++ b/tools/sim/full-loop-runner.js
@@ -329,7 +329,13 @@ async function runFullLoop(http, opts = {}) {
       enemies,
       scenarioId: enc,
       seed: seed ? `${seed}-${step}` : undefined,
-      maxRounds: 40,
+      // 40 -> 80 (2026-07-06): the cap is a runaway bound, not a pacing assert.
+      // Real fights legitimately lengthened across the LOS/AP stack (honest AP
+      // costs #3219, unit-blocking #3205, free ordering #3214): chapter rounds
+      // moved from ~14/25 to ~17/31, so 40 left no slack and winnable chapters
+      // flake-timeouted (fullLoopRouting red on main). 80 = same ample-margin
+      // convention as combatAdapter.test.js's sabotage case (120).
+      maxRounds: 80,
       // A13: link the session to the campaign (read-side woundedStep at /start) and
       // fire /end (write-side wound/heal persist). Off -> byte-identical adapter call.
       ...(a13 ? { campaignId: id, biomeId, endSession: true } : {}),


### PR DESCRIPTION
## Cosa chiude

Il blind-spot CI del 2026-07-06: la regressione #3214 ha lasciato `tests/sim/combatAdapter.test.js` 5/6 ROSSO su main con CI verde. Questo PR (1) chiude il gap di copertura e (2) fixa il rosso residuo che il gap nascondeva.

## Ground-truth glob CI (verificata, non dedotta)

| Sede | Cosa esegue | tests/sim? |
|---|---|---|
| `stack-quality` (ci.yml) -> `npm run test:api` -> `scripts/run-test-api.cjs` | tests/api, play, services (flat + 1 livello nested, wired 2026-05-30), ai, worldgen, difficulty, codex, routes, js + file singoli | **NO** |
| `combat-oracle` (combat-balance-gate.yml) | oracle WR band via `playtest_canonical.py` (N=100 seed 424242) -- non unit test | NO (e il suo paths-filter non include `tools/sim/**`) |
| `tests/services/*.test.js` | GIA' coperto (righe 34-35 del runner; nesting max 1 livello, verificato: nessun file a 3 livelli) | -- |

Risultato: `tests/sim` (32 file, ~229 test) = orfano totale. Nessun workflow, nessun glob.

## Commit 1 -- `fix(sim)`: il rosso residuo che il blind-spot nascondeva

Wire-are il glob su main cosi' com'era = CI rosso: `fullLoopRouting.test.js` FAIL 3/3 deterministico anche DOPO il fix adapter #3225.

- **Bisect**: verde a 3689e3d85 (#3202) -> first-bad `bdbd718ab` (#3214, honest active_unit + free ordering). Stessa famiglia della regressione nota, secondo consumer.
- **Root-cause** (probe wire-level): post-#3214 i driver AP-driven muovono le unita' in ordine FISSO -> lo step approach cieco di `selectPlayerAction` (`stepToward`) incanala una unita' sulla tile di un alleato -> `400 "casella occupata"` OGNI round (25/39 azioni respinte nel chapter `enc_tutorial_05`) -> timeout garantito.
- **Fix A**: estratta la candidate-walk del ramo zone-pursuit (OA2 item 7) in `stepAroundOccupied`, riusata nell'approach. Tile primaria libera = mossa identica a prima (happy path byte-identical); boxed-in -> null (hold, niente spam di mosse respinte).
- **Fix B**: `maxRounds` full-loop 40 -> 80. Il cap e' un runaway bound, non un assert di pacing: i fight si sono legittimamente allungati nello stack LOS/AP (#3219 AP onesti, #3205 unit-blocking, #3214 free ordering; round chapter ~14/25 -> ~17/31) e 40 era diventato marginale (col solo Fix A: 1/6 verde; con A+B: 6/6). Stessa convenzione ample-margin del caso sabotage in combatAdapter.test.js (120).
- **TDD**: red test catturato prima dell'implementazione (`combatPolicy.test.js` "sidesteps around it", FAIL deepStrictEqual sulla tile occupata).

## Commit 2 -- `test(ci)`: wiring del glob

`node --test --test-concurrency=1 tests/sim/*.test.js` in `run-test-api.cjs`:

- **Perche' seriale**: i test spawnano encounter reali via supertest (una porta effimera per request). Glob parallelo su Windows: 9x EADDRINUSE in un run + flake del test di determinismo seed-replay sotto contention. Seriale: 3/3 stabile, ~16s. Un solo comando identico su dev Windows e CI Linux.
- **Paths-filter (requisito 2)**: gia' soddisfatto senza toccare i workflow -- il filtro `stack` di ci.yml include `tools/sim/**` (OD-038), `apps/backend/**`, `tests/**/*.js` e `scripts/run-test-api.cjs` stesso (quindi questo PR ri-esegue la suite che modifica, by construction).
- **No version-bump** (requisito 3): zero dipendenze toccate; `--test-concurrency` e' flag nativo node --test.

## Gate proof (requisito: il glob DEVE fallire se reintroduco il bug)

Adapter riportato a pre-#3225 (`git checkout 61d403ebe -- tools/sim/combat-adapter.js`):

```
exit=1  pass=217 fail=12   (5x combatAdapter, 4x fullLoopRunner, 1x fullLoopBatch/ObjectiveWire/Routing)
```

Adapter ripristinato: `exit=0 pass=229 fail=0`. Il gate cattura la regressione su 4 famiglie di test, oltre il segnale 5/6 originale.

## Evidenze / verifiche

- combatPolicy 26/26, zoneShape 1/1, fullLoopRouting 6/6 (era 1/6 post-#3225, 0/3 prima), glob sim seriale 229/229 x4.
- Baseline storica: fullLoopRouting 6/6 verde a #3202 -> il rot e' arrivato dallo stack LOS/AP, mai eseguito da CI.
- Prettier clean sui 4 file toccati; `node --check` sul runner.
- **Caveat onesto**: verifiche locali su win32 / node 24.11 (unico node su Ryzen). CI = node 22 Linux: la verifica finale e' il run stack-quality di QUESTO PR (il node-delta e' noto dalla saga combat-oracle, ma qui gli assert sono route/completion con headroom 2x, non band WR).

## Metodi applicati (ADR-0026 / guardrail)

| Protocollo | Dove |
|---|---|
| Refresh-verify pre-azione | ground-truth glob letta da runner+workflow reali, non dal report del task |
| Ground-truth > surface | bisect + probe wire-level invece di fidarsi del "fix #3225 = risolto" |
| N-sample anti lucky-run | 6x per fullLoopRouting (pre: 0/3, post: 6/6), 4x glob completo, baseline 6x a #3202 |
| TDD (red prima) | combatPolicy.test.js rosso catturato pre-implementazione |
| Currency Gate | fix #3225 verificato su origin/main appena fetchato, non da memoria |

Merge = Eduardo (review gate). Nota post-merge: il rosso fullLoopRouting era invisibile anche in locale da worktree sporchi -- da ora il glob gira in ogni stack-quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
