### PR TITLE
ci: deliver automation PRs via GitHub App token (fix action_required gate)

### DIFF
--- a/.github/workflows/ai-sim-nightly.yml
+++ b/.github/workflows/ai-sim-nightly.yml
@@ -61,8 +61,26 @@ jobs:
       issues: write
     timeout-minutes: 30
     steps:
+      # Token GitHub App dedicata per la delivery PR (step B3): dal
+      # 2026-06-11 le PR create/aggiornate da github-actions[bot] generano
+      # run pull_request in action_required (approvazione umana). In piu'
+      # GITHUB_TOKEN qui e' contents:read -> il push del baseline PR era un
+      # 403 latente inghiottito da continue-on-error. L'app token risolve
+      # entrambi. Stesso idioma di daily-tracker-refresh.
+      # https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/
+      - name: Mint automation app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Credenziale persistita = app token (job ~9min << TTL 1h):
+          # il git push di B3 usa l'app, non github-actions[bot].
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node 22
         uses: actions/setup-node@v4
@@ -242,12 +260,13 @@ jobs:
           fi
 
       # B3 — commit the updated rolling baseline + generated report via PR,
-      # NOT auto-commit to main (PT2-C). Token is contents+PR scoped.
+      # NOT auto-commit to main (PT2-C). App token: contents+PR scoped,
+      # actor non gated (vedi step app-token).
       - name: Open baseline-update PR
         if: github.event_name == 'schedule' && steps.pillar.outputs.pillar_alert != ''
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
           DATE=$(date -u +%Y-%m-%d)

