### PR TITLE
test(tools): wave-B characterization batch (kpi-alerts + json-schemas + dashboard)

### DIFF
--- a/tests/scripts/test_build_playtest_dashboard.py
+++ b/tests/scripts/test_build_playtest_dashboard.py
@@ -1,0 +1,69 @@
+"""Characterization tests for tools/py/build_playtest_dashboard.py (HTML dashboard builder).
+
+Behavior-only snapshot: the single DATA placeholder in the embedded HTML template,
+the missing-input error path (stderr message + exit 1 + no output written), and the
+happy path (compact-separator JSON injection, placeholder fully replaced, nested
+output directory creation, output larger than the bare template, the OK stdout
+line). main() reads sys.argv, so the tests monkeypatch it. A deliberate change to
+these behaviors SHOULD update these assertions consciously -- that is the point of
+a characterization test.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_PY = PROJECT_ROOT / "tools" / "py"
+if str(TOOLS_PY) not in sys.path:
+    sys.path.insert(0, str(TOOLS_PY))
+
+import build_playtest_dashboard as b  # noqa: E402
+
+
+def test_html_template_has_single_data_placeholder():
+    assert b.HTML.count("/*__DATA__*/") == 1
+
+
+def test_main_missing_input_exits_one(tmp_path, monkeypatch, capsys):
+    out_path = tmp_path / "out.html"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "build_playtest_dashboard.py",
+            "--in",
+            str(tmp_path / "nope.json"),
+            "--out",
+            str(out_path),
+        ],
+    )
+    rc = b.main()
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "aggregates not found:" in captured.err
+    assert "aggregate_session_logs.py first" in captured.err
+    assert not out_path.exists()
+
+
+def test_main_injects_compact_json_and_writes_output(tmp_path, monkeypatch, capsys):
+    inp = tmp_path / "agg.json"
+    inp.write_text(json.dumps({"a": [1, 2], "b": {"c": 3}}), encoding="utf-8")
+    out_path = tmp_path / "nested" / "dir" / "out.html"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["build_playtest_dashboard.py", "--in", str(inp), "--out", str(out_path)],
+    )
+    rc = b.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert out_path.exists()
+    html = out_path.read_text(encoding="utf-8")
+    assert "/*__DATA__*/" not in html
+    assert '{"a":[1,2],"b":{"c":3}}' in html
+    assert len(html) > len(b.HTML)
+    assert captured.out.startswith("OK -> ")
+    assert "KB)" in captured.out

--- a/tests/scripts/test_report_kpi_alerts.py
+++ b/tests/scripts/test_report_kpi_alerts.py
@@ -1,0 +1,108 @@
+"""Characterization tests for tools/py/report_kpi_alerts.py (KPI baseline alert gate).
+
+Behavior-only snapshot: the JSON-loading error message, the _evaluate drop-detection
+rules (strict greater-than tolerance, drops-only, zero-baseline and non-numeric
+guards, the bool-counts-as-numeric quirk, the exact Italian alert format with .1
+percent rendering) and the main() print-vs-raise contract. A deliberate change to
+these behaviors SHOULD update these assertions consciously -- that is the point of
+a characterization test.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_PY = PROJECT_ROOT / "tools" / "py"
+if str(TOOLS_PY) not in sys.path:
+    sys.path.insert(0, str(TOOLS_PY))
+
+import report_kpi_alerts as r  # noqa: E402
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_metrics_error_is_a_runtime_error():
+    assert issubclass(r.MetricsError, RuntimeError)
+
+
+def test_load_json_missing_file_message(tmp_path):
+    with pytest.raises(FileNotFoundError) as exc_info:
+        r._load_json(tmp_path / "missing.json")
+    assert "File JSON non trovato" in str(exc_info.value)
+
+
+def test_load_json_roundtrip(tmp_path):
+    p = tmp_path / "m.json"
+    _write_json(p, {"a": 1})
+    assert r._load_json(p) == {"a": 1}
+
+
+def test_evaluate_drop_beyond_tolerance_exact_format():
+    alerts = r._evaluate({"combat": {"wr": 8}}, {"combat": {"wr": 10}}, 0.1)
+    assert alerts == ["[combat] metrica 'wr' scesa da 10 a 8 (variazione 20.0%)"]
+
+
+def test_evaluate_increase_is_silent():
+    assert r._evaluate({"combat": {"wr": 12}}, {"combat": {"wr": 10}}, 0.1) == []
+
+
+def test_evaluate_drop_at_tolerance_is_silent():
+    # strict > comparison: a drop exactly equal to the tolerance does not alert
+    assert r._evaluate({"combat": {"wr": 9}}, {"combat": {"wr": 10}}, 0.1) == []
+
+
+def test_evaluate_zero_baseline_is_skipped():
+    assert r._evaluate({"s": {"k": -5}}, {"s": {"k": 0}}, 0.1) == []
+
+
+def test_evaluate_non_numeric_values_are_skipped():
+    assert r._evaluate({"s": {"k": 1}}, {"s": {"k": "x"}}, 0.1) == []
+    assert r._evaluate({"s": {"k": "x"}}, {"s": {"k": 10}}, 0.1) == []
+
+
+def test_evaluate_non_dict_or_missing_sections_are_skipped():
+    assert r._evaluate({"s": 5}, {"s": {"k": 10}}, 0.1) == []
+    assert r._evaluate({}, {"s": {"k": 10}}, 0.1) == []
+
+
+def test_evaluate_bool_baseline_counts_as_numeric():
+    # isinstance(True, int) holds, so a bool baseline is compared numerically
+    alerts = r._evaluate({"s": {"k": 0}}, {"s": {"k": True}}, 0.1)
+    assert alerts == ["[s] metrica 'k' scesa da True a 0 (variazione 100.0%)"]
+
+
+def test_main_within_tolerance_prints_ok(tmp_path, capsys):
+    m = tmp_path / "m.json"
+    b = tmp_path / "b.json"
+    _write_json(m, {"s": {"k": 10}})
+    _write_json(b, {"s": {"k": 10}})
+    rc = r.main(["--metrics", str(m), "--baseline", str(b)])
+    out = capsys.readouterr().out
+    assert rc is None
+    assert "Nessuna deviazione KPI oltre la soglia configurata" in out
+
+
+def test_main_prints_alerts_then_raises(tmp_path, capsys):
+    m = tmp_path / "m.json"
+    b = tmp_path / "b.json"
+    _write_json(m, {"s": {"k": 5}})
+    _write_json(b, {"s": {"k": 10}})
+    with pytest.raises(r.MetricsError, match="Deviazioni KPI oltre soglia"):
+        r.main(["--metrics", str(m), "--baseline", str(b)])
+    out = capsys.readouterr().out
+    assert "scesa da 10 a 5" in out
+
+
+def test_main_tolerance_flag_silences_alert(tmp_path, capsys):
+    m = tmp_path / "m.json"
+    b = tmp_path / "b.json"
+    _write_json(m, {"s": {"k": 5}})
+    _write_json(b, {"s": {"k": 10}})
+    rc = r.main(["--metrics", str(m), "--baseline", str(b), "--tolerance", "0.6"])
+    assert rc is None
+    assert "Nessuna deviazione" in capsys.readouterr().out

