### PR TITLE
feat(i18n): wire traits namespace + first curated trait bundle (13 traits)

### DIFF
--- a/apps/play/src/i18n.js
+++ b/apps/play/src/i18n.js
@@ -10,15 +10,34 @@
 // =============================================================================
 
 import { createT } from './i18nCore.js';
-// data/i18n = sorgente unica (ADR-2026-06-08 QA3). Oggi solo `common.json`
-// (10 namespace dentro); lo split per-namespace = PR-5.
+// data/i18n = sorgente unica (ADR-2026-06-08 QA3). `common.json` (10 namespace dentro)
+// + `traits.json` (namespace `traits`, chiavi `traits.<id>.<campo>` = i platform placeholder
+// `i18n:traits.<id>.<campo>` dei file in data/traits/); lo split del resto = PR-5.
 // Import attributes (`with { type: 'json' }`) -- required by node ESM (test runner)
 // and supported by Vite 8; without them node dynamic-import of any module importing
 // this file throws ERR_IMPORT_ATTRIBUTE_MISSING (breaks the migrated modules' tests).
 import itCommon from '../../../data/i18n/it/common.json' with { type: 'json' };
 import enCommon from '../../../data/i18n/en/common.json' with { type: 'json' };
+import itTraits from '../../../data/i18n/it/traits.json' with { type: 'json' };
+import enTraits from '../../../data/i18n/en/traits.json' with { type: 'json' };
 
-const MESSAGES = { it: itCommon, en: enCommon };
+// Merge per-namespace: `_meta` di ogni bundle resta fuori (non e' una chiave traducibile,
+// e un merge shallow lascerebbe vincere l'ultimo importato).
+function mergeBundles(...bundles) {
+  const out = {};
+  for (const bundle of bundles) {
+    for (const [namespace, value] of Object.entries(bundle)) {
+      if (namespace.startsWith('_')) continue;
+      out[namespace] = value;
+    }
+  }
+  return out;
+}
+
+const MESSAGES = {
+  it: mergeBundles(itCommon, itTraits),
+  en: mergeBundles(enCommon, enTraits),
+};
 
 const DEFAULT_LOCALE = (typeof window !== 'undefined' && window.__EVO_LOCALE__) || 'it';
 

--- a/apps/play/src/onboardingPanel.js
+++ b/apps/play/src/onboardingPanel.js
@@ -19,7 +19,21 @@ import { t } from './i18n.js';
 //
 // Auto-select on timeout: default_choice_on_timeout (option_a canonical).
 
