### PR TITLE
refactor(combat): extract apLedger (AP-cost authority)

### DIFF
--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -150,6 +150,7 @@ function createRoundBridge(deps) {
     // 2 AP invece di 4 richiesti).
     // 2026-07 hardening: the sum uses resolveIntentApCost (server-authoritative for
     // attack/ability), so declaring ap_cost:0/negative no longer bypasses the gate.
+    // Keep in lockstep with apLedger.canAfford (extraction follow-up: rewire onto the ledger).
     const apCost = resolveIntentApCost(actor, action);
     const apAvail = Number(actor.ap_remaining != null ? actor.ap_remaining : actor.ap || 0);
     const pendingForActor = ((session.roundState && session.roundState.pending_intents) || [])

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -274,89 +274,17 @@ function createRoundBridge(deps) {
     return null;
   }
 
-  // Server-authoritative move AP cost (security fix 2026-07-05). The resolver
-  // must NOT trust action.ap_cost for moves: the shipped client posts ap_cost:1
-  // for any destination, so a raw request could move N tiles for 1 AP. Cost =
-  // max(1, Manhattan(from,to) - move_bonus), mirroring the legacy /session/action
-  // path (routes/session.js). Terrain-weighted cost stays on that legacy path;
-  // the round path uses the Manhattan basis by design (band-neutral).
-  function resolveMoveApCost(actor, from, to) {
-    const dist = typeof manhattanDistance === 'function' ? manhattanDistance(from, to) : 0;
-    const moveBonus = Math.max(0, Number((actor && actor.move_bonus_bonus) || 0));
-    return Math.max(1, dist - moveBonus);
-  }
-
-  // Canon basic-attack AP cost. The client (apps/play lobbyBridge + ability panel)
-  // and the legacy attack wrapper all use 1; jobs.yaml basic attacks are cost_ap:1.
-  const ATTACK_BASE_AP_COST = 1;
-
-  // Server-authoritative AP cost for non-move round actions, mirroring
-  // resolveMoveApCost. validatePlayerIntent only checks the TOTAL declared
-  // ap_cost against the AP budget -- never a per-action minimum -- so a raw-HTTP
-  // client can post a negative/fractional ap_cost on an attack (gain or undercharge
-  // AP) or ap_cost:1 for a 2-AP ability (undercharge by half) and be undercharged
-  // (OWASP A04, same class as the move undercharge). The client value is advisory:
-  //   - attack             -> ATTACK_BASE_AP_COST (canon), client value ignored
-  //   - ability_id present -> registry cost_ap (same source the ability executor
-  //                           deducts); unknown ability floors at 1 AP
-  //   - anything else (skip/pass/...) -> legacy client default; no server cost
-  //     source exists for these, so behavior is preserved (out of scope).
-  // NOTE: the round-bridge `else` branch deducts this cost but does NOT execute
-  // the ability effect (effects run on /round/execute -> abilityExecutor, which
-  // self-deducts cost_ap). If a future change dispatches the effect on the bridge
-  // path too, drop this deduction there to avoid double-charging.
-  function resolveActionApCost(actor, action) {
-    if (!action || typeof action !== 'object') return 1;
-    if (action.type === 'attack') return ATTACK_BASE_AP_COST;
-    if (action.ability_id) {
-      let spec = null;
-      try {
-        spec = require('../services/abilityExecutor').findAbility(action.ability_id);
-      } catch {
-        /* ability registry optional -- fall back to floored client value */
-      }
-      // Floor at 0 to mirror abilityExecutor's clamp (no ability refunds AP even
-      // if a future jobs.yaml entry ships a negative/NaN cost_ap); cost_ap:0 (e.g.
-      // intercept) is a legitimate 0-AP reaction and passes through.
-      if (spec && spec.cost_ap != null) return Math.max(0, Number(spec.cost_ap) || 0);
-      return Math.max(1, Number(action.ap_cost || 1));
-    }
-    return Number(action.ap_cost || 1);
-  }
-
-  // True when a move destination is a valid, in-grid cell (mirrors the NO_DEST +
-  // OUT_OF_GRID checks in validatePlayerIntent). Used to decide whether the budget
-  // gate can trust a server-authoritative move cost: an off-grid / malformed dest
-  // keeps the advisory client value so its own OUT_OF_GRID / NO_DEST rejection
-  // fires first (clearer error, and no NaN from manhattanDistance on a bad dest).
-  function isValidGridDest(dest) {
-    if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') return false;
-    if (!Number.isFinite(dest.x) || !Number.isFinite(dest.y)) return false;
-    const size = gridSize || 6;
-    return dest.x >= 0 && dest.x < size && dest.y >= 0 && dest.y < size;
-  }
-
-  // Declare-time budget cost of an intent, for validatePlayerIntent. Attack/ability
-  // use the server-authoritative resolveActionApCost, and a move to a valid in-grid
-  // cell uses resolveMoveApCost -- so a client cannot pass the budget gate by
-  // declaring ap_cost:0/negative and over-declare free actions. The resolver charges
-  // the real cost per action but floors ap_remaining at 0, so an un-gated
-  // over-declaration still executes N actions while paying for fewer (OWASP A04):
-  // for moves this means N short moves at ap_cost:0 all clear the pending-sum gate
-  // and the (N+1)th still resolves for free. Charging max(1, dist - move_bonus) per
-  // move in the pending sum closes that. AP_INSUFFICIENT now precedes MOVE_TOO_FAR
-  // for a single over-far in-grid move (both 400 rejections; the over-far move IS
-  // over-budget). skip/off-grid/other keep the client value: skip legitimately
-  // costs 0, and an off-grid dest is rejected by OUT_OF_GRID before this matters.
-  function resolveIntentApCost(actor, act) {
-    if (act && (act.type === 'attack' || act.ability_id)) {
-      return resolveActionApCost(actor, act);
-    }
-    if (act && act.type === 'move' && isValidGridDest(act.move_to)) {
-      return resolveMoveApCost(actor, actor && actor.position, act.move_to);
-    }
-    return Number((act && act.ap_cost) || 0);
-  }
+  // AP cost authority (resolveMoveApCost / resolveActionApCost /
+  // resolveIntentApCost / isValidGridDest) -- extracted to apLedger (spec
+  // docs/superpowers/specs/2026-07-10-sistema-symmetry-design.md sez. 4.1).
+  // Load-bearing comments (anti-double-charge, OWASP A04 hardening) live with
+  // the code there now.
+  const {
+    resolveMoveApCost,
+    resolveActionApCost,
+    resolveIntentApCost,
+    isValidGridDest,
+  } = require('../services/combat/apLedger').createApLedger({ manhattanDistance, gridSize });
 
   // ────────────────────────────────────────────────────────────────
   // Guards + adapters

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -280,12 +280,8 @@ function createRoundBridge(deps) {
   // docs/superpowers/specs/2026-07-10-sistema-symmetry-design.md sez. 4.1).
   // Load-bearing comments (anti-double-charge, OWASP A04 hardening) live with
   // the code there now.
-  const {
-    resolveMoveApCost,
-    resolveActionApCost,
-    resolveIntentApCost,
-    isValidGridDest,
-  } = require('../services/combat/apLedger').createApLedger({ manhattanDistance, gridSize });
+  const { resolveMoveApCost, resolveActionApCost, resolveIntentApCost, isValidGridDest } =
+    require('../services/combat/apLedger').createApLedger({ manhattanDistance, gridSize });
 
   // ────────────────────────────────────────────────────────────────
   // Guards + adapters

--- a/apps/backend/services/combat/apLedger.js
+++ b/apps/backend/services/combat/apLedger.js
@@ -4,6 +4,17 @@
 // docs/superpowers/specs/2026-07-10-sistema-symmetry-design.md sez. 4.1).
 // Factory: injected deps, zero state, zero Express.
 
+/**
+ * Build an AP-cost ledger bound to the given grid deps.
+ *
+ * @param {Object} deps
+ * @param {Function} deps.manhattanDistance - (a, b) -> integer tile distance.
+ * @param {number} deps.gridSize - NUMBER (scalar, square-grid) contract
+ *   inherited verbatim from the bridge (falls back to 6 when falsy).
+ *   Rectangular {width,height} support is explicitly a follow-up of the
+ *   Sistema task and MUST NOT be added here.
+ * @returns {Object} ledger: the 4 verbatim resolvers + apAvailable/canAfford.
+ */
 function createApLedger({ manhattanDistance, gridSize }) {
   // Server-authoritative move AP cost (security fix 2026-07-05). The resolver
   // must NOT trust action.ap_cost for moves: the shipped client posts ap_cost:1
@@ -89,17 +100,45 @@ function createApLedger({ manhattanDistance, gridSize }) {
     return Number((act && act.ap_cost) || 0);
   }
 
+  /**
+   * Spendable AP for an actor.
+   *
+   * Fallback chain: ap_remaining when present (the round-model ledger field),
+   * else ap (legacy/pre-round shape), else 0. A null/absent actor, or one
+   * missing both fields, resolves to 0 so downstream gates fail CLOSED
+   * (nothing is affordable for an unknown actor).
+   *
+   * @param {Object|null} actor
+   * @returns {number} spendable AP (0 when unknowable).
+   */
   function apAvailable(actor) {
     return Number(
       actor && actor.ap_remaining != null ? actor.ap_remaining : (actor && actor.ap) || 0,
     );
   }
 
+  /**
+   * Pending-sum affordability gate (the P1-3 multi-intent hardening,
+   * reusable for the Sistema declare-side).
+   *
+   * Keep in lockstep with the hand-rolled pending-sum gate in
+   * routes/sessionRoundBridge.js validatePlayerIntent (extraction
+   * follow-up: rewire that gate onto this ledger).
+   *
+   * @param {Object|null} actor - priced via resolveIntentApCost + apAvailable.
+   * @param {Array<Object>} declaredActions - array of raw ACTION objects
+   *   ({type, ap_cost, move_to, ability_id, ...}), NOT {unit_id, action}
+   *   intent wrappers, already pre-filtered to THIS actor. Passing intent
+   *   wrappers would price everything at 0 and fail OPEN -- as insurance,
+   *   an element carrying an `.action` key is unwrapped before pricing.
+   * @param {Object} action - the candidate raw action to admit.
+   * @returns {boolean} true when pending + candidate fits in apAvailable(actor).
+   */
   function canAfford(actor, declaredActions, action) {
-    const pending = (declaredActions || []).reduce(
-      (sum, a) => sum + resolveIntentApCost(actor, a),
-      0,
-    );
+    const pending = (declaredActions || []).reduce((sum, a) => {
+      const act = a && a.action ? a.action : a;
+      return sum + resolveIntentApCost(actor, act);
+    }, 0);
     return pending + resolveIntentApCost(actor, action) <= apAvailable(actor);
   }
 

--- a/apps/backend/services/combat/apLedger.js
+++ b/apps/backend/services/combat/apLedger.js
@@ -1,0 +1,116 @@
+'use strict';
+// apLedger -- single authority for AP costs (player + Sistema).
+// Extracted VERBATIM from the sessionRoundBridge closure (spec
+// docs/superpowers/specs/2026-07-10-sistema-symmetry-design.md sez. 4.1).
+// Factory: injected deps, zero state, zero Express.
+
+function createApLedger({ manhattanDistance, gridSize }) {
+  // Server-authoritative move AP cost (security fix 2026-07-05). The resolver
+  // must NOT trust action.ap_cost for moves: the shipped client posts ap_cost:1
+  // for any destination, so a raw request could move N tiles for 1 AP. Cost =
+  // max(1, Manhattan(from,to) - move_bonus), mirroring the legacy /session/action
+  // path (routes/session.js). Terrain-weighted cost stays on that legacy path;
+  // the round path uses the Manhattan basis by design (band-neutral).
+  function resolveMoveApCost(actor, from, to) {
+    const dist = typeof manhattanDistance === 'function' ? manhattanDistance(from, to) : 0;
+    const moveBonus = Math.max(0, Number((actor && actor.move_bonus_bonus) || 0));
+    return Math.max(1, dist - moveBonus);
+  }
+
+  // Canon basic-attack AP cost. The client (apps/play lobbyBridge + ability panel)
+  // and the legacy attack wrapper all use 1; jobs.yaml basic attacks are cost_ap:1.
+  const ATTACK_BASE_AP_COST = 1;
+
+  // Server-authoritative AP cost for non-move round actions, mirroring
+  // resolveMoveApCost. validatePlayerIntent only checks the TOTAL declared
+  // ap_cost against the AP budget -- never a per-action minimum -- so a raw-HTTP
+  // client can post a negative/fractional ap_cost on an attack (gain or undercharge
+  // AP) or ap_cost:1 for a 2-AP ability (undercharge by half) and be undercharged
+  // (OWASP A04, same class as the move undercharge). The client value is advisory:
+  //   - attack             -> ATTACK_BASE_AP_COST (canon), client value ignored
+  //   - ability_id present -> registry cost_ap (same source the ability executor
+  //                           deducts); unknown ability floors at 1 AP
+  //   - anything else (skip/pass/...) -> legacy client default; no server cost
+  //     source exists for these, so behavior is preserved (out of scope).
+  // NOTE: the round-bridge `else` branch deducts this cost but does NOT execute
+  // the ability effect (effects run on /round/execute -> abilityExecutor, which
+  // self-deducts cost_ap). If a future change dispatches the effect on the bridge
+  // path too, drop this deduction there to avoid double-charging.
+  function resolveActionApCost(actor, action) {
+    if (!action || typeof action !== 'object') return 1;
+    if (action.type === 'attack') return ATTACK_BASE_AP_COST;
+    if (action.ability_id) {
+      let spec = null;
+      try {
+        spec = require('../abilityExecutor').findAbility(action.ability_id);
+      } catch {
+        /* ability registry optional -- fall back to floored client value */
+      }
+      // Floor at 0 to mirror abilityExecutor's clamp (no ability refunds AP even
+      // if a future jobs.yaml entry ships a negative/NaN cost_ap); cost_ap:0 (e.g.
+      // intercept) is a legitimate 0-AP reaction and passes through.
+      if (spec && spec.cost_ap != null) return Math.max(0, Number(spec.cost_ap) || 0);
+      return Math.max(1, Number(action.ap_cost || 1));
+    }
+    return Number(action.ap_cost || 1);
+  }
+
+  // True when a move destination is a valid, in-grid cell (mirrors the NO_DEST +
+  // OUT_OF_GRID checks in validatePlayerIntent). Used to decide whether the budget
+  // gate can trust a server-authoritative move cost: an off-grid / malformed dest
+  // keeps the advisory client value so its own OUT_OF_GRID / NO_DEST rejection
+  // fires first (clearer error, and no NaN from manhattanDistance on a bad dest).
+  function isValidGridDest(dest) {
+    if (!dest || typeof dest.x !== 'number' || typeof dest.y !== 'number') return false;
+    if (!Number.isFinite(dest.x) || !Number.isFinite(dest.y)) return false;
+    const size = gridSize || 6;
+    return dest.x >= 0 && dest.x < size && dest.y >= 0 && dest.y < size;
+  }
+
+  // Declare-time budget cost of an intent, for validatePlayerIntent. Attack/ability
+  // use the server-authoritative resolveActionApCost, and a move to a valid in-grid
+  // cell uses resolveMoveApCost -- so a client cannot pass the budget gate by
+  // declaring ap_cost:0/negative and over-declare free actions. The resolver charges
+  // the real cost per action but floors ap_remaining at 0, so an un-gated
+  // over-declaration still executes N actions while paying for fewer (OWASP A04):
+  // for moves this means N short moves at ap_cost:0 all clear the pending-sum gate
+  // and the (N+1)th still resolves for free. Charging max(1, dist - move_bonus) per
+  // move in the pending sum closes that. AP_INSUFFICIENT now precedes MOVE_TOO_FAR
+  // for a single over-far in-grid move (both 400 rejections; the over-far move IS
+  // over-budget). skip/off-grid/other keep the client value: skip legitimately
+  // costs 0, and an off-grid dest is rejected by OUT_OF_GRID before this matters.
+  function resolveIntentApCost(actor, act) {
+    if (act && (act.type === 'attack' || act.ability_id)) {
+      return resolveActionApCost(actor, act);
+    }
+    if (act && act.type === 'move' && isValidGridDest(act.move_to)) {
+      return resolveMoveApCost(actor, actor && actor.position, act.move_to);
+    }
+    return Number((act && act.ap_cost) || 0);
+  }
+
+  function apAvailable(actor) {
+    return Number(
+      actor && actor.ap_remaining != null ? actor.ap_remaining : (actor && actor.ap) || 0,
+    );
+  }
+
+  function canAfford(actor, declaredActions, action) {
+    const pending = (declaredActions || []).reduce(
+      (sum, a) => sum + resolveIntentApCost(actor, a),
+      0,
+    );
+    return pending + resolveIntentApCost(actor, action) <= apAvailable(actor);
+  }
+
+  return {
+    resolveMoveApCost,
+    resolveActionApCost,
+    resolveIntentApCost,
+    isValidGridDest,
+    apAvailable,
+    canAfford,
+  };
+}
+
+module.exports = { createApLedger };

--- a/tests/services/apLedger.test.js
+++ b/tests/services/apLedger.test.js
@@ -1,0 +1,59 @@
+// tests/services/apLedger.test.js -- apLedger = autorita' unica costi AP
+// (estrazione dal closure di sessionRoundBridge, spec sistema-symmetry sez. 4.1).
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createApLedger } = require('../../apps/backend/services/combat/apLedger');
+
+const manhattan = (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+const ledger = createApLedger({ manhattanDistance: manhattan, gridSize: 16 });
+
+test('resolveMoveApCost: max(1, dist - move_bonus)', () => {
+  const actor = { move_bonus_bonus: 0 };
+  assert.equal(ledger.resolveMoveApCost(actor, { x: 0, y: 0 }, { x: 3, y: 0 }), 3);
+  assert.equal(
+    ledger.resolveMoveApCost({ move_bonus_bonus: 2 }, { x: 0, y: 0 }, { x: 3, y: 0 }),
+    1,
+  );
+  assert.equal(
+    ledger.resolveMoveApCost({ move_bonus_bonus: 9 }, { x: 0, y: 0 }, { x: 1, y: 0 }),
+    1,
+  );
+});
+
+test('resolveActionApCost: attack canon 1, client value ignorato', () => {
+  assert.equal(ledger.resolveActionApCost({}, { type: 'attack', ap_cost: -5 }), 1);
+  // NOTA: `Number(action.ap_cost || 1)` nel corpo reale -> ap_cost:0 e' falsy in
+  // JS e ricade sul default 1 (comportamento verbatim, non un bug da correggere
+  // qui: skip/pass non hanno una server cost source, vedi commento sopra).
+  assert.equal(ledger.resolveActionApCost({}, { type: 'skip', ap_cost: 0 }), 1);
+  assert.equal(ledger.resolveActionApCost({}, { type: 'skip', ap_cost: 3 }), 3);
+});
+
+test('isValidGridDest: bounds', () => {
+  assert.equal(ledger.isValidGridDest({ x: 15, y: 15 }), true);
+  assert.equal(ledger.isValidGridDest({ x: 16, y: 0 }), false);
+  assert.equal(ledger.isValidGridDest({ x: 'a', y: 0 }), false);
+});
+
+test('resolveIntentApCost: move in-grid usa costo server, off-grid tiene il client', () => {
+  const actor = { position: { x: 0, y: 0 }, move_bonus_bonus: 0 };
+  assert.equal(
+    ledger.resolveIntentApCost(actor, { type: 'move', move_to: { x: 2, y: 0 }, ap_cost: 0 }),
+    2,
+  );
+  assert.equal(
+    ledger.resolveIntentApCost(actor, { type: 'move', move_to: { x: 99, y: 0 }, ap_cost: 0 }),
+    0,
+  );
+});
+
+test('canAfford: somma pending + candidata vs ap_remaining', () => {
+  const actor = { ap_remaining: 2, position: { x: 0, y: 0 } };
+  const attack = { type: 'attack' };
+  assert.equal(ledger.canAfford(actor, [], attack), true);
+  assert.equal(ledger.canAfford(actor, [attack], attack), true);
+  assert.equal(ledger.canAfford(actor, [attack, attack], attack), false);
+  assert.equal(ledger.canAfford({ ap: 1, position: { x: 0, y: 0 } }, [attack], attack), false);
+});

--- a/tests/services/combat/apLedger.test.js
+++ b/tests/services/combat/apLedger.test.js
@@ -1,10 +1,10 @@
-// tests/services/apLedger.test.js -- apLedger = autorita' unica costi AP
+// tests/services/combat/apLedger.test.js -- apLedger = autorita' unica costi AP
 // (estrazione dal closure di sessionRoundBridge, spec sistema-symmetry sez. 4.1).
 'use strict';
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { createApLedger } = require('../../apps/backend/services/combat/apLedger');
+const { createApLedger } = require('../../../apps/backend/services/combat/apLedger');
 
 const manhattan = (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
 const ledger = createApLedger({ manhattanDistance: manhattan, gridSize: 16 });
@@ -29,6 +29,13 @@ test('resolveActionApCost: attack canon 1, client value ignorato', () => {
   // qui: skip/pass non hanno una server cost source, vedi commento sopra).
   assert.equal(ledger.resolveActionApCost({}, { type: 'skip', ap_cost: 0 }), 1);
   assert.equal(ledger.resolveActionApCost({}, { type: 'skip', ap_cost: 3 }), 3);
+});
+
+test('resolveActionApCost: ability sconosciuta floora a 1 (no undercharge)', () => {
+  assert.equal(
+    ledger.resolveActionApCost({}, { ability_id: 'nope_does_not_exist', ap_cost: 0 }),
+    1,
+  );
 });
 
 test('isValidGridDest: bounds', () => {
@@ -56,4 +63,27 @@ test('canAfford: somma pending + candidata vs ap_remaining', () => {
   assert.equal(ledger.canAfford(actor, [attack], attack), true);
   assert.equal(ledger.canAfford(actor, [attack, attack], attack), false);
   assert.equal(ledger.canAfford({ ap: 1, position: { x: 0, y: 0 } }, [attack], attack), false);
+});
+
+test('canAfford: move in declaredActions prezzato lato server (non ap_cost client)', () => {
+  const actor = { ap_remaining: 3, position: { x: 0, y: 0 } };
+  const move = { type: 'move', move_to: { x: 2, y: 0 }, ap_cost: 0 }; // costo server 2
+  const attack = { type: 'attack' };
+  assert.equal(ledger.canAfford(actor, [move], attack), true); // 2 + 1 <= 3
+  assert.equal(ledger.canAfford(actor, [move, attack], attack), false); // 2 + 1 + 1 > 3
+});
+
+test('canAfford: intent wrapper {unit_id, action} in declaredActions viene unwrappato', () => {
+  // Senza l'unwrap-insurance il wrapper (niente type/ability_id) verrebbe
+  // prezzato 0 e il gate fallirebbe OPEN: 0 + 1 <= 1 -> true. Con l'unwrap
+  // l'attack interno conta 1: 1 + 1 = 2 > 1 -> false (fail closed).
+  const actor = { ap_remaining: 1, position: { x: 0, y: 0 } };
+  const wrapped = { unit_id: 'x', action: { type: 'attack' } };
+  assert.equal(ledger.canAfford(actor, [wrapped], { type: 'attack' }), false);
+});
+
+test('canAfford: fail-closed su actor null o AP NaN', () => {
+  // actor null -> apAvailable 0 -> 1 <= 0 false; NaN -> 1 <= NaN false.
+  assert.equal(ledger.canAfford(null, [], { type: 'attack' }), false);
+  assert.equal(ledger.canAfford({ ap_remaining: NaN }, [], { type: 'attack' }), false);
 });


### PR DESCRIPTION
## Task 1 dell'arco sistema-symmetry (spec+piano: PR #3249)

Estrazione PURA: `resolveMoveApCost` / `resolveActionApCost` / `resolveIntentApCost` / `isValidGridDest` escono dal closure di `sessionRoundBridge` verso `services/combat/apLedger.js` (factory a dipendenze iniettate) + 2 helper NUOVI (`apAvailable`, `canAfford` = il pending-sum gate P1-3, riusabile dal lato dichiarazione Sistema del task successivo).

**Zero behavior change**, provato:
- Byte-compare meccanico dei 4 corpi: identici (verificato indipendentemente dal reviewer)
- Test: apLedger **9/9** (incl. RED-first sull'unwrap fail-open, riprodotto su mirror pre-fix) · regressione bridge **15/15** · suite AI **589/589** · +129/129 file che referenziano il bridge
- Commenti load-bearing migrati (anti-double-charge, OWASP A04); contratti JSDoc espliciti (gridSize scalar-only ereditato, actions-not-intents su canAfford con unwrap insurance)

## Gate review (Codex in usage-limit -> sostituto ratificato)

Two-stage review indipendente: spec-compliance **SPEC COMPLIANT** (diff meccanico vs origin/main) + code-quality **APPROVED** dopo un giro di fix (JSDoc contratti, cross-link bridge<->ledger, 4 test aggiuntivi, git mv in tests/services/combat/). Follow-up P2/P3 dichiarati fuori scope e tracciati (floor ap_cost negativi = chip; isValidGridDest rettangolare = task Sistema).

## Rollback

Revert dei 2 commit. Nessun flag, nessun runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)