### PR TITLE
feat(ai): falsifica l'ipotesi-cap e misura il vero collo di bottiglia

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -132,6 +132,23 @@ function isIntentsRosterScalingEnabled() {
 // actions/round (4 units x 2 AP) and bounds the telegraph UI load.
 const INTENTS_ABS_CAP = 6;
 
+// FALSIFYING EXPERIMENT (owner-authorized 2026-07-10, flag default OFF).
+// The WR 1.0 ceiling of every N=40 ratify is attributed by the docs to the
+// AI-vs-AI driver. It is not: the cap above is an invariant that keeps Sistema
+// under the party's action budget, and it runs in the real game too (callers:
+// routes/session.js, routes/sessionRoundBridge.js). Flag ON = every alive
+// Sistema unit declares its intent (the per-unit AP ledger already exists,
+// session.js validates against actor.ap_remaining); the global cap no longer
+// gates emission. Flag OFF -> byte-identical, band-neutral.
+//
+// SCOPE (declared): ON emits 1 intent per unit, NOT 2 actions/unit like the
+// party. Half the gap -- the half measurable without touching multi-action
+// resolution. This is a probe, not a balance proposal: the telegraph UI load
+// (the cap's second, legitimate reason) is NOT addressed here.
+function isPerUnitActionsEnabled() {
+  return process.env.SISTEMA_PER_UNIT_ACTIONS_ENABLED === 'true';
+}
+
 // Divisor K: one intent per K alive Sistema units (activation ~1/K on big
 // rosters). Env-tunable for probe A/B; invalid values fall back to 3.
 const ROSTER_K_DEFAULT = 3;
@@ -311,6 +328,8 @@ function createDeclareSistemaIntents(deps) {
       session.pressure_tier_floor,
       aliveSistema,
     );
+    // Read at call-time (not module-load) so the probe can toggle per-run.
+    const perUnitActions = isPerUnitActionsEnabled();
 
     const intents = [];
     const decisions = [];
@@ -362,7 +381,7 @@ function createDeclareSistemaIntents(deps) {
       if (!actor) continue;
       if (actor.controlled_by !== 'sistema') continue;
       if (Number(actor.hp || 0) <= 0) continue;
-      if (intentsEmitted >= intentsCap) {
+      if (!perUnitActions && intentsEmitted >= intentsCap) {
         decisions.push({
           unit_id: actor.id,
           rule: 'PRESSURE_CAP',
@@ -669,6 +688,7 @@ module.exports = {
   computePersistentHighThreat,
   intentsCapForPressure,
   isIntentsRosterScalingEnabled,
+  isPerUnitActionsEnabled,
   INTENTS_ABS_CAP,
   detectHiddenAbilityReveals,
   DEFAULT_HIDDEN_ABILITY_THRESHOLD,

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -13902,6 +13902,19 @@
       "track": "active"
     },
     {
+      "path": "docs/research/2026-07-10-sistema-cap-falsification.md",
+      "title": "Falsificazione del cap-ipotesi: il ceiling WR 1.0 non e' il tetto di intent (e il Sistema non attacca mai)",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "combat",
+      "last_verified": "2026-07-10",
+      "source_of_truth": false,
+      "language": "it",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "active"
+    },
+    {
       "path": "docs/research/2026-07-10-grid-terrain-geometry-reprobe.md",
       "title": "Re-ratify N=40 substrate-ON -- 3 grid_sized sotto MOVE_TERRAIN_COST + XP_BUDGET_GEOMETRY (hazard_xp misurato 0)",
       "doc_status": "active",

--- a/docs/planning/2026-07-06-sistema-zone-defense-spec-draft.md
+++ b/docs/planning/2026-07-06-sistema-zone-defense-spec-draft.md
@@ -40,6 +40,33 @@ e' la CONVERSIONE delle attivazioni, non il loro numero -- le unita' extra si at
 avanzano closest-target, muoiono in approccio. Il prossimo lever e' COMPORTAMENTALE:
 un verbo di zona / intent-type differenziato per tier che trasformi l'attivazione in minaccia.
 
+> **AGGIORNAMENTO 2026-07-10 -- l'ipotesi-conversione e' ora MISURATA, non piu' ipotesi.**
+> Evidence: `docs/research/2026-07-10-sistema-cap-falsification.md`.
+>
+> 1. Terzo negative result convergente: rimuovere del tutto il cap (flag
+>    `SISTEMA_PER_UNIT_ACTIONS_ENABLED`, 3 -> 7 unita' attive a regime) lascia dWR **0.000**
+>    su 3/3 encounter, N=10 paired, wiring falsificato (6-8/10 seed divergenti).
+> 2. `tools/sim/intent-mix-probe.js` (18 fight) MISURA la conversione: il Sistema spende
+>    **~55% delle attivazioni in `retreat`** e ne converte in `attack` solo il **4.6%**
+>    (control); a cap rimosso gli attacchi **calano** (11 -> 6). Dorsale seed 1-2: ZERO
+>    attacchi in 15 round.
+> 3. Causa candidata (grep-verificata, non ancora A/B): 1 azione/unita' vs 2 AP del PG +
+>    gittata Sistema 1 vs `p_ranger`/`p_warden` a 2 + `SelfHealth` che premia `retreat`
+>    quando ferito (`utilityBrain.js`, peso 0.7). Il Sistema arriva ferito e scappa.
+>
+> **Conseguenza per questa spec**: il problema non e' il verbo MANCANTE (`defend_zone`) ma
+> il verbo SBAGLIATO (`retreat`) -- un `defend_zone` nuovo rischia di essere scartato dalla
+> stessa consideration che oggi scarta `attack`. Il doc raccomanda **retreat-gating prima
+> di defend_zone**: stesso costo, testa la causa misurata, e non viola l'invariante di
+> asimmetria (`ai_profiles.yaml` `sistema_resource_model.note`, che vieta di rispecchiare
+> le regole del player). I fork sez. 6 NON sono revocati: restano owner-gated.
+>
+> **Correzione recon (sez. 2.1)**: il cap non seleziona per merito. Il loop `:361` scorre
+> `session.units` in ordine di inserimento; le prime vive consumano il tetto e la coda
+> riceve `PRESSURE_CAP -> skip`. I rinforzi, accodati, sono **statue** finche' non muore un
+> membro della wave-1: la metrica `avg_reinforcements: 4.00 (a cap)` dei ratify N=40 misura
+> lo **spawner**, non l'attivita' dei rinforzi.
+
 **Corollario content**: la variante capture_point della dorsale e' pronta nel layout
 (grid-ratify, Gap dichiarati) ma resta ceiling finche' l'AI Sistema non difende una zona --
 il player-sim insegue le zone, il Sistema no (asimmetria misurabile, sez. 2).

--- a/docs/research/2026-07-10-sistema-cap-falsification.md
+++ b/docs/research/2026-07-10-sistema-cap-falsification.md
@@ -1,0 +1,204 @@
+---
+title: "Falsificazione del cap-ipotesi: il ceiling WR 1.0 non e' il tetto di intent (e il Sistema non attacca mai)"
+doc_status: active
+doc_owner: master-dd
+workstream: combat
+last_verified: '2026-07-10'
+source_of_truth: false
+language: it
+review_cycle_days: 90
+---
+
+# Falsificazione del cap-ipotesi -- e il finding vero: il Sistema non attacca
+
+Data: 2026-07-10 | Macchina: Ryzen (Node v24.11.0) | Base: origin/main `3bcf84df3`
+Esperimento autorizzato da Eduardo in sessione. Stato: **NEGATIVE RESULT** sull'ipotesi
+testata, **POSITIVE** su un finding non cercato. Zero flip, zero cambio di banda.
+
+## 1. L'ipotesi (di Eduardo, formalizzata)
+
+> "L'AI non gioca realmente: fa poche azioni rispetto ai player, e non ci sono azioni
+> per unita'."
+
+Formalizzata come ipotesi falsificabile: **il ceiling WR 1.000 di ogni ratify N=40 non e'
+un artefatto del driver AI-vs-AI, ma il cap globale di intent del Sistema.**
+
+L'ipotesi ha basi forti nel codice, non e' un sospetto:
+
+- `declareSistemaIntents.js` `PRESSURE_TIER_INTENT_CAP` = 1/2/3/3/4 intent **globali** per
+  round. I nostri ratify girano a pressure 50 (Escalated) -> **3 intent contro le 8 azioni
+  del party** (4 PG x 2 AP).
+- `INTENTS_ABS_CAP = 6`, commento sorgente: _"keeps Sistema below the party's 8
+  actions/round (4 units x 2 AP) and bounds the telegraph UI load"_. Il vincolo e'
+  deliberato e **circolare**: garantisce cio' che poi misuriamo.
+- Il ledger AP per-unita' **esiste gia'** anche per il Sistema (`session.js:2948` valida
+  contro `actor.ap_remaining`): il cap e' un coperchio sopra un'infrastruttura per-unita'.
+- Correzione a un errore dei doc precedenti: `declareSistemaIntents` e' chiamato da
+  `routes/session.js` e `routes/sessionRoundBridge.js` -- **e' il gioco reale**, non solo il
+  driver di simulazione. Chiamare quel ceiling "limite di modello del driver AI-vs-AI"
+  (doc dorsale 07-06, calibration 07-06, reprobe 07-10) e' impreciso: il cap vale anche
+  quando gioca un umano.
+
+## 2. Finding collaterale (recon, non nella spec-draft 07-06)
+
+Il cap non sceglie **chi** agisce per merito: il loop `:361` scorre `session.units`
+nell'ordine di inserimento, le prime unita' vive consumano il tetto, la coda riceve
+`PRESSURE_CAP -> skip`. Misurato su sessione sintetica a regime (wave-1 + 4 rinforzi):
+
+```
+cap tier Escalated(50) -> intents emessi: 3 / sistema vivi: 7
+  wave1_a  rule=REGOLA_001    intent=approach
+  wave1_b  rule=REGOLA_001    intent=approach
+  wave1_c  rule=REGOLA_001    intent=approach
+  reinf_1  rule=PRESSURE_CAP  intent=skip
+  reinf_2  rule=PRESSURE_CAP  intent=skip
+  reinf_3  rule=PRESSURE_CAP  intent=skip
+  reinf_4  rule=PRESSURE_CAP  intent=skip
+```
+
+**I rinforzi sono statue.** Spawnano, contano nella metrica `avg_reinforcements: 4.00
+(a cap)` dei ratify N=40, e restano fermi finche' non muore qualcuno della wave-1. La
+liveness misurata era quella dello **spawner**, mai quella dei rinforzi. La sez. 2.1 della
+spec-draft zone-defense dichiara verificato quel file ma non riporta l'ordinamento.
+
+## 3. L'esperimento (flag `SISTEMA_PER_UNIT_ACTIONS_ENABLED`, default OFF)
+
+Flag ON = ogni unita' Sistema viva dichiara il suo intent; il cap globale non gata piu'
+l'emissione. Flag OFF = byte-identical.
+
+**Scope dichiarato**: ON emette **1 intent per unita'**, NON 2 azioni/unita' come il party.
+E' meta' del divario -- la meta' misurabile senza toccare la risoluzione multi-azione.
+Il flag e' uno strumento di probe, **non una proposta di bilanciamento**: il telegraph UI
+load (la seconda ragione, legittima, del cap) non e' affrontato qui.
+
+Arm A/B N=10 paired, seed numerici 1..10, contro il control = i N=40 substrate-ON del
+reprobe (stessi seed, stesso harness `grid-band-probe.js`, flag prod terrain+geometry ON).
+
+### Falsificazione del wiring (prima dei risultati)
+
+Prerequisito metodologico: un "nessun effetto" da flag morto e' indistinguibile da un
+"nessun effetto" reale. Divergenza per-seed vs control:
+**dorsale 6/10, canyon 8/10, abisso 7/10**. Il flag morde.
+
+### Risultati
+
+| Encounter     | dWR       | dKO     | dPace (CI95)         | Criterio direction |
+| ------------- | --------- | ------- | -------------------- | ------------------ |
+| dorsale 16x12 | **0.000** | -0.0250 | +0.20 [-0.67, +1.07] | non soddisfatto    |
+| canyon 20x12  | **0.000** | +0.0000 | -1.30 [-3.85, +1.25] | non soddisfatto    |
+| abisso 18x10  | **0.000** | +0.0250 | -0.30 [-1.40, +0.80] | non soddisfatto    |
+
+Criterio (mirror `2026-07-06-intents-roster-scaling-ab.md`): dWR <= -0.2 | dKO >= +0.05 |
+pace fuori banda. **Nessun arm lo soddisfa.** WR 1.000 in tutti e 30 i run, 0 timeout.
+
+**L'ipotesi e' FALSIFICATA.** Il cap non e' la causa del ceiling. Piu' che raddoppiare le
+attivazioni (3 -> 7 a regime) lascia la win-rate del party a 1.000. Nessun N=40 (guardrail
+N-sample: niente direction da ratificare), nessun flip, baseline intatta.
+
+## 4. Il finding vero: la conversione e' ~0 (il Sistema non attacca)
+
+Strumento nuovo: `tools/sim/intent-mix-probe.js` (patch del module-cache di
+`declareSistemaIntents` prima del load di `app.js` -> conta le decisioni sul percorso
+REALE, nessun mock). 3 encounter x 3 seed x 2 arm = 18 fight.
+
+| Arm      | attack | approach | retreat | attivazioni | **attacchi** | vittorie party |
+| -------- | ------ | -------- | ------- | ----------- | ------------ | -------------- |
+| control  | 11     | 94       | 132     | 237         | **4.6%**     | 9/9            |
+| uncapped | 6      | 117      | 137     | 260         | **2.3%**     | 9/9            |
+
+Dorsale seed 1-2: **zero attacchi in 15 round**. Il Sistema spende ~55% delle attivazioni
+in **ritirate** e il resto in avvicinamenti.
+
+E il dato contro-intuitivo, che chiude il cerchio sui due negative result:
+**raddoppiando le attivazioni gli attacchi DIMINUISCONO** (11 -> 6). Piu' unita' attive =
+piu' unita' che avanzano scoperte = piu' danno subito = piu' ritirate.
+
+Questo e' esattamente il "limite di CONVERSIONE" ipotizzato dalla spec-draft 07-06
+(sez. 1, "le unita' extra si attivano, avanzano closest-target, muoiono in approccio"), ora
+**misurato** invece che ipotizzato -- e conferma indipendente del negative result
+roster-scaling #3231.
+
+### Causa candidata (meccanica, verificata a grep -- NON ancora testata A/B)
+
+Tre fatti che compongono un loop:
+
+1. **Il Sistema fa 1 azione per unita' per round; il PG ne fa 2** (2 AP). Il PG puo'
+   `muovi + attacca` nello stesso round; il Sistema fa `muovi` **oppure** `attacca`.
+2. **Asimmetria di gittata**: Sistema `attack_range: 1` (harness + authoring); il party
+   canonico ha 2 PG su 4 con `attack_range: 2` (`p_ranger`, `p_warden`). Chi ha gittata 2 e
+   2 AP colpisce e arretra; chi ha gittata 1 e 1 azione non chiude mai la distanza.
+3. **`SelfHealth` spinge la ritirata**: in `utilityBrain.js` la consideration vale
+   `1 - hp_ratio` per `retreat` (peso 0.7). Il Sistema ferito preferisce ritirarsi ->
+   non attacca -> viene inseguito e colpito -> si ritira ancora.
+
+Il Sistema non e' "tarato male": arriva ferito e scappa, e non e' mai adiacente-e-sano nel
+round in cui potrebbe colpire.
+
+## 5. Vincolo di design da rispettare (trovato durante il recon)
+
+`packs/evo_tactics_pack/data/balance/ai_profiles.yaml`:
+
+```yaml
+sistema_resource_model:
+  economy: 'intent_budget' # non "pt_pool"
+  ignores_trait_costs: true # intent non consuma PT/AP del PG model
+  note: 'Asymmetry invariant -- do NOT refactor to mirror player rules' # em-dash nel sorgente
+```
+
+L'economia asimmetrica del Sistema (budget di intent, non AP) e' un **invariante di design
+dichiarato**, con fonte (`reference_tactical_postmortems.md` sez. A.2): la fairness si risolve
+per outcome misurato, non per simmetria di regole. Dare 2 AP per unita' al Sistema
+**viola esplicitamente quella nota**.
+
+Questo esperimento l'ha violato temporaneamente **dietro flag OFF** e solo in parte (piu'
+intent, non AP), con l'unico scopo di falsificare. Risultato: la violazione non produce
+nemmeno il beneficio sperato. **L'invariante non e' cio' che tiene basso il Sistema.**
+
+## 6. Cosa NON e' stato fatto (e perche')
+
+- **Nessun flip**: il flag resta OFF, in prod nulla cambia.
+- **Nessun N=40**: il criterio direction non e' soddisfatto -> niente da ratificare.
+- **Nessun 2-AP-per-unita'**: viola l'invariante sez. 5 -> decisione owner, non implementativa.
+- **Nessun tocco a `SelfHealth`/retreat**: e' il candidato piu' promettente ma e' un
+  cambio di bilanciamento sul brain, SDMG -> serve fork espliciti + falsificazione esterna.
+
+## 7. Gate eseguiti
+
+- `node --test tests/ai/sistemaPerUnitActions.test.js` **5/5** (nuovi; TDD: RED prima,
+  3 fail su `isPerUnitActionsEnabled is not a function`).
+- `node --test tests/ai/*.test.js` **589/589** (584 pre-esistenti + 5 nuovi), flag unset
+  -> ramo OFF band-neutral provato dalla suite intera.
+- `node --check tools/sim/intent-mix-probe.js` OK; il tool promosso riproduce
+  byte-identico il conteggio dello scratch (dorsale seed 1: attack=0 approach=11
+  retreat=15 capped=7).
+
+## 8. Artifacts
+
+- `reports/sim/{dorsale-ferrosa,canyon-lungo,abisso-colata}-n10-perunit-on/` (arm uncapped)
+- Control paired: `reports/sim/*-n40-terrain-on/` (reprobe 07-10, invariati)
+- `Extras/ollama-runs/2026-07-10-sistema-per-unit-actions-probe.log` (batch A/B)
+- `Extras/ollama-runs/2026-07-10-intent-mix.jsonl` (18 fight, composizione intent)
+
+## 9. Rollback
+
+Revert del commit (flag + test + tool + doc = unita' atomica). Il flag e' default OFF e
+non e' referenziato da nessun encounter, workflow o config: rimuoverlo non tocca prod.
+
+## 10. Prossimo passo (owner-gated, NON deciso qui)
+
+L'ipotesi "poche azioni" e' falsificata nella sua forma "poche **unita' attive**". Resta
+aperta nella forma "poche **azioni per unita'**" (1 vs 2 AP), che pero' e' esattamente cio'
+che l'invariante sez. 5 vieta. Tre strade, decider Eduardo:
+
+- **(a) retreat-gating**: il candidato indicato dalla misura (55% ritirate, 4.6% attacchi).
+  Non viola l'invariante (non tocca l'economia, tocca la policy). A/B su
+  `SelfHealth`/retreat con lo stesso harness. Piu' economico e piu' mirato di `defend_zone`.
+- **(b) `defend_zone`** (spec-draft 07-06, fork gia' ratificati A/B/C+D): un verbo nuovo.
+  La misura di questo doc dice che il problema non e' il verbo mancante ma il verbo
+  sbagliato (retreat) -- `defend_zone` potrebbe non essere scelto piu' di quanto lo sia
+  `attack` oggi, per la stessa consideration.
+- **(c) 2 AP per unita'**: richiede di ratificare la rottura dell'invariante sez. 5, con
+  costo telegraph. Da NON fare senza ADR.
+
+Raccomandazione: **(a) prima di (b)**. Costo simile, ma (a) testa la causa misurata, mentre
+(b) costruisce un verbo che la stessa policy potrebbe scartare.

--- a/reports/sim/abisso-colata-n10-perunit-on/runs.jsonl
+++ b/reports/sim/abisso-colata-n10-perunit-on/runs.jsonl
@@ -1,0 +1,10 @@
+{"seed":1,"outcome":"victory","rounds":13,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":2,"outcome":"victory","rounds":15,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":3,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":4,"outcome":"victory","rounds":15,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":5,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":6,"outcome":"victory","rounds":11,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":7,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":8,"outcome":"victory","rounds":11,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":9,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":10,"outcome":"victory","rounds":16,"kos":0,"rosterN":4,"reinforcements":4}

--- a/reports/sim/abisso-colata-n10-perunit-on/summary.json
+++ b/reports/sim/abisso-colata-n10-perunit-on/summary.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "enc_abisso_colata_basaltica_01",
+  "grid": "18x10 (board_scale=grid_sized)",
+  "party_source": "enc_badlands_pilot_01",
+  "pressure_start": 50,
+  "scaling": {
+    "hpAdd": 0,
+    "modAdd": 0,
+    "dcAdd": 0,
+    "countMult": 1,
+    "rangeAdd": 0
+  },
+  "objective": "elimination",
+  "band_semantics": "completion+pace+liveness (L-069)",
+  "wiring_proof": {
+    "grid_width": 18,
+    "grid_height": 10,
+    "terrain_features": 26,
+    "combat_los_enabled_env": "(unset -> default ON #3226)"
+  },
+  "N": 10,
+  "wins": 10,
+  "defeats": 0,
+  "timeouts": 0,
+  "win_rate": 1,
+  "wr_ci95_wilson": [
+    0.722,
+    1
+  ],
+  "creature_ko_rate": 0.025,
+  "avg_rounds": 13.7,
+  "rounds_sd": 1.64,
+  "rounds_min": 11,
+  "rounds_max": 16,
+  "avg_reinforcements": 4,
+  "node": "v24.11.0"
+}

--- a/reports/sim/canyon-lungo-n10-perunit-on/runs.jsonl
+++ b/reports/sim/canyon-lungo-n10-perunit-on/runs.jsonl
@@ -1,0 +1,10 @@
+{"seed":1,"outcome":"victory","rounds":17,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":2,"outcome":"victory","rounds":17,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":3,"outcome":"victory","rounds":22,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":4,"outcome":"victory","rounds":11,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":5,"outcome":"victory","rounds":19,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":6,"outcome":"victory","rounds":18,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":7,"outcome":"victory","rounds":17,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":8,"outcome":"victory","rounds":19,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":9,"outcome":"victory","rounds":19,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":10,"outcome":"victory","rounds":11,"kos":0,"rosterN":4,"reinforcements":4}

--- a/reports/sim/canyon-lungo-n10-perunit-on/summary.json
+++ b/reports/sim/canyon-lungo-n10-perunit-on/summary.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "enc_badlands_canyon_lungo_01",
+  "grid": "20x12 (board_scale=grid_sized)",
+  "party_source": "enc_badlands_pilot_01",
+  "pressure_start": 50,
+  "scaling": {
+    "hpAdd": 0,
+    "modAdd": 0,
+    "dcAdd": 0,
+    "countMult": 1,
+    "rangeAdd": 0
+  },
+  "objective": "elimination",
+  "band_semantics": "completion+pace+liveness (L-069)",
+  "wiring_proof": {
+    "grid_width": 20,
+    "grid_height": 12,
+    "terrain_features": 34,
+    "combat_los_enabled_env": "(unset -> default ON #3226)"
+  },
+  "N": 10,
+  "wins": 10,
+  "defeats": 0,
+  "timeouts": 0,
+  "win_rate": 1,
+  "wr_ci95_wilson": [
+    0.722,
+    1
+  ],
+  "creature_ko_rate": 0,
+  "avg_rounds": 17,
+  "rounds_sd": 3.5,
+  "rounds_min": 11,
+  "rounds_max": 22,
+  "avg_reinforcements": 4,
+  "node": "v24.11.0"
+}

--- a/reports/sim/dorsale-ferrosa-n10-perunit-on/runs.jsonl
+++ b/reports/sim/dorsale-ferrosa-n10-perunit-on/runs.jsonl
@@ -1,0 +1,10 @@
+{"seed":1,"outcome":"victory","rounds":13,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":2,"outcome":"victory","rounds":16,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":3,"outcome":"victory","rounds":15,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":4,"outcome":"victory","rounds":12,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":5,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":6,"outcome":"victory","rounds":17,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":7,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":8,"outcome":"victory","rounds":12,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":9,"outcome":"victory","rounds":15,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":10,"outcome":"victory","rounds":15,"kos":0,"rosterN":4,"reinforcements":4}

--- a/reports/sim/dorsale-ferrosa-n10-perunit-on/summary.json
+++ b/reports/sim/dorsale-ferrosa-n10-perunit-on/summary.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "enc_badlands_dorsale_ferrosa_01",
+  "grid": "16x12 (board_scale=grid_sized)",
+  "party_source": "enc_badlands_pilot_01",
+  "pressure_start": 50,
+  "scaling": {
+    "hpAdd": 0,
+    "modAdd": 0,
+    "dcAdd": 0,
+    "countMult": 1,
+    "rangeAdd": 0
+  },
+  "objective": "elimination",
+  "band_semantics": "completion+pace+liveness (L-069)",
+  "wiring_proof": {
+    "grid_width": 16,
+    "grid_height": 12,
+    "terrain_features": 36,
+    "combat_los_enabled_env": "(unset -> default ON #3226)"
+  },
+  "N": 10,
+  "wins": 10,
+  "defeats": 0,
+  "timeouts": 0,
+  "win_rate": 1,
+  "wr_ci95_wilson": [
+    0.722,
+    1
+  ],
+  "creature_ko_rate": 0,
+  "avg_rounds": 14.3,
+  "rounds_sd": 1.64,
+  "rounds_min": 12,
+  "rounds_max": 17,
+  "avg_reinforcements": 4,
+  "node": "v24.11.0"
+}

--- a/tests/ai/sistemaPerUnitActions.test.js
+++ b/tests/ai/sistemaPerUnitActions.test.js
@@ -1,0 +1,176 @@
+// tests/ai/sistemaPerUnitActions.test.js -- falsifying experiment (OD-062 probe).
+//
+// Ipotesi sotto test (owner 2026-07-10): il ceiling WR 1.0 dei ratify N=40 NON e' un
+// artefatto del driver AI-vs-AI ma il cap globale di intent del Sistema, che per
+// costruzione tiene il Sistema sotto le 8 azioni/round del party
+// (declareSistemaIntents.js INTENTS_ABS_CAP: "keeps Sistema below the party's 8").
+//
+// Flag SISTEMA_PER_UNIT_ACTIONS_ENABLED (default OFF): ON -> ogni unita' Sistema viva
+// dichiara il suo intent (1/unita', mirror dell'AP ledger che gia' esiste per-unita'),
+// il cap globale non gata piu' l'emissione. OFF -> byte-identical al pre-flag.
+//
+// NOTA DI SCOPE (dichiarata): ON = 1 intent per unita', NON 2 azioni/unita' come il
+// party (4 PG x 2 AP). E' meta' del divario -- la meta' testabile senza toccare la
+// risoluzione multi-azione. Il flag e' un probe, non una proposta di bilanciamento.
+//
+// Il flag e' letto a call-time (non a module-load) -> toggle per-test senza re-require.
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createDeclareSistemaIntents,
+  isPerUnitActionsEnabled,
+} = require('../../apps/backend/services/ai/declareSistemaIntents');
+const { pickLowestHpEnemy, stepTowards } = require('../../apps/backend/routes/sessionHelpers');
+
+const FLAG = 'SISTEMA_PER_UNIT_ACTIONS_ENABLED';
+
+function withFlag(value, fn) {
+  const prev = process.env[FLAG];
+  if (value === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  }
+}
+
+const manhattanDistance = (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+
+function declareFor(session) {
+  const declare = createDeclareSistemaIntents({
+    pickLowestHpEnemy,
+    stepTowards,
+    manhattanDistance,
+    gridSize: 16,
+  });
+  return declare(session);
+}
+
+const sis = (id, x, y) => ({
+  id,
+  controlled_by: 'sistema',
+  hp: 10,
+  max_hp: 10,
+  ap: 2,
+  ap_max: 2,
+  mod: 2,
+  dc: 12,
+  attack_range: 1,
+  initiative: 10,
+  position: { x, y },
+  status: {},
+  ai_profile: 'aggressive',
+  damage: { min: 1, max: 3 },
+});
+
+const pg = (id, x, y) => ({
+  id,
+  controlled_by: 'player',
+  hp: 12,
+  max_hp: 12,
+  ap: 2,
+  ap_max: 2,
+  mod: 2,
+  dc: 12,
+  attack_range: 1,
+  initiative: 12,
+  position: { x, y },
+  status: {},
+});
+
+// Scenario = i 3 grid_sized a regime: wave-1 (3 unita') + 4 rinforzi appesi in coda,
+// come li accoda il runtime. pressure 50 = Escalated -> cap tier 3.
+function sessionAtRegime() {
+  return {
+    units: [
+      sis('wave1_a', 12, 4),
+      sis('wave1_b', 12, 5),
+      sis('wave1_c', 12, 6),
+      sis('reinf_1', 14, 3),
+      sis('reinf_2', 14, 4),
+      sis('reinf_3', 14, 7),
+      sis('reinf_4', 14, 8),
+      pg('p1', 2, 4),
+      pg('p2', 2, 5),
+      pg('p3', 3, 4),
+      pg('p4', 3, 5),
+    ],
+    grid: { width: 16, height: 12 },
+    sistema_pressure: 50,
+  };
+}
+
+test('isPerUnitActionsEnabled: default OFF, solo "true" abilita', () => {
+  withFlag(undefined, () => assert.equal(isPerUnitActionsEnabled(), false));
+  withFlag('true', () => assert.equal(isPerUnitActionsEnabled(), true));
+  withFlag('1', () => assert.equal(isPerUnitActionsEnabled(), false));
+  withFlag('false', () => assert.equal(isPerUnitActionsEnabled(), false));
+});
+
+test('flag OFF: il cap globale morde -- i rinforzi in coda sono statue', () => {
+  withFlag(undefined, () => {
+    const { intents, decisions } = declareFor(sessionAtRegime());
+    assert.equal(intents.length, 3, 'cap tier Escalated = 3 intent su 7 sistema vivi');
+    const capped = decisions.filter((d) => d.rule === 'PRESSURE_CAP').map((d) => d.unit_id);
+    assert.deepEqual(
+      capped,
+      ['reinf_1', 'reinf_2', 'reinf_3', 'reinf_4'],
+      'lo skip segue l ordine di session.units: le prime vive agiscono, la coda no',
+    );
+  });
+});
+
+test('flag ON: ogni unita Sistema viva dichiara, zero PRESSURE_CAP', () => {
+  withFlag('true', () => {
+    const { intents, decisions } = declareFor(sessionAtRegime());
+    assert.equal(intents.length, 7, '7 sistema vivi -> 7 intent (1 per unita)');
+    assert.equal(
+      decisions.filter((d) => d.rule === 'PRESSURE_CAP').length,
+      0,
+      'nessuna unita skippata dal cap',
+    );
+  });
+});
+
+test('flag ON: i morti restano esclusi (il flag toglie il cap, non la selezione vivi)', () => {
+  withFlag('true', () => {
+    const session = sessionAtRegime();
+    session.units[0].hp = 0; // wave1_a morto
+    const { intents } = declareFor(session);
+    assert.equal(intents.length, 6, '6 sistema vivi su 7');
+    assert.ok(
+      !intents.some((i) => i.unit_id === 'wave1_a'),
+      'un morto non dichiara nemmeno a flag ON',
+    );
+  });
+});
+
+test('flag OFF: roster piccolo (<= cap) identico a flag ON -- back-compat band-neutral', () => {
+  const small = () => ({
+    units: [
+      sis('w1', 12, 4),
+      sis('w2', 12, 5),
+      sis('w3', 12, 6),
+      pg('p1', 2, 4),
+      pg('p2', 2, 5),
+      pg('p3', 3, 4),
+      pg('p4', 3, 5),
+    ],
+    grid: { width: 16, height: 12 },
+    sistema_pressure: 50,
+  });
+  const off = withFlag(undefined, () => declareFor(small()));
+  const on = withFlag('true', () => declareFor(small()));
+  assert.equal(off.intents.length, 3);
+  assert.deepEqual(
+    on.intents,
+    off.intents,
+    'wave-1 (3 unita) == cap 3 -> il flag non cambia nulla: la divergenza nasce coi rinforzi',
+  );
+});

--- a/tools/sim/intent-mix-probe.js
+++ b/tools/sim/intent-mix-probe.js
@@ -1,0 +1,190 @@
+'use strict';
+// Intent-mix probe: conta la COMPOSIZIONE delle decisioni Sistema in un fight reale
+// (attack / approach / retreat / skip-da-cap), per arm di flag.
+//
+// Perche' esiste: le bande N=40 misurano completion/pace/liveness ma NON dicono cosa
+// il Sistema STA FACENDO. Due negative result (roster-scaling #3231, per-unit-actions
+// 2026-07-10) hanno mostrato che aumentare le ATTIVAZIONI non muove la win-rate: serviva
+// uno strumento che guardasse dentro il round. Evidence:
+// docs/research/2026-07-10-sistema-cap-falsification.md
+//
+// Metodo: patch del module-cache di declareSistemaIntents PRIMA che app.js lo richieda,
+// cosi' il conteggio e' sul percorso di decisione REALE (nessun mock, nessun fork della
+// logica). Il probe non muta la sessione e non cambia l'esito.
+//
+// Uso:
+//   node tools/sim/intent-mix-probe.js --encounter <enc_id> [--seed 1] [--pressure 50]
+//   SISTEMA_PER_UNIT_ACTIONS_ENABLED=true node tools/sim/intent-mix-probe.js --encounter <id>
+// Output: una riga JSON (jsonl-friendly per batch).
+
+const path = require('node:path');
+const fs = require('node:fs');
+
+const DECL = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'apps',
+  'backend',
+  'services',
+  'ai',
+  'declareSistemaIntents',
+);
+const declMod = require(DECL);
+const origFactory = declMod.createDeclareSistemaIntents;
+
+const tally = { attack: 0, approach: 0, retreat: 0, skip: 0, other: 0, rounds: 0, capped: 0 };
+declMod.createDeclareSistemaIntents = function instrumented(deps) {
+  const inner = origFactory(deps);
+  return function declareAndCount(session) {
+    const r = inner(session);
+    tally.rounds += 1;
+    for (const d of r.decisions || []) {
+      if (d.rule === 'PRESSURE_CAP') tally.capped += 1;
+      const k = String(d.intent || 'other');
+      if (Object.prototype.hasOwnProperty.call(tally, k)) tally[k] += 1;
+      else tally.other += 1;
+    }
+    return r;
+  };
+};
+
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+process.env.IDEA_ENGINE_STUB_ORCHESTRATOR = '1';
+
+const yaml = require('js-yaml');
+const request = require('supertest');
+const { createApp } = require('../../apps/backend/app');
+const { runEncounter } = require('./combat-adapter');
+
+const ENCOUNTER_DIR = path.resolve(__dirname, '..', '..', 'docs', 'planning', 'encounters');
+const TIER_HP = { base: 7, elite: 10, apex: 14 };
+const TIER_MOD = { base: 1, elite: 2, apex: 4 };
+const TIER_DC = { base: 11, elite: 12, apex: 14 };
+
+function parseArgs(argv) {
+  const args = { encounter: null, seed: 1, pressure: 50, partyScenario: 'enc_badlands_pilot_01' };
+  for (let i = 2; i < argv.length; i += 1) {
+    const tok = argv[i];
+    const next = () => argv[(i += 1)];
+    if (tok === '--encounter') args.encounter = next();
+    else if (tok === '--seed') args.seed = Number(next());
+    else if (tok === '--pressure') args.pressure = Number(next());
+    else if (tok === '--party-scenario') args.partyScenario = next();
+    else if (tok.startsWith('--')) console.warn(`unknown arg: ${tok}`);
+  }
+  if (!args.encounter) {
+    console.error('usage: node tools/sim/intent-mix-probe.js --encounter <enc_id> [--seed N]');
+    process.exit(2);
+  }
+  return args;
+}
+
+// Mirror di grid-band-probe.js (stessa tier table -> numeri comparabili).
+function enemiesFromYaml(enc) {
+  const wave1 = [...enc.waves].sort((a, b) => (a.turn_trigger || 0) - (b.turn_trigger || 0))[0];
+  const sp = wave1.spawn_points;
+  const out = [];
+  let i = 0;
+  for (const def of wave1.units) {
+    for (let k = 0; k < (def.count || 1); k += 1) {
+      const tier = def.tier || 'base';
+      const pos = sp[i % sp.length];
+      i += 1;
+      out.push({
+        id: `sis_${i}`,
+        species: def.species,
+        species_id: def.species,
+        hp: TIER_HP[tier],
+        max_hp: TIER_HP[tier],
+        ap: 2,
+        ap_max: 2,
+        mod: TIER_MOD[tier],
+        dc: TIER_DC[tier],
+        attack_range: 1,
+        damage: { min: 1, max: 3 },
+        initiative: 10,
+        position: { x: pos[0], y: pos[1] },
+        ai_profile: def.ai_profile,
+        controlled_by: 'sistema',
+        status: {},
+      });
+    }
+  }
+  return out;
+}
+
+async function fetchParty(partyScenario, playerSpawn) {
+  const { app, close } = createApp({ databasePath: null });
+  try {
+    const r = await request(app).get(`/api/tutorial/${partyScenario}`);
+    if (r.status !== 200) throw new Error(`canon party fetch ${r.status}`);
+    return (r.body.units || [])
+      .filter((u) => u.controlled_by === 'player')
+      .map((u, i) => {
+        const spawn = playerSpawn[i % playerSpawn.length];
+        return { ...u, hp: u.max_hp ?? u.hp, status: {}, position: { x: spawn[0], y: spawn[1] } };
+      });
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const enc = yaml.load(
+    fs.readFileSync(path.join(ENCOUNTER_DIR, `${args.encounter}.yaml`), 'utf8'),
+  );
+  const party = await fetchParty(args.partyScenario, enc.player_spawn);
+
+  const { app, close } = createApp({ databasePath: null });
+  let res;
+  try {
+    const http = {
+      post: (p, b) =>
+        request(app)
+          .post(p)
+          .send(b)
+          .then((r) => ({ status: r.status, body: r.body })),
+      get: (p, q) =>
+        request(app)
+          .get(p)
+          .query(q || {})
+          .then((r) => ({ status: r.status, body: r.body })),
+    };
+    res = await runEncounter(http, {
+      roster: party,
+      enemies: enemiesFromYaml(enc),
+      scenarioId: enc.encounter_id,
+      seed: args.seed,
+      maxRounds: 40,
+      pressureStart: args.pressure,
+      allPlayersActPerRound: true,
+      endSession: true,
+    });
+  } finally {
+    if (typeof close === 'function') await close().catch(() => {});
+  }
+
+  const acted = tally.attack + tally.approach + tally.retreat;
+  console.log(
+    JSON.stringify({
+      arm: process.env.SISTEMA_PER_UNIT_ACTIONS_ENABLED === 'true' ? 'uncapped' : 'control',
+      encounter: args.encounter,
+      seed: args.seed,
+      outcome: res.outcome,
+      rounds: res.rounds,
+      attack: tally.attack,
+      approach: tally.approach,
+      retreat: tally.retreat,
+      capped: tally.capped,
+      acted,
+      attack_pct: acted ? Number(((100 * tally.attack) / acted).toFixed(1)) : 0,
+    }),
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tools/sim/intent-mix-probe.js
+++ b/tools/sim/intent-mix-probe.js
@@ -15,7 +15,20 @@
 // Uso:
 //   node tools/sim/intent-mix-probe.js --encounter <enc_id> [--seed 1] [--pressure 50]
 //   SISTEMA_PER_UNIT_ACTIONS_ENABLED=true node tools/sim/intent-mix-probe.js --encounter <id>
-// Output: una riga JSON (jsonl-friendly per batch).
+// Output: stdout = SOLO una riga JSON (jsonl-friendly: `... >> runs.jsonl` e' safe).
+//
+// stdout JSON-only (Codex P2 su PR #3246): i moduli del backend loggano su console.log
+// al require-time ([prisma], [jobs], [trait-effects], [xpBudget audit], ...). Se stdout
+// li raccoglie, il .jsonl del batch nasce corrotto. Rimappiamo console.* su stderr PRIMA
+// di qualunque require del backend: la diagnostica resta visibile (e redirigibile con
+// 2>), stdout resta un canale dati puro. Il risultato finale va su process.stdout.write.
+for (const level of ['log', 'info', 'debug']) {
+  const orig = console[level].bind(console);
+  console[level] = (...a) => {
+    if (process.env.INTENT_MIX_KEEP_STDOUT === 'true') return orig(...a);
+    process.stderr.write(a.map(String).join(' ') + '\n');
+  };
+}
 
 const path = require('node:path');
 const fs = require('node:fs');
@@ -167,7 +180,8 @@ async function main() {
   }
 
   const acted = tally.attack + tally.approach + tally.retreat;
-  console.log(
+  // process.stdout.write, non console.log: quest'ultimo e' rimappato su stderr sopra.
+  process.stdout.write(
     JSON.stringify({
       arm: process.env.SISTEMA_PER_UNIT_ACTIONS_ENABLED === 'true' ? 'uncapped' : 'control',
       encounter: args.encounter,
@@ -180,7 +194,7 @@ async function main() {
       capped: tally.capped,
       acted,
       attack_pct: acted ? Number(((100 * tally.attack) / acted).toFixed(1)) : 0,
-    }),
+    }) + '\n',
   );
 }
 


### PR DESCRIPTION
## Esperimento falsificante (autorizzato da Eduardo in sessione)

**Ipotesi testata**, formalizzata dalla sua intuizione ("l'AI non gioca realmente, fa poche azioni rispetto ai player"):

> Il ceiling WR 1.000 di ogni ratify N=40 non e' un artefatto del driver AI-vs-AI, ma il **cap globale di intent** del Sistema.

Basi solide nel codice, non un sospetto: `PRESSURE_TIER_INTENT_CAP` = 3 intent globali a Escalated contro 8 azioni del party; `INTENTS_ABS_CAP` ha il commento _"keeps Sistema below the party's 8 actions/round"_ (vincolo deliberato **e circolare**); il ledger AP per-unita' esiste gia' anche per il Sistema. **Correzione ai doc precedenti**: `declareSistemaIntents` e' chiamato da `session.js` + `sessionRoundBridge.js` -- e' il **gioco reale**, non solo la sim. Chiamare quel ceiling "limite di modello del driver" era impreciso.

## Risultato: ipotesi FALSIFICATA

Flag `SISTEMA_PER_UNIT_ACTIONS_ENABLED` (default OFF): ogni unita' viva dichiara, il cap non gata piu' l'emissione. A/B N=10 paired vs i control N=40 substrate-ON, stessi seed.

**Falsificazione del wiring prima dei risultati** (un null da flag morto e' indistinguibile da un null reale): divergenza per-seed **6/10, 8/10, 7/10**. Il flag morde.

| Encounter | dWR | dKO | dPace (CI95) | direction |
|---|---|---|---|---|
| dorsale | **0.000** | -0.0250 | +0.20 [-0.67, +1.07] | non soddisfatto |
| canyon | **0.000** | +0.0000 | -1.30 [-3.85, +1.25] | non soddisfatto |
| abisso | **0.000** | +0.0250 | -0.30 [-1.40, +0.80] | non soddisfatto |

Passare da 3 a 7 unita' attive lascia la vittoria del party a **1.000, 30/30**. Nessun N=40 (niente direction da ratificare), nessun flip, baseline intatta.

## Il finding vero: la conversione e' ~0

Strumento nuovo `tools/sim/intent-mix-probe.js` (patch del module-cache -> conta le decisioni sul percorso REALE). 18 fight:

| Arm | attack | approach | retreat | **attacchi** | vittorie party |
|---|---|---|---|---|---|
| control | 11 | 94 | 132 | **4.6%** | 9/9 |
| uncapped | 6 | 117 | 137 | **2.3%** | 9/9 |

**Dorsale seed 1-2: ZERO attacchi in 15 round.** Il Sistema spende ~55% delle attivazioni in **ritirate**. E raddoppiando le attivazioni gli attacchi **calano** (11 -> 6): piu' unita' avanzano scoperte, prendono danno, si ritirano. Questo chiude il cerchio sui due negative result precedenti (roster-scaling #3231 + questo) e **misura** l'ipotesi-conversione che la spec-draft 07-06 aveva solo supposto.

**Causa candidata** (grep-verificata, NON ancora A/B): 1 azione/unita' vs 2 AP del PG + gittata Sistema 1 vs `p_ranger`/`p_warden` a 2 + `SelfHealth` che premia `retreat` quando ferito (peso 0.7). Il Sistema arriva ferito e scappa.

## Finding collaterale: i rinforzi sono statue

Il cap non sceglie **chi** agisce per merito: il loop scorre `session.units` in ordine d'array, le prime vive consumano il tetto, la coda riceve `PRESSURE_CAP -> skip`. I rinforzi, accodati, restano fermi finche' non muore un membro della wave-1. La metrica `avg_reinforcements: 4.00 (a cap)` dei ratify N=40 misurava lo **spawner**, non i rinforzi. La sez. 2.1 della spec-draft dichiarava quel file verificato ma non riportava l'ordinamento: corretta in questa PR.

## Vincolo di design rispettato

`ai_profiles.yaml` -> `sistema_resource_model.note: "Asymmetry invariant -- do NOT refactor to mirror player rules"`. L'economia asimmetrica e' **dichiarata**. Il flag la viola solo dietro OFF e solo per falsificare -- e la violazione **non compra niente**, quindi l'invariante non e' cio' che tiene basso il Sistema.

## Gate

- `node --test tests/ai/sistemaPerUnitActions.test.js` **5/5** (TDD: RED prima, 3 fail su `isPerUnitActionsEnabled is not a function`)
- `node --test tests/ai/*.test.js` **589/589** con flag unset -> ramo OFF band-neutral provato dalla suite intera
- Tool promosso riproduce byte-identico lo scratch (dorsale seed 1: attack=0 approach=11 retreat=15 capped=7)
- ASCII-clean, registry JSON valido

## Rollback

Revert del commit. Flag default OFF, non referenziato da alcun encounter/workflow/config: rimuoverlo non tocca prod.

## Prossimo passo (owner-gated, NON deciso qui)

Raccomandazione: **retreat-gating prima di `defend_zone`**. Stesso costo, testa la causa misurata, non viola l'invariante di asimmetria. `defend_zone` rischia di essere scartato dalla stessa consideration che oggi scarta `attack`. Terza strada (2 AP per unita') richiede un ADR: rompe l'invariante.

Evidence completa: `docs/research/2026-07-10-sistema-cap-falsification.md`

**Merge = Eduardo.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)