### PR TITLE
feat(traits): buff-steal + oracle-reveal -- make 2 inert traits live

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1648,37 +1648,38 @@ function createSessionRouter(options = {}) {
       // secondo il furto degraderebbe a una copia.
       // Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
       // Band-neutral: nessuna sim unit porta ghiandole_mnemoniche.
-      if (result.hit) {
-        const stolen = stealBuff({ actor, target });
-        if (stolen) {
-          if (!Array.isArray(session._pendingStatusApplies)) {
-            session._pendingStatusApplies = [];
-          }
-          if (!Array.isArray(session._pendingStatusRemovals)) {
-            session._pendingStatusRemovals = [];
-          }
-          session._pendingStatusApplies.push({
-            unit_id: actor.id,
-            status: stolen.stato,
-            duration: stolen.granted_turns,
-          });
-          session._pendingStatusRemovals.push({
-            unit_id: target.id,
-            status: stolen.stato,
-          });
-          evaluation.trait_effects = (evaluation.trait_effects || []).concat({
-            trait: 'ghiandole_mnemoniche',
-            triggered: true,
-            effect: {
-              kind: 'buff_steal',
-              stato: stolen.stato,
-              from: target.id,
-              to: actor.id,
-              stolen_turns: stolen.stolen_turns,
-              granted_turns: stolen.granted_turns,
-            },
-          });
+      // Gia' dentro il blocco `if (result.hit)` aperto sopra: nessun re-gate.
+      // Il furto fra unita' della stessa fazione lo rifiuta stealBuff (isSameFaction):
+      // la route di attacco non valida la fazione del bersaglio.
+      const stolen = stealBuff({ actor, target });
+      if (stolen) {
+        if (!Array.isArray(session._pendingStatusApplies)) {
+          session._pendingStatusApplies = [];
         }
+        if (!Array.isArray(session._pendingStatusRemovals)) {
+          session._pendingStatusRemovals = [];
+        }
+        session._pendingStatusApplies.push({
+          unit_id: actor.id,
+          status: stolen.stato,
+          duration: stolen.granted_turns,
+        });
+        session._pendingStatusRemovals.push({
+          unit_id: target.id,
+          status: stolen.stato,
+        });
+        evaluation.trait_effects = (evaluation.trait_effects || []).concat({
+          trait: 'ghiandole_mnemoniche',
+          triggered: true,
+          effect: {
+            kind: 'buff_steal',
+            stato: stolen.stato,
+            from: target.id,
+            to: actor.id,
+            stolen_turns: stolen.stolen_turns,
+            granted_turns: stolen.granted_turns,
+          },
+        });
       }
 
       // artigli_psionici (creature-trait slice 4): on a MELEE hit the carrier studies

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -138,6 +138,11 @@ const {
   applyTessutiAdaptation,
   computeTessutiResistDelta,
 } = require('../services/combat/tessutiAdattivi');
+// ghiandole_mnemoniche (buff-steal): la logica vive nel modulo; qui la si aggancia
+// post-attacco. La rimozione del buff alla preda passa per il canale dedicato
+// session._pendingStatusRemovals (combat/pendingStatusRemovals.js), perche' il rebuild
+// tracked->dict del round-model annullerebbe un delete fatto a meta' attacco.
+const { stealBuff } = require('../services/combat/ghiandoleMnemoniche');
 // Creature-trait slice 5: membrane_osmotiche duration_absorb (-1 on incoming status
 // durations). filtri_bioattivi turn-start cleanse is wired in sessionRoundBridge.
 const { absorbStatusDuration } = require('../services/combat/membraneOsmotiche');
@@ -1634,6 +1639,46 @@ function createSessionRouter(options = {}) {
             allies_resonated: cortecciaReaction.broadcast.length,
           },
         });
+      }
+
+      // ghiandole_mnemoniche: su un colpo andato a segno il portatore strappa UN buff
+      // temporaneo alla preda e ne indossa una copia a durata dimezzata. Il guadagno
+      // passa per _pendingStatusApplies, la perdita per _pendingStatusRemovals: il
+      // primo canale sa solo aggiungere (applyMoraleStatus = Math.max), quindi senza il
+      // secondo il furto degraderebbe a una copia.
+      // Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+      // Band-neutral: nessuna sim unit porta ghiandole_mnemoniche.
+      if (result.hit) {
+        const stolen = stealBuff({ actor, target });
+        if (stolen) {
+          if (!Array.isArray(session._pendingStatusApplies)) {
+            session._pendingStatusApplies = [];
+          }
+          if (!Array.isArray(session._pendingStatusRemovals)) {
+            session._pendingStatusRemovals = [];
+          }
+          session._pendingStatusApplies.push({
+            unit_id: actor.id,
+            status: stolen.stato,
+            duration: stolen.granted_turns,
+          });
+          session._pendingStatusRemovals.push({
+            unit_id: target.id,
+            status: stolen.stato,
+          });
+          evaluation.trait_effects = (evaluation.trait_effects || []).concat({
+            trait: 'ghiandole_mnemoniche',
+            triggered: true,
+            effect: {
+              kind: 'buff_steal',
+              stato: stolen.stato,
+              from: target.id,
+              to: actor.id,
+              stolen_turns: stolen.stolen_turns,
+              granted_turns: stolen.granted_turns,
+            },
+          });
+        }
       }
 
       // artigli_psionici (creature-trait slice 4): on a MELEE hit the carrier studies

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -442,6 +442,19 @@ function createRoundBridge(deps) {
       }
       session._pendingStatusApplies = [];
     }
