### PR TITLE
feat(ai): threats-only telegraph filter (default OFF)

### DIFF
--- a/apps/backend/services/ai/threatPreview.js
+++ b/apps/backend/services/ai/threatPreview.js
@@ -68,6 +68,28 @@ function buildThreatPreview(session) {
   const pending = session.roundState.pending_intents;
   if (!Array.isArray(pending) || pending.length === 0) return [];
 
+  // Threats-only (spec sistema-symmetry sez. 4.4): col Sistema simmetrico le
+  // azioni/round salgono (~14 a regime); si telegrafano SOLO le minacce --
+  // attack su unita' player, move dentro objective.target_zone (zone-based).
+  // Il movimento ordinario si vede sulla board. Il tier cap (che non gata piu'
+  // l'azione quando la dichiarazione e' a budget) diventa il tetto di
+  // PRESENTAZIONE. ADR-2026-04-18: il plan-reveal promette le MINACCE prima
+  // della risoluzione, non ogni passo (lettura da ratificare nell'ADR di
+  // chiusura arco). Default OFF -> byte-identical.
+  const threatsOnly = process.env.SISTEMA_TELEGRAPH_THREATS_ONLY === 'true';
+  const ZONE_OBJECTIVES = new Set(['capture_point', 'sabotage', 'escape', 'escort']);
+  const objective = session.encounter && session.encounter.objective;
+  const zone =
+    threatsOnly &&
+    objective &&
+    ZONE_OBJECTIVES.has(objective.type) &&
+    Array.isArray(objective.target_zone) &&
+    objective.target_zone.length === 4
+      ? objective.target_zone
+      : null;
+  const inZone = (pos) =>
+    zone && pos && pos.x >= zone[0] && pos.y >= zone[1] && pos.x <= zone[2] && pos.y <= zone[3];
+
   // 2026-04-27 PR-Y2 — StS damage forecast inline su intent.
   // Lazy require predictCombat (evitare circular dep + missing module risk).
   let predictCombatFn = null;
@@ -87,6 +109,13 @@ function buildThreatPreview(session) {
 
     const action = intent.action || {};
     const intentType = action.type || 'unknown';
+
+    if (threatsOnly) {
+      const isThreat =
+        intentType === 'attack' ||
+        ((intentType === 'move' || intentType === 'approach') && inZone(action.move_to));
+      if (!isThreat) continue;
+    }
 
     // PR-Y2 — expected_damage solo per attack (move/skip = null).
     let expectedDamage = null;
@@ -113,6 +142,24 @@ function buildThreatPreview(session) {
       expected_damage: expectedDamage,
       hit_pct: hitPct,
     });
+  }
+  if (threatsOnly && preview.length > 0) {
+    // Cap di presentazione: attack prima, poi zone-entry; taglio al tier cap.
+    // Lazy require per evitare cicli (declareSistemaIntents richiede sessionHelpers).
+    let cap = preview.length;
+    try {
+      // eslint-disable-next-line global-require
+      const { intentsCapForPressure } = require('./declareSistemaIntents');
+      // Chiamata a 2 argomenti VOLUTA: senza aliveSistema il roster-scaling non
+      // entra (guard Number.isFinite) -> cap = solo tier. Non "correggere" a 3 arg.
+      cap = intentsCapForPressure(session.sistema_pressure, session.pressure_tier_floor);
+    } catch {
+      /* cap lookup best-effort: senza, nessun taglio */
+    }
+    preview.sort(
+      (a, b) => (a.intent_type === 'attack' ? -1 : 1) - (b.intent_type === 'attack' ? -1 : 1),
+    );
+    return preview.slice(0, cap);
   }
   return preview;
 }