-'use strict';
+('use strict');
+
+/**
+ * Riga del tratto su una card di onboarding.
+ * Degrada in due passi: senza label curata resta la vecchia riga `Trait: <id>`;
+ * con la label ma senza effetto, mostra solo il nome. t() ritorna la chiave se assente.
+ */
+export function traitLineFor(traitId, locale) {
+  const labelKey = `traits.${traitId}.label`;
+  const effectKey = `traits.${traitId}.uso_funzione`;
+  const label = t(labelKey, null, locale);
+  if (label === labelKey) return t('onboarding.trait_label', { trait_id: traitId }, locale);
+  const effect = t(effectKey, null, locale);
+  return effect === effectKey ? label : `${label} -- ${effect}`;
+}
 
 function el(tag, attrs = {}, children = []) {
   const node = document.createElement(tag);
@@ -105,7 +119,7 @@ export async function openOnboardingPanel({ onboarding, onPick } = {}) {
       card.appendChild(el('h3', { class: 'onboarding-card-label' }, [choice.label]));
       card.appendChild(el('p', { class: 'onboarding-card-narrative' }, [`"${choice.narrative}"`]));
       card.appendChild(
-        el('small', { class: 'onboarding-card-trait' }, [t('onboarding.trait_label', { trait_id: choice.trait_id })]),
+        el('small', { class: 'onboarding-card-trait' }, [traitLineFor(choice.trait_id)]),
       );
       card.addEventListener('click', () => {
         Array.from(cardGrid.children).forEach((c) => c.classList.remove('selected'));

--- a/data/i18n/en/traits.json
+++ b/data/i18n/en/traits.json
@@ -5,29 +5,64 @@
     "direction": "ltr",
     "version": 1,
     "updated": "2026-07-10",
-    "completion_percent": 4
+    "completion_percent": 12
   },
   "traits": {
     "aculei_velenosi": {
       "label": "Venomous Spines",
       "mutazione_indotta": "Dorsal bristles have turned hollow, grafted onto sacs that distil hemolytic toxins.",
-      "spinta_selettiva": "Against predators too large to repel, only making the bite costly remained.",
-      "uso_funzione": "Melee attackers wound themselves on the spines and bleed at length.",
-      "debolezza": "It guards against nothing that strikes from afar: the punishment needs contact."
+      "spinta_selettiva": "One bite was not enough: the wound had to keep killing after the contact.",
+      "uso_funzione": "Every melee hit applies 3 turns of bleeding through vascular breakdown.",
+      "debolezza": "The toxins must get in: against thick armour the spines draw no blood."
+    },
+    "adattamento_volo": {
+      "label": "Gliding Adaptation",
+      "mutazione_indotta": "Skin folds stretch between the limbs, turning every jump into a controlled glide.",
+      "spinta_selettiva": "The worst ground was also the safest: those who glided over it stopped paying its price.",
+      "uso_funzione": "At grade 1 the glide cancels the extra movement cost of normal terrain.",
+      "debolezza": "A glide cannot be corrected midway: whoever starts one no longer picks the landing."
     },
     "ali_ioniche": {
       "label": "Ionic Wings",
       "mutazione_indotta": "Wing membranes gather charge along metallic veins and release it in micro-pulses.",
       "spinta_selettiva": "In the ionic canopy the air is already electric: whoever can spend it moves first.",
-      "uso_funzione": "Grants sudden directional dashes and rapid altitude changes while scouting.",
-      "debolezza": "Each dash drains the charge; without ionised air the wings are inert membranes."
+      "uso_funzione": "An attack delivered from an elevated position applies 1 turn of stun.",
+      "debolezza": "The stun lasts an instant: if the pack does not exploit it at once, it is wasted."
     },
     "antenne_flusso_mareale": {
       "label": "Tidal-Flow Antennae",
       "mutazione_indotta": "The antennae tuned themselves to the tide's rhythm, storing the surge in muscular ducts.",
       "spinta_selettiva": "In the bioreactive lagoon, striking off-beat means striking water and nothing else.",
-      "uso_funzione": "Discharges the stored energy into a single blow that cracks enemy defences.",
-      "debolezza": "The surge must be released: held too long, it discharges into its bearer."
+      "uso_funzione": "On a clean hit (margin 5 or more) perfect timing adds 2 damage.",
+      "debolezza": "A sloppy blow misses the surge: without precision the antennae add nothing."
+    },
+    "artigli_psionici": {
+      "label": "Psionic Claws",
+      "mutazione_indotta": "The claws conduct thought: every grip lifts a fragment of the mind they touch.",
+      "spinta_selettiva": "Whoever hunts the same pack twice learns that knowing the prey beats wounding it.",
+      "uso_funzione": "A melee hit reads the prey: defending against that same prey accrues damage reduction, up to 3.",
+      "debolezza": "The read comes only by contact: against those who keep their distance the claws learn nothing."
+    },
+    "aura_glaciale": {
+      "label": "Glacial Aura",
+      "mutazione_indotta": "Peripheral blood drops below freezing and the air around the body condenses into rime.",
+      "spinta_selettiva": "Slowing the prey costs less than chasing it, and cold never tires.",
+      "uso_funzione": "Each hit applies 2 turns of chill: the target loses 1 AP on reset and suffers -1 to attack rolls.",
+      "debolezza": "Rime dissolves where the air is warm: in scorching biomes the aura cannot condense."
+    },
+    "canto_di_richiamo": {
+      "label": "Calling Chant",
+      "mutazione_indotta": "The vocal sacs widened into chambers that hold a note as long as an entire breath.",
+      "spinta_selettiva": "A pack that does not honour its prey forgets why it hunts together.",
+      "uso_funzione": "After a kill the chant amplifies fury for 2 turns and honours the fallen prey.",
+      "debolezza": "Two turns of fury are few: the chant arrives when the fight is already decided."
+    },
+    "cervello_predittivo": {
+      "label": "Predictive Brain",
+      "mutazione_indotta": "The cortex runs one step ahead of the present and sees the motion before it happens.",
+      "spinta_selettiva": "Between equals, the winner arrives where the other will be, not where the other is.",
+      "uso_funzione": "On an excellent hit (margin 6 or more) the target is stunned for 2 turns.",
+      "debolezza": "Prediction assumes a rule: against the random, the cortex is confidently wrong."
     },
     "corteccia_memetica": {
       "label": "Memetic Bark",
@@ -40,8 +75,15 @@
       "label": "Adaptive Cryostasis",
       "mutazione_indotta": "The blood loads with cryoprotective enzymes that halt metabolism without shattering tissue.",
       "spinta_selettiva": "Those who cannot cross the winter must learn to sleep through it.",
-      "uso_funzione": "Suspends metabolism to survive extreme seasons and prolonged famine.",
-      "debolezza": "Asleep, the body filters nothing: every poison works undisturbed."
+      "uso_funzione": "Once activated it stiffens the tissues and grants +2 defence for 1 turn.",
+      "debolezza": "The stasis lasts a single turn: outside that window the body stands exposed."
+    },
+    "cuore_in_furia": {
+      "label": "Heart in Fury",
+      "mutazione_indotta": "The myocardium has grown past measure and sustains a tachycardia that would kill a normal heart.",
+      "spinta_selettiva": "The first kill opens the rest: those who cannot ride the surge waste it.",
+      "uso_funzione": "After a kill the heart races into tachycardia, unleashing 3 turns of adrenal rage.",
+      "debolezza": "It takes a kill to light it: in a stalemate the heart never starts."
     },
     "denti_seghettati": {
       "label": "Serrated Teeth",
@@ -57,12 +99,68 @@
       "uso_funzione": "A single pulse marks the ground as a resonant zone for 2 rounds.",
       "debolezza": "The echo tells no friend from foe: the zone reveals its own maker too."
     },
+    "ferocia": {
+      "label": "Ferocity",
+      "mutazione_indotta": "The adrenal glands stay half-open and pain always arrives a moment too late.",
+      "spinta_selettiva": "Under pressure hesitation kills more than the wound: the one who doubles the blow survives.",
+      "uso_funzione": "Every kill unleashes 3 turns of rage: no retreat, and +1 damage on successful hits.",
+      "debolezza": "In rage retreat is barred: whoever enters fury stays on the field even while losing."
+    },
+    "filtri_bioattivi": {
+      "label": "Bioactive Filters",
+      "mutazione_indotta": "A lattice of glands filters circulating blood and stitches tissue as it passes through.",
+      "spinta_selettiva": "In fouled water a wound festers before it closes: a body had to wash itself.",
+      "uso_funzione": "Each round it purges 1 bleed and 1 fracture, healing 1 for every status removed.",
+      "debolezza": "The filter works one ailment at a time: under many statuses at once it falls behind."
+    },
     "ghiandole_mnemoniche": {
       "label": "Mnemonic Glands",
       "mutazione_indotta": "Synaptic glands condense altered states into secretions that keep them attenuated.",
       "spinta_selettiva": "In the synaptic fracture every boon fades: those who keep a copy survive.",
       "uso_funzione": "Stores a weakened copy of a buff and redistributes it later.",
       "debolezza": "The copy is always poorer than the original, and occupies the gland until spent."
+    },
+    "intimidatore": {
+      "label": "Intimidating Aura",
+      "mutazione_indotta": "The posture has set into a silhouette the prey's brain reads as inevitable.",
+      "spinta_selettiva": "Prey that flees does not fight: frightening costs less than winning.",
+      "uso_funzione": "Each successful melee hit applies 2 turns of panic to adjacent enemies.",
+      "debolezza": "Terror needs eyes and nearness: from afar it remains only a silhouette."
+    },
+    "legame_di_branco": {
+      "label": "Pack Bond",
+      "mutazione_indotta": "Vocalisations have shrunk to brief signals the pack decodes without looking at one another.",
+      "spinta_selettiva": "A pack that discovers the threat together suffers it only once.",
+      "uso_funzione": "When an adjacent packmate of the same species attacks, it gains +1 attack and +1 defence until the end of the round.",
+      "debolezza": "The bond recognises only its own species: in a mixed squad it stays mute."
+    },
+    "marchio_predatorio": {
+      "label": "Predatory Mark",
+      "mutazione_indotta": "Axillary glands release a pheromone that clings to the prey and makes it legible to the pack.",
+      "spinta_selettiva": "Hunting in numbers means little if each hunter chases a different quarry.",
+      "uso_funzione": "Each hit marks the target for 2 turns: the next attack against it gains +1 damage and consumes the mark.",
+      "debolezza": "The mark is worth a single blow, spent by whoever strikes first, not by whoever strikes best."
+    },
+    "membrane_osmotiche": {
+      "label": "Osmotic Membranes",
+      "mutazione_indotta": "The outer membrane drinks what strikes it, holding part of it back before it reaches the blood.",
+      "spinta_selettiva": "Where every touch is venom, an impermeable body wastes less time healing.",
+      "uso_funzione": "Shortens every incoming status by 1 turn: a 1-turn status is absorbed entirely.",
+      "debolezza": "Against a long status the absorption is a delay, not a defence."
+    },
+    "mente_lucida": {
+      "label": "Lucid Mind",
+      "mutazione_indotta": "Attention does not drift with fear: the gaze holds where the guard opens.",
+      "spinta_selettiva": "In panic everyone sees the weapon. The winner keeps seeing the gap.",
+      "uso_funzione": "A clean hit (margin 5 or more) makes the target feel seen: 2 turns of panic.",
+      "debolezza": "Lucidity is slow: it costs an instant that close melee does not always grant."
+    },
+    "midollo_iperattivo": {
+      "label": "Hyperactive Marrow",
+      "mutazione_indotta": "The bone marrow floods with catecholamines as if every kill were the first.",
+      "spinta_selettiva": "A serial hunter cannot afford to cool between one quarry and the next.",
+      "uso_funzione": "Every kill pumps adrenaline and unleashes 3 turns of rage.",
+      "debolezza": "The marrow consumes itself: the bones regrow slower than they are spent."
     },
     "nodi_micorrizici_oracolari": {
       "label": "Oracular Mycorrhizal Nodes",
@@ -78,6 +176,48 @@
       "uso_funzione": "Cushions every incoming blow and reduces damage taken by 1.",
       "debolezza": "The elastomer blunts impact, not the venom that passes through the skin."
     },
+    "pelli_anti_ustione": {
+      "label": "Burn-Resistant Hide",
+      "mutazione_indotta": "The dermal layer has filled with hollow cells that shed heat before it sinks in.",
+      "spinta_selettiva": "On lava crusts contact is brief and constant: to burn was a slow sentence.",
+      "uso_funzione": "The thermal cushion reduces every incoming hit by 1 damage.",
+      "debolezza": "One point less does not stop a heavy blow: against hard hitters it is nearly nothing."
+    },
+    "pelli_cave": {
+      "label": "Hollow Hide",
+      "mutazione_indotta": "Air pockets have opened beneath the skin, keeping the heat out and the coolness in.",
+      "spinta_selettiva": "In arid land shade is not enough: the body must carry its own.",
+      "uso_funzione": "The air pockets cushion the impact and reduce every hit by 1 damage.",
+      "debolezza": "The pockets blunt the impact but not burns, nor the venom seeping through the pores."
+    },
+    "pelli_fitte": {
+      "label": "Dense Hide",
+      "mutazione_indotta": "The dermal fibres have woven as tight as felt, and water no longer finds a way out.",
+      "spinta_selettiva": "Constant wind does not wound: it drains. Those who hold on survive.",
+      "uso_funzione": "Every melee hit taken is blunted by 2 damage.",
+      "debolezza": "The felt guards melee: against those who strike from afar it blunts nothing."
+    },
+    "radici_ancora_planare": {
+      "label": "Planar Anchor Roots",
+      "mutazione_indotta": "Roots break from the heels and bite into the plane where the body halts.",
+      "spinta_selettiva": "A trunk does not flee. If it must take the blow, better to be impossible to move.",
+      "uso_funzione": "At round start it takes root: while stationary it reduces damage by 2, but moving breaks the anchor.",
+      "debolezza": "An enemy that does not attack it simply ignores it: anchored, the bearer chases no one."
+    },
+    "sensori_sismici": {
+      "label": "Seismic Sensors",
+      "mutazione_indotta": "Cutaneous receptors have sharpened enough to tell shifting weight from settling weight.",
+      "spinta_selettiva": "A predator betrays the strike with its foot before its eyes.",
+      "uso_funzione": "On a clean melee hit (margin 5 or more) it finds the opening and deals 1 extra damage.",
+      "debolezza": "The ground must carry: on water and shifting sand the sensors fall silent."
+    },
+    "spirito_combattivo": {
+      "label": "Combative Spirit",
+      "mutazione_indotta": "The amygdala has recalibrated downward: the threat arrives, but never takes command.",
+      "spinta_selettiva": "A pack that scatters at the first scream loses before it even fights.",
+      "uso_funzione": "When an adjacent ally attacks, the bearer gains +1 to attack until the end of the round.",
+      "debolezza": "Alone it is worth nothing: with no ally beside it, the morale never kindles."
+    },
     "spore_paniche": {
       "label": "Panic Spores",
       "mutazione_indotta": "Sporal sacs ripen beneath the skin and burst at the first sign of threat.",
@@ -85,19 +225,54 @@
       "uso_funzione": "Neurotoxic spores induce hallucinations and rout the target: 3 turns of panic.",
       "debolezza": "The cloud does not choose its lungs: nearby allies breathe the same terror."
     },
+    "sussurro_psichico": {
+      "label": "Psychic Whisper",
+      "mutazione_indotta": "A sublingual sac emits frequencies the eardrum misses and the nerve does not.",
+      "spinta_selettiva": "Confusing a stronger foe costs a breath; facing it costs the pack.",
+      "uso_funzione": "Each solid hit (margin 5 or more) applies 1 turn of disorientation: -2 to attack rolls.",
+      "debolezza": "It needs a clean blow: a barely landed touch never carries the whisper to the nerve."
+    },
+    "tela_appiccicosa": {
+      "label": "Sticky Web",
+      "mutazione_indotta": "Abdominal glands spin a secretion that hardens only when something tries to pull free.",
+      "spinta_selettiva": "There is no need to outrun the prey: it only has to be slower than yesterday.",
+      "uso_funzione": "Each hit applies 3 turns of slow: -1 AP on reset, with at least 1 AP guaranteed.",
+      "debolezza": "Prey that stops pulling does not stay caught: the web punishes only those who struggle."
+    },
+    "tentacoli_uncinati": {
+      "label": "Hooked Tentacles",
+      "mutazione_indotta": "Keratin hooks stud the tentacles and close backward like barbs.",
+      "spinta_selettiva": "Holding the prey one instant longer was worth a second bite.",
+      "uso_funzione": "Every melee hit applies 1 turn of fracture, limiting the target's AP.",
+      "debolezza": "A hook that goes in must come out: tearing free of armoured prey snaps them."
+    },
+    "tessuti_adattivi": {
+      "label": "Adaptive Tissues",
+      "mutazione_indotta": "The tissues sample what wounds them and reorganise against that very channel.",
+      "spinta_selettiva": "An environment that strikes the same way twice teaches its survivors quickly.",
+      "uso_funzione": "After taking 2 or more damage of one channel, it gains +15% resistance to that channel for 3 rounds and heals 1.",
+      "debolezza": "The adaptation looks backward: whoever alternates damage channels never lets it learn."
+    },
     "voce_imperiosa": {
       "label": "Imperious Voice",
       "mutazione_indotta": "The vocal cords thickened into a chamber that resonates below the threshold of hearing.",
       "spinta_selettiva": "In a pack the order to flee arrives before the predator: whoever speaks it commands.",
-      "uso_funzione": "In melee the voice breaks the target's will: 2 turns of panic.",
+      "uso_funzione": "In melee, a clean hit (margin 5 or more) applies 2 turns of panic.",
       "debolezza": "It works only within earshot, and never touches what has no will to break."
     },
     "zampe_a_molla": {
       "label": "Spring-Loaded Limbs",
       "mutazione_indotta": "The hind tendons have coiled into springs that hold the thrust between one leap and the next.",
       "spinta_selettiva": "In the mycelial forest the ground gives way: those who stand still long enough sink.",
-      "uso_funzione": "Stores energy and releases it in a leap that repositions the unit clear of the threat.",
-      "debolezza": "The run-up needs room: in tight quarters the springs have nowhere to unload."
+      "uso_funzione": "Striking from an elevated position with a margin of 5 or more deals 1 extra damage.",
+      "debolezza": "The leap only serves to climb: without a precise strike from above the springs never pay."
+    },
+    "zampe_radianti": {
+      "label": "Radiant Paws",
+      "mutazione_indotta": "The paw pads store the shock of the fall and give it back on impact.",
+      "spinta_selettiva": "Whoever strikes from above already holds the energy: it only had to survive the landing.",
+      "uso_funzione": "Attacking from an elevated position, the kinetic pulse adds 2 damage on impact.",
+      "debolezza": "It needs a drop: on level ground the paws have no fall to convert."
     }
   }
 }

--- a/data/i18n/en/traits.json
+++ b/data/i18n/en/traits.json
@@ -145,7 +145,7 @@
       "label": "Osmotic Membranes",
       "mutazione_indotta": "The outer membrane drinks what strikes it, holding part of it back before it reaches the blood.",
       "spinta_selettiva": "Where every touch is venom, an impermeable body wastes less time healing.",
-      "uso_funzione": "Shortens every incoming status by 1 turn: a 1-turn status is absorbed entirely.",
+      "uso_funzione": "Shortens every incoming status by 1 turn (a 1-turn status never lands); at end of round it heals 1 if adjacent to water or bog.",
       "debolezza": "Against a long status the absorption is a delay, not a defence."
     },
     "mente_lucida": {
@@ -223,7 +223,7 @@
       "mutazione_indotta": "Sporal sacs ripen beneath the skin and burst at the first sign of threat.",
       "spinta_selettiva": "There is no need to kill the predator, only to convince it the pack is already lost.",
       "uso_funzione": "Neurotoxic spores induce hallucinations and rout the target: 3 turns of panic.",
-      "debolezza": "The cloud does not choose its lungs: nearby allies breathe the same terror."
+      "debolezza": "A panicked target flees: the spores pull it out of reach before you can finish it."
     },
     "sussurro_psichico": {
       "label": "Psychic Whisper",
@@ -250,7 +250,7 @@
       "label": "Adaptive Tissues",
       "mutazione_indotta": "The tissues sample what wounds them and reorganise against that very channel.",
       "spinta_selettiva": "An environment that strikes the same way twice teaches its survivors quickly.",
-      "uso_funzione": "After taking 2 or more damage of one channel, it gains +15% resistance to that channel for 3 rounds and heals 1.",
+      "uso_funzione": "After taking 2 or more damage of one channel, it gains +15% resistance to that channel for 3 rounds and heals 1; at most 2 channels at once.",
       "debolezza": "The adaptation looks backward: whoever alternates damage channels never lets it learn."
     },
     "voce_imperiosa": {

--- a/data/i18n/en/traits.json
+++ b/data/i18n/en/traits.json
@@ -1,0 +1,103 @@
+{
+  "_meta": {
+    "locale": "en",
+    "language_name": "English",
+    "direction": "ltr",
+    "version": 1,
+    "updated": "2026-07-10",
+    "completion_percent": 4
+  },
+  "traits": {
+    "aculei_velenosi": {
+      "label": "Venomous Spines",
+      "mutazione_indotta": "Dorsal bristles have turned hollow, grafted onto sacs that distil hemolytic toxins.",
+      "spinta_selettiva": "Against predators too large to repel, only making the bite costly remained.",
+      "uso_funzione": "Melee attackers wound themselves on the spines and bleed at length.",
+      "debolezza": "It guards against nothing that strikes from afar: the punishment needs contact."
+    },
+    "ali_ioniche": {
+      "label": "Ionic Wings",
+      "mutazione_indotta": "Wing membranes gather charge along metallic veins and release it in micro-pulses.",
+      "spinta_selettiva": "In the ionic canopy the air is already electric: whoever can spend it moves first.",
+      "uso_funzione": "Grants sudden directional dashes and rapid altitude changes while scouting.",
+      "debolezza": "Each dash drains the charge; without ionised air the wings are inert membranes."
+    },
+    "antenne_flusso_mareale": {
+      "label": "Tidal-Flow Antennae",
+      "mutazione_indotta": "The antennae tuned themselves to the tide's rhythm, storing the surge in muscular ducts.",
+      "spinta_selettiva": "In the bioreactive lagoon, striking off-beat means striking water and nothing else.",
+      "uso_funzione": "Discharges the stored energy into a single blow that cracks enemy defences.",
+      "debolezza": "The surge must be released: held too long, it discharges into its bearer."
+    },
+    "corteccia_memetica": {
+      "label": "Memetic Bark",
+      "mutazione_indotta": "The bark records every heavy blow as a scar that allies know how to read.",
+      "spinta_selettiva": "In ancient woods, survival belongs to those who turn their wound into a shared warning.",
+      "uso_funzione": "After taking a hit of 3 damage or more it hardens (damage -2) and grants allies within 3 a +1 attack.",
+      "debolezza": "It needs a real wound: against light attrition the bark never wakes."
+    },
+    "criostasi_adattiva": {
+      "label": "Adaptive Cryostasis",
+      "mutazione_indotta": "The blood loads with cryoprotective enzymes that halt metabolism without shattering tissue.",
+      "spinta_selettiva": "Those who cannot cross the winter must learn to sleep through it.",
+      "uso_funzione": "Suspends metabolism to survive extreme seasons and prolonged famine.",
+      "debolezza": "Asleep, the body filters nothing: every poison works undisturbed."
+    },
+    "denti_seghettati": {
+      "label": "Serrated Teeth",
+      "mutazione_indotta": "Dental cusps have splintered into recurved blades that hold flesh fast.",
+      "spinta_selettiva": "Prey kept tearing free of the bite: the wound had to keep working on its own.",
+      "uso_funzione": "The bite lacerates flesh and applies deep bleeding for 2 turns.",
+      "debolezza": "The blades dull on armour and must regrow after every hard kill."
+    },
+    "eco_sismico": {
+      "label": "Seismic Echo",
+      "mutazione_indotta": "Cutaneous plates sense the ground's tremor and return it amplified.",
+      "spinta_selettiva": "Under the rock, sight is useless: all that counts is feeling the weight approach.",
+      "uso_funzione": "A single pulse marks the ground as a resonant zone for 2 rounds.",
+      "debolezza": "The echo tells no friend from foe: the zone reveals its own maker too."
+    },
+    "ghiandole_mnemoniche": {
+      "label": "Mnemonic Glands",
+      "mutazione_indotta": "Synaptic glands condense altered states into secretions that keep them attenuated.",
+      "spinta_selettiva": "In the synaptic fracture every boon fades: those who keep a copy survive.",
+      "uso_funzione": "Stores a weakened copy of a buff and redistributes it later.",
+      "debolezza": "The copy is always poorer than the original, and occupies the gland until spent."
+    },
+    "nodi_micorrizici_oracolari": {
+      "label": "Oracular Mycorrhizal Nodes",
+      "mutazione_indotta": "Dermal roots graft into the fungal network and read its chemical signals in advance.",
+      "spinta_selettiva": "In the mycorrhizal networks the forest knows before you do: better to listen.",
+      "uso_funzione": "Anticipates threats and relays tactical reads to the squad before contact.",
+      "debolezza": "Sever the network and the omens fall silent, leaving only disorientation."
+    },
+    "pelle_elastomera": {
+      "label": "Elastomeric Skin",
+      "mutazione_indotta": "The dermis has layered into elastomeric sheets that give the blow back instead of passing it on.",
+      "spinta_selettiva": "Against a predator you cannot avoid, the only answer is to absorb it and stay standing.",
+      "uso_funzione": "Cushions every incoming blow and reduces damage taken by 1.",
+      "debolezza": "The elastomer blunts impact, not the venom that passes through the skin."
+    },
+    "spore_paniche": {
+      "label": "Panic Spores",
+      "mutazione_indotta": "Sporal sacs ripen beneath the skin and burst at the first sign of threat.",
+      "spinta_selettiva": "There is no need to kill the predator, only to convince it the pack is already lost.",
+      "uso_funzione": "Neurotoxic spores induce hallucinations and rout the target: 3 turns of panic.",
+      "debolezza": "The cloud does not choose its lungs: nearby allies breathe the same terror."
+    },
+    "voce_imperiosa": {
+      "label": "Imperious Voice",
+      "mutazione_indotta": "The vocal cords thickened into a chamber that resonates below the threshold of hearing.",
+      "spinta_selettiva": "In a pack the order to flee arrives before the predator: whoever speaks it commands.",
+      "uso_funzione": "In melee the voice breaks the target's will: 2 turns of panic.",
+      "debolezza": "It works only within earshot, and never touches what has no will to break."
+    },
+    "zampe_a_molla": {
+      "label": "Spring-Loaded Limbs",
+      "mutazione_indotta": "The hind tendons have coiled into springs that hold the thrust between one leap and the next.",
+      "spinta_selettiva": "In the mycelial forest the ground gives way: those who stand still long enough sink.",
+      "uso_funzione": "Stores energy and releases it in a leap that repositions the unit clear of the threat.",
+      "debolezza": "The run-up needs room: in tight quarters the springs have nowhere to unload."
+    }
+  }
+}

--- a/data/i18n/en/traits.json
+++ b/data/i18n/en/traits.json
@@ -75,7 +75,7 @@
       "label": "Adaptive Cryostasis",
       "mutazione_indotta": "The blood loads with cryoprotective enzymes that halt metabolism without shattering tissue.",
       "spinta_selettiva": "Those who cannot cross the winter must learn to sleep through it.",
-      "uso_funzione": "Once activated it stiffens the tissues and grants +2 defence for 1 turn.",
+      "uso_funzione": "Once activated it stiffens the tissues: +2 defence for 1 turn and +20% resistance to the ionic channel.",
       "debolezza": "The stasis lasts a single turn: outside that window the body stands exposed."
     },
     "cuore_in_furia": {
@@ -112,13 +112,6 @@
       "spinta_selettiva": "In fouled water a wound festers before it closes: a body had to wash itself.",
       "uso_funzione": "Each round it purges 1 bleed and 1 fracture, healing 1 for every status removed.",
       "debolezza": "The filter works one ailment at a time: under many statuses at once it falls behind."
-    },
-    "ghiandole_mnemoniche": {
-      "label": "Mnemonic Glands",
-      "mutazione_indotta": "Synaptic glands condense altered states into secretions that keep them attenuated.",
-      "spinta_selettiva": "In the synaptic fracture every boon fades: those who keep a copy survive.",
-      "uso_funzione": "Stores a weakened copy of a buff and redistributes it later.",
-      "debolezza": "The copy is always poorer than the original, and occupies the gland until spent."
     },
     "intimidatore": {
       "label": "Intimidating Aura",
@@ -161,13 +154,6 @@
       "spinta_selettiva": "A serial hunter cannot afford to cool between one quarry and the next.",
       "uso_funzione": "Every kill pumps adrenaline and unleashes 3 turns of rage.",
       "debolezza": "The marrow consumes itself: the bones regrow slower than they are spent."
-    },
-    "nodi_micorrizici_oracolari": {
-      "label": "Oracular Mycorrhizal Nodes",
-      "mutazione_indotta": "Dermal roots graft into the fungal network and read its chemical signals in advance.",
-      "spinta_selettiva": "In the mycorrhizal networks the forest knows before you do: better to listen.",
-      "uso_funzione": "Anticipates threats and relays tactical reads to the squad before contact.",
-      "debolezza": "Sever the network and the omens fall silent, leaving only disorientation."
     },
     "pelle_elastomera": {
       "label": "Elastomeric Skin",

--- a/data/i18n/en/traits.json
+++ b/data/i18n/en/traits.json
@@ -96,8 +96,8 @@
       "label": "Seismic Echo",
       "mutazione_indotta": "Cutaneous plates sense the ground's tremor and return it amplified.",
       "spinta_selettiva": "Under the rock, sight is useless: all that counts is feeling the weight approach.",
-      "uso_funzione": "A single pulse marks the ground as a resonant zone for 2 rounds.",
-      "debolezza": "The echo tells no friend from foe: the zone reveals its own maker too."
+      "uso_funzione": "A pulse marks the ground as a resonant zone for 2 rounds: whoever enters it is disoriented.",
+      "debolezza": "The zone does not chase: an enemy that walks around it suffers nothing."
     },
     "ferocia": {
       "label": "Ferocity",
@@ -124,14 +124,14 @@
       "label": "Intimidating Aura",
       "mutazione_indotta": "The posture has set into a silhouette the prey's brain reads as inevitable.",
       "spinta_selettiva": "Prey that flees does not fight: frightening costs less than winning.",
-      "uso_funzione": "Each successful melee hit applies 2 turns of panic to adjacent enemies.",
+      "uso_funzione": "Each successful melee hit applies 2 turns of panic to the target.",
       "debolezza": "Terror needs eyes and nearness: from afar it remains only a silhouette."
     },
     "legame_di_branco": {
       "label": "Pack Bond",
       "mutazione_indotta": "Vocalisations have shrunk to brief signals the pack decodes without looking at one another.",
       "spinta_selettiva": "A pack that discovers the threat together suffers it only once.",
-      "uso_funzione": "When an adjacent packmate of the same species attacks, it gains +1 attack and +1 defence until the end of the round.",
+      "uso_funzione": "When an adjacent packmate of the same species attacks, the bearer gains +1 attack and +1 defence until the end of the round.",
       "debolezza": "The bond recognises only its own species: in a mixed squad it stays mute."
     },
     "marchio_predatorio": {
@@ -243,7 +243,7 @@
       "label": "Hooked Tentacles",
       "mutazione_indotta": "Keratin hooks stud the tentacles and close backward like barbs.",
       "spinta_selettiva": "Holding the prey one instant longer was worth a second bite.",
-      "uso_funzione": "Every melee hit applies 1 turn of fracture, limiting the target's AP.",
+      "uso_funzione": "Every melee hit applies 1 turn of fracture: the target drops to 1 AP.",
       "debolezza": "A hook that goes in must come out: tearing free of armoured prey snaps them."
     },
     "tessuti_adattivi": {

--- a/data/i18n/it/traits.json
+++ b/data/i18n/it/traits.json
@@ -1,0 +1,103 @@
+{
+  "_meta": {
+    "locale": "it",
+    "language_name": "Italiano",
+    "direction": "ltr",
+    "version": 1,
+    "updated": "2026-07-10",
+    "completion_percent": 4
+  },
+  "traits": {
+    "aculei_velenosi": {
+      "label": "Aculei Velenosi",
+      "mutazione_indotta": "Le setole dorsali si sono fatte cave, innestate su sacche che distillano tossine emolitiche.",
+      "spinta_selettiva": "Contro predatori troppo grandi per essere respinti, restava solo rendere costoso il morso.",
+      "uso_funzione": "Chi attacca in mischia si ferisce sugli aculei e sanguina a lungo.",
+      "debolezza": "Non protegge da nulla che colpisca a distanza: la punizione richiede contatto."
+    },
+    "ali_ioniche": {
+      "label": "Ali Ioniche",
+      "mutazione_indotta": "Le membrane alari accumulano carica lungo nervature metalliche e la scaricano in micro-impulsi.",
+      "spinta_selettiva": "Nella canopia ionica l'aria è già elettrica: chi sa spenderla si muove per primo.",
+      "uso_funzione": "Concede scatti direzionali improvvisi e cambi di quota rapidi in esplorazione.",
+      "debolezza": "Ogni scatto svuota la carica; senza aria ionizzata le ali restano membrane inerti."
+    },
+    "antenne_flusso_mareale": {
+      "label": "Antenne di Flusso Mareale",
+      "mutazione_indotta": "Le antenne si sono sintonizzate sul ritmo delle maree, immagazzinando l'onda nei condotti muscolari.",
+      "spinta_selettiva": "Nella laguna bioreattiva colpire fuori tempo significa colpire l'acqua e nient'altro.",
+      "uso_funzione": "Scarica l'energia accumulata in un colpo singolo che apre le difese avversarie.",
+      "debolezza": "L'onda va rilasciata: trattenuta troppo a lungo, si scarica sul portatore."
+    },
+    "corteccia_memetica": {
+      "label": "Corteccia Memetica",
+      "mutazione_indotta": "La corteccia registra ogni colpo pesante come una cicatrice che gli alleati sanno leggere.",
+      "spinta_selettiva": "Nei boschi antichi sopravvive chi trasforma la propria ferita in avvertimento condiviso.",
+      "uso_funzione": "Subito un colpo da 3 danni o più indurisce (danno -2) e concede +1 attacco agli alleati entro 3.",
+      "debolezza": "Serve essere feriti sul serio: contro il logoramento leggero la corteccia non si sveglia mai."
+    },
+    "criostasi_adattiva": {
+      "label": "Criostasi Adattiva",
+      "mutazione_indotta": "Il sangue si carica di enzimi crioprotettivi che fermano il metabolismo senza spezzare i tessuti.",
+      "spinta_selettiva": "Chi non sa attraversare l'inverno deve saperlo dormire.",
+      "uso_funzione": "Sospende il metabolismo per sopravvivere a stagioni estreme e carestie prolungate.",
+      "debolezza": "Nel sonno il corpo non filtra nulla: ogni veleno lavora indisturbato."
+    },
+    "denti_seghettati": {
+      "label": "Denti Seghettati",
+      "mutazione_indotta": "Le cuspidi dentali si sono scheggiate in lame ricurve che trattengono la carne.",
+      "spinta_selettiva": "Prede che si liberavano dal morso: serviva una ferita che continuasse a lavorare da sola.",
+      "uso_funzione": "Il morso lacera la carne e applica sanguinamento profondo per 2 turni.",
+      "debolezza": "Le lame si spuntano sulle corazze e vanno rifatte dopo ogni preda dura."
+    },
+    "eco_sismico": {
+      "label": "Eco Sismico",
+      "mutazione_indotta": "Placche cutanee percepiscono la vibrazione del suolo e la restituiscono amplificata.",
+      "spinta_selettiva": "Sotto la roccia la vista non serve: conta solo chi sente arrivare il peso.",
+      "uso_funzione": "Un impulso marca il terreno come zona risonante per 2 round.",
+      "debolezza": "L'eco non distingue amico da nemico: la zona rivela anche chi l'ha creata."
+    },
+    "ghiandole_mnemoniche": {
+      "label": "Ghiandole Mnemoniche",
+      "mutazione_indotta": "Ghiandole sinaptiche condensano gli stati alterati in secrezioni che li conservano attenuati.",
+      "spinta_selettiva": "Nella frattura sinaptica ogni potenziamento svanisce: sopravvive chi ne serba una copia.",
+      "uso_funzione": "Conserva una copia indebolita di un potenziamento e la ridistribuisce più tardi.",
+      "debolezza": "La copia è sempre più povera dell'originale e occupa la ghiandola finché non viene spesa."
+    },
+    "nodi_micorrizici_oracolari": {
+      "label": "Nodi Micorrizici Oracolari",
+      "mutazione_indotta": "Radici dermiche si innestano nella rete fungina e ne leggono in anticipo i segnali chimici.",
+      "spinta_selettiva": "Nelle reti micorriziche il bosco sa prima di te: conviene ascoltarlo.",
+      "uso_funzione": "Anticipa le minacce e trasmette letture tattiche alla squadra prima del contatto.",
+      "debolezza": "Recisa la rete, i presagi tacciono e resta solo disorientamento."
+    },
+    "pelle_elastomera": {
+      "label": "Pelle Elastomera",
+      "mutazione_indotta": "Il derma si è stratificato in fogli elastomerici che restituiscono l'urto invece di trasmetterlo.",
+      "spinta_selettiva": "Contro un predatore che non si può evitare, l'unica risposta è assorbire e restare in piedi.",
+      "uso_funzione": "Ammortizza ogni colpo in arrivo e riduce il danno subito di 1.",
+      "debolezza": "L'elastomero attutisce l'impatto, non il veleno che passa attraverso la pelle."
+    },
+    "spore_paniche": {
+      "label": "Spore Paniche",
+      "mutazione_indotta": "Sacche sporali maturano sotto la pelle e si aprono al primo segnale di minaccia.",
+      "spinta_selettiva": "Non serve uccidere il predatore: basta convincerlo che il branco è già perduto.",
+      "uso_funzione": "Le spore neurotossiche inducono allucinazioni e mettono in fuga: 3 turni di panico.",
+      "debolezza": "La nube non sceglie i polmoni: gli alleati vicini respirano lo stesso terrore."
+    },
+    "voce_imperiosa": {
+      "label": "Voce Imperiosa",
+      "mutazione_indotta": "Le corde vocali si sono ispessite in una camera che risuona sotto la soglia dell'udito.",
+      "spinta_selettiva": "In un branco l'ordine di fuga arriva prima del predatore: chi lo pronuncia comanda.",
+      "uso_funzione": "In mischia la voce spezza la volontà del bersaglio: 2 turni di panico.",
+      "debolezza": "Vale solo a portata di voce e non tocca chi non ha volontà da spezzare."
+    },
+    "zampe_a_molla": {
+      "label": "Zampe a Molla",
+      "mutazione_indotta": "I tendini posteriori si sono avvolti come molle che trattengono la spinta fra un balzo e l'altro.",
+      "spinta_selettiva": "Nella foresta miceliale il suolo cede: sopravvive chi non resta fermo abbastanza da sprofondare.",
+      "uso_funzione": "Accumula energia e la libera in un balzo che riposiziona l'unità fuori dalla minaccia.",
+      "debolezza": "Serve spazio per la rincorsa: negli anfratti stretti le molle non hanno dove scaricarsi."
+    }
+  }
+}

--- a/data/i18n/it/traits.json
+++ b/data/i18n/it/traits.json
@@ -145,7 +145,7 @@
       "label": "Membrane Osmotiche",
       "mutazione_indotta": "La membrana esterna beve ciò che la colpisce e ne trattiene una parte prima che raggiunga il sangue.",
       "spinta_selettiva": "Dove ogni tocco è veleno, un corpo impermeabile perde meno tempo a guarire.",
-      "uso_funzione": "Riduce di 1 turno la durata di ogni stato in arrivo: uno stato da 1 turno viene assorbito del tutto.",
+      "uso_funzione": "Accorcia di 1 turno ogni stato in arrivo (uno da 1 turno non attecchisce); a fine round cura 1 se adiacente ad acqua o palude.",
       "debolezza": "Contro uno stato lungo l'assorbimento è un rinvio, non una difesa."
     },
     "mente_lucida": {
@@ -223,7 +223,7 @@
       "mutazione_indotta": "Sacche sporali maturano sotto la pelle e si aprono al primo segnale di minaccia.",
       "spinta_selettiva": "Non serve uccidere il predatore: basta convincerlo che il branco è già perduto.",
       "uso_funzione": "Le spore neurotossiche inducono allucinazioni e mettono in fuga: 3 turni di panico.",
-      "debolezza": "La nube non sceglie i polmoni: gli alleati vicini respirano lo stesso terrore."
+      "debolezza": "Un bersaglio in panico fugge: le spore lo tolgono dalla mischia prima che tu possa finirlo."
     },
     "sussurro_psichico": {
       "label": "Sussurro Psichico",
@@ -250,7 +250,7 @@
       "label": "Tessuti Adattivi",
       "mutazione_indotta": "I tessuti campionano ciò che li ferisce e si riorganizzano contro quello stesso canale.",
       "spinta_selettiva": "Un ambiente che colpisce sempre allo stesso modo insegna in fretta a chi sopravvive.",
-      "uso_funzione": "Subiti 2 o più danni di un canale, guadagna +15% di resistenza a quel canale per 3 round e cura 1.",
+      "uso_funzione": "Subiti 2 o più danni di un canale, ottiene +15% di resistenza a quel canale per 3 round e cura 1; al massimo 2 canali insieme.",
       "debolezza": "L'adattamento guarda indietro: chi alterna i canali di danno non gli lascia mai imparare."
     },
     "voce_imperiosa": {

--- a/data/i18n/it/traits.json
+++ b/data/i18n/it/traits.json
@@ -96,8 +96,8 @@
       "label": "Eco Sismico",
       "mutazione_indotta": "Placche cutanee percepiscono la vibrazione del suolo e la restituiscono amplificata.",
       "spinta_selettiva": "Sotto la roccia la vista non serve: conta solo chi sente arrivare il peso.",
-      "uso_funzione": "Un impulso marca il terreno come zona risonante per 2 round.",
-      "debolezza": "L'eco non distingue amico da nemico: la zona rivela anche chi l'ha creata."
+      "uso_funzione": "Un impulso marca il terreno come zona risonante per 2 round: chi vi entra resta disorientato.",
+      "debolezza": "La zona non insegue: un nemico che la aggira non ne subisce nulla."
     },
     "ferocia": {
       "label": "Ferocia",
@@ -124,14 +124,14 @@
       "label": "Aura Intimidatoria",
       "mutazione_indotta": "La postura si è irrigidita in una sagoma che il cervello della preda legge come inevitabile.",
       "spinta_selettiva": "Una preda che scappa non combatte: spaventare costa meno che vincere.",
-      "uso_funzione": "Ogni colpo in mischia riuscito applica 2 turni di panico agli avversari adiacenti.",
+      "uso_funzione": "Ogni colpo in mischia riuscito applica 2 turni di panico al bersaglio.",
       "debolezza": "Il terrore ha bisogno di occhi e di vicinanza: da lontano resta solo una sagoma."
     },
     "legame_di_branco": {
       "label": "Legame di Branco",
       "mutazione_indotta": "Le vocalizzazioni si sono ridotte a segnali brevi che il branco decodifica senza guardarsi.",
       "spinta_selettiva": "Un branco che scopre la minaccia insieme la subisce una volta sola.",
-      "uso_funzione": "Quando un compagno adiacente della stessa specie attacca, guadagna +1 all'attacco e +1 alla difesa fino a fine round.",
+      "uso_funzione": "Quando un compagno adiacente della stessa specie attacca, il portatore ottiene +1 all'attacco e +1 alla difesa fino a fine round.",
       "debolezza": "Il legame riconosce solo la propria specie: in una squadra mista resta muto."
     },
     "marchio_predatorio": {
@@ -243,7 +243,7 @@
       "label": "Tentacoli Uncinati",
       "mutazione_indotta": "Uncini di cheratina spuntano lungo i tentacoli e si chiudono all'indietro come ami.",
       "spinta_selettiva": "Trattenere la preda un istante in più valeva quanto un secondo morso.",
-      "uso_funzione": "Ogni colpo in mischia applica 1 turno di frattura, limitando gli AP del bersaglio.",
+      "uso_funzione": "Ogni colpo in mischia applica 1 turno di frattura: il bersaglio scende a 1 AP.",
       "debolezza": "Un uncino che entra deve uscire: staccarsi da una preda corazzata li spezza."
     },
     "tessuti_adattivi": {

--- a/data/i18n/it/traits.json
+++ b/data/i18n/it/traits.json
@@ -75,7 +75,7 @@
       "label": "Criostasi Adattiva",
       "mutazione_indotta": "Il sangue si carica di enzimi crioprotettivi che fermano il metabolismo senza spezzare i tessuti.",
       "spinta_selettiva": "Chi non sa attraversare l'inverno deve saperlo dormire.",
-      "uso_funzione": "Attivata, irrigidisce i tessuti e concede +2 alla difesa per 1 turno.",
+      "uso_funzione": "Attivata, irrigidisce i tessuti: +2 alla difesa per 1 turno e +20% di resistenza al canale ionico.",
       "debolezza": "La stasi dura un turno soltanto: fuori da quella finestra il corpo resta scoperto."
     },
     "cuore_in_furia": {
@@ -112,13 +112,6 @@
       "spinta_selettiva": "Nelle acque marce la ferita infetta prima di chiudersi: serviva un corpo che si lavasse da solo.",
       "uso_funzione": "Ogni round purga 1 sanguinamento e 1 frattura, e cura 1 per ogni stato rimosso.",
       "debolezza": "Il filtro lavora un male alla volta: sotto molti stati insieme resta indietro."
-    },
-    "ghiandole_mnemoniche": {
-      "label": "Ghiandole Mnemoniche",
-      "mutazione_indotta": "Ghiandole sinaptiche condensano gli stati alterati in secrezioni che li conservano attenuati.",
-      "spinta_selettiva": "Nella frattura sinaptica ogni potenziamento svanisce: sopravvive chi ne serba una copia.",
-      "uso_funzione": "Conserva una copia indebolita di un potenziamento e la ridistribuisce più tardi.",
-      "debolezza": "La copia è sempre più povera dell'originale e occupa la ghiandola finché non viene spesa."
     },
     "intimidatore": {
       "label": "Aura Intimidatoria",
@@ -161,13 +154,6 @@
       "spinta_selettiva": "Chi caccia in serie non può permettersi di raffreddarsi fra una preda e l'altra.",
       "uso_funzione": "Ogni uccisione pompa adrenalina e scatena 3 turni di furia.",
       "debolezza": "Il midollo consuma sé stesso: le ossa si rigenerano più lente di quanto si spendano."
-    },
-    "nodi_micorrizici_oracolari": {
-      "label": "Nodi Micorrizici Oracolari",
-      "mutazione_indotta": "Radici dermiche si innestano nella rete fungina e ne leggono in anticipo i segnali chimici.",
-      "spinta_selettiva": "Nelle reti micorriziche il bosco sa prima di te: conviene ascoltarlo.",
-      "uso_funzione": "Anticipa le minacce e trasmette letture tattiche alla squadra prima del contatto.",
-      "debolezza": "Recisa la rete, i presagi tacciono e resta solo disorientamento."
     },
     "pelle_elastomera": {
       "label": "Pelle Elastomera",

--- a/data/i18n/it/traits.json
+++ b/data/i18n/it/traits.json
@@ -5,29 +5,64 @@
     "direction": "ltr",
     "version": 1,
     "updated": "2026-07-10",
-    "completion_percent": 4
+    "completion_percent": 12
   },
   "traits": {
     "aculei_velenosi": {
       "label": "Aculei Velenosi",
       "mutazione_indotta": "Le setole dorsali si sono fatte cave, innestate su sacche che distillano tossine emolitiche.",
-      "spinta_selettiva": "Contro predatori troppo grandi per essere respinti, restava solo rendere costoso il morso.",
-      "uso_funzione": "Chi attacca in mischia si ferisce sugli aculei e sanguina a lungo.",
-      "debolezza": "Non protegge da nulla che colpisca a distanza: la punizione richiede contatto."
+      "spinta_selettiva": "Un morso solo non bastava: serviva che la ferita continuasse a uccidere dopo il contatto.",
+      "uso_funzione": "Ogni colpo in mischia applica 3 turni di sanguinamento per disgregazione vascolare.",
+      "debolezza": "Le tossine devono entrare: contro una corazza spessa gli aculei non pescano sangue."
+    },
+    "adattamento_volo": {
+      "label": "Adattamento al Volo",
+      "mutazione_indotta": "Pieghe cutanee si tendono fra gli arti e trasformano ogni salto in una planata controllata.",
+      "spinta_selettiva": "Il terreno peggiore era anche il più sicuro: chi lo sorvolava smetteva di pagarne il prezzo.",
+      "uso_funzione": "Al grado 1 la planata annulla il costo di movimento aggiuntivo del terreno normale.",
+      "debolezza": "Una planata non si corregge a metà: chi la inizia non sceglie più dove atterrare."
     },
     "ali_ioniche": {
       "label": "Ali Ioniche",
       "mutazione_indotta": "Le membrane alari accumulano carica lungo nervature metalliche e la scaricano in micro-impulsi.",
       "spinta_selettiva": "Nella canopia ionica l'aria è già elettrica: chi sa spenderla si muove per primo.",
-      "uso_funzione": "Concede scatti direzionali improvvisi e cambi di quota rapidi in esplorazione.",
-      "debolezza": "Ogni scatto svuota la carica; senza aria ionizzata le ali restano membrane inerti."
+      "uso_funzione": "Un attacco portato da posizione sopraelevata applica 1 turno di stordimento.",
+      "debolezza": "Lo stordimento dura un istante: se il branco non lo sfrutta subito, è sprecato."
     },
     "antenne_flusso_mareale": {
       "label": "Antenne di Flusso Mareale",
       "mutazione_indotta": "Le antenne si sono sintonizzate sul ritmo delle maree, immagazzinando l'onda nei condotti muscolari.",
       "spinta_selettiva": "Nella laguna bioreattiva colpire fuori tempo significa colpire l'acqua e nient'altro.",
-      "uso_funzione": "Scarica l'energia accumulata in un colpo singolo che apre le difese avversarie.",
-      "debolezza": "L'onda va rilasciata: trattenuta troppo a lungo, si scarica sul portatore."
+      "uso_funzione": "Con un colpo netto (margine 5 o più) il timing perfetto aggiunge 2 danni.",
+      "debolezza": "Un colpo approssimativo manca l'ondata: senza precisione le antenne non aggiungono nulla."
+    },
+    "artigli_psionici": {
+      "label": "Artigli Psionici",
+      "mutazione_indotta": "Le unghie conducono il pensiero: ogni presa preleva un frammento della mente che tocca.",
+      "spinta_selettiva": "Chi caccia lo stesso branco due volte impara che conoscere la preda vale più che ferirla.",
+      "uso_funzione": "Colpendo in mischia studia la preda: difendendosi da quella stessa preda accumula riduzione danno, fino a 3.",
+      "debolezza": "La lettura arriva solo col contatto: contro chi tiene le distanze gli artigli non sanno nulla."
+    },
+    "aura_glaciale": {
+      "label": "Aura Glaciale",
+      "mutazione_indotta": "Il sangue periferico scende sotto zero e l'aria intorno al corpo si condensa in brina.",
+      "spinta_selettiva": "Rallentare la preda costa meno che inseguirla, e il freddo non si stanca mai.",
+      "uso_funzione": "Ogni colpo applica 2 turni di gelo: il bersaglio perde 1 AP al reset e subisce -1 agli attacchi.",
+      "debolezza": "La brina si dissolve dove l'aria è calda: nei biomi roventi l'aura non riesce a condensare."
+    },
+    "canto_di_richiamo": {
+      "label": "Canto di Richiamo",
+      "mutazione_indotta": "Le sacche vocali si sono ampliate in camere che sostengono una nota lunga quanto un respiro intero.",
+      "spinta_selettiva": "Un branco che non celebra la preda dimentica perché caccia insieme.",
+      "uso_funzione": "Dopo un'uccisione il canto amplifica la furia per 2 turni e onora la preda caduta.",
+      "debolezza": "Due turni di furia sono pochi: il canto arriva quando lo scontro è già deciso."
+    },
+    "cervello_predittivo": {
+      "label": "Cervello Predittivo",
+      "mutazione_indotta": "La corteccia gira un passo avanti al presente e vede il movimento prima che accada.",
+      "spinta_selettiva": "In uno scontro fra pari vince chi arriva dove l'altro sarà, non dove l'altro è.",
+      "uso_funzione": "Con un colpo eccellente (margine 6 o più) il bersaglio resta stordito per 2 turni.",
+      "debolezza": "La previsione presuppone una regola: contro chi agisce a caso la corteccia sbaglia con sicurezza."
     },
     "corteccia_memetica": {
       "label": "Corteccia Memetica",
@@ -40,8 +75,15 @@
       "label": "Criostasi Adattiva",
       "mutazione_indotta": "Il sangue si carica di enzimi crioprotettivi che fermano il metabolismo senza spezzare i tessuti.",
       "spinta_selettiva": "Chi non sa attraversare l'inverno deve saperlo dormire.",
-      "uso_funzione": "Sospende il metabolismo per sopravvivere a stagioni estreme e carestie prolungate.",
-      "debolezza": "Nel sonno il corpo non filtra nulla: ogni veleno lavora indisturbato."
+      "uso_funzione": "Attivata, irrigidisce i tessuti e concede +2 alla difesa per 1 turno.",
+      "debolezza": "La stasi dura un turno soltanto: fuori da quella finestra il corpo resta scoperto."
+    },
+    "cuore_in_furia": {
+      "label": "Cuore in Furia",
+      "mutazione_indotta": "Il miocardio è cresciuto oltre misura e regge una tachicardia che ucciderebbe un cuore normale.",
+      "spinta_selettiva": "La prima uccisione apre le altre: chi non sa incassare l'euforia la spreca.",
+      "uso_funzione": "Dopo un'uccisione il cuore entra in tachicardia e scatena 3 turni di furia adrenalinica.",
+      "debolezza": "Serve un'uccisione per accenderlo: in una battaglia di stallo il cuore non parte mai."
     },
     "denti_seghettati": {
       "label": "Denti Seghettati",
@@ -57,12 +99,68 @@
       "uso_funzione": "Un impulso marca il terreno come zona risonante per 2 round.",
       "debolezza": "L'eco non distingue amico da nemico: la zona rivela anche chi l'ha creata."
     },
+    "ferocia": {
+      "label": "Ferocia",
+      "mutazione_indotta": "Le ghiandole surrenali restano semiaperte e il dolore arriva sempre un istante troppo tardi.",
+      "spinta_selettiva": "Sotto pressione l'esitazione uccide più della ferita: sopravvive chi raddoppia il colpo.",
+      "uso_funzione": "Ogni uccisione scatena 3 turni di furia: niente ritirata e +1 danno sui colpi riusciti.",
+      "debolezza": "In furia la ritirata è preclusa: chi entra in rabbia resta in campo anche mentre perde."
+    },
+    "filtri_bioattivi": {
+      "label": "Filtri Bioattivi",
+      "mutazione_indotta": "Un reticolo di ghiandole filtra il sangue in circolo e ricuce i tessuti mentre li attraversa.",
+      "spinta_selettiva": "Nelle acque marce la ferita infetta prima di chiudersi: serviva un corpo che si lavasse da solo.",
+      "uso_funzione": "Ogni round purga 1 sanguinamento e 1 frattura, e cura 1 per ogni stato rimosso.",
+      "debolezza": "Il filtro lavora un male alla volta: sotto molti stati insieme resta indietro."
+    },
     "ghiandole_mnemoniche": {
       "label": "Ghiandole Mnemoniche",
       "mutazione_indotta": "Ghiandole sinaptiche condensano gli stati alterati in secrezioni che li conservano attenuati.",
       "spinta_selettiva": "Nella frattura sinaptica ogni potenziamento svanisce: sopravvive chi ne serba una copia.",
       "uso_funzione": "Conserva una copia indebolita di un potenziamento e la ridistribuisce più tardi.",
       "debolezza": "La copia è sempre più povera dell'originale e occupa la ghiandola finché non viene spesa."
+    },
+    "intimidatore": {
+      "label": "Aura Intimidatoria",
+      "mutazione_indotta": "La postura si è irrigidita in una sagoma che il cervello della preda legge come inevitabile.",
+      "spinta_selettiva": "Una preda che scappa non combatte: spaventare costa meno che vincere.",
+      "uso_funzione": "Ogni colpo in mischia riuscito applica 2 turni di panico agli avversari adiacenti.",
+      "debolezza": "Il terrore ha bisogno di occhi e di vicinanza: da lontano resta solo una sagoma."
+    },
+    "legame_di_branco": {
+      "label": "Legame di Branco",
+      "mutazione_indotta": "Le vocalizzazioni si sono ridotte a segnali brevi che il branco decodifica senza guardarsi.",
+      "spinta_selettiva": "Un branco che scopre la minaccia insieme la subisce una volta sola.",
+      "uso_funzione": "Quando un compagno adiacente della stessa specie attacca, guadagna +1 all'attacco e +1 alla difesa fino a fine round.",
+      "debolezza": "Il legame riconosce solo la propria specie: in una squadra mista resta muto."
+    },
+    "marchio_predatorio": {
+      "label": "Marchio Predatorio",
+      "mutazione_indotta": "Ghiandole ascellari rilasciano un feromone che aderisce alla preda e la rende leggibile al branco.",
+      "spinta_selettiva": "Cacciare in molti serve a poco se ognuno insegue una preda diversa.",
+      "uso_funzione": "Ogni colpo marchia il bersaglio per 2 turni: il prossimo attacco su di lui ottiene +1 danno e consuma il marchio.",
+      "debolezza": "Il marchio vale un colpo solo, e lo spende il primo che arriva, non il migliore."
+    },
+    "membrane_osmotiche": {
+      "label": "Membrane Osmotiche",
+      "mutazione_indotta": "La membrana esterna beve ciò che la colpisce e ne trattiene una parte prima che raggiunga il sangue.",
+      "spinta_selettiva": "Dove ogni tocco è veleno, un corpo impermeabile perde meno tempo a guarire.",
+      "uso_funzione": "Riduce di 1 turno la durata di ogni stato in arrivo: uno stato da 1 turno viene assorbito del tutto.",
+      "debolezza": "Contro uno stato lungo l'assorbimento è un rinvio, non una difesa."
+    },
+    "mente_lucida": {
+      "label": "Mente Lucida",
+      "mutazione_indotta": "L'attenzione non si sposta con la paura: lo sguardo resta fermo dove la guardia si apre.",
+      "spinta_selettiva": "Nel panico tutti vedono l'arma. Vince chi continua a vedere il varco.",
+      "uso_funzione": "Un colpo netto (margine 5 o più) fa sentire visto il bersaglio: 2 turni di panico.",
+      "debolezza": "La lucidità è lenta: costa un istante che in mischia stretta non sempre esiste."
+    },
+    "midollo_iperattivo": {
+      "label": "Midollo Iperattivo",
+      "mutazione_indotta": "Il midollo osseo produce catecolamine come se ogni uccisione fosse la prima.",
+      "spinta_selettiva": "Chi caccia in serie non può permettersi di raffreddarsi fra una preda e l'altra.",
+      "uso_funzione": "Ogni uccisione pompa adrenalina e scatena 3 turni di furia.",
+      "debolezza": "Il midollo consuma sé stesso: le ossa si rigenerano più lente di quanto si spendano."
     },
     "nodi_micorrizici_oracolari": {
       "label": "Nodi Micorrizici Oracolari",
@@ -78,6 +176,48 @@
       "uso_funzione": "Ammortizza ogni colpo in arrivo e riduce il danno subito di 1.",
       "debolezza": "L'elastomero attutisce l'impatto, non il veleno che passa attraverso la pelle."
     },
+    "pelli_anti_ustione": {
+      "label": "Pelli Anti-Ustione",
+      "mutazione_indotta": "Lo strato dermico si è riempito di cellule vuote che disperdono il calore prima che scenda.",
+      "spinta_selettiva": "Sulle croste laviche il contatto è breve e continuo: bruciarsi era una condanna lenta.",
+      "uso_funzione": "L'effetto cuscinetto termico riduce di 1 il danno di ogni colpo subito.",
+      "debolezza": "Un punto di danno in meno non ferma un colpo grosso: contro chi picchia forte è quasi nulla."
+    },
+    "pelli_cave": {
+      "label": "Pelli Cave",
+      "mutazione_indotta": "Sotto la pelle si sono aperte sacche d'aria che trattengono il caldo fuori e il fresco dentro.",
+      "spinta_selettiva": "Nell'arido l'ombra non basta: il corpo deve portarsi addosso la propria.",
+      "uso_funzione": "Le sacche d'aria attutiscono l'impatto e riducono di 1 il danno di ogni colpo.",
+      "debolezza": "Le sacche riducono l'urto ma non l'ustione, né il veleno che filtra tra i pori."
+    },
+    "pelli_fitte": {
+      "label": "Pelli Fitte",
+      "mutazione_indotta": "Le fibre dermiche si sono intrecciate fitte come un feltro, e l'acqua non trova più uscita.",
+      "spinta_selettiva": "Il vento costante non ferisce: prosciuga. Sopravvive chi trattiene.",
+      "uso_funzione": "Ogni colpo in mischia subito viene attutito di 2 danni.",
+      "debolezza": "Il feltro para la mischia: contro chi colpisce da lontano non attutisce nulla."
+    },
+    "radici_ancora_planare": {
+      "label": "Radici Ancora Planare",
+      "mutazione_indotta": "Radici escono dai talloni e mordono il piano su cui il corpo si ferma.",
+      "spinta_selettiva": "Un tronco non fugge. Se deve reggere l'urto, tanto vale essere impossibile da spostare.",
+      "uso_funzione": "A inizio round mette radici: da fermo riduce di 2 il danno, ma muoversi rompe l'ancora.",
+      "debolezza": "Un nemico che non lo attacca lo ignora: ancorato, il portatore non insegue nessuno."
+    },
+    "sensori_sismici": {
+      "label": "Sensori Sismici",
+      "mutazione_indotta": "Recettori cutanei si sono affinati fino a distinguere il peso che si sposta da quello che si posa.",
+      "spinta_selettiva": "Un predatore tradisce l'attacco col piede prima che con gli occhi.",
+      "uso_funzione": "Con un colpo netto in mischia (margine 5 o più) entra nell'apertura e infligge 1 danno extra.",
+      "debolezza": "Il suolo deve trasmettere: sull'acqua e sulla sabbia mossa i sensori tacciono."
+    },
+    "spirito_combattivo": {
+      "label": "Spirito Combattivo",
+      "mutazione_indotta": "L'amigdala si è calibrata verso il basso: la minaccia arriva, ma non prende il comando.",
+      "spinta_selettiva": "Un branco che si sfalda al primo urlo perde prima ancora di combattere.",
+      "uso_funzione": "Quando un alleato adiacente attacca, il portatore guadagna +1 all'attacco fino a fine round.",
+      "debolezza": "Da solo non vale nulla: senza un alleato accanto il morale non si accende."
+    },
     "spore_paniche": {
       "label": "Spore Paniche",
       "mutazione_indotta": "Sacche sporali maturano sotto la pelle e si aprono al primo segnale di minaccia.",
@@ -85,19 +225,54 @@
       "uso_funzione": "Le spore neurotossiche inducono allucinazioni e mettono in fuga: 3 turni di panico.",
       "debolezza": "La nube non sceglie i polmoni: gli alleati vicini respirano lo stesso terrore."
     },
+    "sussurro_psichico": {
+      "label": "Sussurro Psichico",
+      "mutazione_indotta": "Una sacca sublinguale emette frequenze che il timpano non registra ma il nervo sì.",
+      "spinta_selettiva": "Confondere un avversario più forte costa un soffio; affrontarlo costa il branco.",
+      "uso_funzione": "Ogni colpo solido (margine 5 o più) applica 1 turno di disorientamento: -2 ai tiri d'attacco.",
+      "debolezza": "Serve un colpo netto: un tocco appena riuscito non porta il sussurro fino al nervo."
+    },
+    "tela_appiccicosa": {
+      "label": "Tela Appiccicosa",
+      "mutazione_indotta": "Ghiandole addominali filano un secreto che indurisce solo quando qualcosa prova a staccarsene.",
+      "spinta_selettiva": "Non serve essere più veloci della preda: basta che sia più lenta di ieri.",
+      "uso_funzione": "Ogni colpo applica 3 turni di rallentamento: -1 AP al reset, con almeno 1 AP garantito.",
+      "debolezza": "Una preda che smette di tirare non resta invischiata: la tela punisce chi si dibatte."
+    },
+    "tentacoli_uncinati": {
+      "label": "Tentacoli Uncinati",
+      "mutazione_indotta": "Uncini di cheratina spuntano lungo i tentacoli e si chiudono all'indietro come ami.",
+      "spinta_selettiva": "Trattenere la preda un istante in più valeva quanto un secondo morso.",
+      "uso_funzione": "Ogni colpo in mischia applica 1 turno di frattura, limitando gli AP del bersaglio.",
+      "debolezza": "Un uncino che entra deve uscire: staccarsi da una preda corazzata li spezza."
+    },
+    "tessuti_adattivi": {
+      "label": "Tessuti Adattivi",
+      "mutazione_indotta": "I tessuti campionano ciò che li ferisce e si riorganizzano contro quello stesso canale.",
+      "spinta_selettiva": "Un ambiente che colpisce sempre allo stesso modo insegna in fretta a chi sopravvive.",
+      "uso_funzione": "Subiti 2 o più danni di un canale, guadagna +15% di resistenza a quel canale per 3 round e cura 1.",
+      "debolezza": "L'adattamento guarda indietro: chi alterna i canali di danno non gli lascia mai imparare."
+    },
     "voce_imperiosa": {
       "label": "Voce Imperiosa",
       "mutazione_indotta": "Le corde vocali si sono ispessite in una camera che risuona sotto la soglia dell'udito.",
       "spinta_selettiva": "In un branco l'ordine di fuga arriva prima del predatore: chi lo pronuncia comanda.",
-      "uso_funzione": "In mischia la voce spezza la volontà del bersaglio: 2 turni di panico.",
+      "uso_funzione": "In mischia, un colpo netto (margine 5 o più) applica 2 turni di panico.",
       "debolezza": "Vale solo a portata di voce e non tocca chi non ha volontà da spezzare."
     },
     "zampe_a_molla": {
       "label": "Zampe a Molla",
       "mutazione_indotta": "I tendini posteriori si sono avvolti come molle che trattengono la spinta fra un balzo e l'altro.",
       "spinta_selettiva": "Nella foresta miceliale il suolo cede: sopravvive chi non resta fermo abbastanza da sprofondare.",
-      "uso_funzione": "Accumula energia e la libera in un balzo che riposiziona l'unità fuori dalla minaccia.",
-      "debolezza": "Serve spazio per la rincorsa: negli anfratti stretti le molle non hanno dove scaricarsi."
+      "uso_funzione": "Colpendo da posizione sopraelevata con margine 5 o più, infligge 1 danno extra.",
+      "debolezza": "Il balzo serve solo a salire: senza un colpo preciso dall'alto le molle non pagano."
+    },
+    "zampe_radianti": {
+      "label": "Zampe Radianti",
+      "mutazione_indotta": "I cuscinetti plantari accumulano l'urto della caduta e lo restituiscono all'impatto.",
+      "spinta_selettiva": "Chi attacca dall'alto ha già l'energia: bastava non sprecarla nell'atterraggio.",
+      "uso_funzione": "Attaccando da posizione sopraelevata la pulsazione cinetica aggiunge 2 danni all'impatto.",
+      "debolezza": "Serve un dislivello: sul piano le zampe non hanno caduta da convertire."
     }
   }
 }