--- a/tests/scripts/test_validate_json_schemas.py
+++ b/tests/scripts/test_validate_json_schemas.py
@@ -1,0 +1,120 @@
+"""Characterization tests for tools/py/validate_json_schemas.py (schema validity gate).
+
+Behavior-only snapshot: cwd-relative discovery (root order schemas/ then
+config/schemas/, per-root sorted rglob, the .yml-is-excluded pin), Draft 2020-12
+schema checking, YAML syntax checking, and the main() error-report format and
+exit codes. A deliberate change to these behaviors SHOULD update these assertions
+consciously -- that is the point of a characterization test.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema.exceptions import SchemaError
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_PY = PROJECT_ROOT / "tools" / "py"
+if str(TOOLS_PY) not in sys.path:
+    sys.path.insert(0, str(TOOLS_PY))
+
+import validate_json_schemas as v  # noqa: E402
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_iter_json_schema_files_empty_when_roots_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert list(v.iter_json_schema_files()) == []
+
+
+def test_iter_json_schema_files_root_order_then_sorted(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "schemas" / "b.json", "{}")
+    _write(tmp_path / "schemas" / "a.json", "{}")
+    _write(tmp_path / "config" / "schemas" / "c.json", "{}")
+    assert list(v.iter_json_schema_files()) == [
+        Path("schemas/a.json"),
+        Path("schemas/b.json"),
+        Path("config/schemas/c.json"),
+    ]
+
+
+def test_iter_json_schema_files_ignores_non_json(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "schemas" / "x.yaml", "a: 1\n")
+    assert list(v.iter_json_schema_files()) == []
+
+
+def test_iter_yaml_files_empty_without_schemas_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert list(v.iter_yaml_files()) == []
+
+
+def test_iter_yaml_files_sorted_and_yml_excluded(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "schemas" / "y.yaml", "a: 1\n")
+    _write(tmp_path / "schemas" / "x.yaml", "a: 1\n")
+    _write(tmp_path / "schemas" / "z.yml", "a: 1\n")
+    assert list(v.iter_yaml_files()) == [Path("schemas/x.yaml"), Path("schemas/y.yaml")]
+
+
+def test_validate_json_schema_accepts_valid(tmp_path):
+    p = tmp_path / "ok.json"
+    p.write_text(json.dumps({"type": "object"}), encoding="utf-8")
+    v.validate_json_schema(p)
+
+
+def test_validate_json_schema_rejects_invalid(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text(json.dumps({"type": 123}), encoding="utf-8")
+    with pytest.raises(SchemaError):
+        v.validate_json_schema(p)
+
+
+def test_validate_yaml_file_accepts_valid(tmp_path):
+    p = tmp_path / "ok.yaml"
+    p.write_text("a: 1\n", encoding="utf-8")
+    v.validate_yaml_file(p)
+
+
+def test_validate_yaml_file_rejects_broken(tmp_path):
+    p = tmp_path / "bad.yaml"
+    p.write_text("a: [", encoding="utf-8")
+    with pytest.raises(yaml.YAMLError):
+        v.validate_yaml_file(p)
+
+
+def test_main_empty_tree_reports_zero_and_passes(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    rc = v.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Validated 0 JSON schema files and 0 YAML files without errors." in out
+
+
+def test_main_reports_errors_and_fails(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "schemas" / "bad.json", json.dumps({"type": 123}))
+    _write(tmp_path / "schemas" / "bad.yaml", "a: [")
+    rc = v.main()
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "JSON schema errors detected:" in out
+    assert "YAML syntax errors detected:" in out
+
+
+def test_main_counts_validated_files(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "schemas" / "ok.json", json.dumps({"type": "object"}))
+    _write(tmp_path / "config" / "schemas" / "ok2.json", json.dumps({"type": "object"}))
+    _write(tmp_path / "schemas" / "ok.yaml", "a: 1\n")
+    rc = v.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Validated 2 JSON schema files and 1 YAML files without errors." in out


### PR DESCRIPTION
## Cosa

Batch Wave B della lane L3 characterization-test (piano ratificato 2026-07-06): 28 pin su 3 tool untested.

| File | Pin | Modulo | Perche' |
|---|---|---|---|
| test_report_kpi_alerts.py | 13 | tools/py/report_kpi_alerts.py | Gate CI qa-kpi-monitor, stabile 252gg, 0 test |
| test_validate_json_schemas.py | 12 | tools/py/validate_json_schemas.py | Gate CI schema-validate, stabile 210gg, 0 test |
| test_build_playtest_dashboard.py | 3 | tools/py/build_playtest_dashboard.py | Fronte playtest, churn 4gg, 0 test |

Pin notevoli: strict-> su tolerance + quirk bool-is-numeric + formato alert IT esatto (kpi); ordine root schemas->config/schemas + esclusione .yml + exit codes (schemas); contratto placeholder singolo + injection JSON compact + creazione dir annidata (dashboard).

## Gate stack (tutto verde)

- 38 pin-check pre-verificati contro i moduli reali PRIMA del dispatch (32 + 6 delta fixture-esatte).
- dels==0 x3, solo file target x3, ASCII x3, **BYTE-IDENTICAL x3** allo spec embedded.
- `pytest tests/` collect 1285 item zero collisioni; 28/28 passed locale.
- Recon onesta: analyze_telemetry / build_ermes_report / calibrate_map_elites / sparkline_dashboard SKIPPATI (gia' testati co-locati in tools/py -- lezione #3189).

## Governance

- Jules sessions 4864950833591874989 / 14352730295906500985 / 4925241632746651642; task: codemasterdd docs/jules-batch/tasks/2026-07-06-game-*-chartest.md (9f0d62f).
- **Merge delegato attivo** (jules-lane-policy Addendum 2026-07-06, cdd #515 merged): mergio io a CI verde. Qualsiasi giallo -> passa a Eduardo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)