### PR TITLE
feat(ai): symmetry flags -- retreat gate + per-unit AP (OFF)

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -158,6 +158,16 @@ function isRetreatGateEnabled() {
   return process.env.SISTEMA_RETREAT_GATE_ENABLED === 'true';
 }
 
+// Per-unit AP declaration (spec sistema-symmetry sez. 4.2): ogni unita' Sistema
+// dichiara fino al SUO budget (ap_remaining ?? ap), mirror del PG. L'addebito a
+// risoluzione e il refill per-round esistono GIA' per il Sistema (bridge resolve
+// loop + applyApRefill, nessun filtro fazione -- verificato 2026-07-10): questo
+// flag chiude l'unico buco, l'affordability alla dichiarazione. Il cap globale
+// resta per la PRESENTAZIONE telegraph (spec sez. 4.4). Default OFF.
+function isPerUnitApEnabled() {
+  return process.env.SISTEMA_PER_UNIT_AP_ENABLED === 'true';
+}
+
 // Divisor K: one intent per K alive Sistema units (activation ~1/K on big
 // rosters). Env-tunable for probe A/B; invalid values fall back to 3.
 const ROSTER_K_DEFAULT = 3;
@@ -339,6 +349,7 @@ function createDeclareSistemaIntents(deps) {
     );
     // Read at call-time (not module-load) so the probe can toggle per-run.
     const perUnitActions = isPerUnitActionsEnabled();
+    const perUnitAp = isPerUnitApEnabled();
 
     const intents = [];
     const decisions = [];
@@ -386,16 +397,66 @@ function createDeclareSistemaIntents(deps) {
       }, null);
     }
 
+    // Slot-2 (spec sez. 4.2, mirror lookahead2): dopo il primo intent, se il
+    // budget regge, dichiara un attack SOLO se il target e' in gittata dalla
+    // posizione VIRTUALE post-move e la LOS e' libera da li'. Niente re-run
+    // della policy: deterministico, nessuna mutazione (il modulo resta puro),
+    // nessuna interazione col commit-window (bookkeeping invariato).
+    function declareSecondAttack(ctx) {
+      const {
+        actor, target, policy, virtualPos, remaining, intents, decisions, takenTargetIds, session,
+      } = ctx;
+      if (remaining < 1) return 0;
+      if (!target || Number(target.hp || 0) <= 0) return 0;
+      const range = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
+      if (manhattanDistance(virtualPos, target.position) > range) return 0;
+      if (!losClearForAi(session.grid, virtualPos, target.position, session.units)) return 0;
+      const action = {
+        id: `sis-attack2-${actor.id}`,
+        type: 'attack',
+        actor_id: actor.id,
+        target_id: target.id,
+        ability_id: null,
+        ap_cost: 1,
+        channel: pickExploitChannel(target),
+        damage_dice: deps._damageDice || { count: 1, sides: 6, modifier: 2 },
+        source_ia_rule: `${policy.rule}_AP2`,
+      };
+      intents.push({ unit_id: actor.id, action });
+      takenTargetIds.add(target.id);
+      decisions.push({
+        unit_id: actor.id,
+        rule: `${policy.rule}_AP2`,
+        intent: 'attack',
+        target_id: target.id,
+      });
+      return 1;
+    }
+
     for (const actor of session.units) {
       if (!actor) continue;
       if (actor.controlled_by !== 'sistema') continue;
       if (Number(actor.hp || 0) <= 0) continue;
-      if (!perUnitActions && intentsEmitted >= intentsCap) {
+      if (!perUnitActions && !perUnitAp && intentsEmitted >= intentsCap) {
         decisions.push({
           unit_id: actor.id,
           rule: 'PRESSURE_CAP',
           intent: 'skip',
           reason: `pressure cap raggiunto (${intentsEmitted}/${intentsCap})`,
+        });
+        continue;
+      }
+
+      // Budget AP dell'attore (solo flag ON; OFF -> percorso invariato).
+      const apBudget = perUnitAp
+        ? Number(actor.ap_remaining != null ? actor.ap_remaining : actor.ap || 0)
+        : Infinity;
+      if (perUnitAp && apBudget < 1) {
+        decisions.push({
+          unit_id: actor.id,
+          rule: 'NO_AP',
+          intent: 'skip',
+          reason: `ap esauriti (${apBudget})`,
         });
         continue;
       }
@@ -623,6 +684,14 @@ function createDeclareSistemaIntents(deps) {
           score: policy.score,
           breakdown: policy.breakdown,
         });
+        if (perUnitAp) {
+          intentsEmitted += declareSecondAttack({
+            actor, target, policy,
+            virtualPos: actor.position,
+            remaining: apBudget - 1,
+            intents, decisions, takenTargetIds, session,
+          });
+        }
         continue;
       }
 
