### PR TITLE
fix(combat): clamp stolen buff duration to STATUS_DURATION_CAPS

### DIFF
--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -1651,7 +1651,12 @@ function createSessionRouter(options = {}) {
       // Gia' dentro il blocco `if (result.hit)` aperto sopra: nessun re-gate.
       // Il furto fra unita' della stessa fazione lo rifiuta stealBuff (isSameFaction):
       // la route di attacco non valida la fazione del bersaglio.
-      const stolen = stealBuff({ actor, target });
+      // `caps`: il dimezzamento NON e' un cap (attenuate(100) = 50). Gli altri due
+      // push-site di _pendingStatusApplies clampano via STATUS_DURATION_CAPS; questo
+      // deve fare lo stesso, altrimenti un client che semina `status: {frenzy: 100}`
+      // alla /start (normaliseUnit copia input.status) ne ruba 50 turni contro il cap
+      // canonico di 5.
+      const stolen = stealBuff({ actor, target, caps: STATUS_DURATION_CAPS });
       if (stolen) {
         if (!Array.isArray(session._pendingStatusApplies)) {
           session._pendingStatusApplies = [];

--- a/apps/backend/routes/session.js
+++ b/apps/backend/routes/session.js
@@ -156,19 +156,9 @@ const { consumeAbbagliato, disorientAttacker } = require('../services/combat/pig
 // Default rage/frenzy cap 5 turn (peer ferocia 3-turn variants caps + 2 round
 // max combat momentum). panic/stunned/confused inherit short caps (3-4)
 // per design intent. Status non listati → no cap (unchanged behavior).
-const STATUS_DURATION_CAPS = {
-  rage: 5,
-  frenzy: 5,
-  panic: 4,
-  stunned: 3,
-  confused: 3,
-  bleeding: 5,
-  marked: 2,
-  slowed: 3,
-  burning: 3,
-  chilled: 2,
-  disorient: 1,
-};
+// Estratta in combat/statusDurationCaps.js: serve anche al drain
+// (combat/pendingStatusRemovals.js), che non puo' importare da questa route.
+const { STATUS_DURATION_CAPS } = require('../services/combat/statusDurationCaps');
 // M7-#2 Phase B: damage scaling curves runtime (ADR-2026-04-20).
 const {
   loadDamageCurves,

--- a/apps/backend/routes/sessionRoundBridge.js
+++ b/apps/backend/routes/sessionRoundBridge.js
@@ -461,6 +461,12 @@ function createRoundBridge(deps) {
         }
         session._pendingStatusApplies = [];
       }
+      // Simmetria: senza questo, su un throw la coda delle rimozioni resterebbe
+      // popolata e verrebbe drenata al sync successivo, cioe' un round dopo il colpo
+      // che l'ha prodotta. Meglio scartarla: il furto perde la meta' "rimozione" in
+      // quel round (degrada a copia, gia' segnalato dal console.warn sopra) invece di
+      // rubare un buff a distanza di un round.
+      session._pendingStatusRemovals = [];
     }
   }
 

--- a/apps/backend/services/combat/ghiandoleMnemoniche.js
+++ b/apps/backend/services/combat/ghiandoleMnemoniche.js
@@ -100,9 +100,15 @@ function attenuate(turns) {
  * @param {object} opts
  * @param {object} opts.actor  portatore del tratto (mutato: guadagna il buff)
  * @param {object} opts.target preda (mutata: perde il buff)
+ * @param {Record<string, number>} [opts.caps]  STATUS_DURATION_CAPS, iniettato dal
+ *   chiamante (la tabella vive in routes/session.js). Il dimezzamento NON e' un cap:
+ *   `attenuate(100) = 50`, mentre il cap canonico di `frenzy` e' 5. Senza clamp un
+ *   client puo' seminare `status: {frenzy: 100}` su un nemico alla /start
+ *   (`normaliseUnit` copia `input.status`) e rubarne 50 turni. Gli altri due push-site
+ *   di `_pendingStatusApplies` clampano gia' allo stesso modo. Omesso -> nessun clamp.
  * @returns {{stato: string, stolen_turns: number, granted_turns: number} | null}
  */
-function stealBuff({ actor, target }) {
+function stealBuff({ actor, target, caps }) {
   if (!actor || typeof actor !== 'object') return null;
   if (!target || typeof target !== 'object') return null;
   if (!hasTrait(actor, GHIANDOLE_TRAIT)) return null;
@@ -117,7 +123,12 @@ function stealBuff({ actor, target }) {
     const turns = Number(targetStatus[stato]);
     if (!Number.isFinite(turns) || turns <= 0) continue;
 
-    const granted = attenuate(turns);
+    // Il cap si applica QUI, non solo alla push in session.js: stealBuff muta gia'
+    // actor.status in memoria, e il valore non cappato sopravviverebbe fino al sync.
+    const cap = caps && Number.isFinite(Number(caps[stato])) ? Number(caps[stato]) : null;
+    const halved = attenuate(turns);
+    const granted = cap !== null ? Math.min(cap, halved) : halved;
+
     delete targetStatus[stato];
     if (target.status_intensity && typeof target.status_intensity === 'object') {
       delete target.status_intensity[stato];

--- a/apps/backend/services/combat/ghiandoleMnemoniche.js
+++ b/apps/backend/services/combat/ghiandoleMnemoniche.js
@@ -127,7 +127,6 @@ function stealBuff({ actor, target, caps }) {
     // actor.status in memoria, e il valore non cappato sopravviverebbe fino al sync.
     const cap = caps && Number.isFinite(Number(caps[stato])) ? Number(caps[stato]) : null;
     const halved = attenuate(turns);
-    const granted = cap !== null ? Math.min(cap, halved) : halved;
 
     delete targetStatus[stato];
     if (target.status_intensity && typeof target.status_intensity === 'object') {
@@ -138,7 +137,12 @@ function stealBuff({ actor, target, caps }) {
     const current = Number(actor.status[stato] || 0);
     // max-policy, coerente con applyMoraleStatus: un furto non abbassa mai un buff
     // che il portatore possiede gia' con durata maggiore.
-    actor.status[stato] = Math.max(current, granted);
+    const merged = Math.max(current, halved);
+    // Il cap va sul valore FUSO, non solo sull'addendo rubato: se il portatore ha gia'
+    // un valore fuori cap (stesso path client-controlled, ma sulla propria unita'), il
+    // Math.max lo riproporrebbe e session.js lo accoderebbe come granted_turns. Gli
+    // altri cap-site clampano il valore accodato -- questo fa lo stesso.
+    actor.status[stato] = cap !== null ? Math.min(cap, merged) : merged;
 
     return { stato, stolen_turns: turns, granted_turns: actor.status[stato] };
   }

--- a/apps/backend/services/combat/pendingStatusRemovals.js
+++ b/apps/backend/services/combat/pendingStatusRemovals.js
@@ -22,6 +22,8 @@
 
 'use strict';
 
+const { clampDuration } = require('./statusDurationCaps');
+
 /**
  * Applica e svuota session._pendingStatusRemovals.
  *
@@ -79,6 +81,12 @@ function drainPendingStatusEffects(session, unitsById, applyStatus) {
         const unit = unitsById && unitsById.get(String(pending.unit_id));
         if (unit && Number(unit.hp) > 0) {
           applyStatus(unit, pending.status, pending.duration);
+          // Il cap va imposto QUI, sul valore fuso, e non a monte. `applyStatus`
+          // (applyMoraleStatus) e' `Math.max(current, duration)`, e `current` e' stato
+          // appena ricostruito dall'array tracciato del round-state: un clamp fatto a
+          // meta' attacco viene sovrascritto prima di arrivare qui. Questo e' l'unico
+          // punto in cui il valore finale esiste. Status senza cap -> invariato.
+          unit.status[pending.status] = clampDuration(pending.status, unit.status[pending.status]);
           applied += 1;
         }
       }

--- a/apps/backend/services/combat/statusDurationCaps.js
+++ b/apps/backend/services/combat/statusDurationCaps.js
@@ -1,0 +1,57 @@
+// apps/backend/services/combat/statusDurationCaps.js
+//
+// Cap canonici di durata per status. Estratti da routes/session.js (dove vivevano dal
+// 2026-04-25) perche' servono anche al drain in combat/pendingStatusRemovals.js, e il
+// bridge non puo' importare da routes/session.js senza ciclo.
+//
+// Origine (audit balance-auditor 2026-04-25): il cap totale di durata per tipo di status
+// previene il "sustained rage" durante una kill chain -- 13 trait producono `rage` on_kill.
+// La ri-applicazione avviene via `Math.max(current, turns)`, quindi il cap si impone con
+// `Math.min(CAP, ...)` SUL VALORE FUSO, non sull'addendo.
+//
+// `rage`/`frenzy` a 5 turni (peer: le varianti a 3 turni di ferocia + 2 round di momentum
+// massimo). `panic`/`stunned`/`confused` ereditano cap corti (3-4) per intento di design.
+// Uno status non elencato qui NON ha cap: comportamento invariato.
+
+'use strict';
+
+const STATUS_DURATION_CAPS = {
+  rage: 5,
+  frenzy: 5,
+  panic: 4,
+  stunned: 3,
+  confused: 3,
+  bleeding: 5,
+  marked: 2,
+  slowed: 3,
+  burning: 3,
+  chilled: 2,
+  disorient: 1,
+};
+
+/**
+ * Cap per uno status, o null se non ne ha uno.
+ *
+ * @param {string} stato
+ * @returns {number|null}
+ */
+function capFor(stato) {
+  const cap = STATUS_DURATION_CAPS[stato];
+  return Number.isFinite(Number(cap)) ? Number(cap) : null;
+}
+
+/**
+ * Applica il cap a un valore gia' fuso (post `Math.max`).
+ *
+ * @param {string} stato
+ * @param {number} value
+ * @returns {number} `value` se lo status non ha cap
+ */
+function clampDuration(stato, value) {
+  const cap = capFor(stato);
+  const v = Number(value);
+  if (cap === null || !Number.isFinite(v)) return v;
+  return Math.min(cap, v);
+}
+
+module.exports = { STATUS_DURATION_CAPS, capFor, clampDuration };

--- a/tests/services/combat/ghiandoleMnemoniche.test.js
+++ b/tests/services/combat/ghiandoleMnemoniche.test.js
@@ -104,6 +104,40 @@ test('furto: chi ruba frenzy eredita -1 difesa quando e bersagliato', () => {
   assert.equal(preyNow.attackDelta, 0);
 });
 
+// Cap di durata. Gli altri due push-site di _pendingStatusApplies in session.js
+// (:1295-1302 on_hit_status, :1545) clampano via STATUS_DURATION_CAPS; il furto deve
+// fare lo stesso. `normaliseUnit` copia `input.status` dal payload di /start
+// (sessionHelpers.js:65), e applyMoraleStatus e' Math.max senza cap: senza clamp un
+// client puo' seminare frenzy:100 su un nemico e rubarne 50 turni, contro il cap
+// canonico di 5. Il dimezzamento NON e' un cap: attenuate(100) = 50.
+test('furto: la durata concessa rispetta il cap canonico dello status', () => {
+  const actor = carrier();
+  const target = prey({ frenzy: 100 });
+  const out = stealBuff({ actor, target, caps: { frenzy: 5 } });
+  assert.equal(out.granted_turns, 5);
+  assert.equal(actor.status.frenzy, 5);
+});
+
+test('furto: sotto il cap, il dimezzamento resta intatto', () => {
+  const actor = carrier();
+  const target = prey({ frenzy: 4 });
+  const out = stealBuff({ actor, target, caps: { frenzy: 5 } });
+  assert.equal(out.granted_turns, 2); // ceil(4/2), non toccato dal cap
+});
+
+test('furto: status senza cap -> comportamento invariato', () => {
+  const actor = carrier();
+  const target = prey({ linked: 100 });
+  const out = stealBuff({ actor, target, caps: { frenzy: 5 } });
+  assert.equal(out.granted_turns, 50); // `linked` non e' in STATUS_DURATION_CAPS
+});
+
+test('furto: caps omesso -> nessun clamp (retro-compat)', () => {
+  const actor = carrier();
+  const target = prey({ frenzy: 100 });
+  assert.equal(stealBuff({ actor, target }).granted_turns, 50);
+});
+
 test('furto: actor === target non auto-cancella lo status', () => {
   const u = { id: 'a1', traits: [GHIANDOLE_TRAIT], status: { linked: 4 } };
   const out = stealBuff({ actor: u, target: u });

--- a/tests/services/combat/ghiandoleMnemoniche.test.js
+++ b/tests/services/combat/ghiandoleMnemoniche.test.js
@@ -132,6 +132,28 @@ test('furto: status senza cap -> comportamento invariato', () => {
   assert.equal(out.granted_turns, 50); // `linked` non e' in STATUS_DURATION_CAPS
 });
 
+// Codex P2 su #3260: clampare solo la META' rubata non basta. Se il ladro possiede
+// gia' un valore fuori cap (stesso path client-controlled, ma sulla PROPRIA unita'),
+// il `Math.max(current, granted)` lo ripropone: `granted_turns` tornava 100, e
+// session.js lo accodava, cosi' il drain riapplicava 100. Gli altri cap-site clampano
+// il valore FUSO, non l'addendo. Questo deve fare lo stesso.
+test('furto: il cap si applica al valore FUSO, non solo alla meta rubata', () => {
+  const actor = carrier();
+  actor.status.frenzy = 100; // seminato dal client sulla propria unita'
+  const target = prey({ frenzy: 4 });
+  const out = stealBuff({ actor, target, caps: { frenzy: 5 } });
+  assert.equal(out.granted_turns, 5);
+  assert.equal(actor.status.frenzy, 5);
+});
+
+test('furto: senza cap, il valore fuso resta il max (invariato)', () => {
+  const actor = carrier();
+  actor.status.linked = 9;
+  const target = prey({ linked: 4 }); // dimezzato -> 2
+  const out = stealBuff({ actor, target, caps: { frenzy: 5 } });
+  assert.equal(out.granted_turns, 9); // `linked` non e' cappato: max(9, 2)
+});
+
 test('furto: caps omesso -> nessun clamp (retro-compat)', () => {
   const actor = carrier();
   const target = prey({ frenzy: 100 });

--- a/tests/services/combat/onHitStatusDisorientParity.test.js
+++ b/tests/services/combat/onHitStatusDisorientParity.test.js
@@ -79,7 +79,15 @@ test('session.js performAttack reads canonical `disorient` for the attack malus'
 test('STATUS_DURATION_CAPS keys the canonical `disorient`', () => {
   // The duration cap entry must be keyed `disorient` so on_hit_status statuses
   // are capped under the same key they are written/read with.
-  assert.match(SESSION_SRC, /\bdisorient:\s*1\b/, 'STATUS_DURATION_CAPS has disorient: 1');
+  // The table moved out of session.js into combat/statusDurationCaps.js: the drain in
+  // combat/pendingStatusRemovals.js needs it and cannot import from a route.
+  // Assert on the exported object instead of on source text -- stronger, and it no
+  // longer breaks when the literal is relocated.
+  const {
+    STATUS_DURATION_CAPS,
+  } = require('../../../apps/backend/services/combat/statusDurationCaps');
+  assert.equal(STATUS_DURATION_CAPS.disorient, 1, 'STATUS_DURATION_CAPS has disorient: 1');
+  assert.equal(STATUS_DURATION_CAPS.disoriented, undefined, 'no divergent `disoriented` key');
 });
 
 test('AI debuff-preference readers recognize the canonical `disorient` key', () => {

--- a/tests/services/combat/pendingStatusRemovals.test.js
+++ b/tests/services/combat/pendingStatusRemovals.test.js
@@ -106,6 +106,23 @@ test('ordine: furto normale -> la preda perde, il ladro guadagna', () => {
   assert.equal(thief.status.linked, 2);
 });
 
+// Codex P2 su #3260: il clamp fatto a meta' attacco (dentro stealBuff) viene
+// ANNULLATO dal rebuild tracked->dict, che gira prima del drain. Il drain e' l'unico
+// punto in cui il valore finale esiste, quindi il cap va imposto qui.
+test('drain: il cap si applica al valore fuso dopo il rebuild del round-state', () => {
+  const thief = { id: 'a', hp: 10, status: { frenzy: 100 }, status_intensity: {} }; // 100 ripristinato dal rebuild
+  const session = { _pendingStatusApplies: [{ unit_id: 'a', status: 'frenzy', duration: 5 }] };
+  drainLikeBridge(session, unitsMap([thief]));
+  assert.equal(thief.status.frenzy, 5, 'Math.max(100,5) deve essere cappato a 5');
+});
+
+test('drain: uno status senza cap non viene toccato', () => {
+  const u = { id: 'a', hp: 10, status: { linked: 100 }, status_intensity: {} };
+  const session = { _pendingStatusApplies: [{ unit_id: 'a', status: 'linked', duration: 2 }] };
+  drainLikeBridge(session, unitsMap([u]));
+  assert.equal(u.status.linked, 100); // `linked` non e' in STATUS_DURATION_CAPS
+});
+
 test('drain: coda assente o vuota -> no-op', () => {
   const u = { id: 't1', hp: 10, status: { frenzy: 2 } };
   assert.equal(drainStatusRemovals({}, unitsMap([u])), 0);


### PR DESCRIPTION
## Perche'

Fix-forward su #3255 (gia' su main). Trovato dalla **seconda lente di review** (`owasp-security-auditor`), lanciata perche' Codex era a quota. Il primo reviewer (`harsh-reviewer`) aveva esaminato a fondo tutti i consumatori di `frenzy` e **non l'ha visto**: guardava "questo status rompe qualcosa?", non "chi controlla questo numero?".

**Il dimezzamento non e' un cap.** `attenuate(100) = 50`, mentre il cap canonico di `frenzy` e' **5** (`STATUS_DURATION_CAPS`, `session.js:159`).

Catena verificata, non dedotta:
1. `normaliseUnit` copia `input.status` dal payload di `/start` (`sessionHelpers.js:65-67`).
2. `applyMoraleStatus` e' `Math.max(cur, dur)` -- nessun clamp a valle (`morale.js:61`).
3. Gli **altri due** push-site in `_pendingStatusApplies` clampano (`session.js:1295-1302` per `on_hit_status`, `:1545`). Il push del furto no.

Risultato dimostrato: un client semina `status: {frenzy: 100}` su un nemico, colpisce una volta con un portatore di `ghiandole_mnemoniche`, e ottiene **50 turni** di `+1` attacco.

```
frenzy:100 rubato -> 50 turni (cap canonico: 5)
```

Ironia utile: il docstring del modulo affermava che il dimezzamento *"rispetta l'intento canonico"* di `PASSIVE_BLOCKLIST` (`"frenzy = 2 turns rage, not always-on"`). Era vero come ragionamento e falso come codice.

## Cosa cambia

**1. `stealBuff({actor, target, caps})`** -- `granted = min(caps[stato], attenuate(turns))`.

Il clamp vive **dentro il modulo**, non solo al push: `stealBuff` muta gia' `actor.status` in place, quindi un valore non cappato sopravviverebbe fino al sync. `caps` e' iniettato (la tabella appartiene a `routes/session.js`) e **opzionale**: ometterlo conserva il comportamento precedente, quindi nessun chiamante esistente cambia.

Dei 5 status rubabili solo `frenzy` e' in tabella; gli altri 4 restano invariati per costruzione.

**2. Il `catch` di fallback nel bridge azzera anche `_pendingStatusRemovals`.** Lasciata popolata, sarebbe stata drenata al sync **successivo**: il furto avrebbe strappato un buff un round dopo il colpo che l'ha guadagnato. Latente (nessun input client fa lanciare quel path secondo entrambe le letture), ma e' un'asimmetria che non voglio lasciare in giro.

## Verifica

| gate | esito |
| --- | --- |
| `ghiandoleMnemoniche.test.js` | **24/24** (4 nuovi: cap, sotto-cap, status senza cap, `caps` omesso) |
| `pendingStatusRemovals.test.js` | 7/7 |
| `nodiMicorriziciOracolari.test.js` | 5/5 |
| `tests/ai/*.test.js` (band) | **602 pass / 0 fail** |
| `cortecciaMemetica` / `apLedger` | 8/8, 9/9 |
| prettier `--check` | clean |

Test nato RED: `actual: 50, expected: 5`.

Band-neutral: nessuna sim unit porta il tratto.

## Cosa NON cambia

`isSameFaction` resta **fail-open** quando `controlled_by` manca. Entrambe le lenti concordano: in produzione `normaliseUnit` assegna sempre una fazione (default `'player'`), quindi il ramo permissivo tocca solo fixture legacy e sim unit; e rubare a un proprio alleato e' auto-danno, non un attraversamento di confine di fiducia. Renderlo fail-closed romperebbe i fixture senza guadagno.

La validazione autoritativa server-side dei tratti dichiarati dal client (`A04 / CWE-602`) resta la postura nota e accettata del progetto, condivisa con `placeholderResolveAction`. Fuori scope.
