### PR TITLE
test(sim): seed census -- pin non-deterministic seeds (post #3232)

### DIFF
--- a/tools/sim/batch-ai-runner.js
+++ b/tools/sim/batch-ai-runner.js
@@ -101,7 +101,12 @@ function buildCombinations(args) {
     for (const scenario of args.scenarios) {
       for (let s = 0; s < args.seedCount; s += 1) {
         runIdx += 1;
-        const seed = 1000 + runIdx; // deterministic, monotonic
+        // Deterministic + monotonic, BUT: the worker (tests/smoke/ai-driven-sim.js)
+        // forwards this as coop `run_seed` (world_confirm), which feeds ONLY the
+        // world enricher (coopOrchestrator.confirmWorld) -- the combat session RNG
+        // is NOT pinned by it (seed census 2026-07-06). Pinning combat here needs a
+        // backend seam (coop world_confirm -> session seed), tracked out of scope.
+        const seed = 1000 + runIdx;
         combos.push({
           run_id: runIdx,
           seed,

--- a/tools/sim/form-pulse-v2-graded-ab-probe.js
+++ b/tools/sim/form-pulse-v2-graded-ab-probe.js
@@ -364,9 +364,10 @@ async function measureBiome(http, party, biomeId, N, seedBase, w, driftFloor = f
     if (g.v2BrancoSource === 'imprint') impWins += 1;
     if (g.v2BrancoId || g.minorIds.some(Boolean)) grantedTeams += 1;
     // NUMERIC seed (Codex #3139 P1): /api/session/start seeds the combat RNG ONLY when
-    // Number(seed) is finite (session.js:2102) -- a STRING seed leaves it unset (Math.random),
-    // so the A/B/C arms would NOT be paired and reruns would not replay. A numeric seed shared
-    // across the arms of one team makes them genuinely paired + the artifact reproducible.
+    // Number(seed) is finite (session.js:2102). NB post-#3232: combat-adapter now hashes a
+    // non-numeric seed to a stable uint32 before /start, so a string seed would ALSO pin the
+    // RNG today -- the numeric seed here stays as the direct, hash-free convention. A seed
+    // shared across the arms of one team makes them genuinely paired + the artifact replayable.
     const seed = seedBase + i;
     const rosterBaseline = attachTraits(party, g.baselineBrancoId, null);
     const rosterV2 = attachTraits(party, g.v2BrancoId, g.minorIds);

--- a/tools/sim/full-loop-batch.js
+++ b/tools/sim/full-loop-batch.js
@@ -93,8 +93,10 @@ function parseArgs(argv) {
     a13MaxRetries: 1,
     // --gate: exit 1 if any ratified meta band-metric is out of band (CI gate mode).
     // Default OFF = diagnostic mode (always exit 0 on completion). The batch is NOT
-    // bit-deterministic per seed (recruit/mate/attrition vary), so this is a STATISTICAL
-    // gate -- the bands carry margin; use it warn-only until the runner is fully seed-pinned.
+    // bit-deterministic per seed: the COMBAT leg is pinned since #3232 (combat-adapter
+    // hashes the runner's `${seed}-${step}` string to a uint32 that seeds the session
+    // RNG), but the META leg (recruit/mate rolls server-side) has no seed seam, so this
+    // is a STATISTICAL gate -- the bands carry margin; use it warn-only until then.
     gate: false,
   };
   for (let i = 2; i < argv.length; i += 1) {


### PR DESCRIPTION
## M3 -- Censimento seed non-pinnati in `tests/sim/` + `tools/sim/` (post #3232)

**Esito onesto: 0 seed non-pinnati trovati -- post-#3232 tutto il combat in scope e' gia' RNG-pinned.** La PR e' comment-only (3 commenti stale/fuorvianti corretti, comportamento byte-identical). Nessun assert aggiornato: nessun assert testava rumore (suite gia' 229/229 su main post-#3232).

### Convenzione #3232 (verificata sul diff `a225f71ad`)
`tools/sim/combat-adapter.js runEncounter` hasha ogni seed non-numerico a uint32 stabile (stesso fold di `tools/ts/roll_pack.ts hashSeed`) prima di `/api/session/start`; i numerici passano invariati. Ogni caller che passa da `runEncounter` (o da `runFullLoop`, che manda `${seed}-${step}`) e' quindi pinnato, string o numerico.

### Tabella censimento -- tests/sim

| File:riga | Seed | Classe | Azione |
|---|---|---|---|
| combatAdapter.test.js:89,116,140,205,258,304,316 | 'fl-seed-1','det-1','graded-1','stale-1','oa2-test','apr-1'x2 | STRINGA-HASHATA (runEncounter) | nessuna |
| fullLoopObjectiveWire.test.js:87 | 'surv-wire-1' | STRINGA-HASHATA | nessuna |
| fullLoopRunner.test.js:69,506,692 | 'fl1b','fl2c-esfp','fl-pi-skirm' | STRINGA-HASHATA (via `${seed}-${step}`) | nessuna |
| fullLoopRunner.test.js:288-289 | 'b1','b2' (**non nei sospetti**) | STRINGA-HASHATA | nessuna |
| fullLoopRouting.test.js:88,116,137 | 'route-g/i/e' | STRINGA-HASHATA (oggetto di #3232) | nessuna |
| fullLoopBatch.test.js:476 (e2e K=2) | seedBase 7000 -> '700X-step' | STRINGA-HASHATA | nessuna |
| fullLoopBatch.test.js:437 e unit vari | fixture, runOne iniettato | N/A (no combat) | nessuna |
| combatAdapterA13/Events/Overcharge/Personality, fullLoopA13, nidoEconomy | -- | N/A (fake http, no RNG) | nessuna |
| overcharge/pressureFloor/woundMagnitude/specIGates/fpDelta Probe.test.js | -- | N/A (unit su aggregatori) | nessuna |
| metaNetworkDriver.test.js | -- | N/A (createApp ma meta-only, no combat) | nessuna |
| altri 12 file (policy/scenario/aggregator puri) | -- | N/A | nessuna |

### Tabella censimento -- tools/sim

| File | Seed ingress | Classe | Azione |
|---|---|---|---|
| combat-adapter.js:108 | punto di hash #3232 | NUMERICO passthrough / STRINGA->uint32 | nessuna |
| full-loop-runner.js:331 | `${seed}-${step}` | STRINGA-HASHATA | nessuna |
| full-loop-batch.js:229 | String(seedBase+i) -> runner | STRINGA-HASHATA (combat); meta leg senza seed seam | commento aggiornato (quale leg e' pinnato) |
| d8-chain-fire-count.js:178 / d8-chain-graded:96 / er6-carryover:69 / overcharge:190 / pressure-floor:292 / spec-i-gates:359 / wound-magnitude:91 | 'd8fire-N','d8chain-N','er6carry-N','oc-N','pf-N','er1/er6/er7-N','wd-N' | STRINGA-HASHATA (tutte via runEncounter) | nessuna (probe ratificati, non toccati) |
| d8-chain-fire-count.js:123 (self-test) | ASSENTE | /start senza seed MA esito RNG-indipendente (mod:99 = hit garantito, assert binario di wiring, counter resettati dopo) | nessuna |
| d6-imprint:265, dorsale-ferrosa, grid-band, focus-fire, form-pulse-v2, los-n, los-repos, move-terrain x3, radici, ultima-caccia x2 | numerici (loop s=1..N / 42 / 999999 / 424242 / 20260701) | NUMERICO | nessuna |
| form-pulse-v2-graded-ab-probe.js:366 | (commento) | -- | commento stale corretto ("STRING seed = Math.random" era vero solo pre-#3232) |
| fp-delta / fp-trait-delta / epigenome_lineage | LCG locale seedato numerico | NUMERICO (no combat RNG) | nessuna |
| batch-ai-runner.js:104 | 1000+runIdx (numerico) | **NON-PINNATO il combat**: il worker `tests/smoke/ai-driven-sim.js` lo inoltra come coop `run_seed` (world_confirm) che alimenta SOLO il world-enricher (`coopOrchestrator.confirmWorld:671`) -- mai l'RNG di sessione | commento onesto aggiunto; fix = seam backend (coop world_confirm -> session seed), FUORI scope (apps/backend vietato) |
| campaign-driver, meta-network-driver, nido-economy, recruit-resolver, scenario-enemies, encounter-biome, species-roles, policy x3, telemetry-bridge, check-x2, visual-baseline-compare, a13-wound-aggregator, aliena-enforcement-probe, er7-season-trace | -- | N/A (nessun combat run / nessun seed) | nessuna |

### Scoperte (contraddicono/estendono i sospetti)
1. **Tutti i sospetti pre-individuati = gia' coperti da #3232** (passano tutti da runEncounter/runFullLoop). 0 fix codice necessari.
2. `'b1'`/`'b2'` (fullLoopRunner courtship test) mancavano dalla lista sospetti -- anch'essi coperti.
3. **batch-ai-runner -> ai-driven-sim: il combat non e' MAI stato pinnato** (run_seed = world-enricher only, stesso pattern del bug Codex #2561 fixato solo nel combat-adapter). Conseguenza: il pairing by-seed di `fp-trait-ab-analyze.js` sui batch coop era label-only, non variance-controlled. Fix richiede backend -> ticket/owner.
4. Le ratifiche pre-#3232 basate sui probe string-seed (oc-/pf-/wd-/er*/d8*) giravano di fatto **unpaired** (seed droppato): restano valide come confronto a campioni indipendenti, ma non variance-controlled. Post-#3232 un re-run sarebbe genuinamente paired -- owner call se ri-ratificare.
5. Residuo noto invariato: il **meta leg** del full-loop (recruit/mate server-side) non ha seed seam -> il gate batch resta statistico warn-only (commento ora lo dice esplicitamente).

### Prova (doppio run + valori)
- `node --test` sui 32 file di tests/sim, seriali, **2 run completi**: **229/229 pass, 0 fail entrambi**, diff per-file pass/fail = **identico**.
- Value-probe string seed (runEncounter, app reale): stesso seed -> `{outcome,rounds,hp_remaining_pct,enemy_hp_remaining_pct,units_lost,survivorIds}` **byte-identical**; seed diverso -> traiettoria diversa; senza seed -> valori variano tra run (Math.random, atteso).
- `npx prettier --check` sui 3 file toccati: clean.

### Rollback
Revert del singolo commit `14761b502` (comment-only, zero rischio runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)