--- a/tests/play/i18nTraits.test.js
+++ b/tests/play/i18nTraits.test.js
@@ -1,0 +1,20 @@
+// Trait flavor i18n -- il bundle `traits` deve essere risolvibile via t() come `common`.
+// Senza questo wiring i placeholder `i18n:traits.<id>.<campo>` non hanno alcun consumatore
+// a runtime e il testo curato resta invisibile al giocatore.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function load() {
+  return import('../../apps/play/src/i18n.js');
+}
+
+describe('i18n traits namespace', () => {
+  test('resolves a trait label in IT and EN', async () => {
+    const { t } = await load();
+    assert.equal(t('traits.denti_seghettati.label', null, 'it'), 'Denti Seghettati');
+    assert.equal(t('traits.denti_seghettati.label', null, 'en'), 'Serrated Teeth');
+  });
+});

--- a/tests/play/onboardingTraitLine.test.js
+++ b/tests/play/onboardingTraitLine.test.js
@@ -1,0 +1,40 @@
+// Onboarding card -- la riga del tratto. Oggi mostra al giocatore l'id grezzo
+// (`Trait: zampe_a_molla`). Con il bundle `traits` curato deve mostrare il nome e
+// l'effetto in chiaro; per i tratti non ancora curati deve degradare, non rompersi.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadModule() {
+  return import('../../apps/play/src/onboardingPanel.js');
+}
+
+describe('traitLineFor', () => {
+  test('curated trait -> label + effetto in chiaro', async () => {
+    const { traitLineFor } = await loadModule();
+    assert.equal(
+      traitLineFor('denti_seghettati', 'it'),
+      'Denti Seghettati -- Il morso lacera la carne e applica sanguinamento profondo per 2 turni.',
+    );
+  });
+
+  test('uncurated trait -> vecchia riga `Trait: <id>`, mai la chiave grezza', async () => {
+    const { traitLineFor } = await loadModule();
+    const line = traitLineFor('tratto_non_ancora_curato', 'it');
+    assert.equal(line, 'Trait: tratto_non_ancora_curato');
+    assert.ok(!line.includes('traits.'), 'non deve perdere una chiave i18n nella UI');
+  });
+
+  test('i tre tratti dell onboarding sono tutti curati, IT e EN', async () => {
+    const { traitLineFor } = await loadModule();
+    for (const id of ['zampe_a_molla', 'pelle_elastomera', 'denti_seghettati']) {
+      for (const loc of ['it', 'en']) {
+        const line = traitLineFor(id, loc);
+        assert.ok(line.includes(' -- '), `${id}/${loc}: manca l'effetto in chiaro (${line})`);
+        assert.ok(!line.startsWith('Trait: '), `${id}/${loc}: caduto nel fallback`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Perche'

I placeholder `i18n:traits.<id>.<campo>` nei 309 file di `data/traits/**` **non avevano alcun consumatore a runtime**:

- `apps/backend/services/traitRepository.js:81` usa il prefisso solo per estrarre l'id via regex;
- `traitStyleGuide.js` lo valida come convenzione di naming;
- `locales/it/traits.json` (263 entry) ha **zero lettori**;
- la spec lo dice: *"Backend: nessun loader i18n reale (il prefisso `i18n:traits.*` e' convenzione di naming, non runtime)"* -- `docs/design/evo-tactics-localization-i18n.md`.

Effetto visibile: la card di onboarding mostrava al giocatore l'id grezzo -- `Trait: zampe_a_molla`.

## Cosa cambia

- **`data/i18n/{it,en}/traits.json`** (nuovi): namespace `traits`, 13 tratti curati -- i 10 del primo lotto autorato + i 3 delle scelte di onboarding (`zampe_a_molla`, `pelle_elastomera`, `denti_seghettati`). Destinazione per **ADR-2026-06-08 (QA3, `data/i18n` = sorgente unica)**. `validate_i18n_parity.py` li raccoglie da solo (glob `<locale>/*.json`): **namespaces `['common','traits']`, 0 errori**, nessuna riga di codice aggiunta al validator.
- **`apps/play/src/i18n.js`**: merge del bundle `traits` in `MESSAGES` **per-namespace**, cosi' che `_meta` di un bundle non sovrascriva quello del fratello (uno spread shallow lo farebbe).
- **`apps/play/src/onboardingPanel.js`**: nuova funzione pura `traitLineFor()`. La card mostra `<label> -- <effetto in chiaro>`. **Degrada in due passi**: senza label curata torna alla vecchia riga `Trait: <id>`; con label ma senza effetto mostra solo il nome. 296 tratti su 309 sono ancora da curare, quindi il fallback e' il caso comune, non l'eccezione.

## Contenuto: come e' stato prodotto

Il testo segue un template a 4 campi che rispecchia lo schema reale (`traitStyleGuide.js:6`):
`mutazione_indotta` (cosa il corpo ha cambiato) / `spinta_selettiva` (la pressione che l'ha selezionato) /
`uso_funzione` (**l'effetto in chiaro, con i numeri del canone alla lettera**) / `debolezza` (una contromossa reale, non una tassa di manutenzione).

Routing scelto con eval misurata (llmfit shortlist -> task-eval N-sample sul prompt reale), non a occhio. I modelli locali passano lo schema ma rompono il **contratto col dato**: `gemma3:12b` ha inventato *"riduce i danni del 50%"* per `criostasi_adattiva` (meccanica non autorizzata dal canone), `mistral` inventa chiavi. Un `harsh-reviewer` in blind A/B/C ha giudicato il testo qui incluso *"pubblicabile cosi' com'e'"*.

Nota: `denti_seghettati` porta il numero canonico (**sanguinamento 2 turni**) che una prima bozza aveva perso.

## Verifica

| gate | esito |
| --- | --- |
| `tests/play` (26 file, run esplicito per-file) | **324/324** |
| `tests/i18n/parity.test.js` | 4/4 |
| `tests/play/i18nTraits.test.js` (nuovo) | 1/1 |
| `tests/play/onboardingTraitLine.test.js` (nuovo) | 3/3 |
| `validate_i18n_parity.py --root data/i18n` | **0 errori**, 4 warning (`completion_percent < 90`, atteso: 13/309) |

I due test nuovi sono nati RED: `t('traits.denti_seghettati.label')` restituiva la chiave; `traitLineFor is not a function`.

`node --test tests/play/` (modalita' directory) fallisce con `MODULE_NOT_FOUND` **anche su albero pulito** -- Node 24 in ambiente, il repo e' Node-22-canonico. Non e' una regressione di questo PR; ho eseguito i 26 file esplicitamente.

## Fuori scope (follow-up)

`locales/it/traits.json` + `scripts/sync_trait_locales.py` restano un **secondo key-space**, in conflitto con QA3. Vanno migrate le ~119 stringhe uniche (delle 237 presenti, ~118 sono cloni boilerplate ripetuti fino a 14 volte) e ritirato lo script. Separato per tenere questo PR rivedibile.

Prossimo lotto: 25 tratti, raggruppati per categoria, partendo dai 46 senza alcuna entry.