### PR TITLE
[do NOT merge -- owner] fix(ci): stack paths-filter blind spot for encounter YAML + schemas/evo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,19 @@ jobs:
               # test:api). A codex-only edit matched 'data' (-> dataset-checks)
               # but not 'stack', so the authoring gate it polices never ran.
               - 'data/codex/**/*.yaml'
+              # 2026-07-10 -- same blind spot found on PR #3244 (issue #2744
+              # backport): encounter YAML + the evo schema feed AJV/author-guard
+              # gates inside test:api (tests/scripts/encounterSchema.test.js on
+              # docs/planning/encounters, tests/services/combat/
+              # encounterGridSchema.test.js on schemas/evo/encounter.schema.json,
+              # tests/difficulty + tests/codex species_hint cross-check on
+              # data/encounters), but none of these paths matched 'stack', so an
+              # encounter-only or schema-only PR skipped stack-quality entirely
+              # (every check "skipping" on #3244; gate covered by local run only).
+              - 'data/encounters/**/*.yaml'
+              - 'docs/planning/encounters/**/*.yaml'
+              - 'docs/planning/encounters-draft/**/*.yaml'
+              - 'schemas/evo/**'
               - 'packs/**/*.yaml'
               - 'packages/contracts/schemas/**'
               # OD-038 — sim bridge JS must hit stack-quality (Prettier).

--- a/scripts/run-test-api.cjs
+++ b/scripts/run-test-api.cjs
@@ -22,6 +22,12 @@ const steps = [
   'node --test tests/scripts/replaceAllSafety.test.js',
   'node --test tests/scripts/damageCurvesIntegrity.test.js',
   'node --test tests/scripts/crossPlatformRunners.test.js',
+  // tests/scripts/encounterSchema.test.js was CI-orphaned (anti-pattern #10):
+  // never listed above nor matched by any glob, so the AJV gate validating
+  // docs/planning/encounters/*.yaml against schemas/evo/encounter.schema.json
+  // only ever ran locally (found on PR #3244 together with the ci.yml 'stack'
+  // paths-filter blind spot; both fixed 2026-07-10).
+  'node --test tests/scripts/encounterSchema.test.js',
   'node --test tests/i18n/parity.test.js',
   'node --test tests/play/*.test.js',
   // tests/services/** + tests/ai/** were not covered by the globs above ->


### PR DESCRIPTION
> **do NOT merge** -- tocca `.github/workflows/` (forbidden path): merge esplicito di Eduardo richiesto.

## Problema

Blind spot nel paths-filter di `ci.yml` scoperto sul backport #2744 (PR #3244, merged): i path `data/encounters/**`, `docs/planning/encounters/**`, `docs/planning/encounters-draft/**` e `schemas/evo/**` non matchavano NESSUN filtro, quindi un PR encounter-only o schema-only saltava `stack-quality` -- su #3244 tutti i check risultavano "skipping", gate coperto solo dal run locale.

## Ground-truth (step 2 del task)

- `stack-quality` (gated `stack == 'true'`) esegue `npm run test:api` -> `scripts/run-test-api.cjs`. Confermato.
- `tests/services/combat/encounterGridSchema.test.js` -> coperto dal glob `node --test tests/services/*/*.test.js` (riga 35 del runner). OK.
- 🔴 `tests/scripts/encounterSchema.test.js` era **CI-orfano** (anti-pattern #10): il runner usa entry esplicite per `tests/scripts/` (nessun glob) e quel file non era in lista, ne' referenziato in alcun job/Makefile/package.json. Il solo fix del filtro avrebbe triggherato un job che comunque NON faceva girare quel gate -> falso-verde peggiore del blind spot.

## Fix (2 file)

1. **`.github/workflows/ci.yml`** -- filtro `stack`: aggiunti `data/encounters/**/*.yaml`, `docs/planning/encounters/**/*.yaml`, `docs/planning/encounters-draft/**/*.yaml`, `schemas/evo/**` con commento datato 2026-07-10 nello stile dei fix precedenti (post-#2223, audit 2026-06-18).
2. **`scripts/run-test-api.cjs`** -- wire esplicito di `tests/scripts/encounterSchema.test.js` (AJV su `docs/planning/encounters/*.yaml` vs `schemas/evo/encounter.schema.json`), commento anti-pattern #10.

Copertura dei path aggiunti dentro test:api: `docs/planning/encounters` -> encounterSchema (ora wired) + tests/difficulty author-guard; `schemas/evo` -> encounterSchema + encounterGridSchema; `data/encounters` -> tests/codex species_hint cross-check (#2851).

## Gate eseguiti (locale)

- `actionlint 1.7.7` su ci.yml: **clean** (lesson PR cdd #498: mai solo PyYAML)
- `node --test tests/scripts/encounterSchema.test.js`: **22/22 pass**
- `node --test tests/services/combat/encounterGridSchema.test.js`: **0 fail**
- `node --test tests/scripts/crossPlatformRunners.test.js`: **0 fail** (asserisce internals dei runner)
- `npx prettier --check` sui 2 file: **clean**
- Nessun workflow dispatchato pre-merge (come da task).

## Rollback (03A)

Revert singolo commit `284664251` -- additive-only (19 righe), zero cambi runtime: torna al comportamento pre-fix (blind spot incluso). Nessuna migrazione/stato.

## Changelog

- fix(ci): encounter YAML + schemas/evo ora triggherano stack-quality; encounterSchema.test.js wired in test:api.

Trace-Id: 019f4b27-ec77-7cd1-9039-77327ef10f7b

🤖 Generated with [Claude Code](https://claude.com/claude-code)