### PR TITLE
docs(core): bande pace grid_sized in 15-LEVEL_DESIGN + sync marker big-maps

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,9 +35,10 @@ L'AI gioca il loop INTERO (campagna→combat reale→advance→Nido recruit→ch
 
 **fase-2c grid-wiring SHIPPED + MERGED** ([#3199](https://github.com/MasterDD-L34D/Game/pull/3199) `6703f782` + ADR flip [#3200](https://github.com/MasterDD-L34D/Game/pull/3200) `cf158b09`). `board_scale: party_sized|grid_sized` LIVE, band-neutral (0/21 encounter cambia board). ADR-2026-07-03 `active`. Handoff [`docs/planning/2026-07-03-fase2c-grid-wiring-handoff.md`](docs/planning/2026-07-03-fase2c-grid-wiring-handoff.md). Memory `project_big_maps_arc_fase2c_2026_07_03`.
 
-- [ ] **Autora >=1 encounter `board_scale: grid_sized`** con `grid_size` grande (in `docs/planning/encounters/`) — rende il wiring osservabile (oggi capacita' dormiente, nessuna big-board autorata).
-- [ ] **N=10 probe -> N=40 ratify** su quell'encounter (author-guard `tools/js/validate_encounter_grid_ratify.js`, #3197; la ratifica NON si trasferisce fra taglie).
-- [ ] **Flip gate geometria** xpBudget (`XP_BUDGET_GEOMETRY_ENABLED`, OFF) post-N=40, per misurare hazard/activation sul board reale.
+- [x] **Autora >=1 encounter `board_scale: grid_sized`** -- FATTO 2026-07-06: `enc_badlands_dorsale_ferrosa_01` 16x12 (#3229 `c8d108da8`) + `enc_badlands_canyon_lungo_01` 20x12 cap larghezza (#3230 `88b1d34b6`), in `docs/planning/encounters/`. #3229 ha fixato 3 bug backend reali esposti dalla prima board grande (clamp pre-resolve, ID rinforzi duplicati, stepAway quadrato).
+- [x] **N=10 probe -> N=40 ratify** -- FATTO: bande pace ratificate 16x12 [10,18] + 20x12 [10,17] (evidence `docs/research/2026-07-06-dorsale-ferrosa-grid-ratify.md` + `2026-07-06-canyon-lungo-grid-ratify.md`); baseline aggiornata, `validate_encounter_grid_ratify.js` 0 warn. Probe GENERICO `tools/sim/grid-band-probe.js --encounter <id>` (#3230).
+- [ ] **Lever D4 comportamentale** (zone-defense / conversione attivazioni): scaling intents SHIPPED flag-OFF #3231 `8026f9c49`, A/B N=10 = NEGATIVE result (lever attivazione da solo non rompe il ceiling; collo ipotizzato = conversione) -- evidence `docs/research/2026-07-06-intents-roster-scaling-ab.md`. Serve spec con fork owner PRIMA del build.
+- [ ] **Flip gate geometria** xpBudget (`XP_BUDGET_GEOMETRY_ENABLED`, OFF) post-calibrazione D9 (il termine OVER-predice sui grid_sized: dorsale ratio 2.95 `critical_over` vs WR 1.0 misurato -- warn->calibra->block).
 - [ ] Convergenza xpBudget Node (`xpBudget.js`) vs Python (`encounter_xp_budget.py`) — follow-up noto (modelli divergenti).
 
 ---

--- a/COMPACT_CONTEXT.md
+++ b/COMPACT_CONTEXT.md
@@ -5,7 +5,21 @@
 
 ---
 
-## ⚡ Sessione corrente 2026-07-03 -- fase-2c grid-wiring SHIPPED + ADR active
+## ⚡ Sessione corrente 2026-07-06 -- big-maps arc: 2 grid_sized RATIFICATI + D4 scaling flag-OFF
+
+**3 PR merged** (main `8026f9c49`): **#3229** `c8d108da8` primo encounter `board_scale: grid_sized`
+16x12 (`enc_badlands_dorsale_ferrosa_01`) + N=40 ratify banda pace [10,18] + 3 bug backend reali
+fixati (clamp pre-resolve, ID rinforzi duplicati, stepAway quadrato su board rettangolare);
+**#3230** `88b1d34b6` secondo grid_sized al cap 20x12 (`enc_badlands_canyon_lungo_01`, banda [10,17])
+
+- probe GENERICO `tools/sim/grid-band-probe.js`; **#3231** `8026f9c49` D4 intents roster-scaling
+  flag-OFF, A/B N=10 = NEGATIVE (lever attivazione da solo non rompe il ceiling). Evidence:
+  `docs/research/2026-07-06-{dorsale-ferrosa,canyon-lungo}-grid-ratify.md` + `2026-07-06-intents-roster-scaling-ab.md`.
+  Residui: calibrazione D9 geometry (over-predict 2.95x) -> flip owner-gated; spec D5 zone-defense;
+  variante capture_point gated su D5. Il blocco 07-03 sotto = storico (i suoi residui "autora+ratify"
+  sono CHIUSI qui).
+
+## ⚡ Sessione 2026-07-03 -- fase-2c grid-wiring SHIPPED + ADR active
 
 Handoff: `docs/planning/2026-07-03-fase2c-grid-wiring-handoff.md`. **2 PR merged.** Keystone big-maps arc D1: un `encounter.grid_size` autorato ora dimensiona la board, ma SOLO se l'encounter opta `board_scale: grid_sized` (naming owner-ratified su `auto|authored` dello spec-draft); default `party_sized` = legacy byte-identical -> **band-neutral** (0/21 encounter cambia board).
 

--- a/docs/core/15-LEVEL_DESIGN.md
+++ b/docs/core/15-LEVEL_DESIGN.md
@@ -2,7 +2,7 @@
 doc_status: active
 doc_owner: master-dd
 workstream: dataset-pack
-last_verified: '2026-06-07'
+last_verified: '2026-07-06'
 source_of_truth: false
 language: it
 review_cycle_days: 30
@@ -128,6 +128,19 @@ ANY encounter il cui `grid_size` (o blocco `grid`) cambia DEVE ri-eseguire il ci
 NON si trasferisce a una nuova taglia (la geometria muove la difficolta' reale). Author-guard
 advisory: `tools/js/validate_encounter_grid_ratify.js` + baseline `data/core/balance/grid_ratify_baseline.json`.
 Aggiorna il baseline (grid_size + evidence_ref) solo dopo l'evidence N=40.
+
+**Bande pace RATIFICATE N=40 -- board grid_sized (2026-07-06).** Semantica banda =
+completion + pace + reinforcement-liveness, NON letalita': sul driver round-model AI-vs-AI
+la letalita' e' ceiling strutturale (WR 1.0 su ogni arm, throughput cappato dal dial
+`intents_per_round` -- vedi "Limite di modello" nell'evidence dorsale). Un resize futuro si
+confronta su completion/pace: fuori banda = il guard L-069 ha morso.
+
+| Board                        | Encounter esemplare (`docs/planning/encounters/`) | Banda pace (avg_rounds) | N=40 misurato                          | Evidence                                                  |
+| ---------------------------- | ------------------------------------------------- | ----------------------- | -------------------------------------- | --------------------------------------------------------- |
+| 16x12                        | `enc_badlands_dorsale_ferrosa_01`                 | [10, 18]                | avg 14.03 (sd 1.9), WR 1.0, reinf 4/4  | `docs/research/2026-07-06-dorsale-ferrosa-grid-ratify.md` |
+| 20x12 (cap larghezza schema) | `enc_badlands_canyon_lungo_01`                    | [10, 17]                | avg 12.85 (sd 1.25), WR 1.0, reinf 4/4 | `docs/research/2026-07-06-canyon-lungo-grid-ratify.md`    |
+
+Probe generico riusabile: `tools/sim/grid-band-probe.js --encounter <id>` (#3230).
 
 ## Relazione Bioma → Livello
 

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -3479,7 +3479,7 @@
       "doc_status": "active",
       "doc_owner": "master-dd",
       "workstream": "dataset-pack",
-      "last_verified": "2026-06-07",
+      "last_verified": "2026-07-06",
       "source_of_truth": false,
       "language": "it",
       "review_cycle_days": 180,


### PR DESCRIPTION
## Cosa (M4 del triage — doc-only)

1. **`docs/core/15-LEVEL_DESIGN.md`**: aggiunte le bande pace RATIFICATE N=40 dei primi 2 encounter `grid_sized` nella sez. "Regola re-ratify grid" — 16x12 **[10, 18]** (dorsale, avg 14.03 sd 1.9) + 20x12 **[10, 17]** (canyon, avg 12.85 sd 1.25), con semantica banda (completion+pace+liveness, NON letalità — ceiling di modello) + pointer al probe generico. `last_verified` bump.
2. **`BACKLOG.md`** sez. big-maps: 2 checkbox CHIUSI con SHA (#3229 `c8d108da8` / #3230 `88b1d34b6`) — erano stale (anti-pattern #19); aggiunta riga lever D4 (#3231 `8026f9c49`, A/B N=10 negative); riga flip geometria aggiornata con l'evidenza over-predict (ratio 2.95).
3. **`COMPACT_CONTEXT.md`**: nuovo blocco sessione 2026-07-06 in testa (il blocco 07-03 resta come storico).
4. **`docs_registry.json`**: sync `last_verified` 15-LEVEL_DESIGN stessa PR (atomico).

## Evidenza

- `check_docs_governance.py --strict` → **errors=0** (7 warnings baseline legacy)
- `npx prettier --write` sui 4 file (lint-staged green)
- Fonte bande: `docs/research/2026-07-06-dorsale-ferrosa-grid-ratify.md` + `2026-07-06-canyon-lungo-grid-ratify.md` (merged #3229/#3230)

## Changelog

- docs: bande pace grid_sized documentate nel core level-design; marker big-maps sincronizzati con git.

## Rollback (03A)

Revert singolo commit `1d853d3b1` (doc-only, zero runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)