+
+    // Canale di RIMOZIONE (buff-steal, ghiandole_mnemoniche). Il drain sopra sa solo
+    // AGGIUNGERE (applyMoraleStatus = Math.max(cur,dur)) e il rebuild tracked->dict
+    // poco sopra ripristinerebbe un delete fatto a meta' attacco. Qui siamo DOPO quel
+    // rebuild: il prossimo adaptSessionToRoundState ri-deriva l'array tracciato dal
+    // dict, quindi la cancellazione sopravvive. Best-effort; mai bloccante.
+    // Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+    try {
+      const { drainStatusRemovals } = require('../services/combat/pendingStatusRemovals');
+      drainStatusRemovals(session, unitsById);
+    } catch {
+      /* modulo assente -> nessuna rimozione, il round prosegue */
+    }
   }
 
   function placeholderResolveAction(state, action, _catalog, _rng) {

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -427,33 +427,40 @@ function createRoundBridge(deps) {
     // adaptSessionToRoundState promotes the re-applied keys to tracked
     // orchestrator statuses (universal decay included). Best-effort; never
     // blocks the round.
-    if (Array.isArray(session._pendingStatusApplies) && session._pendingStatusApplies.length) {
-      let applyMoraleStatus = null;
-      try {
-        ({ applyMoraleStatus } = require('../services/combat/morale'));
-      } catch {
-        applyMoraleStatus = null;
-      }
-      if (applyMoraleStatus) {
-        for (const pending of session._pendingStatusApplies) {
-          const u = unitsById.get(String(pending.unit_id));
-          if (u && Number(u.hp) > 0) applyMoraleStatus(u, pending.status, pending.duration);
-        }
-      }
-      session._pendingStatusApplies = [];
-    }
-
-    // Canale di RIMOZIONE (buff-steal, ghiandole_mnemoniche). Il drain sopra sa solo
-    // AGGIUNGERE (applyMoraleStatus = Math.max(cur,dur)) e il rebuild tracked->dict
-    // poco sopra ripristinerebbe un delete fatto a meta' attacco. Qui siamo DOPO quel
-    // rebuild: il prossimo adaptSessionToRoundState ri-deriva l'array tracciato dal
-    // dict, quindi la cancellazione sopravvive. Best-effort; mai bloccante.
+    // Il canale di apply sa solo AGGIUNGERE (applyMoraleStatus = Math.max(cur,dur)), e
+    // il rebuild tracked->dict poco sopra ripristinerebbe qualsiasi delete fatto a meta'
+    // attacco. Serve quindi un canale di RIMOZIONE simmetrico (buff-steal,
+    // ghiandole_mnemoniche), drenato qui, DOPO quel rebuild: il prossimo
+    // adaptSessionToRoundState ri-deriva l'array tracciato dal dict, e la cancellazione
+    // sopravvive.
+    //
+    // L'ORDINE (rimozioni, poi applies) vive in combat/pendingStatusRemovals.js perche'
+    // sia coperto da test: invertirlo farebbe annichilire il buff quando due ladri di
+    // fazione opposta rubano lo stesso status nello stesso round.
     // Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+    let applyMoraleStatus = null;
     try {
-      const { drainStatusRemovals } = require('../services/combat/pendingStatusRemovals');
-      drainStatusRemovals(session, unitsById);
+      ({ applyMoraleStatus } = require('../services/combat/morale'));
     } catch {
-      /* modulo assente -> nessuna rimozione, il round prosegue */
+      applyMoraleStatus = null;
+    }
+    try {
+      const { drainPendingStatusEffects } = require('../services/combat/pendingStatusRemovals');
+      drainPendingStatusEffects(session, unitsById, applyMoraleStatus);
+    } catch (err) {
+      // Fallback storico: senza il modulo si drenano almeno gli applies, cosi' un
+      // errore qui non regredisce il comportamento pre-esistente. Rumoroso di
+      // proposito: un throw silenzioso degraderebbe il furto in copia.
+      console.warn('[round-bridge] pending-status drain fallback:', err && err.message);
+      if (Array.isArray(session._pendingStatusApplies) && session._pendingStatusApplies.length) {
+        if (applyMoraleStatus) {
+          for (const pending of session._pendingStatusApplies) {
+            const u = unitsById.get(String(pending.unit_id));
+            if (u && Number(u.hp) > 0) applyMoraleStatus(u, pending.status, pending.duration);
+          }
+        }
+        session._pendingStatusApplies = [];
+      }
     }
   }
 

--- a/apps/backend/services/combat/ghiandoleMnemoniche.js
+++ b/apps/backend/services/combat/ghiandoleMnemoniche.js
@@ -64,6 +64,23 @@ function hasTrait(unit, traitId) {
 }
 
 /**
+ * Guardia di fazione. La route di attacco NON valida la fazione del bersaglio
+ * (`session.units.find((u) => u.id === body.target_id)`), quindi un attacco puo'
+ * colpire un alleato: senza questa guardia un tratto di SABOTAGGIO deruberebbe un
+ * compagno di squadra. Stesso criterio di combat/telepathicReveal, che salta le
+ * unita' della stessa fazione.
+ *
+ * Conservativa: se una delle due unita' non dichiara `controlled_by` (fixture legacy,
+ * sim units) non si puo' dimostrare che siano alleate, e il furto procede.
+ *
+ * @returns {boolean} true solo quando entrambe dichiarano la STESSA fazione
+ */
+function isSameFaction(actor, target) {
+  return Boolean(actor.controlled_by && target.controlled_by) &&
+    actor.controlled_by === target.controlled_by;
+}
+
+/**
  * Durata attenuata: 50% arrotondato per eccesso, con floor 1 su input positivi.
  *
  * @param {number} turns
@@ -87,6 +104,7 @@ function stealBuff({ actor, target }) {
   if (!actor || typeof actor !== 'object') return null;
   if (!target || typeof target !== 'object') return null;
   if (!hasTrait(actor, GHIANDOLE_TRAIT)) return null;
+  if (isSameFaction(actor, target)) return null;
 
   const targetStatus = target.status;
   if (!targetStatus || typeof targetStatus !== 'object' || Array.isArray(targetStatus)) {
@@ -118,6 +136,12 @@ module.exports = {
   stealBuff,
   attenuate,
   hasTrait,
+  isSameFaction,
   GHIANDOLE_TRAIT,
-  STEALABLE,
+  // Copia difensiva: l'ordine della whitelist E' il design (frenzy-first = sabotaggio).
+  // Esportare l'array vivo lascerebbe a un consumatore la possibilita' di riordinarlo
+  // o svuotarlo a runtime, cambiando il comportamento del tratto ovunque.
+  get STEALABLE() {
+    return [...STEALABLE];
+  },
 };

--- a/apps/backend/services/combat/ghiandoleMnemoniche.js
+++ b/apps/backend/services/combat/ghiandoleMnemoniche.js
@@ -76,8 +76,10 @@ function hasTrait(unit, traitId) {
  * @returns {boolean} true solo quando entrambe dichiarano la STESSA fazione
  */
 function isSameFaction(actor, target) {
-  return Boolean(actor.controlled_by && target.controlled_by) &&
-    actor.controlled_by === target.controlled_by;
+  return (
+    Boolean(actor.controlled_by && target.controlled_by) &&
+    actor.controlled_by === target.controlled_by
+  );
 }
 
 /**

--- a/apps/backend/services/combat/ghiandoleMnemoniche.js
+++ b/apps/backend/services/combat/ghiandoleMnemoniche.js
@@ -1,0 +1,123 @@
+// apps/backend/services/combat/ghiandoleMnemoniche.js
+//
+// ghiandole_mnemoniche -- furto di buff.
+// Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+//
+// Intento autoriale (docs/traits/Frattura_Abissale_Sinaptica_trait_draft.md:57,
+// role_template "Sciame Memetico", tier 3, functional_tags sabotaggio + furto_buff):
+// "micro-larve che rubano buff temporanei e li riapplicano in forma ridotta".
+// Su un colpo andato a segno il portatore strappa UN buff alla preda e ne indossa
+// una copia attenuata.
+//
+// SCOSTAMENTO DAL CANONE, deliberato. Il canone (trait_reference_manual.md:35, il
+// gemello riverbero_memetico) dice "duplica prossimo buff al 50%". La magnitudo di
+// uno status NON e' scalabile in questo motore: computeStatusModifiers legge
+// status_intensity per il solo `abbagliato` (statusModifiers.js:241); tutti gli altri
+// status sono binari (isPositive -> delta fisso). Non esiste "mezzo linked". Il 50%
+// e' quindi reso sulla DURATA. Non convertirlo in magnitudo senza riaprire la
+// decisione: toccherebbe ~12 rami di computeStatusModifiers e ri-bilancerebbe ogni
+// tratto esistente che produce quegli status.
+//
+// `frenzy` e' primo in whitelist per scelta di design (master-dd): la priorita' e'
+// TOGLIERE al nemico (tag `sabotaggio`), non massimizzare il guadagno proprio. Ed e'
+// l'unico buff il cui furto NON e' un guadagno netto: computeStatusModifiers legge lo
+// STESSO status sui due lati -- +1 attacco quando si attacca (:202), -1 difesa quando
+// si e' bersagliati (:253) -- quindi il ladro eredita anche la guardia abbassata.
+//
+// PASSIVE_BLOCKLIST contiene frenzy (passiveStatusApplier.js:45), ma vieta
+// l'auto-applicazione PASSIVA ("frenzy = 2 turns rage, not always-on"). Qui il buff e'
+// applicato direttamente e a durata dimezzata: nessun conflitto, e la regola
+// dimezzante rispetta quell'intento canonico.
+//
+// Esclusi dalla whitelist: `nucleo_intatto` (stato strutturale, non un buff; il suo
+// rovescio danno_nucleo e' governato da combat/nucleiWeakPoint.js) e `telepatic_link`
+// (firma di nodi_micorrizici_oracolari: rubarlo incrocerebbe i due tratti in un modo
+// che nessuno ha progettato).
+//
+// Questo tratto resta fuori da tests/helpers/traitLiveness.js DI PROPOSITO: il mirror
+// esclude ogni persistent_marker, cosi' i path di grant automatico (imprintTraitGrant,
+// brancoTraitEmergence) non lo pescheranno mai senza un ratify N=40 dedicato.
+// Non e' una dimenticanza.
+//
+// Puro rispetto al modulo: muta in place gli status-map di actor e target, come i pari
+// cortecciaMemetica / tessutiAdattivi. La PERSISTENZA della rimozione nel path
+// round-model e' responsabilita' del chiamante: routes/session.js pusha in
+// session._pendingStatusRemovals (vedi combat/pendingStatusRemovals.js), perche' il
+// rebuild tracked->dict annullerebbe un delete fatto a meta' attacco.
+//
+// Band-neutral: nessuna sim unit porta ghiandole_mnemoniche.
+
+'use strict';
+
+const GHIANDOLE_TRAIT = 'ghiandole_mnemoniche';
+
+// Ordine di priorita' deterministico. Un solo buff per colpo.
+const STEALABLE = ['frenzy', 'linked', 'sensed', 'coordinamento', 'risonanza_memetica'];
+
+function hasTrait(unit, traitId) {
+  const raw = unit && Array.isArray(unit.traits) ? unit.traits : [];
+  for (const t of raw) {
+    if (typeof t === 'string' && t === traitId) return true;
+    if (t && typeof t === 'object' && t.id === traitId) return true;
+  }
+  return false;
+}
+
+/**
+ * Durata attenuata: 50% arrotondato per eccesso, con floor 1 su input positivi.
+ *
+ * @param {number} turns
+ * @returns {number} 0 quando l'input non e' un numero positivo
+ */
+function attenuate(turns) {
+  const t = Number(turns);
+  if (!Number.isFinite(t) || t <= 0) return 0;
+  return Math.max(1, Math.ceil(t / 2));
+}
+
+/**
+ * Ruba il primo buff in whitelist posseduto dal target. Muta entrambe le unita'.
+ *
+ * @param {object} opts
+ * @param {object} opts.actor  portatore del tratto (mutato: guadagna il buff)
+ * @param {object} opts.target preda (mutata: perde il buff)
+ * @returns {{stato: string, stolen_turns: number, granted_turns: number} | null}
+ */
+function stealBuff({ actor, target }) {
+  if (!actor || typeof actor !== 'object') return null;
+  if (!target || typeof target !== 'object') return null;
+  if (!hasTrait(actor, GHIANDOLE_TRAIT)) return null;
+
+  const targetStatus = target.status;
+  if (!targetStatus || typeof targetStatus !== 'object' || Array.isArray(targetStatus)) {
+    return null;
+  }
+
+  for (const stato of STEALABLE) {
+    const turns = Number(targetStatus[stato]);
+    if (!Number.isFinite(turns) || turns <= 0) continue;
+
+    const granted = attenuate(turns);
+    delete targetStatus[stato];
+    if (target.status_intensity && typeof target.status_intensity === 'object') {
+      delete target.status_intensity[stato];
+    }
+
+    if (!actor.status || typeof actor.status !== 'object') actor.status = {};
+    const current = Number(actor.status[stato] || 0);
+    // max-policy, coerente con applyMoraleStatus: un furto non abbassa mai un buff
+    // che il portatore possiede gia' con durata maggiore.
+    actor.status[stato] = Math.max(current, granted);
+
+    return { stato, stolen_turns: turns, granted_turns: actor.status[stato] };
+  }
+  return null;
+}
+
+module.exports = {
+  stealBuff,
+  attenuate,
+  hasTrait,
+  GHIANDOLE_TRAIT,
+  STEALABLE,
+};

--- a/apps/backend/services/combat/pendingStatusRemovals.js
+++ b/apps/backend/services/combat/pendingStatusRemovals.js
@@ -48,4 +48,44 @@ function drainStatusRemovals(session, unitsById) {
   return applied;
 }
 
-module.exports = { drainStatusRemovals };
+/**
+ * Drena ENTRAMBE le code nell'ordine corretto: rimozioni, poi applies.
+ *
+ * L'ordine e' load-bearing, non estetico. Se gli applies girassero per primi, due ladri
+ * di fazione opposta che nello stesso round rubano lo stesso status se lo
+ * annichilirebbero: entrambi guadagnano, poi entrambe le rimozioni cancellano. Con le
+ * rimozioni per prime ciascuno perde il proprio e guadagna quello dell'altro -- il
+ * risultato semanticamente corretto. Stesso motivo per cui un `actor === target` non si
+ * auto-cancella: rimuove, poi riapplica a durata dimezzata.
+ *
+ * Vive qui, e non nella closure di createRoundBridge, proprio perche' l'ordine sia
+ * coperto da un test.
+ *
+ * @param {object} session
+ * @param {Map<string,object>} unitsById
+ * @param {(unit: object, status: string, duration: number) => unknown} [applyStatus]
+ *   applyMoraleStatus, iniettato dal chiamante. Assente -> gli applies sono saltati
+ *   (comportamento storico del bridge quando il modulo morale non si carica).
+ * @returns {{removed: number, applied: number}}
+ */
+function drainPendingStatusEffects(session, unitsById, applyStatus) {
+  const removed = drainStatusRemovals(session, unitsById);
+
+  let applied = 0;
+  if (session && Array.isArray(session._pendingStatusApplies)) {
+    if (typeof applyStatus === 'function') {
+      for (const pending of session._pendingStatusApplies) {
+        if (!pending || !pending.status) continue;
+        const unit = unitsById && unitsById.get(String(pending.unit_id));
+        if (unit && Number(unit.hp) > 0) {
+          applyStatus(unit, pending.status, pending.duration);
+          applied += 1;
+        }
+      }
+    }
+    session._pendingStatusApplies = [];
+  }
+  return { removed, applied };
+}
+
+module.exports = { drainStatusRemovals, drainPendingStatusEffects };

--- a/apps/backend/services/combat/pendingStatusRemovals.js
+++ b/apps/backend/services/combat/pendingStatusRemovals.js
@@ -1,0 +1,51 @@
+// apps/backend/services/combat/pendingStatusRemovals.js
+//
+// Canale di RIMOZIONE degli status, simmetrico a session._pendingStatusApplies.
+// Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md (sez. 2b)
+//
+// Perche' serve. Il canale di apply e' drenato con combat/morale.applyMoraleStatus,
+// che e' `unit.status[s] = Math.max(cur, dur)`: monotono crescente, incapace di
+// rimuovere. E il loop di syncStatusesFromRoundState riscrive sessionUnit.status
+// dall'array tracciato roundUnit.statuses, ripristinando qualsiasi delete fatto a
+// meta' attacco. Senza questo canale il furto di ghiandole_mnemoniche degraderebbe
+// silenziosamente a una COPIA nel path round-model, restando un FURTO in quello
+// legacy: due path dello stesso motore con comportamento divergente.
+//
+// Quando invocarlo: SUBITO DOPO il drain degli applies, cioe' dopo il rebuild
+// tracked->dict. adaptSessionToRoundState ri-deriva l'array tracciato leggendo il
+// dict, quindi la cancellazione sopravvive al giro successivo.
+//
+// Estratto in un modulo proprio perche' syncStatusesFromRoundState e' una closure non
+// esportata di createRoundBridge: qui e' testabile in isolamento.
+//
+// Best-effort: non lancia mai, non blocca il round.
+
+'use strict';
+
+/**
+ * Applica e svuota session._pendingStatusRemovals.
+ *
+ * @param {object} session                oggetto sessione (mutato: la coda viene svuotata)
+ * @param {Map<string,object>} unitsById  unita' per id (mutate: perdono lo status)
+ * @returns {number} quante rimozioni sono state applicate
+ */
+function drainStatusRemovals(session, unitsById) {
+  if (!session || !Array.isArray(session._pendingStatusRemovals)) return 0;
+  if (session._pendingStatusRemovals.length === 0) return 0;
+
+  let applied = 0;
+  for (const pending of session._pendingStatusRemovals) {
+    if (!pending || !pending.status) continue;
+    const unit = unitsById && unitsById.get(String(pending.unit_id));
+    if (!unit || !unit.status || typeof unit.status !== 'object') continue;
+    delete unit.status[pending.status];
+    if (unit.status_intensity && typeof unit.status_intensity === 'object') {
+      delete unit.status_intensity[pending.status];
+    }
+    applied += 1;
+  }
+  session._pendingStatusRemovals = [];
+  return applied;
+}
+
+module.exports = { drainStatusRemovals };

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -7884,3 +7884,28 @@ traits:
       premonitori. Il portatore percepisce le intenzioni delle creature ostili
       entro tre caselle prima che agiscano (fase di pianificazione). Non conferisce
       alcun bonus di attacco o difesa: e' informazione, non potenza.
+
+  # Buff-steal -- spec docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+  # persistent_marker = sola REGISTRAZIONE: la logica vive in
+  # apps/backend/services/combat/ghiandoleMnemoniche.js, wired post-attacco in
+  # routes/session.js. Stesso pattern di corteccia_memetica / artigli_psionici.
+  # Il canone dice "al 50%": e' reso sulla DURATA, non sulla magnitudo (status_intensity
+  # e' letto solo per abbagliato). Whitelist ordinata frenzy-first: la priorita' e'
+  # togliere al nemico, non massimizzare il guadagno.
+  # Band-neutral: nessuna sim unit porta questo tratto.
+  ghiandole_mnemoniche:
+    tier: T2
+    category: supporto
+    applies_to: actor
+    trigger:
+      action_type: passive
+    effect:
+      kind: persistent_marker
+      marker: ghiandole_mnemoniche
+      log_tag: ghiandole_mnemoniche
+    description_it: |
+      Ghiandole mnemoniche: secrezioni che trattengono copie attenuate dei buff.
+      Su un colpo andato a segno il portatore strappa alla preda un potenziamento
+      temporaneo (priorita': frenesia, legame, percezione, coordinamento, risonanza)
+      e ne indossa una copia per meta' della durata residua. Rubare la frenesia non
+      e' un affare pulito: se ne eredita anche la guardia abbassata.

--- a/data/core/traits/active_effects.yaml
+++ b/data/core/traits/active_effects.yaml
@@ -7859,3 +7859,28 @@ traits:
       Modulo strategico che mantiene priorita e finestre d'attacco allineate:
       quando il colpo cade su una finestra ben allineata (margine alto) aggiunge
       +1 al danno, premiando il tempismo invece della forza bruta.
+
+  # Oracle reveal -- spec docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+  # Primo produttore PASSIVO di telepatic_link: la pipe combat/telepathicReveal.js era
+  # gia' wired (sessionRoundBridge begin-planning) ma affamata -- l'unico produttore,
+  # risonanza_magnetica, e' gated on_kill + min_mos 5 (boss-finish, spara ~mai).
+  # telepatic_link non concede alcun delta statistico (statusModifiers.js:206-208):
+  # il tratto da' informazione, non forza. Contenimento = il raggio (manhattan 3,
+  # default di computeTelepathicReveal), non la rarita'.
+  # Band-neutral: nessuna sim unit porta questo tratto.
+  nodi_micorrizici_oracolari:
+    tier: T3
+    category: sensoriale
+    applies_to: actor
+    trigger:
+      action_type: passive
+    effect:
+      kind: apply_status
+      stato: telepatic_link
+      turns: 2
+      log_tag: nodi_micorrizici_oracolari
+    description_it: |
+      Nodi micorrizici oracolari: la rete fungina simbiotica trasporta segnali
+      premonitori. Il portatore percepisce le intenzioni delle creature ostili
+      entro tre caselle prima che agiscano (fase di pianificazione). Non conferisce
+      alcun bonus di attacco o difesa: e' informazione, non potenza.

--- a/docs/superpowers/plans/2026-07-10-buff-steal-oracle-reveal.md
+++ b/docs/superpowers/plans/2026-07-10-buff-steal-oracle-reveal.md
@@ -1,0 +1,858 @@
+# Buff-steal e oracle-reveal -- Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rendere meccanicamente vivi due tratti oggi inerti -- `nodi_micorrizici_oracolari` (reveal degli intent nemici) e `ghiandole_mnemoniche` (furto di un buff temporaneo, riapplicato a durata dimezzata).
+
+**Architecture:** `nodi_micorrizici_oracolari` non richiede codice: una entry `passive` + `apply_status` + `stato: telepatic_link` in `active_effects.yaml` accende `passiveStatusApplier` -> `computeTelepathicReveal`, una pipe gia' wired ma senza produttori passivi. `ghiandole_mnemoniche` segue il pattern `persistent_marker` + modulo dedicato (come `cortecciaMemetica`): la logica vive in `combat/ghiandoleMnemoniche.js`, wired post-attacco in `routes/session.js`. Poiche' il sync round-model ricostruisce `unit.status` dall'array tracciato e il canale `_pendingStatusApplies` sa solo aggiungere (`applyMoraleStatus` = `Math.max`), serve un canale di rimozione simmetrico, estratto in un modulo puro per essere testabile.
+
+**Tech Stack:** Node 22 (repo canonico), CommonJS, `node:test` + `node:assert/strict`, `js-yaml`.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md`
+**Branch:** `feat/trait-buff-steal-oracle-reveal` (da `origin/main`)
+
+---
+
+## File Structure
+
+| File                                                     | Responsabilita'                               | Azione                  |
+| -------------------------------------------------------- | --------------------------------------------- | ----------------------- |
+| `data/core/traits/active_effects.yaml`                   | registro meccanico dei tratti                 | Modify (append 2 entry) |
+| `apps/backend/services/combat/ghiandoleMnemoniche.js`    | logica pura del furto di buff                 | Create                  |
+| `apps/backend/services/combat/pendingStatusRemovals.js`  | drain puro del canale di rimozione            | Create                  |
+| `apps/backend/routes/sessionRoundBridge.js`              | drena il canale dopo il rebuild tracked->dict | Modify (~3 righe)       |
+| `apps/backend/routes/session.js`                         | wire post-attacco del furto                   | Modify (~20 righe)      |
+| `tests/services/combat/nodiMicorriziciOracolari.test.js` | inchioda la entry YAML + la pipe reveal       | Create                  |
+| `tests/services/combat/ghiandoleMnemoniche.test.js`      | inchioda il furto, la whitelist, l'ordine     | Create                  |
+| `tests/services/combat/pendingStatusRemovals.test.js`    | inchioda il drain di rimozione                | Create                  |
+
+**Non toccare:** `tests/helpers/traitLiveness.js` (spec sezione 4 -- l'esclusione dei `persistent_marker` e' voluta).
+
+---
+
+### Task 0: Allineare lo spec ai fatti verificati su questo branch
+
+Il commit dello spec (`3fadcb86a`) cita `sessionRoundBridge.js:2373` -- corretto sul branch `feat/trait-i18n-wiring-lotto1`, sbagliato qui: su `origin/main` la chiamata e' alla riga **2302**. Va corretto, e va documentato il canale di rimozione, che nello spec non c'era.
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md`
+
+- [ ] **Step 1: correggere il numero di riga**
+
+Nel fatto (4) della sezione "Ground truth accertata", sostituire
+`routes/sessionRoundBridge.js:2373` con `routes/sessionRoundBridge.js:2302`.
+
+- [ ] **Step 2: aggiungere la sezione sul canale di rimozione**
+
+Inserire dopo la sezione `### 2. ghiandole_mnemoniche -- un modulo dedicato`:
+
+```markdown
+### 2b. Canale di rimozione (`_pendingStatusRemovals`)
+
+Il furto non persiste senza un canale dedicato. `_pendingStatusApplies` e' drenato
+con `applyMoraleStatus` (`combat/morale.js:61`), che e'
+`unit.status[s] = Math.max(cur, dur)` -- monotono crescente, non sa rimuovere. E il
+loop di `syncStatusesFromRoundState` (`sessionRoundBridge.js:415-419`) riscrive
+`sessionUnit.status` dall'array tracciato `roundUnit.statuses`, ripristinando
+qualsiasi `delete` fatto a meta' attacco.
+
+Senza rimozione, `ghiandole_mnemoniche` diventerebbe silenziosamente una COPIA nel
+path round-model e un FURTO in quello legacy: due path dello stesso motore con
+comportamento divergente.
+
+Soluzione: `session._pendingStatusRemovals` (`[{unit_id, status}]`), drenato subito
+dopo gli applies, cioe' DOPO il rebuild tracked->dict. `adaptSessionToRoundState`
+(`sessionRoundBridge.js:297-309`) ri-deriva l'array tracciato dal dict, quindi la
+cancellazione sopravvive al giro successivo.
+
+Il drain vive in `combat/pendingStatusRemovals.js` -- funzione pura, testabile --
+perche' `syncStatusesFromRoundState` e' una closure non esportata di
+`createRoundBridge`.
+
+Band-neutral: nessuna unita' pusha rimozioni se non porta il tratto.
+```
+
+- [ ] **Step 3: commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+git commit -m "docs(spec): add removal channel, fix sessionRoundBridge line ref
+
+Coding-Agent: claude-opus-4-8
+Trace-Id: <nuovo uuidv7>"
+```
+
+---
+
+### Task 1: `nodi_micorrizici_oracolari` -- entry YAML
+
+**Files:**
+
+- Modify: `data/core/traits/active_effects.yaml` (append in coda, dopo `pianificatore:`)
+- Test: `tests/services/combat/nodiMicorriziciOracolari.test.js`
+
+- [ ] **Step 1: scrivere il test che fallisce**
+
+Creare `tests/services/combat/nodiMicorriziciOracolari.test.js`:
+
+```js
+// tests/services/combat/nodiMicorriziciOracolari.test.js
+//
+// nodi_micorrizici_oracolari -- oracle reveal (spec 2026-07-10).
+// Il tratto e' data-only: applica passivamente `telepatic_link`, che
+// computeTelepathicReveal consuma per rivelare gli intent nemici entro raggio 3.
+// Nessun modulo dedicato: questi test inchiodano la entry YAML e la pipe.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const {
+  applyPassiveAncestors,
+} = require('../../../apps/backend/services/combat/passiveStatusApplier');
+const {
+  computeTelepathicReveal,
+} = require('../../../apps/backend/services/combat/telepathicReveal');
+const { isEngineLiveReliable } = require('../../helpers/traitLiveness');
+
+const REGISTRY = yaml.load(
+  fs.readFileSync(path.resolve(__dirname, '../../../data/core/traits/active_effects.yaml'), 'utf8'),
+).traits;
+
+const TRAIT = 'nodi_micorrizici_oracolari';
+
+test('nodi: la entry esiste ed e riconosciuta engine-LIVE', () => {
+  const def = REGISTRY[TRAIT];
+  assert.ok(def, 'entry assente da active_effects.yaml');
+  assert.equal(def.trigger.action_type, 'passive');
+  assert.equal(def.effect.kind, 'apply_status');
+  assert.equal(def.effect.stato, 'telepatic_link');
+  assert.equal(isEngineLiveReliable(def), true);
+});
+
+test('nodi: applyPassiveAncestors concede telepatic_link', () => {
+  const unit = { id: 'u1', traits: [TRAIT], status: {} };
+  const events = applyPassiveAncestors(unit, REGISTRY);
+  assert.equal(unit.status.telepatic_link, 2);
+  assert.ok(events.some((e) => e.trait === TRAIT && e.stato === 'telepatic_link'));
+});
+
+test('nodi: un unita senza il tratto non riceve telepatic_link', () => {
+  const unit = { id: 'u2', traits: [], status: {} };
+  applyPassiveAncestors(unit, REGISTRY);
+  assert.equal(unit.status.telepatic_link, undefined);
+});
+
+function sessionWith(enemyPos) {
+  return {
+    units: [
+      {
+        id: 'p1',
+        controlled_by: 'player',
+        hp: 10,
+        position: { x: 0, y: 0 },
+        status: { telepatic_link: 2 },
+      },
+      { id: 'e1', controlled_by: 'sistema', hp: 10, position: enemyPos, status: {} },
+    ],
+    roundState: {
+      pending_intents: [{ unit_id: 'e1', action: { type: 'attack', target_id: 'p1' } }],
+    },
+  };
+}
+
+test('nodi: il portatore vede lintent nemico entro raggio 3', () => {
+  const out = computeTelepathicReveal(sessionWith({ x: 2, y: 1 })); // manhattan 3
+  assert.equal(out.length, 1);
+  assert.equal(out[0].actor_id, 'p1');
+  assert.equal(out[0].revealed[0].enemy_id, 'e1');
+  assert.equal(out[0].revealed[0].intent_type, 'attack');
+});
+
+test('nodi: oltre raggio 3 lintent resta nascosto', () => {
+  const out = computeTelepathicReveal(sessionWith({ x: 4, y: 0 })); // manhattan 4
+  assert.equal(out.length, 0);
+});
+```
+
+- [ ] **Step 2: eseguire il test e verificare che fallisca**
+
+Run: `node --test tests/services/combat/nodiMicorriziciOracolari.test.js`
+Expected: FAIL sul primo test -- `entry assente da active_effects.yaml`.
+(Gli ultimi due passano gia': la pipe esiste; e' il produttore che manca.)
+
+- [ ] **Step 3: aggiungere la entry YAML**
+
+Appendere in coda a `data/core/traits/active_effects.yaml` (dopo il blocco `pianificatore:`, stessa indentazione a 2 spazi):
+
+```yaml
+# Oracle reveal -- spec docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+# Primo produttore PASSIVO di telepatic_link: la pipe combat/telepathicReveal.js era
+# wired (sessionRoundBridge begin-planning) ma affamata -- l'unico produttore,
+# risonanza_magnetica, e' gated on_kill + min_mos 5 (boss-finish).
+# telepatic_link non concede alcun delta statistico (statusModifiers.js:206-208):
+# il tratto da' informazione, non forza. Contenimento = il raggio (manhattan 3),
+# non la rarita'. Band-neutral: nessuna sim unit porta questo tratto.
+nodi_micorrizici_oracolari:
+  tier: T3
+  category: sensoriale
+  applies_to: actor
+  trigger:
+    action_type: passive
+  effect:
+    kind: apply_status
+    stato: telepatic_link
+    turns: 2
+    log_tag: nodi_micorrizici_oracolari
+  description_it: |
+    Nodi micorrizici oracolari: la rete fungina simbiotica trasporta segnali
+    premonitori. Il portatore percepisce le intenzioni delle creature ostili
+    entro tre caselle prima che agiscano (fase di pianificazione). Non conferisce
+    alcun bonus di attacco o difesa: e' informazione, non potenza.
+```
+
+- [ ] **Step 4: eseguire il test e verificare che passi**
+
+Run: `node --test tests/services/combat/nodiMicorriziciOracolari.test.js`
+Expected: PASS, 5/5.
+
+- [ ] **Step 5: commit**
+
+```bash
+git add data/core/traits/active_effects.yaml tests/services/combat/nodiMicorriziciOracolari.test.js
+git commit -m "feat(traits): nodi_micorrizici_oracolari -- passive oracle reveal
+
+First passive producer of telepatic_link. The reveal pipe
+(combat/telepathicReveal.js) was already wired into begin-planning but
+starved: its only producer, risonanza_magnetica, is gated on_kill+min_mos 5.
+telepatic_link carries no stat delta, so this is information, not power.
+
+Coding-Agent: claude-opus-4-8
+Trace-Id: <nuovo uuidv7>"
+```
+
+---
+
+### Task 2: modulo `ghiandoleMnemoniche.js`
+
+**Files:**
+
+- Create: `apps/backend/services/combat/ghiandoleMnemoniche.js`
+- Test: `tests/services/combat/ghiandoleMnemoniche.test.js`
+
+- [ ] **Step 1: scrivere il test che fallisce**
+
+Creare `tests/services/combat/ghiandoleMnemoniche.test.js`:
+
+```js
+// tests/services/combat/ghiandoleMnemoniche.test.js
+//
+// ghiandole_mnemoniche -- furto di buff (spec 2026-07-10).
+// Su hit andato a segno il portatore strappa UN buff temporaneo alla preda e ne
+// indossa una copia attenuata (50% della durata, minimo 1).
+// Whitelist ordinata: frenzy, linked, sensed, coordinamento, risonanza_memetica.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  stealBuff,
+  attenuate,
+  hasTrait,
+  GHIANDOLE_TRAIT,
+  STEALABLE,
+} = require('../../../apps/backend/services/combat/ghiandoleMnemoniche');
+
+function carrier() {
+  return { id: 'a1', traits: [GHIANDOLE_TRAIT], status: {} };
+}
+function prey(status) {
+  return { id: 't1', traits: [], status: { ...status } };
+}
+
+test('attenuate: dimezza per eccesso, con floor 1', () => {
+  assert.equal(attenuate(4), 2);
+  assert.equal(attenuate(3), 2);
+  assert.equal(attenuate(1), 1);
+  assert.equal(attenuate(0), 0);
+});
+
+test('whitelist: frenzy e primo, risonanza_memetica ultimo', () => {
+  assert.deepEqual(STEALABLE, [
+    'frenzy',
+    'linked',
+    'sensed',
+    'coordinamento',
+    'risonanza_memetica',
+  ]);
+});
+
+test('furto: linked 4 -> la preda lo perde, il portatore lo guadagna con 2', () => {
+  const actor = carrier();
+  const target = prey({ linked: 4 });
+  const out = stealBuff({ actor, target });
+  assert.equal(out.stato, 'linked');
+  assert.equal(target.status.linked, undefined);
+  assert.equal(actor.status.linked, 2);
+});
+
+test('furto: linked 1 -> il portatore lo guadagna con 1 (floor)', () => {
+  const actor = carrier();
+  const target = prey({ linked: 1 });
+  stealBuff({ actor, target });
+  assert.equal(actor.status.linked, 1);
+});
+
+test('furto: un solo buff per colpo, il primo in whitelist', () => {
+  const actor = carrier();
+  const target = prey({ sensed: 4, linked: 4 });
+  const out = stealBuff({ actor, target });
+  assert.equal(out.stato, 'linked'); // linked precede sensed
+  assert.equal(target.status.sensed, 4); // sensed resta alla preda
+});
+
+test('furto: frenzy ha priorita su linked', () => {
+  const actor = carrier();
+  const target = prey({ linked: 4, frenzy: 2 });
+  const out = stealBuff({ actor, target });
+  assert.equal(out.stato, 'frenzy');
+  assert.equal(target.status.frenzy, undefined);
+  assert.equal(target.status.linked, 4);
+  assert.equal(actor.status.frenzy, 1);
+});
+
+test('furto: nucleo_intatto e telepatic_link non sono rubabili', () => {
+  const actor = carrier();
+  const target = prey({ nucleo_intatto: 99, telepatic_link: 2 });
+  assert.equal(stealBuff({ actor, target }), null);
+  assert.equal(target.status.nucleo_intatto, 99);
+  assert.equal(target.status.telepatic_link, 2);
+});
+
+test('furto: senza il tratto, nessun effetto', () => {
+  const actor = { id: 'a2', traits: [], status: {} };
+  const target = prey({ linked: 4 });
+  assert.equal(stealBuff({ actor, target }), null);
+  assert.equal(target.status.linked, 4);
+});
+
+test('furto: preda senza buff -> null, nessuna mutazione', () => {
+  const actor = carrier();
+  const target = prey({});
+  assert.equal(stealBuff({ actor, target }), null);
+  assert.deepEqual(actor.status, {});
+});
+
+test('furto: status_intensity della preda viene ripulito', () => {
+  const actor = carrier();
+  const target = prey({ linked: 4 });
+  target.status_intensity = { linked: 2 };
+  stealBuff({ actor, target });
+  assert.equal(target.status_intensity.linked, undefined);
+});
+
+test('furto: non abbassa un buff gia posseduto dal portatore', () => {
+  const actor = carrier();
+  actor.status.linked = 3;
+  const target = prey({ linked: 2 }); // attenuato -> 1
+  stealBuff({ actor, target });
+  assert.equal(actor.status.linked, 3); // max(3, 1)
+});
+
+test('hasTrait: accetta stringhe e oggetti {id}', () => {
+  assert.equal(hasTrait({ traits: [GHIANDOLE_TRAIT] }, GHIANDOLE_TRAIT), true);
+  assert.equal(hasTrait({ traits: [{ id: GHIANDOLE_TRAIT }] }, GHIANDOLE_TRAIT), true);
+  assert.equal(hasTrait({ traits: [] }, GHIANDOLE_TRAIT), false);
+});
+```
+
+- [ ] **Step 2: eseguire il test e verificare che fallisca**
+
+Run: `node --test tests/services/combat/ghiandoleMnemoniche.test.js`
+Expected: FAIL con `Cannot find module '.../ghiandoleMnemoniche'`.
+
+- [ ] **Step 3: scrivere il modulo**
+
+Creare `apps/backend/services/combat/ghiandoleMnemoniche.js`:
+
+```js
+// apps/backend/services/combat/ghiandoleMnemoniche.js
+//
+// ghiandole_mnemoniche -- furto di buff.
+// Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+//
+// Intento autoriale (docs/traits/Frattura_Abissale_Sinaptica_trait_draft.md:57,
+// role_template "Sciame Memetico"): "micro-larve che rubano buff temporanei e li
+// riapplicano in forma ridotta". Su un colpo andato a segno il portatore strappa
+// UN buff alla preda e ne indossa una copia attenuata.
+//
+// SCOSTAMENTO DAL CANONE, deliberato: il canone (trait_reference_manual.md:35, il
+// gemello riverbero_memetico) dice "al 50%". La magnitudo di uno status NON e'
+// scalabile in questo motore -- computeStatusModifiers legge status_intensity per
+// il solo `abbagliato` (statusModifiers.js:241); tutti gli altri sono binari
+// (isPositive -> delta fisso). Il 50% e' quindi reso sulla DURATA. Non "correggere"
+// questo in magnitudo senza riaprire la decisione: toccherebbe ~12 rami di
+// computeStatusModifiers e ri-bilancerebbe ogni tratto che produce quegli status.
+//
+// `frenzy` e' primo in whitelist per scelta di design: la priorita' e' TOGLIERE
+// (tag `sabotaggio` del role_template), non massimizzare il guadagno. Ed e' l'unico
+// buff il cui furto NON e' un guadagno netto: computeStatusModifiers legge lo STESSO
+// status sui due lati -- +1 attacco quando si attacca (:202), -1 difesa quando si e'
+// bersagliati (:253) -- quindi il ladro eredita anche la guardia abbassata.
+//
+// NB: questo tratto resta fuori da tests/helpers/traitLiveness.js di proposito (il
+// mirror esclude ogni persistent_marker). Cosi' i path di grant automatico
+// (imprintTraitGrant, brancoTraitEmergence) non lo pescheranno mai senza un ratify
+// N=40 dedicato. Non e' una dimenticanza.
+//
+// Puro rispetto al modulo: muta in place gli status-map di actor e target, come i
+// pari cortecciaMemetica / tessutiAdattivi. La PERSISTENZA della rimozione nel path
+// round-model e' responsabilita' del chiamante (session.js pusha in
+// session._pendingStatusRemovals; vedi combat/pendingStatusRemovals.js).
+//
+// Band-neutral: nessuna sim unit porta ghiandole_mnemoniche.
+
+'use strict';
+
+const GHIANDOLE_TRAIT = 'ghiandole_mnemoniche';
+
+// Ordine di priorita' deterministico. Un solo buff per colpo.
+const STEALABLE = ['frenzy', 'linked', 'sensed', 'coordinamento', 'risonanza_memetica'];
+
+function hasTrait(unit, traitId) {
+  const raw = unit && Array.isArray(unit.traits) ? unit.traits : [];
+  for (const t of raw) {
+    if (typeof t === 'string' && t === traitId) return true;
+    if (t && typeof t === 'object' && t.id === traitId) return true;
+  }
+  return false;
+}
+
+/**
+ * Durata attenuata: 50% arrotondato per eccesso, con floor 1 su input positivi.
+ *
+ * @param {number} turns
+ * @returns {number} 0 se l'input non e' un numero positivo
+ */
+function attenuate(turns) {
+  const t = Number(turns);
+  if (!Number.isFinite(t) || t <= 0) return 0;
+  return Math.max(1, Math.ceil(t / 2));
+}
+
+/**
+ * Ruba il primo buff in whitelist posseduto dal target. Muta entrambe le unita'.
+ *
+ * @param {object} opts
+ * @param {object} opts.actor  portatore del tratto (mutato: guadagna il buff)
+ * @param {object} opts.target preda (mutata: perde il buff)
+ * @returns {{stato: string, stolen_turns: number, granted_turns: number} | null}
+ */
+function stealBuff({ actor, target }) {
+  if (!actor || typeof actor !== 'object') return null;
+  if (!target || typeof target !== 'object') return null;
+  if (!hasTrait(actor, GHIANDOLE_TRAIT)) return null;
+
+  const ts = target.status;
+  if (!ts || typeof ts !== 'object' || Array.isArray(ts)) return null;
+
+  for (const stato of STEALABLE) {
+    const turns = Number(ts[stato]);
+    if (!Number.isFinite(turns) || turns <= 0) continue;
+
+    const granted = attenuate(turns);
+    delete ts[stato];
+    if (target.status_intensity && typeof target.status_intensity === 'object') {
+      delete target.status_intensity[stato];
+    }
+
+    if (!actor.status || typeof actor.status !== 'object') actor.status = {};
+    const current = Number(actor.status[stato] || 0);
+    actor.status[stato] = Math.max(current, granted);
+
+    return { stato, stolen_turns: turns, granted_turns: actor.status[stato] };
+  }
+  return null;
+}
+
+module.exports = {
+  stealBuff,
+  attenuate,
+  hasTrait,
+  GHIANDOLE_TRAIT,
+  STEALABLE,
+};
+```
+
+- [ ] **Step 4: eseguire il test e verificare che passi**
+
+Run: `node --test tests/services/combat/ghiandoleMnemoniche.test.js`
+Expected: PASS, 12/12.
+
+- [ ] **Step 5: commit**
+
+```bash
+git add apps/backend/services/combat/ghiandoleMnemoniche.js tests/services/combat/ghiandoleMnemoniche.test.js
+git commit -m "feat(combat): ghiandoleMnemoniche buff-steal module
+
+Steals one whitelisted buff per landed hit and re-applies it at half
+duration (canon says 50%; magnitude is not scalable in this engine, so
+the 50% lands on duration -- documented in the module).
+
+frenzy is whitelisted first: sabotage priority, and it is the only steal
+that is not a net gain (the thief inherits the lowered guard).
+
+Coding-Agent: claude-opus-4-8
+Trace-Id: <nuovo uuidv7>"
+```
+
+---
+
+### Task 3: canale di rimozione puro
+
+**Files:**
+
+- Create: `apps/backend/services/combat/pendingStatusRemovals.js`
+- Test: `tests/services/combat/pendingStatusRemovals.test.js`
+
+- [ ] **Step 1: scrivere il test che fallisce**
+
+Creare `tests/services/combat/pendingStatusRemovals.test.js`:
+
+```js
+// tests/services/combat/pendingStatusRemovals.test.js
+//
+// Canale di rimozione simmetrico a session._pendingStatusApplies.
+// Serve al furto di buff (ghiandole_mnemoniche): applyMoraleStatus e' Math.max,
+// quindi il canale di apply non sa rimuovere, e il rebuild tracked->dict
+// ripristinerebbe qualsiasi delete fatto a meta' attacco.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  drainStatusRemovals,
+} = require('../../../apps/backend/services/combat/pendingStatusRemovals');
+
+function unitsMap(units) {
+  return new Map(units.map((u) => [String(u.id), u]));
+}
+
+test('drain: rimuove lo status e la sua intensity', () => {
+  const u = { id: 't1', hp: 10, status: { frenzy: 2, linked: 1 }, status_intensity: { frenzy: 1 } };
+  const session = { _pendingStatusRemovals: [{ unit_id: 't1', status: 'frenzy' }] };
+  drainStatusRemovals(session, unitsMap([u]));
+  assert.equal(u.status.frenzy, undefined);
+  assert.equal(u.status_intensity.frenzy, undefined);
+  assert.equal(u.status.linked, 1);
+});
+
+test('drain: svuota la coda', () => {
+  const u = { id: 't1', hp: 10, status: { frenzy: 2 } };
+  const session = { _pendingStatusRemovals: [{ unit_id: 't1', status: 'frenzy' }] };
+  drainStatusRemovals(session, unitsMap([u]));
+  assert.deepEqual(session._pendingStatusRemovals, []);
+});
+
+test('drain: unita sconosciuta -> no-op, nessun throw', () => {
+  const session = { _pendingStatusRemovals: [{ unit_id: 'ghost', status: 'frenzy' }] };
+  drainStatusRemovals(session, unitsMap([]));
+  assert.deepEqual(session._pendingStatusRemovals, []);
+});
+
+test('drain: unita senza status -> no-op, nessun throw', () => {
+  const u = { id: 't1', hp: 10 };
+  const session = { _pendingStatusRemovals: [{ unit_id: 't1', status: 'frenzy' }] };
+  drainStatusRemovals(session, unitsMap([u]));
+  assert.deepEqual(session._pendingStatusRemovals, []);
+});
+
+test('drain: coda assente o vuota -> no-op', () => {
+  const u = { id: 't1', hp: 10, status: { frenzy: 2 } };
+  drainStatusRemovals({}, unitsMap([u]));
+  drainStatusRemovals({ _pendingStatusRemovals: [] }, unitsMap([u]));
+  assert.equal(u.status.frenzy, 2);
+});
+```
+
+- [ ] **Step 2: eseguire il test e verificare che fallisca**
+
+Run: `node --test tests/services/combat/pendingStatusRemovals.test.js`
+Expected: FAIL con `Cannot find module '.../pendingStatusRemovals'`.
+
+- [ ] **Step 3: scrivere il modulo**
+
+Creare `apps/backend/services/combat/pendingStatusRemovals.js`:
+
+```js
+// apps/backend/services/combat/pendingStatusRemovals.js
+//
+// Canale di RIMOZIONE degli status, simmetrico a session._pendingStatusApplies.
+// Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+//
+// Perche' serve: il canale di apply e' drenato con combat/morale.applyMoraleStatus,
+// che e' `unit.status[s] = Math.max(cur, dur)` -- monotono crescente, incapace di
+// rimuovere. E syncStatusesFromRoundState riscrive sessionUnit.status dall'array
+// tracciato roundUnit.statuses, ripristinando qualsiasi delete fatto a meta' attacco.
+//
+// Questo drain va invocato SUBITO DOPO quello degli applies, cioe' dopo il rebuild
+// tracked->dict. adaptSessionToRoundState ri-deriva l'array tracciato leggendo il
+// dict, quindi la cancellazione sopravvive al giro successivo.
+//
+// Estratto in un modulo proprio perche' syncStatusesFromRoundState e' una closure
+// non esportata di createRoundBridge: qui e' testabile in isolamento.
+//
+// Best-effort: non lancia mai, non blocca il round.
+
+'use strict';
+
+/**
+ * Applica e svuota session._pendingStatusRemovals.
+ *
+ * @param {object} session         oggetto sessione (mutato: la coda viene svuotata)
+ * @param {Map<string,object>} unitsById  unita' vive per id (mutate: perdono lo status)
+ * @returns {number} quante rimozioni sono state applicate
+ */
+function drainStatusRemovals(session, unitsById) {
+  if (!session || !Array.isArray(session._pendingStatusRemovals)) return 0;
+  if (session._pendingStatusRemovals.length === 0) return 0;
+
+  let applied = 0;
+  for (const pending of session._pendingStatusRemovals) {
+    if (!pending || !pending.status) continue;
+    const unit = unitsById && unitsById.get(String(pending.unit_id));
+    if (!unit || !unit.status || typeof unit.status !== 'object') continue;
+    delete unit.status[pending.status];
+    if (unit.status_intensity && typeof unit.status_intensity === 'object') {
+      delete unit.status_intensity[pending.status];
+    }
+    applied += 1;
+  }
+  session._pendingStatusRemovals = [];
+  return applied;
+}
+
+module.exports = { drainStatusRemovals };
+```
+
+- [ ] **Step 4: eseguire il test e verificare che passi**
+
+Run: `node --test tests/services/combat/pendingStatusRemovals.test.js`
+Expected: PASS, 5/5.
+
+- [ ] **Step 5: commit**
+
+```bash
+git add apps/backend/services/combat/pendingStatusRemovals.js tests/services/combat/pendingStatusRemovals.test.js
+git commit -m "feat(combat): symmetric status-removal drain channel
+
+_pendingStatusApplies can only ADD (applyMoraleStatus is Math.max), and
+the tracked->dict rebuild restores anything deleted mid-attack. Without
+this channel a buff steal would silently degrade to a buff copy in the
+round-model path while remaining a steal in the legacy path.
+
+Coding-Agent: claude-opus-4-8
+Trace-Id: <nuovo uuidv7>"
+```
+
+---
+
+### Task 4: wire nel bridge e nella route
+
+**Files:**
+
+- Modify: `apps/backend/routes/sessionRoundBridge.js` (dopo il drain degli applies, riga ~447)
+- Modify: `apps/backend/routes/session.js` (require in testa; wire dopo il blocco `applyCortecciaReaction`, riga ~1636)
+
+- [ ] **Step 1: drenare le rimozioni nel bridge**
+
+In `apps/backend/routes/sessionRoundBridge.js`, dentro `syncStatusesFromRoundState`, **subito dopo** la riga `session._pendingStatusApplies = [];` che chiude il blocco degli applies (riga ~447), inserire:
+
+```js
+// Canale di RIMOZIONE (buff-steal, ghiandole_mnemoniche). Il drain sopra sa solo
+// AGGIUNGERE (applyMoraleStatus = Math.max(cur,dur)) e il rebuild tracked->dict
+// ripristinerebbe un delete fatto a meta' attacco. Qui siamo DOPO quel rebuild:
+// il prossimo adaptSessionToRoundState ri-deriva l'array tracciato dal dict,
+// quindi la cancellazione sopravvive. Best-effort; mai bloccante.
+try {
+  const { drainStatusRemovals } = require('../services/combat/pendingStatusRemovals');
+  drainStatusRemovals(session, unitsById);
+} catch {
+  /* modulo assente -> nessuna rimozione, il round prosegue */
+}
+```
+
+- [ ] **Step 2: importare il modulo in session.js**
+
+In `apps/backend/routes/session.js`, accanto agli altri require di `services/combat/` (vicino alla riga 140, dove si importa `tessutiAdattivi`), aggiungere:
+
+```js
+const { stealBuff } = require('../services/combat/ghiandoleMnemoniche');
+```
+
+- [ ] **Step 3: agganciare il furto post-attacco**
+
+In `apps/backend/routes/session.js`, **subito dopo** la chiusura del blocco `if (cortecciaReaction) { ... }` (riga ~1636), inserire:
+
+```js
+// ghiandole_mnemoniche: su un colpo andato a segno il portatore strappa UN buff
+// temporaneo alla preda e ne indossa una copia a durata dimezzata. La rimozione
+// ha bisogno del canale dedicato: il rebuild tracked->dict la annullerebbe.
+// Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+// Band-neutral: nessuna sim unit porta ghiandole_mnemoniche.
+if (result.hit) {
+  const stolen = stealBuff({ actor, target });
+  if (stolen) {
+    if (!Array.isArray(session._pendingStatusApplies)) {
+      session._pendingStatusApplies = [];
+    }
+    if (!Array.isArray(session._pendingStatusRemovals)) {
+      session._pendingStatusRemovals = [];
+    }
+    session._pendingStatusApplies.push({
+      unit_id: actor.id,
+      status: stolen.stato,
+      duration: stolen.granted_turns,
+    });
+    session._pendingStatusRemovals.push({
+      unit_id: target.id,
+      status: stolen.stato,
+    });
+    evaluation.trait_effects = (evaluation.trait_effects || []).concat({
+      trait: 'ghiandole_mnemoniche',
+      triggered: true,
+      effect: {
+        kind: 'buff_steal',
+        stato: stolen.stato,
+        from: target.id,
+        to: actor.id,
+        stolen_turns: stolen.stolen_turns,
+        granted_turns: stolen.granted_turns,
+      },
+    });
+  }
+}
+```
+
+- [ ] **Step 4: aggiungere la entry YAML di registrazione**
+
+Appendere in coda a `data/core/traits/active_effects.yaml`:
+
+```yaml
+# Buff-steal -- spec docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+# persistent_marker = registrazione: la logica vive in
+# apps/backend/services/combat/ghiandoleMnemoniche.js, wired post-attacco in
+# routes/session.js. Stesso pattern di corteccia_memetica / artigli_psionici.
+# Band-neutral: nessuna sim unit porta questo tratto.
+ghiandole_mnemoniche:
+  tier: T2
+  category: supporto
+  applies_to: actor
+  trigger:
+    action_type: passive
+  effect:
+    kind: persistent_marker
+    marker: ghiandole_mnemoniche
+    log_tag: ghiandole_mnemoniche
+  description_it: |
+    Ghiandole mnemoniche: secrezioni che trattengono copie attenuate dei buff.
+    Su un colpo andato a segno il portatore strappa alla preda un potenziamento
+    temporaneo (priorita': frenesia, legame, percezione, coordinamento, risonanza)
+    e ne indossa una copia per meta' della durata residua. Rubare la frenesia non
+    e' un affare pulito: se ne eredita anche la guardia abbassata.
+```
+
+- [ ] **Step 5: verificare che nulla si sia rotto**
+
+Run: `node --check apps/backend/routes/session.js && node --check apps/backend/routes/sessionRoundBridge.js`
+Expected: nessun output (sintassi valida).
+
+Run: `node --test tests/services/combat/`
+Expected: PASS su tutti i file, inclusi i tre nuovi.
+
+- [ ] **Step 6: commit**
+
+```bash
+git add apps/backend/routes/session.js apps/backend/routes/sessionRoundBridge.js data/core/traits/active_effects.yaml
+git commit -m "feat(traits): wire ghiandole_mnemoniche buff-steal into the attack pipeline
+
+persistent_marker registration + post-attack hook next to consumeRisonanza.
+The stolen status is pushed to _pendingStatusApplies (gain, on the thief)
+and _pendingStatusRemovals (loss, on the prey) so it survives the
+round-model sync in both directions.
+
+Coding-Agent: claude-opus-4-8
+Trace-Id: <nuovo uuidv7>"
+```
+
+---
+
+### Task 5: verifica band-neutral e chiusura
+
+- [ ] **Step 1: la band AI non si muove**
+
+Run: `node --test tests/ai/*.test.js`
+Expected: 557/557 pass, byte-stable. Nessuna sim unit porta i due tratti, quindi
+nessuna run cambia. **Se un solo test cambia risultato, fermarsi**: significa che un
+carrier e' entrato in un roster e il change non e' piu' band-neutral -- serve un
+ratify N=40, non un merge.
+
+- [ ] **Step 2: la api-suite non regredisce**
+
+Run: `npm run test:api`
+Expected: zero `AssertionError`. Su Ryzen il full-run inonda le porte effimere
+(`EADDRINUSE` a cascata, ~290): e' infrastruttura, non logica. Contano solo gli
+`AssertionError`. Se compaiono, verificare per-file i soli test toccati.
+
+- [ ] **Step 3: guardia ASCII + validazione tratti**
+
+Run: `python tools/lint/trait_schema_gate.py data/core/traits/active_effects.yaml`
+Expected: exit 0.
+
+Run: `LC_ALL=C grep -n '[^ -~]' apps/backend/services/combat/ghiandoleMnemoniche.js apps/backend/services/combat/pendingStatusRemovals.js`
+Expected: nessun output.
+
+- [ ] **Step 4: `traitLiveness.js` e' rimasto invariato**
+
+Run: `git diff --stat origin/main -- tests/helpers/traitLiveness.js`
+Expected: nessun output. Se il file compare, e' un errore: lo spec (sezione 4) lo
+esclude di proposito.
+
+- [ ] **Step 5: PR**
+
+```bash
+git push -u origin feat/trait-buff-steal-oracle-reveal
+gh pr create --title "feat(traits): buff-steal + oracle-reveal for 2 inert traits" --body "<vedi spec>"
+```
+
+PR **ready, mai draft** (policy master-dd). Poi `@codex review`, poll di review E
+reaction, triage P1/P2/P3.
+
+---
+
+## Self-Review
+
+**Copertura dello spec:** decisione 1 -> Task 1. Decisione 2 -> Task 2 + Task 4.
+Decisione 2b (canale di rimozione, aggiunta) -> Task 3 + Task 4 Step 1. Decisione 3
+(scostamento dal canone) -> docstring in Task 2 Step 3. Decisione 4 (`traitLiveness`
+invariato) -> docstring in Task 2 Step 3 + guardia in Task 5 Step 4. Verifica ->
+Task 5. Nessun requisito dello spec resta scoperto.
+
+**Segnaposto:** nessuno. Ogni step che tocca codice mostra il codice. I `<nuovo uuidv7>`
+nei messaggi di commit sono l'unico valore da generare al volo (uno per commit, come
+richiede ADR-0011).
+
+**Coerenza dei tipi:** `stealBuff` ritorna `{stato, stolen_turns, granted_turns}` in
+Task 2 ed e' consumato con esattamente quei nomi in Task 4 Step 3.
+`drainStatusRemovals(session, unitsById)` e' definito in Task 3 e invocato con quella
+firma in Task 4 Step 1. `STEALABLE` e' asserito in Task 2 Step 1 e definito con lo
+stesso ordine in Step 3.

--- a/docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
@@ -1,0 +1,246 @@
+# Buff-steal e oracle-reveal -- design
+
+- **Data**: 2026-07-10
+- **Stato**: approvato (master-dd, AskUserQuestion)
+- **Tratti coperti**: `ghiandole_mnemoniche`, `nodi_micorrizici_oracolari`
+- **Chiude**: la voce "Owner design call" dei cluster _buff-manipulation_ e
+  _recon/foresight_ in `docs/planning/2026-06-28-gap2-next-block-mechanics-proposal.md`
+  e `docs/planning/2026-06-29-gap2-block3-mechanics-proposal.md`
+
+## Problema
+
+Entrambi i tratti hanno definizione in `data/traits/**` e voce nel glossario, ma
+nessuna entry in `data/core/traits/active_effects.yaml`. In partita non fanno
+nulla. Sono stati esclusi dal bundle i18n player-facing (PR #3247) perche' il
+testo curato prometteva un effetto inesistente.
+
+Sono due dei **64** tratti indicizzati (su 309) privi di entry meccanica. Questo
+spec ne copre due; non pretende di chiudere la coorte.
+
+## Ground truth accertata (verifica diretta, non inferenza)
+
+Fatti load-bearing, ognuno letto a codice prima di progettare:
+
+1. **Nessuno dei due e' acquisibile da un'unita' viva, oggi.** L'unica sorgente di
+   `unit.traits` e' il payload di richiesta, via `normaliseUnit`
+   (`apps/backend/routes/sessionHelpers.js:54,97`). Nessun produttore vivo li
+   inietta: `species_catalog.json` `trait_refs` non ha **alcun** consumatore
+   backend; `biome_pools.json` `preferred_traits` e' solo un criterio di peso in
+   `biomeSpawnBias.js:122`; nessun `trait_swap.add` li concede; onboarding e
+   character-creation pescano da set fissi.
+
+2. **Avere una entry in `active_effects.yaml` non basta a essere vivi.**
+   `passesBasicTriggers` (`apps/backend/services/traitEffects.js:308`) rifiuta
+   ogni `trigger.action_type !== 'attack'`. Per questo
+   `spore_psichiche_silenziate` -- che _ha_ una entry, con `melee_attack` -- e'
+   inerte. La superficie viva reale e' rispecchiata da
+   `tests/helpers/traitLiveness.js`.
+
+3. **`conflitti` non e' letto dal motore.** Unico lettore:
+   `apps/backend/services/traitStyleGuide.js:494`, un linter. Il conflitto
+   dichiarato di `nodi_micorrizici_oracolari` verso `spore_psichiche_silenziate`
+   e' gia' inerte da entrambi i lati.
+
+4. **La pipe di reveal esiste, e' wired, ed e' affamata.**
+   `combat/telepathicReveal.js` e' invocata in
+   `routes/sessionRoundBridge.js:2373` dentro `begin-planning`. Rivela gli intent
+   nemici (`intent_type`, `target_id`, `distance`) entro manhattan `opts.range`
+   (default 3) a ogni attore con `status.telepatic_link > 0`. Il suo unico
+   produttore attuale, `risonanza_magnetica`, e' gated su
+   `on_result: hit` + `on_kill: true` + `min_mos: 5` -- il commento nel YAML
+   ammette che serve a limitare la firing-rate al boss-finish. **Zero produttori
+   passivi.**
+
+5. **`telepatic_link` non ha alcun delta statistico.**
+   `combat/statusModifiers.js:206-208`: _"No stat effect -- narrative reveal
+   marker only."_ Renderlo permanente non introduce power-creep numerico.
+
+6. **La magnitudo di uno status non e' scalabile.** `computeStatusModifiers` legge
+   `status_intensity` per un solo status, `abbagliato`
+   (`statusModifiers.js:241`). Tutti gli altri sono binari: `isPositive(turni>0)`
+   -> delta fisso. Non esiste "mezzo `linked`".
+
+7. **`unit.traits` (combat) e `unit.trait_ids` (mutazioni/meta) sono namespace
+   distinti.** `normaliseUnit` non popola mai `trait_ids`;
+   `mutationEngine.js:141,156` e `mutationCatalogLoader.js:147` leggono e scrivono
+   solo `trait_ids`.
+
+## Decisioni
+
+### 1. `nodi_micorrizici_oracolari` -- solo dati
+
+Non richiede alcun primitive nuovo. Il fatto (4) rende la forma seguente
+interamente interna alla superficie viva esistente:
+
+```yaml
+nodi_micorrizici_oracolari:
+  tier: T3
+  category: sensoriale
+  applies_to: actor
+  trigger:
+    action_type: passive
+  effect:
+    kind: apply_status
+    stato: telepatic_link
+    turns: 2
+    log_tag: nodi_micorrizici_oracolari
+```
+
+Consumo: `combat/passiveStatusApplier.applyPassiveAncestors` (inizio sessione +
+fine round) applica `telepatic_link`; `computeTelepathicReveal` lo legge in
+`begin-planning`. `passiveStatusSpec` legge esattamente `trigger.action_type`,
+`effect.kind`, `effect.stato`, `effect.turns` -- nessun `target_side` richiesto.
+
+L'applier e' un **refresh-to-floor** (`if (current >= spec.turns) continue`), per
+cui `turns: 2` equivale a "sempre attivo" senza codice aggiuntivo.
+
+Contenimento della potenza: **il raggio, non la rarita'.** Il reveal e' gia'
+limitato a manhattan 3 dal default di `computeTelepathicReveal`, e per il fatto
+(5) non concede statistiche. Il tratto e' informazione locale, non forza.
+
+`isEngineLiveReliable` riconosce questa forma come viva (caso _d_):
+**`tests/helpers/traitLiveness.js` non va modificato.**
+
+### 2. `ghiandole_mnemoniche` -- un modulo dedicato
+
+Intento autoriale, da `docs/traits/Frattura_Abissale_Sinaptica_trait_draft.md:57`
+(`role_template` "Sciame Memetico", tier 3, `preferred_traits:
+[ghiandole_mnemoniche, organi_metacronici]`, `functional_tags: ["sabotaggio",
+"furto_buff"]`):
+
+> micro-larve che rubano buff temporanei e li riapplicano in forma ridotta
+
+Quindi: **furto**, non copia. Serve stato/logica custom -> pattern
+`persistent_marker` + modulo dedicato, come `cortecciaMemetica` /
+`artigliPsionici` / `tessutiAdattivi`.
+
+- **File**: `apps/backend/services/combat/ghiandoleMnemoniche.js`
+- **Entry YAML**: `trigger: {action_type: passive}`, `effect: {kind:
+persistent_marker, marker: ghiandole_mnemoniche, log_tag:
+ghiandole_mnemoniche}` (registrazione; la logica vive nel modulo)
+- **Wire**: `apps/backend/routes/session.js`, post-attacco, accanto a
+  `consumeRisonanza`
+- **Comportamento**: su hit andato a segno, se il bersaglio possiede uno status in
+  whitelist, il primo in ordine deterministico di whitelist viene **rimosso** da
+  `target.status` (e da `target.status_intensity`, se presente) e applicato ad
+  `actor.status` con durata `max(1, ceil(turni_originali / 2))`. Un solo buff per
+  colpo.
+
+**Whitelist**, in ordine di priorita' deterministico:
+
+1. `frenzy`
+2. `linked`
+3. `sensed`
+4. `coordinamento`
+5. `risonanza_memetica`
+
+`frenzy` e' primo per scelta di design (master-dd): il tratto va sempre per la
+preda piu' grossa, coerente col tag `sabotaggio` del role_template -- la priorita'
+e' TOGLIERE al nemico, non massimizzare il guadagno proprio.
+
+**Perche' `frenzy` e' rubabile e non ambiguo.** `computeStatusModifiers` lo legge
+su entrambi i lati, ma sono le due facce dello stesso status sulla stessa unita':
+`:202` `isPositive(actorStatus.frenzy) -> attackDelta += 1` ("rage variant") e
+`:253` `isPositive(targetStatus.frenzy) -> defenseDelta -= 1` ("rage exposure").
+Chi porta `frenzy` colpisce meglio e si difende peggio. Lo status si sposta con
+l'unita' e si porta dietro il proprio lato negativo.
+
+Ne segue una proprieta' voluta: `frenzy` e' l'unico buff della whitelist il cui
+furto **non e' un guadagno netto**. Il portatore strappa +1 attacco al nemico ma
+ne eredita la guardia abbassata. Gli altri quattro sono puro upside.
+
+`PASSIVE_BLOCKLIST` contiene `frenzy` (`passiveStatusApplier.js:45`), ma vieta
+l'auto-applicazione _passiva_ ("frenzy = 2 turns rage, not always-on"). Il modulo
+lo applica direttamente a durata dimezzata: nessun conflitto, e la regola
+dimezzante rispetta quell'intento canonico.
+
+Esclusi, con motivo:
+
+- `nucleo_intatto` -- e' uno stato strutturale, non un buff temporaneo; il suo
+  rovescio `danno_nucleo` e' governato da `combat/nucleiWeakPoint.js`.
+- `telepatic_link` -- e' la firma di `nodi_micorrizici_oracolari` (decisione 1);
+  rubarlo incrocerebbe i due tratti in un modo che nessuno ha progettato.
+
+### 3. Scostamento dal canone, dichiarato
+
+Il canone (`docs/traits/trait_reference_manual.md:35`, tratto gemello
+`riverbero_memetico`) dice _"duplica prossimo buff al 50%"_. Per il fatto (6) il
+50% di magnitudo **non e' esprimibile** senza toccare `computeStatusModifiers` su
+circa dodici rami, il che ri-bilancerebbe ogni tratto esistente che produce quegli
+status.
+
+Consegniamo quindi il 50% **di durata**. E' uno scostamento consapevole, va
+annotato nel docstring del modulo, e non va corretto silenziosamente in futuro
+senza ri-aprire questa decisione.
+
+### 4. `traitLiveness.js` resta invariato -- di proposito
+
+Il mirror esclude gia' ogni `persistent_marker` (`corteccia_memetica`,
+`artigli_psionici`, `tessuti_adattivi` sono tutti fuori). Lasciare
+`ghiandole_mnemoniche` fuori significa che i path di grant automatico
+(`imprint/imprintTraitGrant.js`, `identity/brancoTraitEmergence.js`) non lo
+pescheranno mai. E' il comportamento conservativo corretto: un tratto con stato
+custom non deve entrare in una mappatura di grant senza un ratify N=40 dedicato.
+
+Motivare la scelta nel docstring del modulo, cosi' che il prossimo lettore non la
+scambi per una dimenticanza.
+
+## Fuori scope (deliberatamente)
+
+- **La mutazione `simbionte_micorriza_radici`** resta irraggiungibile. Il suo
+  prereq `prerequisites.traits: [nodi_micorrizici_oracolari]` punta -- dopo questo
+  change -- a un tratto vivo, quindi _non va toccato_. Cio' che la blocca e' il
+  fatto (7): `listEligibleForUnit` interroga `unit.trait_ids`, che nessuna unita'
+  di combattimento possiede. E' un bug di namespace, separato e piu' grande.
+- **I 18 tratti che dichiarano `passive` + `apply_status` + `stato: focused`**
+  (`percezione`, `olfatto`, `controllo_cognitivo`, `localizzazione_delle_minacce`,
+  `memoria_iconica`, ...). `focused` non e' in `WAVE_A_STATUSES`, quindi
+  `passiveStatusApplier` li scarta tutti. **Non e' una scoperta e non ha impatto
+  sul giocatore**: il gap e' gia' documentato in `services/ai/policy.js:121-124`
+  ("rimandati a sprint futuri ... richiedono modifica `resolveAttack` per
+  focused") e in `imprint/imprintTraitGrant.js:88`, dove il recon li aveva gia'
+  rifiutati dai path di grant. Nessuno dei 18 e' in `data/traits/index.json`,
+  quindi nessuno e' assegnabile. E' un rinvio di design consapevole, non un
+  difetto latente.
+- **Gli altri 62 tratti inerti.** Nessuna policy generale viene ratificata qui.
+
+## Verifica
+
+Il change e' **band-neutral**: nessuna sim unit porta i due tratti (fatto 1),
+quindi le run AI restano byte-stabili.
+
+1. TDD: test RED prima del codice, per entrambi i tratti.
+2. `node --test` sui nuovi file di test.
+3. `node --test tests/ai/*.test.js` -> 557/557 byte-stable (band-neutral, no
+   carrier).
+4. `npm run test:api` -> considerare reali solo gli `AssertionError` (il full-run
+   inonda le porte effimere su Ryzen; vedi memoria `reference_game_apisuite_eaddrinuse`).
+5. ASCII-guard + `validate_traits`.
+
+## Test previsti
+
+**`nodi_micorrizici_oracolari`** (data-only, ma il comportamento va inchiodato):
+
+- `applyPassiveAncestors` su un'unita' col tratto -> `status.telepatic_link === 2`.
+- `computeTelepathicReveal` con quell'unita' + un intent nemico pendente entro
+  raggio 3 -> l'intent e' rivelato; oltre il raggio -> non lo e'.
+- `isEngineLiveReliable(def)` -> `true` (protegge dal caso in cui qualcuno cambi
+  la forma e la renda inerte senza accorgersene).
+
+**`ghiandole_mnemoniche`**:
+
+- hit su bersaglio con `linked: 4` -> il bersaglio perde `linked`, l'attaccante lo
+  guadagna con `2`.
+- hit su bersaglio con `linked: 1` -> l'attaccante lo guadagna con `1` (floor).
+- hit su bersaglio con `sensed` + `linked` -> ruba **solo** `linked` (precede
+  `sensed` in whitelist), un buff per colpo.
+- hit su bersaglio con `frenzy` + `linked` -> ruba `frenzy` (primo in whitelist),
+  **non** `linked`.
+- hit su bersaglio con `frenzy: 2` -> il bersaglio perde `frenzy`; l'attaccante lo
+  guadagna con `1`, e da quel momento `computeStatusModifiers` gli concede `+1`
+  attacco (`:202`) e gli applica `-1` difesa quando e' bersagliato (`:253`). Il
+  test verifica **entrambi** i lati: il furto non e' un guadagno netto.
+- hit su bersaglio con `nucleo_intatto` / `telepatic_link` -> **nessun** furto
+  (esclusi).
+- miss -> nessun furto.
+- portatore assente -> no-op (nessuna mutazione degli status).

--- a/docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
@@ -185,6 +185,20 @@ Il drain vive in `combat/pendingStatusRemovals.js` -- funzione pura, testabile -
 perche' `syncStatusesFromRoundState` e' una closure non esportata di
 `createRoundBridge`.
 
+**L'ordine e' load-bearing: rimozioni PRIMA degli applies.** Se gli applies girassero
+per primi, due ladri di fazione opposta che nello stesso round rubano lo stesso status
+se lo annichilirebbero (entrambi guadagnano, poi entrambe le rimozioni cancellano --
+verificato: l'ordine invertito lascia `frenzy: undefined` a entrambi). Con le rimozioni
+per prime ciascuno perde il proprio e guadagna quello dell'altro. Per lo stesso motivo
+un `actor === target` non si auto-cancella: rimuove, poi riapplica dimezzato.
+
+Per questo la sequenza vive in `drainPendingStatusEffects(session, unitsById,
+applyStatus)`, nello stesso modulo, e non nella closure del bridge: cosi' l'ordine e'
+coperto da un test invece che affidato a due chiamate adiacenti. Il bridge conserva un
+fallback rumoroso (`console.warn`) che drena almeno gli applies se il modulo non si
+carica -- un throw silenzioso degraderebbe il furto in copia, esattamente il difetto
+che questo canale esiste per impedire.
+
 Band-neutral: nessuna unita' pusha rimozioni se non porta il tratto.
 
 ### 3. Scostamento dal canone, dichiarato
@@ -263,9 +277,18 @@ quindi le run AI restano byte-stabili.
 - hit su bersaglio con `frenzy` + `linked` -> ruba `frenzy` (primo in whitelist),
   **non** `linked`.
 - hit su bersaglio con `frenzy: 2` -> il bersaglio perde `frenzy`; l'attaccante lo
-  guadagna con `1`, e da quel momento `computeStatusModifiers` gli concede `+1`
-  attacco (`:202`) e gli applica `-1` difesa quando e' bersagliato (`:253`). Il
-  test verifica **entrambi** i lati: il furto non e' un guadagno netto.
+  guadagna con `1`. Il test chiama `computeStatusModifiers` **due volte sul motore
+  vero** -- col ladro come attore (`attackDelta === 1`) e col ladro come bersaglio
+  (`defenseDelta === -1`) -- invece di fermarsi alla status-map. Il furto non e' un
+  guadagno netto, e questo lo dimostra.
+- furto da un'unita' della **stessa fazione** -> nessun furto. La route di attacco non
+  valida la fazione del bersaglio (`session.units.find((u) => u.id === body.target_id)`),
+  quindi senza guardia un tratto di sabotaggio deruberebbe un alleato. `isSameFaction`
+  e' conservativa: `controlled_by` mancante (fixture legacy, sim units) non prova
+  l'alleanza, e il furto procede.
+- `actor === target` -> rimuove e riapplica dimezzato, non cancella.
+- `STEALABLE` e' esposto come **copia difensiva**: l'ordine e' il design, e un array
+  vivo esportato sarebbe riordinabile a runtime da qualunque consumatore.
 - hit su bersaglio con `nucleo_intatto` / `telepatic_link` -> **nessun** furto
   (esclusi).
 - miss -> nessun furto.

--- a/docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
@@ -43,7 +43,7 @@ Fatti load-bearing, ognuno letto a codice prima di progettare:
 
 4. **La pipe di reveal esiste, e' wired, ed e' affamata.**
    `combat/telepathicReveal.js` e' invocata in
-   `routes/sessionRoundBridge.js:2373` dentro `begin-planning`. Rivela gli intent
+   `routes/sessionRoundBridge.js:2302` dentro `begin-planning`. Rivela gli intent
    nemici (`intent_type`, `target_id`, `distance`) entro manhattan `opts.range`
    (default 3) a ogni attore con `status.telepatic_link > 0`. Il suo unico
    produttore attuale, `risonanza_magnetica`, e' gated su
@@ -160,6 +160,32 @@ Esclusi, con motivo:
   rovescio `danno_nucleo` e' governato da `combat/nucleiWeakPoint.js`.
 - `telepatic_link` -- e' la firma di `nodi_micorrizici_oracolari` (decisione 1);
   rubarlo incrocerebbe i due tratti in un modo che nessuno ha progettato.
+
+### 2b. Canale di rimozione (`_pendingStatusRemovals`)
+
+Il furto non persiste senza un canale dedicato. `_pendingStatusApplies` e' drenato
+con `applyMoraleStatus` (`combat/morale.js:61`), che e'
+`unit.status[s] = Math.max(cur, dur)` -- monotono crescente, non sa rimuovere. E il
+loop di `syncStatusesFromRoundState` (`sessionRoundBridge.js:415-419`) riscrive
+`sessionUnit.status` dall'array tracciato `roundUnit.statuses`, ripristinando
+qualsiasi `delete` fatto a meta' attacco.
+
+Senza rimozione, `ghiandole_mnemoniche` diventerebbe silenziosamente una COPIA nel
+path round-model e un FURTO in quello legacy: due path dello stesso motore con
+comportamento divergente. E' la stessa classe di difetto che questo spec chiude --
+una meccanica che sembra viva perche' il codice c'e', ma il cui effetto viene
+mangiato da un seam a valle.
+
+Soluzione: `session._pendingStatusRemovals` (`[{unit_id, status}]`), drenato subito
+dopo gli applies, cioe' DOPO il rebuild tracked->dict. `adaptSessionToRoundState`
+(`sessionRoundBridge.js:297-309`) ri-deriva l'array tracciato leggendo il dict,
+quindi la cancellazione sopravvive al giro successivo.
+
+Il drain vive in `combat/pendingStatusRemovals.js` -- funzione pura, testabile --
+perche' `syncStatusesFromRoundState` e' una closure non esportata di
+`createRoundBridge`.
+
+Band-neutral: nessuna unita' pusha rimozioni se non porta il tratto.
 
 ### 3. Scostamento dal canone, dichiarato
 

--- a/tests/services/combat/ghiandoleMnemoniche.test.js
+++ b/tests/services/combat/ghiandoleMnemoniche.test.js
@@ -19,9 +19,7 @@ const {
   GHIANDOLE_TRAIT,
   STEALABLE,
 } = require('../../../apps/backend/services/combat/ghiandoleMnemoniche');
-const {
-  computeStatusModifiers,
-} = require('../../../apps/backend/services/combat/statusModifiers');
+const { computeStatusModifiers } = require('../../../apps/backend/services/combat/statusModifiers');
 
 function carrier() {
   return { id: 'a1', traits: [GHIANDOLE_TRAIT], status: {} };

--- a/tests/services/combat/ghiandoleMnemoniche.test.js
+++ b/tests/services/combat/ghiandoleMnemoniche.test.js
@@ -119,6 +119,48 @@ test('furto: non abbassa un buff gia posseduto piu a lungo dal portatore', () =>
   assert.equal(actor.status.linked, 3); // max(3, 1)
 });
 
+// Guardia di fazione. La route di attacco NON valida la fazione del bersaglio
+// (session.js: `session.units.find((u) => u.id === body.target_id)`), quindi un
+// attacco puo' colpire un alleato. Senza questa guardia il tratto di SABOTAGGIO
+// deruberebbe un compagno di squadra. Stesso criterio di computeTelepathicReveal,
+// che salta le unita' della stessa fazione.
+test('furto: nessun furto da un alleato (stessa fazione)', () => {
+  const actor = { id: 'a1', controlled_by: 'player', traits: [GHIANDOLE_TRAIT], status: {} };
+  const ally = { id: 't1', controlled_by: 'player', traits: [], status: { linked: 4 } };
+  assert.equal(stealBuff({ actor, target: ally }), null);
+  assert.equal(ally.status.linked, 4);
+  assert.deepEqual(actor.status, {});
+});
+
+test('furto: ruba da una fazione avversa', () => {
+  const actor = { id: 'a1', controlled_by: 'player', traits: [GHIANDOLE_TRAIT], status: {} };
+  const enemy = { id: 't1', controlled_by: 'sistema', traits: [], status: { linked: 4 } };
+  assert.equal(stealBuff({ actor, target: enemy }).stato, 'linked');
+  assert.equal(actor.status.linked, 2);
+});
+
+// Fazione assente su una delle due unita' (fixture legacy, sim units): non si puo'
+// dimostrare che siano alleate -> il furto procede. Conserva i test esistenti.
+test('furto: fazione mancante -> non blocca il furto', () => {
+  const actor = { id: 'a1', traits: [GHIANDOLE_TRAIT], status: {} };
+  const target = { id: 't1', traits: [], status: { linked: 4 } };
+  assert.equal(stealBuff({ actor, target }).stato, 'linked');
+});
+
+// STEALABLE e' esposto come copia: l'ordine E' il design, un consumatore non deve
+// poterlo riordinare o svuotare a runtime cambiando il tratto ovunque.
+test('whitelist: STEALABLE e una copia difensiva, non larray vivo', () => {
+  const mod = require('../../../apps/backend/services/combat/ghiandoleMnemoniche');
+  const first = mod.STEALABLE;
+  first.length = 0; // tentativo di sabotaggio
+  assert.deepEqual(mod.STEALABLE[0], 'frenzy');
+
+  // e il furto continua a funzionare dopo il tentativo
+  const actor = carrier();
+  const target = prey({ frenzy: 2 });
+  assert.equal(stealBuff({ actor, target }).stato, 'frenzy');
+});
+
 test('hasTrait: accetta stringhe e oggetti {id}', () => {
   assert.equal(hasTrait({ traits: [GHIANDOLE_TRAIT] }, GHIANDOLE_TRAIT), true);
   assert.equal(hasTrait({ traits: [{ id: GHIANDOLE_TRAIT }] }, GHIANDOLE_TRAIT), true);

--- a/tests/services/combat/ghiandoleMnemoniche.test.js
+++ b/tests/services/combat/ghiandoleMnemoniche.test.js
@@ -1,0 +1,126 @@
+// tests/services/combat/ghiandoleMnemoniche.test.js
+//
+// ghiandole_mnemoniche -- furto di buff.
+// Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+//   Su un hit andato a segno il portatore strappa UN buff temporaneo alla preda
+//   e ne indossa una copia attenuata (50% della durata, minimo 1).
+//   Whitelist ordinata: frenzy, linked, sensed, coordinamento, risonanza_memetica.
+// Real-module tests (CommonJS), CI-gated via tests/services/*/*.test.js.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  stealBuff,
+  attenuate,
+  hasTrait,
+  GHIANDOLE_TRAIT,
+  STEALABLE,
+} = require('../../../apps/backend/services/combat/ghiandoleMnemoniche');
+
+function carrier() {
+  return { id: 'a1', traits: [GHIANDOLE_TRAIT], status: {} };
+}
+function prey(status) {
+  return { id: 't1', traits: [], status: { ...status } };
+}
+
+test('furto: linked 4 -> la preda lo perde, il portatore lo guadagna con 2', () => {
+  const actor = carrier();
+  const target = prey({ linked: 4 });
+  const out = stealBuff({ actor, target });
+  assert.equal(out.stato, 'linked');
+  assert.equal(target.status.linked, undefined);
+  assert.equal(actor.status.linked, 2);
+});
+
+test('attenuate: dimezza per eccesso, con floor 1', () => {
+  assert.equal(attenuate(4), 2);
+  assert.equal(attenuate(3), 2);
+  assert.equal(attenuate(1), 1);
+  assert.equal(attenuate(0), 0);
+  assert.equal(attenuate(undefined), 0);
+});
+
+test('furto: linked 1 -> il portatore lo guadagna con 1 (floor)', () => {
+  const actor = carrier();
+  const target = prey({ linked: 1 });
+  stealBuff({ actor, target });
+  assert.equal(actor.status.linked, 1);
+});
+
+// L'ordine della whitelist E' il design (spec decisione 2): se cambia, cambia come si
+// gioca il tratto. Questo test lo blocca.
+test('whitelist: frenzy e primo, risonanza_memetica ultimo', () => {
+  assert.deepEqual(STEALABLE, [
+    'frenzy',
+    'linked',
+    'sensed',
+    'coordinamento',
+    'risonanza_memetica',
+  ]);
+});
+
+test('furto: un solo buff per colpo, il primo in whitelist', () => {
+  const actor = carrier();
+  const target = prey({ sensed: 4, linked: 4 });
+  const out = stealBuff({ actor, target });
+  assert.equal(out.stato, 'linked'); // linked precede sensed
+  assert.equal(target.status.sensed, 4); // sensed resta alla preda
+});
+
+test('furto: frenzy ha priorita su linked', () => {
+  const actor = carrier();
+  const target = prey({ linked: 4, frenzy: 2 });
+  const out = stealBuff({ actor, target });
+  assert.equal(out.stato, 'frenzy');
+  assert.equal(target.status.frenzy, undefined);
+  assert.equal(target.status.linked, 4);
+  assert.equal(actor.status.frenzy, 1);
+});
+
+test('furto: nucleo_intatto e telepatic_link non sono rubabili', () => {
+  const actor = carrier();
+  const target = prey({ nucleo_intatto: 99, telepatic_link: 2 });
+  assert.equal(stealBuff({ actor, target }), null);
+  assert.equal(target.status.nucleo_intatto, 99);
+  assert.equal(target.status.telepatic_link, 2);
+});
+
+test('furto: senza il tratto, nessun effetto', () => {
+  const actor = { id: 'a2', traits: [], status: {} };
+  const target = prey({ linked: 4 });
+  assert.equal(stealBuff({ actor, target }), null);
+  assert.equal(target.status.linked, 4);
+});
+
+test('furto: preda senza buff -> null, nessuna mutazione', () => {
+  const actor = carrier();
+  const target = prey({});
+  assert.equal(stealBuff({ actor, target }), null);
+  assert.deepEqual(actor.status, {});
+});
+
+test('furto: status_intensity della preda viene ripulito', () => {
+  const actor = carrier();
+  const target = prey({ linked: 4 });
+  target.status_intensity = { linked: 2 };
+  stealBuff({ actor, target });
+  assert.equal(target.status_intensity.linked, undefined);
+});
+
+test('furto: non abbassa un buff gia posseduto piu a lungo dal portatore', () => {
+  const actor = carrier();
+  actor.status.linked = 3;
+  const target = prey({ linked: 2 }); // attenuato -> 1
+  stealBuff({ actor, target });
+  assert.equal(actor.status.linked, 3); // max(3, 1)
+});
+
+test('hasTrait: accetta stringhe e oggetti {id}', () => {
+  assert.equal(hasTrait({ traits: [GHIANDOLE_TRAIT] }, GHIANDOLE_TRAIT), true);
+  assert.equal(hasTrait({ traits: [{ id: GHIANDOLE_TRAIT }] }, GHIANDOLE_TRAIT), true);
+  assert.equal(hasTrait({ traits: [] }, GHIANDOLE_TRAIT), false);
+});