--- a/.github/workflows/daily-tracker-refresh.yml
+++ b/.github/workflows/daily-tracker-refresh.yml
@@ -14,14 +14,29 @@ env:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN non serve piu' in scrittura: push + PR passano dal token
+    # della GitHub App (step app-token). Least privilege: read-only.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
+      # Token GitHub App dedicata al posto di GITHUB_TOKEN: dal 2026-06-11
+      # le PR create/aggiornate da github-actions[bot] generano run
+      # pull_request in stato action_required (approvazione umana richiesta)
+      # -> PR #3196 bloccata 6 giorni. L'attore app-bot dedicato non e' gated.
+      # https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/
+      - name: Mint automation app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Credenziale persistita = app token: git push usa l'app, non
+          # github-actions[bot].
+          token: ${{ steps.app-token.outputs.token }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -32,12 +47,12 @@ jobs:
         run: python scripts/daily_tracker_refresh.py --export-json reports/daily_tracker_summary.json
       - name: Open tracker-refresh PR
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
-          # main e' protetto: il bot github-actions non puo' pushare diretto
-          # (403 -> git-auto-commit-action exit 128). Consegna via PR branch +
-          # auto-PR, idioma riusato da ai-sim-nightly (B3) e skiv-monitor.
+          # main e' protetto: nessun push diretto. Consegna via PR branch +
+          # auto-PR (idioma riusato da ai-sim-nightly B3), con app token
+          # cosi' i check pull_request partono senza approvazione manuale.
           if git diff --quiet -- docs/00-INDEX.md; then
             echo "Tracker index invariato -- nessun PR necessario"
             exit 0


### PR DESCRIPTION
## Problema

Le PR dell'automazione (daily tracker, PR #3196 bloccata 6 giorni) restano BLOCKED: i run `pull_request` finiscono in `action_required` (approvazione manuale) ogni giorno.

## Root cause (non e' un setting del repo)

Cambio piattaforma GitHub, rollout 10-17 giugno 2026: le PR **create o aggiornate** da `github-actions[bot]` (= `GITHUB_TOKEN`) ora generano run `pull_request` in attesa di approvazione umana ("Approve workflows to run"). Prima non partivano affatto.
Ref: https://github.blog/changelog/2026-06-11-bot-created-pull-requests-can-run-workflows-if-approved/

Verificato: nessun opt-out repo-level per `github-actions[bot]` (esiste solo per Copilot coding agent); il fork-PR approval policy (`first_time_contributors`) non c'entra (PR same-repo); endpoint `/actions/runs/{id}/approve` = solo fork -> 403; i run `workflow_dispatch` sullo stesso SHA non popolano il `statusCheckRollup` della PR.

## Fix

Push branch + `gh pr create` con **token di una GitHub App dedicata** (mint via `actions/create-github-app-token@v2`, TTL 1h) invece di `GITHUB_TOKEN`. L'attore diventa l'app-bot -> niente gate, check partono subito.

Scope:
- `daily-tracker-refresh.yml` -- sintomo riportato. Bonus: permissions GITHUB_TOKEN downgrade a `contents: read` (least privilege, non scrive piu' nulla).
- `ai-sim-nightly.yml` (B3 baseline PR) -- stesso idioma. Bonus: fixa 403 latente (job ha `contents: read` ma B3 pushava con GITHUB_TOKEN; `continue-on-error` lo inghiottiva -- mai nessun PR `auto/playtest2-baseline-*` creato, 0 trovati).
- `skiv-monitor.yml` ESCLUSO: non crea PR (OD-042-A: orphan branch `skiv-monitor/state`, no-PR by design) -> non colpito dal gate.
- `mission-console-build.yml` gia' coperto: usa `AUTODEPLOY_PAT` (presente nei secrets). Nota: il suo fallback GITHUB_TOKEN + dispatch CI e' rotto post-2026-06-11 (i dispatch non popolano il rollup), ma finche' il PAT esiste non si attiva.

## Setup PRIMA del merge (a cura di Eduardo, ~15 min)

1. GitHub -> Settings (profilo) -> Developer settings -> GitHub Apps -> **New GitHub App**:
   - Nome: es. `game-automation` (il bot apparira' come `game-automation[bot]`)
   - Homepage: URL del repo. **Webhook: OFF** (deseleziona Active)
   - Permissions (Repository): **Contents: Read and write**, **Pull requests: Read and write**, **Issues: Read and write** (serve per `--label` su `gh pr create`)
   - Where can this app be installed: **Only on this account**
2. Create -> annota **App ID** -> **Generate a private key** (scarica il `.pem`)
3. **Install App** -> solo sul repo `Game`
4. Repo Game -> Settings -> Secrets and variables -> Actions -> New repository secret:
   - `AUTOMATION_APP_ID` = App ID (numero)
   - `AUTOMATION_APP_PRIVATE_KEY` = contenuto integrale del `.pem`
5. Merge di questa PR

Se i secrets mancano al momento del run, lo step di mint fallisce ad alta voce (fail-loud, niente fallback silenzioso al token gated).

## Sicurezza

- Token effimero (1h), least-privilege (3 permessi, 1 repo), revocabile (delete key/uninstall app).
- Nessuna credenziale long-lived nuova; nessuna impersonazione dell'owner (audit trail: attore = app-bot dedicato).
- Il gate 2026-06-11 esiste per bloccare codice generato che si auto-esegue: qui il contenuto PR e' output deterministico di script versionati nel repo (tracker index, pillar baseline), non codice arbitrario -> bypass motivato.
- Rischio residuo: GitHub potrebbe estendere il gate ad altri bot in futuro (non annunciato).

## Verifica post-merge (criterio: CLEAN senza interventi)

Prossimo run schedulato (12:00 UTC daily tracker), poi:
```
gh pr list --repo MasterDD-L34D/Game --author "app/game-automation" --json number
gh pr checks <PR> --repo MasterDD-L34D/Game     # governance + ci-gate devono partire e andare green da soli
gh pr view <PR> --repo MasterDD-L34D/Game --json mergeStateStatus   # atteso: CLEAN (o BLOCKED solo per review, non per checks)
```

## Rollback

`git revert d9d2f94` -- si torna a GITHUB_TOKEN (PR di nuovo gated, come oggi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