@@ -687,6 +756,15 @@ function createDeclareSistemaIntents(deps) {
         position_from: positionFrom,
         source_ia_rule: policy.rule,
       };
+      if (perUnitAp && moveAction.ap_cost > apBudget) {
+        decisions.push({
+          unit_id: actor.id,
+          rule: 'NO_AP',
+          intent: 'skip',
+          reason: `move cost ${moveAction.ap_cost} > budget ${apBudget}`,
+        });
+        continue;
+      }
       intents.push({ unit_id: actor.id, action: moveAction });
       intentsEmitted++;
       decisions.push({
@@ -699,6 +777,14 @@ function createDeclareSistemaIntents(deps) {
         score: policy.score,
         breakdown: policy.breakdown,
       });
+      if (perUnitAp) {
+        intentsEmitted += declareSecondAttack({
+          actor, target, policy,
+          virtualPos: nextPos,
+          remaining: apBudget - moveAction.ap_cost,
+          intents, decisions, takenTargetIds, session,
+        });
+      }
     }
 
     // SPEC-Q M-4 -- reveal records emitted OFF THE SIDE (never touches intents).
@@ -716,6 +802,7 @@ module.exports = {
   isIntentsRosterScalingEnabled,
   isPerUnitActionsEnabled,
   isRetreatGateEnabled,
+  isPerUnitApEnabled,
   INTENTS_ABS_CAP,
   detectHiddenAbilityReveals,
   DEFAULT_HIDDEN_ABILITY_THRESHOLD,

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -163,7 +163,8 @@ function isRetreatGateEnabled() {
 // risoluzione e il refill per-round esistono GIA' per il Sistema (bridge resolve
 // loop + applyApRefill, nessun filtro fazione -- verificato 2026-07-10): questo
 // flag chiude l'unico buco, l'affordability alla dichiarazione. Il cap globale
-// resta per la PRESENTAZIONE telegraph (spec sez. 4.4). Default OFF.
+// resta per la PRESENTAZIONE telegraph (spec sez. 4.4, gradino successivo,
+// non in questo branch). Default OFF.
 function isPerUnitApEnabled() {
   return process.env.SISTEMA_PER_UNIT_AP_ENABLED === 'true';
 }
@@ -350,6 +351,10 @@ function createDeclareSistemaIntents(deps) {
     // Read at call-time (not module-load) so the probe can toggle per-run.
     const perUnitActions = isPerUnitActionsEnabled();
     const perUnitAp = isPerUnitApEnabled();
+    // Retreat gate: flag e config-base (fallback soglia) hoistati per-call,
+    // non per-actor -- nessuno dei due cambia dentro il loop attori.
+    const retreatGateOn = isRetreatGateEnabled();
+    const retreatGateBaseCfg = retreatGateOn ? loadAiConfig() : null;
 
     const intents = [];
     const decisions = [];
@@ -404,13 +409,25 @@ function createDeclareSistemaIntents(deps) {
     // nessuna interazione col commit-window (bookkeeping invariato).
     function declareSecondAttack(ctx) {
       const {
-        actor, target, policy, virtualPos, remaining, intents, decisions, takenTargetIds, session,
+        actor,
+        target,
+        policy,
+        virtualPos,
+        remaining,
+        intents,
+        decisions,
+        takenTargetIds,
+        session,
       } = ctx;
       if (remaining < 1) return 0;
       if (!target || Number(target.hp || 0) <= 0) return 0;
       const range = actor.attack_range ?? DEFAULT_ATTACK_RANGE;
       if (manhattanDistance(virtualPos, target.position) > range) return 0;
-      if (!losClearForAi(session.grid, virtualPos, target.position, session.units)) return 0;
+      // LOS senza l'attore: virtualPos e' la cella post-move ma l'attore e'
+      // ancora nella cella VECCHIA dentro session.units -- con units_block_los
+      // ON (dormant) il suo stesso corpo si auto-bloccherebbe la linea.
+      const unitsSansActor = session.units.filter((u) => u && u.id !== actor.id);
+      if (!losClearForAi(session.grid, virtualPos, target.position, unitsSansActor)) return 0;
       const action = {
         id: `sis-attack2-${actor.id}`,
         type: 'attack',
@@ -448,9 +465,11 @@ function createDeclareSistemaIntents(deps) {
       }
 
       // Budget AP dell'attore (solo flag ON; OFF -> percorso invariato).
-      const apBudget = perUnitAp
-        ? Number(actor.ap_remaining != null ? actor.ap_remaining : actor.ap || 0)
-        : Infinity;
+      // NaN-guard: con ap sporco (non numerico) ogni confronto di budget a
+      // valle sarebbe false -> NaN passerebbe tutti i gate come budget
+      // illimitato. Non-finito -> 0 (fail-closed).
+      const rawAp = Number(actor.ap_remaining != null ? actor.ap_remaining : actor.ap || 0);
+      const apBudget = perUnitAp ? (Number.isFinite(rawAp) ? rawAp : 0) : Infinity;
       if (perUnitAp && apBudget < 1) {
         decisions.push({
           unit_id: actor.id,
@@ -526,15 +545,14 @@ function createDeclareSistemaIntents(deps) {
         // went inert for any Sistema unit running a use_utility_brain profile.
         // Retreat gate: sopra soglia la ritirata esce dalle azioni legali.
         let retreatGated = false;
-        if (isRetreatGateEnabled()) {
+        if (retreatGateOn) {
           const gateProf =
             aiProfiles && aiProfiles.profiles && actor.ai_profile
               ? aiProfiles.profiles[actor.ai_profile]
               : null;
           const gateOverrides = (gateProf && gateProf.overrides) || {};
-          const baseCfg = loadAiConfig();
           const threshold = Number(
-            gateOverrides.retreat_hp_pct ?? baseCfg.LOW_HP_RETREAT_THRESHOLD,
+            gateOverrides.retreat_hp_pct ?? retreatGateBaseCfg.LOW_HP_RETREAT_THRESHOLD,
           );
           const hpRatio =
             Number(actor.max_hp) > 0 ? Number(actor.hp || 0) / Number(actor.max_hp) : 1;
@@ -686,10 +704,15 @@ function createDeclareSistemaIntents(deps) {
         });
         if (perUnitAp) {
           intentsEmitted += declareSecondAttack({
-            actor, target, policy,
+            actor,
+            target,
+            policy,
             virtualPos: actor.position,
             remaining: apBudget - 1,
-            intents, decisions, takenTargetIds, session,
+            intents,
+            decisions,
+            takenTargetIds,
+            session,
           });
         }
         continue;
@@ -779,10 +802,15 @@ function createDeclareSistemaIntents(deps) {
       });
       if (perUnitAp) {
         intentsEmitted += declareSecondAttack({
-          actor, target, policy,
+          actor,
+          target,
+          policy,
           virtualPos: nextPos,
           remaining: apBudget - moveAction.ap_cost,
-          intents, decisions, takenTargetIds, session,
+          intents,
+          decisions,
+          takenTargetIds,
+          session,
         });
       }
     }

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -149,6 +149,15 @@ function isPerUnitActionsEnabled() {
   return process.env.SISTEMA_PER_UNIT_ACTIONS_ENABLED === 'true';
 }
 
+// Retreat gate (spec sistema-symmetry sez. 4.3): utilityBrain deve rispettare
+// la stessa retreat_hp_pct che il path rule-based onora gia' (misurato: 44/45
+// ritirate vengono da UTILITY_AI che la ignora). Nessun knob nuovo: soglia =
+// profiles.<ai_profile>.overrides.retreat_hp_pct, fallback config base.
+// Default OFF -> byte-identical.
+function isRetreatGateEnabled() {
+  return process.env.SISTEMA_RETREAT_GATE_ENABLED === 'true';
+}
+
 // Divisor K: one intent per K alive Sistema units (activation ~1/K on big
 // rosters). Env-tunable for probe A/B; invalid values fall back to 3.
 const ROSTER_K_DEFAULT = 3;
@@ -454,8 +463,25 @@ function createDeclareSistemaIntents(deps) {
         // Utility AI path too (was dropped here; legacy path at selectAiPolicy
         // below already reads threatCtx). Without this, M1's defensive overlay
         // went inert for any Sistema unit running a use_utility_brain profile.
+        // Retreat gate: sopra soglia la ritirata esce dalle azioni legali.
+        let retreatGated = false;
+        if (isRetreatGateEnabled()) {
+          const gateProf =
+            aiProfiles && aiProfiles.profiles && actor.ai_profile
+              ? aiProfiles.profiles[actor.ai_profile]
+              : null;
+          const gateOverrides = (gateProf && gateProf.overrides) || {};
+          const baseCfg = loadAiConfig();
+          const threshold = Number(
+            gateOverrides.retreat_hp_pct ?? baseCfg.LOW_HP_RETREAT_THRESHOLD,
+          );
+          const hpRatio =
+            Number(actor.max_hp) > 0 ? Number(actor.hp || 0) / Number(actor.max_hp) : 1;
+          retreatGated = hpRatio > threshold;
+        }
         const utilityState = {
           persistent_high_threat: !!(threatCtx && threatCtx.persistent_high_threat),
+          retreat_gated: retreatGated,
         };
         policy = selectAiPolicyUtility(actor, target, utilityState, stickyDifficulty);
       } else {
@@ -689,6 +715,7 @@ module.exports = {
   intentsCapForPressure,
   isIntentsRosterScalingEnabled,
   isPerUnitActionsEnabled,
+  isRetreatGateEnabled,
   INTENTS_ABS_CAP,
   detectHiddenAbilityReveals,
   DEFAULT_HIDDEN_ABILITY_THRESHOLD,

--- a/apps/backend/services/ai/utilityBrain.js
+++ b/apps/backend/services/ai/utilityBrain.js
@@ -2,7 +2,7 @@
 // ADR: docs/adr/ADR-2026-04-16-ai-architecture-utility.md
 //
 // Architecture:
-//   1. enumerateLegalActions(state, actorId) → [{type, target?, params}]
+//   1. enumerateLegalActions(actor, state) -> [{type, target?, params}]
 //   2. scoreAction(action, actor, state, considerations, weights) → number
 //   3. selectAction(scores, difficultyProfile) → chosen action
 //
@@ -376,8 +376,9 @@ function enumerateLegalActions(actor, state) {
     actions.push({ type: 'approach', target: targetId });
   }
 
-  // Retreat (always available if HP > 0)
-  if (actor.hp > 0) {
+  // Retreat: legale se HP > 0 e non gated (retreat gate, spec sistema-symmetry
+  // sez. 4.3 -- il flag vive in declareSistemaIntents, qui arriva via state).
+  if (actor.hp > 0 && !(state && state.retreat_gated)) {
     actions.push({ type: 'retreat' });
   }
 

--- a/tests/ai/sistemaPerUnitAp.test.js
+++ b/tests/ai/sistemaPerUnitAp.test.js
@@ -36,13 +36,35 @@ function declareFor(session) {
   return declare(session);
 }
 const sis = (id, x, y, over = {}) => ({
-  id, controlled_by: 'sistema', hp: 10, max_hp: 10, ap: 2, ap_max: 2, mod: 2, dc: 12,
-  attack_range: 1, initiative: 10, position: { x, y }, status: {},
-  ai_profile: 'aggressive', damage: { min: 1, max: 3 }, ...over,
+  id,
+  controlled_by: 'sistema',
+  hp: 10,
+  max_hp: 10,
+  ap: 2,
+  ap_max: 2,
+  mod: 2,
+  dc: 12,
+  attack_range: 1,
+  initiative: 10,
+  position: { x, y },
+  status: {},
+  ai_profile: 'aggressive',
+  damage: { min: 1, max: 3 },
+  ...over,
 });
 const pg = (id, x, y) => ({
-  id, controlled_by: 'player', hp: 12, max_hp: 12, ap: 2, ap_max: 2, mod: 2, dc: 12,
-  attack_range: 1, initiative: 12, position: { x, y }, status: {},
+  id,
+  controlled_by: 'player',
+  hp: 12,
+  max_hp: 12,
+  ap: 2,
+  ap_max: 2,
+  mod: 2,
+  dc: 12,
+  attack_range: 1,
+  initiative: 12,
+  position: { x, y },
+  status: {},
 });
 function session(units) {
   return { units, grid: { width: 16, height: 12 }, sistema_pressure: 50 };

--- a/tests/ai/sistemaPerUnitAp.test.js
+++ b/tests/ai/sistemaPerUnitAp.test.js
@@ -1,0 +1,106 @@
+// tests/ai/sistemaPerUnitAp.test.js -- dichiarazione a budget AP (spec sez. 4.2).
+// Flag ON: ogni unita' Sistema dichiara fino al suo budget (mirror lookahead2:
+// move, poi attack se in gittata dalla posizione POST-move). Flag OFF: 1 intent.
+// La risoluzione e' per priorita', non per ordine di dichiarazione -> l'attack
+// slot-2 si dichiara SOLO se in range dal move_to.
+'use strict';
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  createDeclareSistemaIntents,
+  isPerUnitApEnabled,
+} = require('../../apps/backend/services/ai/declareSistemaIntents');
+const { pickLowestHpEnemy, stepTowards } = require('../../apps/backend/routes/sessionHelpers');
+
+const FLAG = 'SISTEMA_PER_UNIT_AP_ENABLED';
+const manhattan = (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+function withFlag(value, fn) {
+  const prev = process.env[FLAG];
+  if (value === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  }
+}
+function declareFor(session) {
+  const declare = createDeclareSistemaIntents({
+    pickLowestHpEnemy,
+    stepTowards,
+    manhattanDistance: manhattan,
+    gridSize: 16,
+  });
+  return declare(session);
+}
+const sis = (id, x, y, over = {}) => ({
+  id, controlled_by: 'sistema', hp: 10, max_hp: 10, ap: 2, ap_max: 2, mod: 2, dc: 12,
+  attack_range: 1, initiative: 10, position: { x, y }, status: {},
+  ai_profile: 'aggressive', damage: { min: 1, max: 3 }, ...over,
+});
+const pg = (id, x, y) => ({
+  id, controlled_by: 'player', hp: 12, max_hp: 12, ap: 2, ap_max: 2, mod: 2, dc: 12,
+  attack_range: 1, initiative: 12, position: { x, y }, status: {},
+});
+function session(units) {
+  return { units, grid: { width: 16, height: 12 }, sistema_pressure: 50 };
+}
+
+test('isPerUnitApEnabled: default OFF, solo "true"', () => {
+  withFlag(undefined, () => assert.equal(isPerUnitApEnabled(), false));
+  withFlag('true', () => assert.equal(isPerUnitApEnabled(), true));
+});
+
+test('ON: target a 2 celle -> move + attack della stessa unita (<= 2 AP)', () => {
+  withFlag('true', () => {
+    const { intents } = declareFor(session([sis('s1', 4, 5), pg('p1', 2, 5)]));
+    const mine = intents.filter((i) => i.unit_id === 's1');
+    assert.equal(mine.length, 2, 'move + attack slot-2');
+    assert.equal(mine[0].action.type, 'move');
+    assert.equal(mine[1].action.type, 'attack');
+    const cost = mine.reduce((s, i) => s + Number(i.action.ap_cost || 0), 0);
+    assert.ok(cost <= 2, `costo totale ${cost} <= budget 2`);
+  });
+});
+
+test('ON: gia in gittata -> attack + attack, id univoci', () => {
+  withFlag('true', () => {
+    const { intents } = declareFor(session([sis('s1', 3, 5), pg('p1', 2, 5)]));
+    const mine = intents.filter((i) => i.unit_id === 's1');
+    assert.equal(mine.length, 2);
+    assert.ok(mine.every((i) => i.action.type === 'attack'));
+    assert.notEqual(mine[0].action.id, mine[1].action.id, 'id univoci');
+  });
+});
+
+test('ON: target lontano dal move_to -> SOLO move (niente attack a vuoto)', () => {
+  withFlag('true', () => {
+    // NOTA: x=5 (non 9) -- sessionHelpers.stepTowards() clampa senza bounds su
+    // GRID_SIZE=6 legacy (ignora il gridSize:16 del test); x=9 avrebbe prodotto
+    // uno "step" fantasma di 4 celle (9->5) collassando ap_cost oltre il budget
+    // e mascherando l'assert (NO_AP invece di un move singolo). x=5 resta il
+    // caso "target lontano dopo un passo singolo" senza toccare quel clamp.
+    const { intents } = declareFor(session([sis('s1', 5, 5), pg('p1', 2, 5)]));
+    const mine = intents.filter((i) => i.unit_id === 's1');
+    assert.equal(mine.length, 1, 'nessun attack fuori gittata post-move');
+    assert.equal(mine[0].action.type, 'move');
+  });
+});
+
+test('ON: ap_remaining 1 -> un intent; 0 -> zero intent con rule NO_AP', () => {
+  withFlag('true', () => {
+    const one = declareFor(session([sis('s1', 3, 5, { ap_remaining: 1 }), pg('p1', 2, 5)]));
+    assert.equal(one.intents.filter((i) => i.unit_id === 's1').length, 1);
+    const zero = declareFor(session([sis('s1', 3, 5, { ap_remaining: 0 }), pg('p1', 2, 5)]));
+    assert.equal(zero.intents.filter((i) => i.unit_id === 's1').length, 0);
+    const d = zero.decisions.find((x) => x.unit_id === 's1');
+    assert.equal(d.rule, 'NO_AP');
+  });
+});
+
+test('OFF: 1 intent per unita, come oggi', () => {
+  const off = withFlag(undefined, () => declareFor(session([sis('s1', 4, 5), pg('p1', 2, 5)])));
+  assert.equal(off.intents.filter((i) => i.unit_id === 's1').length, 1);
+});

--- a/tests/ai/sistemaRetreatGate.test.js
+++ b/tests/ai/sistemaRetreatGate.test.js
@@ -1,0 +1,96 @@
+// tests/ai/sistemaRetreatGate.test.js -- il gate fa rispettare a utilityBrain la
+// retreat_hp_pct che il path rule-based onora gia' (spec sistema-symmetry sez. 4.3;
+// misura: 44/45 ritirate da UTILITY_AI, docs/research/2026-07-10-sistema-cap-falsification.md).
+// Flag SISTEMA_RETREAT_GATE_ENABLED default OFF -> byte-identical.
+'use strict';
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  isRetreatGateEnabled,
+  createDeclareSistemaIntents,
+} = require('../../apps/backend/services/ai/declareSistemaIntents');
+const { enumerateLegalActions } = require('../../apps/backend/services/ai/utilityBrain');
+const { pickLowestHpEnemy, stepTowards } = require('../../apps/backend/routes/sessionHelpers');
+
+const FLAG = 'SISTEMA_RETREAT_GATE_ENABLED';
+const manhattan = (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+function withFlag(value, fn) {
+  const prev = process.env[FLAG];
+  if (value === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  }
+}
+function declareFor(session) {
+  const declare = createDeclareSistemaIntents({
+    pickLowestHpEnemy,
+    stepTowards,
+    manhattanDistance: manhattan,
+    gridSize: 16,
+  });
+  return declare(session);
+}
+function woundedSession() {
+  return {
+    units: [
+      {
+        id: 'sis_w', controlled_by: 'sistema', hp: 5, max_hp: 10, ap: 2, ap_max: 2,
+        mod: 2, dc: 12, attack_range: 1, initiative: 10, position: { x: 10, y: 5 },
+        status: {}, ai_profile: 'aggressive', damage: { min: 1, max: 3 },
+      },
+      {
+        id: 'p1', controlled_by: 'player', hp: 12, max_hp: 12, ap: 2, ap_max: 2,
+        mod: 2, dc: 12, attack_range: 1, initiative: 12, position: { x: 2, y: 5 }, status: {},
+      },
+    ],
+    grid: { width: 16, height: 12 },
+    sistema_pressure: 50,
+  };
+}
+
+test('isRetreatGateEnabled: default OFF, solo "true" abilita', () => {
+  withFlag(undefined, () => assert.equal(isRetreatGateEnabled(), false));
+  withFlag('true', () => assert.equal(isRetreatGateEnabled(), true));
+  withFlag('1', () => assert.equal(isRetreatGateEnabled(), false));
+});
+
+test('enumerateLegalActions: state.retreat_gated toglie retreat dalle legali', () => {
+  const actor = { id: 'a', hp: 10, max_hp: 10, position: { x: 0, y: 0 }, controlled_by: 'sistema' };
+  const enemy = { id: 'p', hp: 10, max_hp: 10, position: { x: 5, y: 5 }, controlled_by: 'player' };
+  const state = { units: { a: actor, p: enemy } };
+  const withRetreat = enumerateLegalActions(actor, state).map((a) => a.type);
+  assert.ok(withRetreat.includes('retreat'), 'senza gate retreat legale');
+  const gated = enumerateLegalActions(actor, { ...state, retreat_gated: true }).map((a) => a.type);
+  assert.ok(!gated.includes('retreat'), 'gated: retreat non proposta');
+  assert.ok(gated.includes('approach'), 'le altre azioni restano');
+});
+
+test('gate ON: unita ferita sopra soglia NON dichiara retreat', () => {
+  withFlag('true', () => {
+    const { decisions } = declareFor(woundedSession());
+    const d = decisions.find((x) => x.unit_id === 'sis_w');
+    assert.ok(d, 'decisione emessa');
+    assert.notEqual(d.intent, 'retreat', `atteso non-retreat, avuto ${d.intent} (${d.rule})`);
+  });
+});
+
+test('gate ON: sotto soglia (hp 10%) il declare loop non crasha', () => {
+  withFlag('true', () => {
+    const s = woundedSession();
+    s.units[0].hp = 1;
+    const { decisions } = declareFor(s);
+    assert.ok(decisions.find((x) => x.unit_id === 'sis_w'), 'decisione emessa');
+  });
+});
+
+test('gate OFF: determinismo baseline (flag unset)', () => {
+  const off1 = withFlag(undefined, () => declareFor(woundedSession()));
+  const off2 = withFlag(undefined, () => declareFor(woundedSession()));
+  assert.deepEqual(off1.decisions, off2.decisions, 'determinismo baseline');
+});

--- a/tests/ai/sistemaRetreatGate.test.js
+++ b/tests/ai/sistemaRetreatGate.test.js
@@ -50,13 +50,34 @@ function woundedSession() {
   return {
     units: [
       {
-        id: 'sis_w', controlled_by: 'sistema', hp: 5, max_hp: 10, ap: 2, ap_max: 2,
-        mod: 2, dc: 12, attack_range: 1, initiative: 10, position: { x: 10, y: 5 },
-        status: {}, ai_profile: 'aggressive', damage: { min: 1, max: 3 },
+        id: 'sis_w',
+        controlled_by: 'sistema',
+        hp: 5,
+        max_hp: 10,
+        ap: 2,
+        ap_max: 2,
+        mod: 2,
+        dc: 12,
+        attack_range: 1,
+        initiative: 10,
+        position: { x: 10, y: 5 },
+        status: {},
+        ai_profile: 'aggressive',
+        damage: { min: 1, max: 3 },
       },
       {
-        id: 'p1', controlled_by: 'player', hp: 12, max_hp: 12, ap: 2, ap_max: 2,
-        mod: 2, dc: 12, attack_range: 1, initiative: 12, position: { x: 2, y: 5 }, status: {},
+        id: 'p1',
+        controlled_by: 'player',
+        hp: 12,
+        max_hp: 12,
+        ap: 2,
+        ap_max: 2,
+        mod: 2,
+        dc: 12,
+        attack_range: 1,
+        initiative: 12,
+        position: { x: 2, y: 5 },
+        status: {},
       },
     ],
     grid: { width: 16, height: 12 },
@@ -105,6 +126,12 @@ test('gate ON: sotto soglia (hp 10%) il declare loop non crasha', () => {
     // Stessa anti-vacuita' del test sopra: sotto soglia (10% < 0.15) il gate
     // NON scatta (retreat resta legale) ma il path deve essere quello utility.
     assert.match(d.rule, /^UTILITY/, `atteso rule utility, avuto ${d.rule}`);
+    // Mutation-proof (quality review 2026-07-10): a hp 1/10 retreat e' argmax
+    // deterministico (score 2.28 vs 1.16, noise 0, non flaky). Con la soglia
+    // morta (mutazione retreatGated = true) retreat sparisce dalle legali e
+    // questo assert fallisce -- senza, il test non distingue gate-corretto
+    // da gate-sempre-attivo.
+    assert.equal(d.intent, 'retreat', 'sotto soglia retreat resta legale e vince');
   });
 });
 

--- a/tests/ai/sistemaRetreatGate.test.js
+++ b/tests/ai/sistemaRetreatGate.test.js
@@ -33,6 +33,16 @@ function declareFor(session) {
     stepTowards,
     manhattanDistance: manhattan,
     gridSize: 16,
+    // Load-bearing: senza aiProfiles resolveUseUtilityBrain() -> false e la
+    // decisione passa dal path legacy (selectAiPolicy), dove il gate non vive:
+    // i test ON diventerebbero vacui (verificato RED: rule REGOLA_001).
+    // Mirror di packs/.../ai_profiles.yaml profiles.aggressive (use_utility_brain
+    // true + overrides.retreat_hp_pct 0.15), la stessa shape che il gate legge.
+    aiProfiles: {
+      profiles: {
+        aggressive: { use_utility_brain: true, overrides: { retreat_hp_pct: 0.15 } },
+      },
+    },
   });
   return declare(session);
 }
@@ -76,6 +86,11 @@ test('gate ON: unita ferita sopra soglia NON dichiara retreat', () => {
     const { decisions } = declareFor(woundedSession());
     const d = decisions.find((x) => x.unit_id === 'sis_w');
     assert.ok(d, 'decisione emessa');
+    // Anti-vacuita': il gate vive SOLO nel branch utility di declareSistemaIntents.
+    // Se declareFor perde aiProfiles (o il profilo perde use_utility_brain) la
+    // decisione esce dal path legacy (REGOLA_*) e questo assert DEVE fallire --
+    // altrimenti il notEqual sotto passerebbe anche cancellando il gate.
+    assert.match(d.rule, /^UTILITY/, `atteso rule utility, avuto ${d.rule}`);
     assert.notEqual(d.intent, 'retreat', `atteso non-retreat, avuto ${d.intent} (${d.rule})`);
   });
 });
@@ -85,7 +100,11 @@ test('gate ON: sotto soglia (hp 10%) il declare loop non crasha', () => {
     const s = woundedSession();
     s.units[0].hp = 1;
     const { decisions } = declareFor(s);
-    assert.ok(decisions.find((x) => x.unit_id === 'sis_w'), 'decisione emessa');
+    const d = decisions.find((x) => x.unit_id === 'sis_w');
+    assert.ok(d, 'decisione emessa');
+    // Stessa anti-vacuita' del test sopra: sotto soglia (10% < 0.15) il gate
+    // NON scatta (retreat resta legale) ma il path deve essere quello utility.
+    assert.match(d.rule, /^UTILITY/, `atteso rule utility, avuto ${d.rule}`);
   });
 });
 


### PR DESCRIPTION
## Task 2+3 dell'arco sistema-symmetry (spec+piano merged: #3249; Task 1: #3251)

Due flag **default OFF, byte-identical spenti** (provato: full tests/ai 600/600 flag unset):

1. **`SISTEMA_RETREAT_GATE_ENABLED`** -- utilityBrain non puo' piu' proporre `retreat` sopra la `retreat_hp_pct` che il path rule-based onora gia' (misura a monte: 44/45 ritirate da UTILITY_AI che la ignorava, `docs/research/2026-07-10-sistema-cap-falsification.md`). Zero knob nuovi: soglia da `profiles.<x>.overrides.retreat_hp_pct ?? loadAiConfig()`. Sotto soglia retreat resta legale e vince (threshold-sensitivity **mutation-pinned**: soglia-morta -> 1 fail esatto, kill verificato da due agent indipendenti).
2. **`SISTEMA_PER_UNIT_AP_ENABLED`** -- dichiarazione a budget AP per-creatura (`ap_remaining ?? ap`, NaN fail-closed a 0): move+attack nello stesso round come un PG. Slot-2 mirror di `lookahead2`: attack dichiarato SOLO se in gittata e con LOS libera dalla posizione POST-move (copre il rischio risoluzione-per-priorita'); LOS calcolata senza l'attore stesso (self-block latente con `units_block_los` dormant). Addebito a risoluzione e refill per-round esistevano gia' per il Sistema: questo chiude l'unico buco (affordability alla dichiarazione).

## Gate review (Codex usage-limit -> sostituto ratificato)

Two-stage per ogni task + 2 giri di fix verificati: spec-compliance riga-per-riga (incl. RED-first provato empiricamente: senza il fix i test cadevano su `REGOLA_001`) + quality **APPROVED** (mutation testing rieseguito dal reviewer, prettier provato confinato alle righe del branch, budget arithmetic senza path negativi, `_AP2`/`sis-attack2-` collision-free su grep dei consumer).

## Domanda owner (non bloccante, pre-misure flag-ON)

Il gate usa la soglia PIATTA come da spec sez. 4.3. Il path rule-based pero' ALLARGA a `threshold * 1.2` sotto `persistent_high_threat` (M1): nella banda `(thr, 1.2*thr]` con un PG killer sul campo, legacy ritira e utility-gated no. **Eduardo**: addendum spec (widening anche nel gate) o simmetria piatta voluta? Da decidere prima di arm di misura con M1 attivo -- il fattoriale sui 3 grid_sized non ha `persistent_high_threat`, quindi non blocca il Task 4.

## Finding collaterale confermato in review

`stepTowards` clampa al box 6x6 legacy su board grid_sized (bug prod, verificato da 2 reviewer indipendenti) -> gia' in lavorazione su PR #3253 (altra sessione, dal chip), sequenziata DOPO le misure del fattoriale (paired = internamente valido col clamp in entrambi gli arm).

## Rollback

Revert dei 4 commit. Flag OFF, non referenziati da encounter/config/workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)