--- a/tests/services/combat/ghiandoleMnemoniche.test.js
+++ b/tests/services/combat/ghiandoleMnemoniche.test.js
@@ -19,6 +19,9 @@ const {
   GHIANDOLE_TRAIT,
   STEALABLE,
 } = require('../../../apps/backend/services/combat/ghiandoleMnemoniche');
+const {
+  computeStatusModifiers,
+} = require('../../../apps/backend/services/combat/statusModifiers');
 
 function carrier() {
   return { id: 'a1', traits: [GHIANDOLE_TRAIT], status: {} };
@@ -79,6 +82,49 @@ test('furto: frenzy ha priorita su linked', () => {
   assert.equal(target.status.frenzy, undefined);
   assert.equal(target.status.linked, 4);
   assert.equal(actor.status.frenzy, 1);
+});
+
+// Il furto di frenzy NON e' un guadagno netto: chi lo ruba eredita la guardia
+// abbassata. Lo spec lo afferma; qui lo si dimostra sul motore vero, non sulla
+// status-map. computeStatusModifiers legge lo STESSO status sui due lati.
+test('furto: chi ruba frenzy eredita -1 difesa quando e bersagliato', () => {
+  const thief = { id: 'a1', controlled_by: 'player', traits: [GHIANDOLE_TRAIT], status: {} };
+  const enemy = { id: 't1', controlled_by: 'sistema', traits: [], status: { frenzy: 2 } };
+  stealBuff({ actor: thief, target: enemy });
+  assert.equal(thief.status.frenzy, 1);
+
+  // il ladro ora ATTACCA: +1 attacco
+  const onOffense = computeStatusModifiers(thief, enemy, []);
+  assert.equal(onOffense.attackDelta, 1);
+
+  // il ladro ora e' BERSAGLIATO: -1 difesa (l'esposizione ereditata)
+  const onDefense = computeStatusModifiers(enemy, thief, []);
+  assert.equal(onDefense.defenseDelta, -1);
+
+  // e la preda non ha piu' ne' l'uno ne' l'altro
+  const preyNow = computeStatusModifiers(enemy, thief, []);
+  assert.equal(preyNow.attackDelta, 0);
+});
+
+test('furto: actor === target non auto-cancella lo status', () => {
+  const u = { id: 'a1', traits: [GHIANDOLE_TRAIT], status: { linked: 4 } };
+  const out = stealBuff({ actor: u, target: u });
+  assert.equal(out.stato, 'linked');
+  assert.equal(u.status.linked, 2); // rimosso e riapplicato dimezzato, non cancellato
+});
+
+test('furto: preda con status non-oggetto -> null, nessun throw', () => {
+  const actor = carrier();
+  assert.equal(stealBuff({ actor, target: { id: 't1', status: null } }), null);
+  assert.equal(stealBuff({ actor, target: { id: 't2', status: ['linked'] } }), null);
+});
+
+test('furto: turns negativi o frazionari', () => {
+  const actor = carrier();
+  assert.equal(stealBuff({ actor, target: prey({ linked: -3 }) }), null);
+  const a2 = carrier();
+  stealBuff({ actor: a2, target: prey({ linked: 2.5 }) });
+  assert.equal(a2.status.linked, 2); // ceil(2.5/2) = 2
 });
 
 test('furto: nucleo_intatto e telepatic_link non sono rubabili', () => {

--- a/tests/services/combat/nodiMicorriziciOracolari.test.js
+++ b/tests/services/combat/nodiMicorriziciOracolari.test.js
@@ -1,0 +1,94 @@
+// tests/services/combat/nodiMicorriziciOracolari.test.js
+//
+// nodi_micorrizici_oracolari -- oracle reveal.
+// Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md
+//
+// Il tratto e' data-only: applica passivamente `telepatic_link`, che
+// computeTelepathicReveal consuma per rivelare gli intent nemici entro raggio 3.
+// Nessun modulo dedicato -- questi test inchiodano la entry YAML e la pipe.
+// Real-module tests (CommonJS), CI-gated via tests/services/*/*.test.js.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const yaml = require('js-yaml');
+
+const {
+  applyPassiveAncestors,
+} = require('../../../apps/backend/services/combat/passiveStatusApplier');
+const {
+  computeTelepathicReveal,
+} = require('../../../apps/backend/services/combat/telepathicReveal');
+const { isEngineLiveReliable } = require('../../helpers/traitLiveness');
+
+const REGISTRY = yaml.load(
+  fs.readFileSync(path.resolve(__dirname, '../../../data/core/traits/active_effects.yaml'), 'utf8'),
+).traits;
+
+const TRAIT = 'nodi_micorrizici_oracolari';
+
+test('nodi: la entry esiste ed e riconosciuta engine-LIVE', () => {
+  const def = REGISTRY[TRAIT];
+  assert.ok(def, 'entry assente da active_effects.yaml');
+  assert.equal(def.trigger.action_type, 'passive');
+  assert.equal(def.effect.kind, 'apply_status');
+  assert.equal(def.effect.stato, 'telepatic_link');
+  assert.equal(isEngineLiveReliable(def), true);
+});
+
+test('nodi: applyPassiveAncestors concede telepatic_link', () => {
+  const unit = { id: 'u1', traits: [TRAIT], status: {} };
+  const events = applyPassiveAncestors(unit, REGISTRY);
+  assert.equal(unit.status.telepatic_link, 2);
+  assert.ok(events.some((e) => e.trait === TRAIT && e.stato === 'telepatic_link'));
+});
+
+test('nodi: un unita senza il tratto non riceve telepatic_link', () => {
+  const unit = { id: 'u2', traits: [], status: {} };
+  applyPassiveAncestors(unit, REGISTRY);
+  assert.equal(unit.status.telepatic_link, undefined);
+});
+
+// End-to-end del valore del tratto: lo status passivo accende la pipe di reveal.
+// L'unita' porta il tratto -> applyPassiveAncestors le da' telepatic_link ->
+// computeTelepathicReveal le mostra l'intent nemico.
+function sessionWithEnemyAt(enemyPos) {
+  const carrier = {
+    id: 'p1',
+    controlled_by: 'player',
+    hp: 10,
+    position: { x: 0, y: 0 },
+    traits: [TRAIT],
+    status: {},
+  };
+  applyPassiveAncestors(carrier, REGISTRY);
+  return {
+    units: [
+      carrier,
+      { id: 'e1', controlled_by: 'sistema', hp: 10, position: enemyPos, status: {} },
+    ],
+    roundState: {
+      pending_intents: [{ unit_id: 'e1', action: { type: 'attack', target_id: 'p1' } }],
+    },
+  };
+}
+
+test('nodi: il portatore vede lintent nemico entro raggio 3', () => {
+  const out = computeTelepathicReveal(sessionWithEnemyAt({ x: 2, y: 1 })); // manhattan 3
+  assert.equal(out.length, 1);
+  assert.equal(out[0].actor_id, 'p1');
+  assert.equal(out[0].revealed[0].enemy_id, 'e1');
+  assert.equal(out[0].revealed[0].intent_type, 'attack');
+  assert.equal(out[0].revealed[0].target_id, 'p1');
+});
+
+// Il contenimento della potenza e' il RAGGIO, non la rarita' (spec decisione 1):
+// telepatic_link non concede statistiche, quindi cio' che limita il tratto e' quanto
+// lontano vede. Se questo test si rompe, il contenimento e' saltato.
+test('nodi: oltre raggio 3 lintent resta nascosto', () => {
+  const out = computeTelepathicReveal(sessionWithEnemyAt({ x: 4, y: 0 })); // manhattan 4
+  assert.equal(out.length, 0);
+});

--- a/tests/services/combat/pendingStatusRemovals.test.js
+++ b/tests/services/combat/pendingStatusRemovals.test.js
@@ -16,6 +16,7 @@ const assert = require('node:assert/strict');
 
 const {
   drainStatusRemovals,
+  drainPendingStatusEffects,
 } = require('../../../apps/backend/services/combat/pendingStatusRemovals');
 
 function unitsMap(units) {
@@ -56,6 +57,53 @@ test('drain: unita senza status -> no-op, nessun throw', () => {
   const session = { _pendingStatusRemovals: [{ unit_id: 't1', status: 'frenzy' }] };
   assert.equal(drainStatusRemovals(session, unitsMap([u])), 0);
   assert.deepEqual(session._pendingStatusRemovals, []);
+});
+
+// ORDINE DEI DRAIN -- invariante load-bearing.
+// syncStatusesFromRoundState drena le RIMOZIONI prima degli APPLIES. Se l'ordine
+// fosse invertito, due ladri di fazione opposta che nello stesso round rubano lo
+// stesso status se lo annichilirebbero a vicenda (entrambi guadagnano, poi entrambe
+// le rimozioni cancellano). Con l'ordine corretto ciascuno perde il proprio e
+// guadagna quello dell'altro. Stesso motivo per cui actor===target non si
+// auto-cancella: rimuove, poi riapplica dimezzato.
+//
+// Il bridge e' una closure non esportata, quindi qui si riproduce la sua sequenza con
+// il vero applyMoraleStatus.
+const { applyMoraleStatus } = require('../../../apps/backend/services/combat/morale');
+
+// La funzione VERA usata dal bridge, con il vero applyMoraleStatus.
+const drainLikeBridge = (session, units) =>
+  drainPendingStatusEffects(session, units, applyMoraleStatus);
+
+test('ordine: furto reciproco non annichila il buff', () => {
+  const a = { id: 'a', hp: 10, status: { frenzy: 2 } };
+  const b = { id: 'b', hp: 10, status: { frenzy: 4 } };
+  const session = {
+    // a ruba a b (4 -> 2), b ruba ad a (2 -> 1)
+    _pendingStatusApplies: [
+      { unit_id: 'a', status: 'frenzy', duration: 2 },
+      { unit_id: 'b', status: 'frenzy', duration: 1 },
+    ],
+    _pendingStatusRemovals: [
+      { unit_id: 'b', status: 'frenzy' },
+      { unit_id: 'a', status: 'frenzy' },
+    ],
+  };
+  drainLikeBridge(session, unitsMap([a, b]));
+  assert.equal(a.status.frenzy, 2, 'a deve conservare il frenzy rubato a b');
+  assert.equal(b.status.frenzy, 1, 'b deve conservare il frenzy rubato ad a');
+});
+
+test('ordine: furto normale -> la preda perde, il ladro guadagna', () => {
+  const thief = { id: 'a', hp: 10, status: {} };
+  const preyUnit = { id: 'b', hp: 10, status: { linked: 4 } };
+  const session = {
+    _pendingStatusApplies: [{ unit_id: 'a', status: 'linked', duration: 2 }],
+    _pendingStatusRemovals: [{ unit_id: 'b', status: 'linked' }],
+  };
+  drainLikeBridge(session, unitsMap([thief, preyUnit]));
+  assert.equal(preyUnit.status.linked, undefined);
+  assert.equal(thief.status.linked, 2);
 });
 
 test('drain: coda assente o vuota -> no-op', () => {

--- a/tests/services/combat/pendingStatusRemovals.test.js
+++ b/tests/services/combat/pendingStatusRemovals.test.js
@@ -1,0 +1,66 @@
+// tests/services/combat/pendingStatusRemovals.test.js
+//
+// Canale di rimozione simmetrico a session._pendingStatusApplies.
+// Spec: docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md (sez. 2b)
+//
+// Serve al furto di buff (ghiandole_mnemoniche): il canale di apply e' drenato con
+// applyMoraleStatus = Math.max(cur,dur), che non sa rimuovere, e il rebuild
+// tracked->dict di syncStatusesFromRoundState ripristinerebbe qualsiasi delete fatto
+// a meta' attacco.
+// Real-module tests (CommonJS), CI-gated via tests/services/*/*.test.js.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  drainStatusRemovals,
+} = require('../../../apps/backend/services/combat/pendingStatusRemovals');
+
+function unitsMap(units) {
+  return new Map(units.map((u) => [String(u.id), u]));
+}
+
+test('drain: rimuove lo status e la sua intensity, lascia il resto', () => {
+  const u = {
+    id: 't1',
+    hp: 10,
+    status: { frenzy: 2, linked: 1 },
+    status_intensity: { frenzy: 1 },
+  };
+  const session = { _pendingStatusRemovals: [{ unit_id: 't1', status: 'frenzy' }] };
+  drainStatusRemovals(session, unitsMap([u]));
+  assert.equal(u.status.frenzy, undefined);
+  assert.equal(u.status_intensity.frenzy, undefined);
+  assert.equal(u.status.linked, 1);
+});
+
+test('drain: svuota la coda e riporta quante rimozioni ha applicato', () => {
+  const u = { id: 't1', hp: 10, status: { frenzy: 2 } };
+  const session = { _pendingStatusRemovals: [{ unit_id: 't1', status: 'frenzy' }] };
+  assert.equal(drainStatusRemovals(session, unitsMap([u])), 1);
+  assert.deepEqual(session._pendingStatusRemovals, []);
+});
+
+// Best-effort: il drain non deve MAI bloccare un round. I tre casi sotto sono le vie
+// per cui potrebbe lanciare.
+test('drain: unita sconosciuta -> no-op, nessun throw', () => {
+  const session = { _pendingStatusRemovals: [{ unit_id: 'ghost', status: 'frenzy' }] };
+  assert.equal(drainStatusRemovals(session, unitsMap([])), 0);
+  assert.deepEqual(session._pendingStatusRemovals, []);
+});
+
+test('drain: unita senza status -> no-op, nessun throw', () => {
+  const u = { id: 't1', hp: 10 };
+  const session = { _pendingStatusRemovals: [{ unit_id: 't1', status: 'frenzy' }] };
+  assert.equal(drainStatusRemovals(session, unitsMap([u])), 0);
+  assert.deepEqual(session._pendingStatusRemovals, []);
+});
+
+test('drain: coda assente o vuota -> no-op', () => {
+  const u = { id: 't1', hp: 10, status: { frenzy: 2 } };
+  assert.equal(drainStatusRemovals({}, unitsMap([u])), 0);
+  assert.equal(drainStatusRemovals({ _pendingStatusRemovals: [] }, unitsMap([u])), 0);
+  assert.equal(u.status.frenzy, 2);
+});


### PR DESCRIPTION
## Perche'

Due tratti -- `ghiandole_mnemoniche` e `nodi_micorrizici_oracolari` -- avevano definizione in `data/traits/**` e voce nel glossario, ma **nessuna entry** in `active_effects.yaml`. In partita non facevano nulla. Erano stati esclusi dal bundle i18n player-facing (#3247) perche' il testo curato prometteva un effetto inesistente.

Entrambi erano stati triageati due volte -- `docs/planning/2026-06-28-gap2-next-block-mechanics-proposal.md` e `2026-06-29-gap2-block3-mechanics-proposal.md` -- e rinviati come **"Owner design call"**: servivano primitive che non esistevano. Master-dd ha ratificato il design (AskUserQuestion). Spec: `docs/superpowers/specs/2026-07-10-buff-steal-e-oracle-reveal-design.md`.

## Ground truth verificata prima di progettare

- **Nessuno dei due era acquisibile** da un'unita' viva: `normaliseUnit` (`sessionHelpers.js:54,97`) e' l'unica sorgente di `unit.traits`; `species_catalog.json` `trait_refs` non ha alcun consumatore backend; `biome_pools.json` `preferred_traits` e' solo un criterio di peso in `biomeSpawnBias.js:122`.
- **Avere una entry non basta**: `passesBasicTriggers` (`traitEffects.js:308`) rifiuta ogni `action_type !== 'attack'`. Per questo `spore_psichiche_silenziate` -- che *ha* una entry, con `melee_attack` -- e' inerte.
- **La pipe di reveal esisteva gia'**, wired in `sessionRoundBridge` `begin-planning`, ma **affamata**: il suo unico produttore, `risonanza_magnetica`, e' gated `on_result:hit` + `on_kill` + `min_mos:5` (boss-finish).
- **`telepatic_link` non concede statistiche** (`statusModifiers.js:206-208`: *"No stat effect -- narrative reveal marker only"*). Un reveal permanente non e' power-creep numerico.
- **La magnitudo di uno status non e' scalabile**: `status_intensity` e' letto per il solo `abbagliato` (`statusModifiers.js:241`).

## Cosa cambia

### `nodi_micorrizici_oracolari` -- solo dati, zero codice motore
Entry `passive` + `apply_status` + `stato: telepatic_link`. Diventa il **primo produttore passivo** della pipe di reveal: il portatore vede gli intent nemici entro manhattan 3 in fase di pianificazione. Il contenimento e' il **raggio**, non la rarita'. `isEngineLiveReliable` la riconosce viva (caso *d*).

### `ghiandole_mnemoniche` -- modulo dedicato
`persistent_marker` + `combat/ghiandoleMnemoniche.js`, pattern `cortecciaMemetica`. Su hit andato a segno ruba **un** buff alla preda e ne indossa una copia a durata dimezzata.

Whitelist ordinata: `frenzy`, `linked`, `sensed`, `coordinamento`, `risonanza_memetica`. `frenzy` e' primo (priorita' `sabotaggio` del role_template *"Sciame Memetico"*) ed e' l'unico furto **non a guadagno netto**: `computeStatusModifiers` legge lo stesso status sui due lati (`+1` att a `:202`, `-1` dif a `:253`), quindi il ladro eredita la guardia abbassata.

Esclusi: `nucleo_intatto` (stato strutturale, `nucleiWeakPoint` possiede il suo rovescio) e `telepatic_link` (firma di `nodi`).

### `_pendingStatusRemovals` -- canale nuovo (non previsto dallo spec iniziale)
`_pendingStatusApplies` sa **solo aggiungere**: e' drenato con `applyMoraleStatus` = `Math.max(cur,dur)`. E `syncStatusesFromRoundState` riscrive `unit.status` dall'array tracciato, ripristinando qualsiasi `delete` fatto a meta' attacco.

Senza un canale di rimozione, il furto sarebbe degradato **silenziosamente a una copia** nel path round-model restando un furto in quello legacy. Il drain vive in `combat/pendingStatusRemovals.js` -- funzione pura -- perche' `syncStatusesFromRoundState` e' una closure non esportata; gira subito dopo gli applies, e `adaptSessionToRoundState` (`:293`) ri-deriva l'array tracciato dal dict, quindi la cancellazione sopravvive.

## Scostamento dal canone, dichiarato

Il canone (`trait_reference_manual.md:35`, gemello `riverbero_memetico`) dice *"duplica prossimo buff al 50%"*. Il 50% di **magnitudo** non e' esprimibile senza toccare ~12 rami di `computeStatusModifiers`, ri-bilanciando ogni tratto che produce quegli status. Consegniamo il 50% **di durata**, annotato nel docstring del modulo.

## `traitLiveness.js` NON e' toccato -- di proposito

Il mirror esclude ogni `persistent_marker` (come `corteccia_memetica`, `artigli_psionici`, `tessuti_adattivi`). Lasciare `ghiandole_mnemoniche` fuori impedisce ai path di grant automatico (`imprintTraitGrant`, `brancoTraitEmergence`) di pescarlo senza un ratify N=40 dedicato. Motivato nel modulo perche' non venga scambiato per una dimenticanza.

## Verifica

| gate | esito |
| --- | --- |
| `tests/services/combat/nodiMicorriziciOracolari.test.js` | **5/5** |
| `tests/services/combat/ghiandoleMnemoniche.test.js` | **12/12** |
| `tests/services/combat/pendingStatusRemovals.test.js` | **5/5** |
| `tests/ai/*.test.js` (42 file, band) | **589 pass / 0 fail** |
| `cortecciaMemetica` + `tessutiAdattivi` + `apLedger` (regressione) | 8/8, 8/8, 9/9 |
| `trait_schema_gate.py --check` | exit 0 |
| `check_trait_mirror_consistency.py` | PASS |
| ASCII-guard sui file nuovi | pulito |

**Band-neutral, provato due volte**: (a) nessuna sim unit porta i due tratti -- `grep` su `tests/`, `services/ai/`, `hardcoreScenario`, `tutorialScenario` non trova carrier; (b) `tests/ai` e `services/ai/` non sono toccati dal diff. Se un solo test AI cambiasse esito, vorrebbe dire che un carrier e' entrato in un roster, e servirebbe un ratify N=40 invece di un merge.

Test eseguiti **per-file**: `node --test <dir>` fallisce con `MODULE_NOT_FOUND` su Node 24 anche su albero pulito (il repo e' Node-22-canonico).

## Fuori scope, registrato

- **`simbionte_micorriza_radici`** resta irraggiungibile. Il suo prereq punta ora a un tratto vivo, quindi non va toccato: cio' che la blocca e' che `listEligibleForUnit` interroga `unit.trait_ids`, un namespace che nessuna unita' di combattimento popola (`normaliseUnit` non lo scrive mai). Bug separato e piu' grande.
- **18 tratti** dichiarano `passive` + `apply_status` + `stato: focused`, che non e' in `WAVE_A_STATUSES` -> tutti inerti. Gia' noto e documentato (`ai/policy.js:121-124`, `imprintTraitGrant.js:88`); nessuno dei 18 e' in `index.json`, quindi zero impatto player.
- **Gli altri 62 tratti inerti.** Nessuna policy generale ratificata qui.
