### PR TITLE
fix(sim): hash string seeds so full-loop combats pin the RNG

### DIFF
--- a/tools/sim/combat-adapter.js
+++ b/tools/sim/combat-adapter.js
@@ -9,6 +9,18 @@
 
 const { selectPlayerAction } = require('./combat-policy');
 
+// String seed -> stable uint32 (same fold as tools/ts/roll_pack.ts hashSeed, kept
+// in sync so the two sim stacks derive the same stream from the same label).
+function hashStringSeed(seed) {
+  let h = 1779033703 ^ seed.length;
+  for (let i = 0; i < seed.length; i += 1) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  const normalized = h >>> 0;
+  return normalized === 0 ? 0x6d2b79f5 : normalized;
+}
+
 async function runEncounter(
   http,
   {
@@ -86,7 +98,16 @@ async function runEncounter(
     // /api/session/start seeds the per-session deterministic RNG from `seed`
     // (session.js:1637), NOT `run_seed` (that is the co-op WS world_confirm field).
     // Codex #2561 P2 — sending `seed` makes full-loop encounters replayable.
-    ...(seed !== undefined && seed !== null && seed !== '' ? { seed } : {}),
+    // /start only accepts a FINITE NUMERIC seed (Number(seed) must be isFinite,
+    // else combatRng.state stays null = Math.random passthrough): the string
+    // seeds every sim caller threads (full-loop-runner sends `${seed}-${step}`)
+    // were silently DROPPED, so "seeded" full-loop combats still rolled live
+    // d20s and marginal encounters flaked (fullLoopRouting CI red). Hash a
+    // non-numeric seed to a stable uint32 so string seeds really pin the
+    // per-session RNG; numeric seeds pass through unchanged.
+    ...(seed !== undefined && seed !== null && seed !== ''
+      ? { seed: Number.isFinite(Number(seed)) ? seed : hashStringSeed(String(seed)) }
+      : {}),
     // A13 N=40 evidence (SPEC-I gate): campaign_id links the session to the campaign
     // (read-side woundedStep lookup at /start, session.js:1761) and biome_id selects
     // the eco profile the wound amplifies. Absent -> byte-identical start body.


### PR DESCRIPTION
## Problema
`tests/sim/fullLoopRouting.test.js` restava occasionalmente flaky in CI anche dopo #3228 (visto 2026-07-06: 1 fail su PR #3229 post-update + 1 fail sul run main `88b1d34b6`).

## Root cause (piu' profonda della diagnosi iniziale)
La diagnosi era "i roll d20 non sono seedati nel path graph-mode". Ground-truth: **nessun full-loop run e' MAI stato seedato a livello combat**, in nessun path.

- `/api/session/start` accetta solo seed **numerico finito**: `Number(seedRaw)` non-finito -> `combatRng.state = null` -> Math.random passthrough (routes/session.js, blocco TKT-PLAYTEST-SEED).
- `full-loop-runner` threada SEMPRE una stringa: `` `${seed}-${step}` `` (es. `route-g-1`) -> `Number()` = NaN -> seed silenziosamente scartato.
- Il commento nell'adapter ("sending `seed` makes full-loop encounters replayable", Codex #2561 P2) era falso da sempre; il test di determinismo `combatAdapter.test.js` ('det-1') passava banalmente perche' il fixture vince a prescindere dai roll.

Con i d20 live, gli encounter marginali del route graph ogni tanto flippano -> flake.

## Fix (band-safe, zero engine change)
`tools/sim/combat-adapter.js`: seed non-numerico -> hash uint32 stabile (stesso fold di `tools/ts/roll_pack.ts hashSeed`, cosi' i due stack sim derivano lo stesso stream dalla stessa label) prima dell'invio a `/start`. Seed numerici passano invariati (byte-identical).

Beneficio collaterale: tutti i probe/batch sim che passano seed stringa (band-batch inclusi) diventano davvero replay-deterministici — i futuri batch di calibrazione potrebbero mostrare distribuzioni leggermente diverse (prima erano random non-seedate: era un bug, non una baseline).

## Verifica
- `fullLoopRouting.test.js`: **10/10 run consecutivi verdi** locali.
- Probe determinismo seed-stringa: stesso seed -> outcome/rounds/hp **bit-identici**; seed diverso -> traiettoria diversa (lo stream e' davvero pinnato).
- Suite completa `node --test --test-concurrency=1 tests/sim/*.test.js` (mirror CI #3228): **229/229 pass**.
- `prettier --check` + `lint-stack` puliti (gate stack-quality su `tools/sim/**`).
- Nota: verificato su Node 24.11 locale; mulberry32 + fold hash = int-math pura, stream identico cross-versione.

## Metodo (protocolli applicati)
| Protocollo | Dove |
|---|---|
| Refresh-verify / Currency Gate | claim "seed threadato" verificata su codice reale prima del fix (adapter GIA' inviava seed; il drop era backend-side) |
| Ground-truth > report | root-cause raffinata: non "graph-mode non seedato" ma "seed stringa scartato ovunque" |
| Quality Gate smoke+evidence | 10/10 run + probe determinismo + suite 229/229, output nel commit |
| ADR-0011 | trailer Coding-Agent + Trace-Id |

Merge = Eduardo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)