### PR TITLE
refactor(ai): one AP authority -- price the Sistema declare-side through apLedger

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -46,6 +46,7 @@ const {
 const { selectAiPolicyUtility } = require('./utilityBrain');
 const { stepToRegainLos } = require('../combat/losReposition');
 const { occupiedSetFromUnits } = require('../combat/occupancy');
+const { createApLedger } = require('../combat/apLedger');
 const { ARCHETYPE_VULN_CHANNEL } = require('../../routes/sessionConstants');
 // A2 (TKT-PRESSURE-TIER-ENCOUNTER): per-encounter pressure_tier_floor mirror.
 // sessionHelpers owns the single effectivePressure SoT (flag-gated, default OFF).
@@ -275,6 +276,13 @@ function createDeclareSistemaIntents(deps) {
     threatConfig, // override per threat thresholds (from ai_intent_scores.yaml → threat)
     hiddenAbilityReveal = null, // SPEC-Q M-4 { enabled, defaultThreshold } -- flag OFF default
   } = deps || {};
+
+  // Unica autorita' dei costi AP (spec sez. 4.1). Il declare-side prezza e gata
+  // con gli stessi resolver che la risoluzione usa per addebitare: un ap_cost
+  // calcolato qui a mano divergerebbe dall'addebito server-side non appena il
+  // move smette di essere un passo singolo (budget-v2 multi-tile) o l'attore
+  // porta un move_bonus_bonus.
+  const apLedger = createApLedger({ manhattanDistance, gridSize });
 
   /**
    * Resolve Utility AI flag per-actor (ADR-2026-04-17 gradual rollout).
@@ -768,18 +776,20 @@ function createDeclareSistemaIntents(deps) {
         actor_id: actor.id,
         target_id: null,
         ability_id: null,
-        // Real move distance (was hardcoded 1): stepTowards/stepAway still cost 1,
-        // but a budget-v2 multi-tile reposition costs its full Manhattan distance.
-        // The WEGO resolver deducts this FIELD without recomputing (bridge :1927),
-        // so it must carry the true cost -- and buildMoveEvent's ap_spent (= real
-        // distance) stays in sync with what is actually charged.
-        ap_cost: manhattanDistance(positionFrom, nextPos),
+        // Prezzo server-authoritative dal ledger: max(1, dist - move_bonus_bonus),
+        // lo STESSO resolver che la risoluzione ricalcola per addebitare. Con
+        // stepTowards/stepAway (1 casella) vale 1 come prima; un budget-v2
+        // multi-tile o un move_bonus_bonus rendono la differenza osservabile.
+        // Il campo resta load-bearing anche a valle: buildMoveEvent lo pubblica
+        // come ap_spent e il resolver display lo deduce senza ricalcolare, quindi
+        // deve gia' portare il costo vero.
+        ap_cost: apLedger.resolveMoveApCost(actor, positionFrom, nextPos),
         channel: null,
         move_to: { x: nextPos.x, y: nextPos.y },
         position_from: positionFrom,
         source_ia_rule: policy.rule,
       };
-      if (perUnitAp && moveAction.ap_cost > apBudget) {
+      if (perUnitAp && !apLedger.canAfford(actor, [], moveAction)) {
         decisions.push({
           unit_id: actor.id,
           rule: 'NO_AP',

--- a/tests/ai/sistemaPerUnitAp.test.js
+++ b/tests/ai/sistemaPerUnitAp.test.js
@@ -12,6 +12,7 @@ const {
   isPerUnitApEnabled,
 } = require('../../apps/backend/services/ai/declareSistemaIntents');
 const { pickLowestHpEnemy, stepTowards } = require('../../apps/backend/routes/sessionHelpers');
+const { createApLedger } = require('../../apps/backend/services/combat/apLedger');
 
 const FLAG = 'SISTEMA_PER_UNIT_AP_ENABLED';
 const manhattan = (a, b) => Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
@@ -125,4 +126,61 @@ test('ON: ap_remaining 1 -> un intent; 0 -> zero intent con rule NO_AP', () => {
 test('OFF: 1 intent per unita, come oggi', () => {
   const off = withFlag(undefined, () => declareFor(session([sis('s1', 4, 5), pg('p1', 2, 5)])));
   assert.equal(off.intents.filter((i) => i.unit_id === 's1').length, 1);
+});
+
+// --- Il declare-side deve prezzare dal ledger, non da Manhattan grezzo. ---
+// La risoluzione (sessionRoundBridge, ramo action.type === 'move') addebita
+// SEMPRE resolveMoveApCost = max(1, dist - move_bonus_bonus), ricalcolato
+// server-side. Se la dichiarazione prezza la dist grezza, il gate di budget e
+// l'addebito divergono. Le unita' Sistema ricevono move_bonus_bonus davvero:
+// il loop Ennea (bridge, `for (const unit of session.units)`) non filtra fazione.
+//
+// stepTowards reale muove 1 casella -> dist=1 -> max(1, 1-bonus) === 1 === dist:
+// le due formule COINCIDONO e la divergenza resta invisibile in prod. Lo step
+// iniettato qui salta 2 caselle, che e' il "budget-v2 multi-tile" gia' promesso
+// dal commento sul campo ap_cost. E' li' che la divergenza morde.
+function declareWithMultiTileStep(session_) {
+  const jumpTwo = (from, to) => {
+    const next = { ...from };
+    if (from.x !== to.x) next.x += from.x < to.x ? 2 : -2;
+    return next;
+  };
+  const declare = createDeclareSistemaIntents({
+    pickLowestHpEnemy,
+    stepTowards: jumpTwo,
+    manhattanDistance: manhattan,
+    gridSize: 16,
+  });
+  return declare(session_);
+}
+
+test('ON: move multi-tile prezzato dal ledger -- move_bonus sconta il gate', () => {
+  withFlag('true', () => {
+    const actor = sis('s1', 6, 5, { ap_remaining: 1, move_bonus_bonus: 1 });
+    const { intents } = declareWithMultiTileStep(session([actor, pg('p1', 2, 5)]));
+    const mine = intents.filter((i) => i.unit_id === 's1');
+    assert.equal(mine.length, 1, 'max(1, 2-1) = 1 AP <= budget 1 -> il move e affordabile');
+    assert.equal(mine[0].action.type, 'move');
+    const led = createApLedger({ manhattanDistance: manhattan, gridSize: 16 });
+    assert.equal(
+      mine[0].action.ap_cost,
+      led.resolveMoveApCost(actor, { x: 6, y: 5 }, mine[0].action.move_to),
+      'ap_cost dichiarato == quello che la risoluzione addebitera',
+    );
+  });
+});
+
+// Caratterizzazione: perche' la divergenza NON ha mai morso in prod. stepTowards
+// muove 1 casella, quindi dist=1 e max(1, 1 - bonus) === 1 === dist qualunque sia
+// il move_bonus. Se un domani il passo diventa multi-tile, questo test resta verde
+// ma quello sopra e' l'unico che cattura la regressione: non cancellarlo.
+test('ON: passo singolo -- ledger e Manhattan coincidono (percio prod era salvo)', () => {
+  withFlag('true', () => {
+    const actor = sis('s1', 4, 5, { ap_remaining: 2, move_bonus_bonus: 1 });
+    const { intents } = declareFor(session([actor, pg('p1', 2, 5)]));
+    const move = intents.find((i) => i.unit_id === 's1' && i.action.type === 'move');
+    assert.ok(move, 'approach a 2 celle -> move');
+    assert.equal(manhattan({ x: 4, y: 5 }, move.action.move_to), 1, 'stepTowards = 1 casella');
+    assert.equal(move.action.ap_cost, 1, 'max(1, 1-1) = 1 = dist grezza: nessuna divergenza');
+  });
 });


### PR DESCRIPTION
## Da dove nasce

Harsh-reviewer su #3252: *"`canAfford` ha zero caller di produzione, superficie speculativa"*.

Ground-truth: **non e' speculativa, e' falsificata**. Il consumatore promesso dalla spec
(`docs/superpowers/specs/2026-07-10-sistema-symmetry-design.md` sez. 4.2) era **gia' atterrato**
con #3254 -- ed era passato accanto alla seam, rifacendo a mano il pricing AP.

Il rimedio corretto e' opposto alla lettera della review: non si cancella `canAfford`, si
ricollega il consumatore.

## Cosa c'era

| | `apLedger.js` (autorita' canonica) | `declareSistemaIntents.js` (prima) |
|---|---|---|
| import ledger | -- | nessuno |
| gate budget | `canAfford` | `apBudget` inline |
| costo move | `max(1, dist - move_bonus_bonus)` | `manhattanDistance()` grezzo |

Due autorita' AP -- la condizione che #3252 ("one AP authority") elimina sul lato player.

## Il bug: dormiente, non morto

La dichiarazione prezzava il move a `manhattanDistance` grezzo; la risoluzione
(`sessionRoundBridge.js`, ramo `action.type === 'move'`) ricalcola sempre
`resolveMoveApCost` = `max(1, dist - move_bonus_bonus)`.

Le unita' Sistema ricevono `move_bonus_bonus` davvero: il loop Ennea nel bridge itera
`for (const unit of session.units)` **senza filtro fazione**, `ENNEA_EFFECTS` concede
`move_bonus +1` e `STAT_RUNTIME_KIND.move_bonus = 'mechanical'`.

**Ma `dist` e' sempre 1**: `stepTowards` muove una casella, `stepToRegainLos` gira a
`budget: 1`. `max(1, 1 - bonus) === 1 === dist`. Quindi:

- prod **non e' mai stato colpito**;
- il fattoriale 2x2 (gradino 4) **non e' contaminato** -- i suoi probe non settano
  `COMBAT_LOS_REPOSITION_MODE`, l'unico knob che produce un `nextPos` multi-tile;
- il bug si sveglia il giorno che arriva il budget-v2 multi-tile, cioe' **esattamente cio' che
  il vecchio commento sul campo `ap_cost` prometteva di supportare**.

Questo NON blocca il gradino 4. E' cleanup che chiude un latente prima che morda.

## Cosa cambia

- `declareSistemaIntents` costruisce `createApLedger({ manhattanDistance, gridSize })` dalle deps
  che gia' riceve (zero nuove dipendenze).
- Il move prezza con `resolveMoveApCost` e gata con `canAfford` (pending-sum).
- `canAfford` acquisisce il caller di produzione che il suo JSDoc gia' rivendica.

**Non toccato di proposito**: l'`ap_cost: 1` letterale degli attack. `resolveActionApCost`
ritorna `ATTACK_BASE_AP_COST` per ogni attack e il Sistema non dichiara ability: instradarlo
sul ledger sarebbe un rename a comportamento identico, non un fix. Nessun test poteva guidarlo
(tdd-guard lo ha correttamente rifiutato come premature implementation).

Flag `SISTEMA_PER_UNIT_AP_ENABLED` resta default OFF. Prod invariato.

## TDD

RED prima: `ON: move multi-tile prezzato dal ledger` fallisce con `actual: 0` intent -- il gate
scartava un move che l'attore poteva permettersi (`max(1, 2-1) = 1 <= 1 AP`).
Il passo multi-tile e' iniettato via la dep `stepTowards`, perche' con lo step reale la
divergenza e' invisibile.

Secondo test di caratterizzazione: `ON: passo singolo -- ledger e Manhattan coincidono`,
che documenta **perche'** prod era salvo, cosi' il prossimo lettore non ripete l'errore di
leggere la catena causale senza verificarne la magnitudine.

## Gate

```
node --test tests/ai/sistemaPerUnitAp.test.js                 8/8
node --test tests/services/combat/apLedger.test.js            9/9
node --test tests/api/sessionDeclareIntentValidation.test.js  8/8
node --test tests/ai/*.test.js (flag unset)                   604/604
```

Il ramo OFF e' provato byte-identical dall'intera suite AI con flag unset.

## Relazione con #3252

File disgiunti (`declareSistemaIntents.js` vs `apLedger.js` + `sessionRoundBridge.js`).
Nessun conflitto, nessun vincolo di ordine di merge: `canAfford` e `resolveMoveApCost` sono
gia' esportati su `main`; #3252 ne indurisce l'interno, non la firma.

Nota per #3252: il suo body afferma *"one AP authority"*, cosa che su `main` non e' vera dal
merge di #3254. Dopo questa PR lo diventa.