--- a/tests/ai/threatPreviewThreatsOnly.test.js
+++ b/tests/ai/threatPreviewThreatsOnly.test.js
@@ -1,0 +1,100 @@
+// tests/ai/threatPreviewThreatsOnly.test.js -- telegraph threats-only (spec sez. 4.4).
+// Flag ON: righe solo per attack su player + move dentro objective.target_zone
+// (objective zone-based). Move/retreat ordinari NON telegrafati (si vedono in
+// board). Cap presentazione = intentsCapForPressure. Flag OFF: byte-identical.
+'use strict';
+process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildThreatPreview } = require('../../apps/backend/services/ai/threatPreview');
+
+const FLAG = 'SISTEMA_TELEGRAPH_THREATS_ONLY';
+function withFlag(value, fn) {
+  const prev = process.env[FLAG];
+  if (value === undefined) delete process.env[FLAG];
+  else process.env[FLAG] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = prev;
+  }
+}
+
+function fakeSession() {
+  const units = [
+    { id: 's1', controlled_by: 'sistema', hp: 5, position: { x: 1, y: 1 } },
+    { id: 's2', controlled_by: 'sistema', hp: 5, position: { x: 2, y: 2 } },
+    { id: 's3', controlled_by: 'sistema', hp: 5, position: { x: 3, y: 3 } },
+    { id: 'p1', controlled_by: 'player', hp: 9, position: { x: 5, y: 5 } },
+  ];
+  return {
+    units,
+    sistema_pressure: 50,
+    encounter: { objective: { type: 'capture_point', target_zone: [7, 7, 9, 9] } },
+    roundState: {
+      pending_intents: [
+        { unit_id: 's1', action: { type: 'attack', target_id: 'p1' } },
+        { unit_id: 's2', action: { type: 'move', move_to: { x: 8, y: 8 } } },
+        { unit_id: 's3', action: { type: 'move', move_to: { x: 4, y: 4 } } },
+      ],
+    },
+  };
+}
+
+test('OFF: tutte le righe SIS come oggi (3)', () => {
+  withFlag(undefined, () => {
+    assert.equal(buildThreatPreview(fakeSession()).length, 3);
+  });
+});
+
+test('ON: attack + move-in-zona si, move ordinario no', () => {
+  withFlag('true', () => {
+    const rows = buildThreatPreview(fakeSession());
+    const ids = rows.map((r) => r.actor_id).sort();
+    assert.deepEqual(ids, ['s1', 's2'], 'move ordinario (s3) non telegrafato');
+  });
+});
+
+test('ON: objective non zone-based -> solo attack', () => {
+  withFlag('true', () => {
+    const s = fakeSession();
+    s.encounter.objective = { type: 'elimination' };
+    const rows = buildThreatPreview(s);
+    assert.deepEqual(
+      rows.map((r) => r.actor_id),
+      ['s1'],
+      'niente zona -> solo attack',
+    );
+  });
+});
+
+test('ON: cap presentazione = tier (Escalated 3), attack prioritari', () => {
+  withFlag('true', () => {
+    const s = fakeSession();
+    s.roundState.pending_intents = [1, 2, 3, 4, 5].map((i) => ({
+      unit_id: `s${i}`,
+      action: { type: 'attack', target_id: 'p1' },
+    }));
+    s.units = [
+      ...[1, 2, 3, 4, 5].map((i) => ({
+        id: `s${i}`,
+        controlled_by: 'sistema',
+        hp: 5,
+        position: { x: i, y: i },
+      })),
+      { id: 'p1', controlled_by: 'player', hp: 9, position: { x: 5, y: 5 } },
+    ];
+    assert.equal(buildThreatPreview(s).length, 3);
+  });
+});
+
+test('ON: retreat mai telegrafato anche in zona', () => {
+  withFlag('true', () => {
+    const s = fakeSession();
+    s.roundState.pending_intents = [
+      { unit_id: 's1', action: { type: 'retreat', move_to: { x: 8, y: 8 } } },
+    ];
+    assert.equal(buildThreatPreview(s).length, 0);
+  });
+});

--- a/tests/ai/threatPreviewThreatsOnly.test.js
+++ b/tests/ai/threatPreviewThreatsOnly.test.js
@@ -98,3 +98,30 @@ test('ON: retreat mai telegrafato anche in zona', () => {
     assert.equal(buildThreatPreview(s).length, 0);
   });
 });
+
+test('ON: attack sopravvive al taglio anche se dichiarato ULTIMO', () => {
+  withFlag('true', () => {
+    // 3 zone-entry dichiarate PRIMA + 1 attack dichiarato ULTIMO, cap tier 3
+    // (pressure 50, Escalated): senza la sort attack-first la slice(0, 3)
+    // scarterebbe l'attack. Pinna la priorita' di presentazione.
+    const s = fakeSession();
+    s.units = [
+      ...[1, 2, 3, 4].map((i) => ({
+        id: `s${i}`,
+        controlled_by: 'sistema',
+        hp: 5,
+        position: { x: i, y: i },
+      })),
+      { id: 'p1', controlled_by: 'player', hp: 9, position: { x: 5, y: 5 } },
+    ];
+    s.roundState.pending_intents = [
+      { unit_id: 's1', action: { type: 'move', move_to: { x: 7, y: 7 } } },
+      { unit_id: 's2', action: { type: 'move', move_to: { x: 8, y: 8 } } },
+      { unit_id: 's3', action: { type: 'move', move_to: { x: 9, y: 9 } } },
+      { unit_id: 's4', action: { type: 'attack', target_id: 'p1' } },
+    ];
+    const rows = buildThreatPreview(s);
+    assert.equal(rows.length, 3, 'cap tier Escalated = 3');
+    assert.equal(rows[0].intent_type, 'attack', 'attack prioritario sopravvive alla slice');
+  });
+});


### PR DESCRIPTION
## Task 6 dell'arco sistema-symmetry (spec #3249, flags #3254)

Flag **`SISTEMA_TELEGRAPH_THREATS_ONLY`** (default OFF, byte-identical spento): col Sistema simmetrico le azioni/round salgono (~14 a regime) e il plan-reveal deve mostrare le MINACCE, non ogni passo:

- **ON**: telegrafati solo attack su unita' player + move/approach che ENTRANO in `objective.target_zone` (objective zone-based); move/retreat ordinari si vedono sulla board. `PRESSURE_TIER_INTENT_CAP` diventa il tetto di PRESENTAZIONE (attack prioritari nel taglio -- sort pinnata da mutation test: senza, la slice scarta l'attack).
- Conformita' ADR-2026-04-18 (plan-reveal = minacce prima della risoluzione, non ogni passo): lettura da ratificare nell'ADR di chiusura arco (Task 7, owner).

## Gate review (Codex usage-limit -> sostituto)

Review combinata spec+quality **APPROVED**: OFF path provato invariato (filtro/sort/slice tutti dentro il ramo flag), trap semantiche verificate (attack fuori zona sempre minaccia; encounter assente -> solo attack; sort stabile ES2019), RED riprodotto retroattivamente sul parent commit (1 pass/4 fail), seam `pressure_tier_floor` = path canonico. Il minor (sort non pinnata) e' chiuso dal secondo commit con mutazione reale verificata due volte.

Test: nuovo file 6/6 · threatPreview totale 15/15 · full tests/ai **608/608** flag unset.

## Rollback

Revert dei 2 commit. Flag OFF, nessun consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)