### PR TITLE
fix(ai): telegraph threats-only -- hidden rows replace dropped intents

### DIFF
--- a/apps/backend/services/ai/threatPreview.js
+++ b/apps/backend/services/ai/threatPreview.js
@@ -5,7 +5,7 @@
 //
 //   {
 //     actor_id: 'e_nomad_1',
-//     intent_type: 'attack' | 'move' | 'skip' | 'unknown',
+//     intent_type: 'attack' | 'move' | 'skip' | 'hidden' | 'unknown',
 //     intent_icon: 'fist' | 'move' | 'shield' | '?',
 //     target_id: 'p_scout' | null,
 //     threat_tiles: [{ x, y }],
@@ -14,6 +14,14 @@
 // `threat_tiles` per attack = cella del target (dove sta cadendo il colpo).
 // `threat_tiles` per move = cella di destinazione (dove SIS sta andando).
 // `threat_tiles` per skip = [].
+//
+// Contratto threats-only (Codex P2 PR #3258): con SISTEMA_TELEGRAPH_THREATS_ONLY
+// ogni unita' SIS viva con intent pendente ha SEMPRE una riga; intent non-threat
+// o tagliato dal cap -> riga mascherata `intent_type: 'hidden'` (icon '?', zero
+// campi informativi). Riga assente = "preview non disponibile" (pre-declare /
+// legacy flow), MAI "intent filtrato": i consumer con fallback-attacco su riga
+// assente (apps/play archiviato, render.js/main.js) non devono mentire proprio
+// sulle unita' che il flag vuole nascondere.
 //
 // NB: legge solo da `session.roundState.pending_intents` → richiede che
 // `declareSistemaIntents` sia già stato chiamato (flow /round/begin-planning).
@@ -29,11 +37,27 @@ const INTENT_ICON_MAP = {
   skip: 'shield',
   defend: 'shield',
   overwatch: 'shield',
+  hidden: '?',
 };
 
 function _iconFor(type) {
   if (!type || typeof type !== 'string') return '?';
   return INTENT_ICON_MAP[type] || '?';
+}
+
+// Riga mascherata threats-only (contratto in testa al file). Costruita da zero,
+// mai derivata mascherando una riga threat: un downgrade da attack che
+// conservasse target/expected_damage/threat_tiles renderebbe il mask cosmetico.
+function _hiddenRow(actorId) {
+  return {
+    actor_id: actorId,
+    intent_type: 'hidden',
+    intent_icon: _iconFor('hidden'),
+    target_id: null,
+    threat_tiles: [],
+    expected_damage: null,
+    hit_pct: null,
+  };
 }
 
 function _unitById(session, id) {
@@ -101,6 +125,7 @@ function buildThreatPreview(session) {
   }
 
   const preview = [];
+  const hidden = [];
   for (const intent of pending) {
     if (!intent || !intent.unit_id) continue;
     const actor = _unitById(session, intent.unit_id);
@@ -114,7 +139,10 @@ function buildThreatPreview(session) {
       const isThreat =
         intentType === 'attack' ||
         ((intentType === 'move' || intentType === 'approach') && inZone(action.move_to));
-      if (!isThreat) continue;
+      if (!isThreat) {
+        hidden.push(_hiddenRow(actor.id));
+        continue;
+      }
     }
 
     // PR-Y2 — expected_damage solo per attack (move/skip = null).
@@ -143,7 +171,7 @@ function buildThreatPreview(session) {
       hit_pct: hitPct,
     });
   }
-  if (threatsOnly && preview.length > 0) {
+  if (threatsOnly) {
     // Cap di presentazione: attack prima, poi zone-entry; taglio al tier cap.
     // Lazy require per evitare cicli (declareSistemaIntents richiede sessionHelpers).
     let cap = preview.length;
@@ -159,7 +187,12 @@ function buildThreatPreview(session) {
     preview.sort(
       (a, b) => (a.intent_type === 'attack' ? -1 : 1) - (b.intent_type === 'attack' ? -1 : 1),
     );
-    return preview.slice(0, cap);
+    // Oltre-cap: downgrade a riga hidden, non drop (contratto in testa al file).
+    // Il cap resta il tetto delle MINACCE telegrafate; le righe hidden non
+    // contano contro il cap perche' non presentano nulla.
+    const kept = preview.slice(0, cap);
+    for (const cut of preview.slice(cap)) hidden.push(_hiddenRow(cut.actor_id));
+    return kept.concat(hidden);
   }
   return preview;
 }

--- a/apps/play/src/main.js
+++ b/apps/play/src/main.js
@@ -693,6 +693,9 @@ function buildUnitTooltip(unit) {
       skip: 'difesa',
       defend: 'difesa',
       overwatch: 'sentinella',
+      // Threats-only (Codex P2 PR #3258): intent filtrato arriva come riga
+      // 'hidden' (mai assente) -- il fallback attacco sotto non scatta piu'.
+      hidden: 'nascosto',
     };
     if (row) {
       const glyph = glyphMap[row.intent_icon] || '?';

--- a/docs/adr/ADR-2026-07-10-sistema-action-symmetry.md
+++ b/docs/adr/ADR-2026-07-10-sistema-action-symmetry.md
@@ -104,3 +104,27 @@ piu' un tuning del tetto.
 - Sostituire utilityBrain con lookahead2: scartata dal decider (personalita' = pilastro).
 - 2 AP senza gate ne' fix stepTowards: "castello immobile" (misura contaminata, doc
   fattoriale sez. 1).
+
+## Addendum 2026-07-10 -- Contratto telegraph threats-only (pre-flip, Codex P2 PR #3258)
+
+Con `SISTEMA_TELEGRAPH_THREATS_ONLY=true` il filtro non droppa piu' le righe
+non-threat: ogni unita' SIS viva con intent pendente ha SEMPRE una riga in
+`threat_preview`; intent non-threat o tagliato dal cap -> riga mascherata
+`intent_type: "hidden"` (icon `?`, zero campi informativi: niente target,
+tiles, expected_damage). Riga assente = solo "preview non disponibile"
+(pre-declare / legacy flow), mai "intent filtrato".
+
+Motivo: il consumer legacy (apps/play, archiviato ma di riferimento) tratta la
+riga assente di un'unita' SIS viva come fallback attacco ("Intento: attacco" +
+icona fist) -- il telegraph mentiva proprio nel caso che il flag vuole
+nascondere. Il downgrade oltre-cap ricostruisce la riga da zero (mai mask di
+una riga threat esistente: conservare expected_damage sarebbe leak).
+
+Il frontend canonico Godot (Game-Godot-v2) oggi NON consuma `threat_preview`
+backend: il port locale `ThreatPreview` non ha consumer surface (roadmap
+deferred) ne' filtro threats-only. Quando verra' cablato deve rispettare questo
+contratto (riga sempre presente, `hidden` renderizzato come intent sconosciuto,
+pattern StS).
+
+Stato: pre-condizione (1) del flip risolta. Impl: `threatPreview.js` +
+`tests/ai/threatPreviewThreatsOnly.test.js`.

--- a/tests/ai/threatPreviewThreatsOnly.test.js
+++ b/tests/ai/threatPreviewThreatsOnly.test.js
@@ -1,7 +1,10 @@
 // tests/ai/threatPreviewThreatsOnly.test.js -- telegraph threats-only (spec sez. 4.4).
-// Flag ON: righe solo per attack su player + move dentro objective.target_zone
-// (objective zone-based). Move/retreat ordinari NON telegrafati (si vedono in
-// board). Cap presentazione = intentsCapForPressure. Flag OFF: byte-identical.
+// Flag ON: righe threat solo per attack su player + move dentro objective.target_zone
+// (objective zone-based). Move/retreat ordinari e righe oltre-cap NON spariscono:
+// diventano righe mascherate intent_type 'hidden' (contratto Codex P2 PR #3258 --
+// riga assente = solo "preview non disponibile", mai "intent filtrato").
+// Cap presentazione = intentsCapForPressure (conta solo le righe threat).
+// Flag OFF: byte-identical, nessuna riga hidden.
 'use strict';
 process.env.IDEA_ENGINE_DISABLE_STATUS_REFRESH = '1';
 const test = require('node:test');
@@ -42,34 +45,76 @@ function fakeSession() {
   };
 }
 
-test('OFF: tutte le righe SIS come oggi (3)', () => {
+const isHidden = (r) => r.intent_type === 'hidden';
+
+// La riga mascherata non deve trasportare NESSUN campo informativo: un
+// downgrade da riga attack che conservasse target/expected_damage renderebbe
+// il mask cosmetico (leak di cio' che il flag vuole nascondere).
+function assertMasked(row) {
+  assert.equal(row.intent_type, 'hidden');
+  assert.equal(row.intent_icon, '?');
+  assert.equal(row.target_id, null);
+  assert.deepEqual(row.threat_tiles, []);
+  assert.equal(row.expected_damage, null);
+  assert.equal(row.hit_pct, null);
+}
+
+test('OFF: tutte le righe SIS come oggi (3), nessuna hidden', () => {
   withFlag(undefined, () => {
-    assert.equal(buildThreatPreview(fakeSession()).length, 3);
+    const rows = buildThreatPreview(fakeSession());
+    assert.equal(rows.length, 3);
+    assert.equal(rows.filter(isHidden).length, 0, 'flag OFF byte-identical');
   });
 });
 
-test('ON: attack + move-in-zona si, move ordinario no', () => {
+test('ON: attack + move-in-zona telegrafati, move ordinario -> riga hidden', () => {
   withFlag('true', () => {
     const rows = buildThreatPreview(fakeSession());
-    const ids = rows.map((r) => r.actor_id).sort();
-    assert.deepEqual(ids, ['s1', 's2'], 'move ordinario (s3) non telegrafato');
+    const threats = rows.filter((r) => !isHidden(r));
+    assert.deepEqual(
+      threats.map((r) => r.actor_id).sort(),
+      ['s1', 's2'],
+      'threat rows = attack + zone-entry',
+    );
+    const hidden = rows.filter(isHidden);
+    assert.deepEqual(
+      hidden.map((r) => r.actor_id),
+      ['s3'],
+      'move ordinario (s3) presente ma mascherato, non assente',
+    );
+    assertMasked(hidden[0]);
   });
 });
 
-test('ON: objective non zone-based -> solo attack', () => {
+test('ON: ogni unita SIS viva con intent ha ESATTAMENTE una riga', () => {
+  withFlag('true', () => {
+    const rows = buildThreatPreview(fakeSession());
+    assert.deepEqual(
+      rows.map((r) => r.actor_id).sort(),
+      ['s1', 's2', 's3'],
+      'riga assente = solo preview non disponibile, mai intent filtrato',
+    );
+  });
+});
+
+test('ON: objective non zone-based -> solo attack threat, resto hidden', () => {
   withFlag('true', () => {
     const s = fakeSession();
     s.encounter.objective = { type: 'elimination' };
     const rows = buildThreatPreview(s);
     assert.deepEqual(
-      rows.map((r) => r.actor_id),
+      rows.filter((r) => !isHidden(r)).map((r) => r.actor_id),
       ['s1'],
-      'niente zona -> solo attack',
+      'niente zona -> solo attack telegrafato',
+    );
+    assert.deepEqual(
+      rows.filter(isHidden).map((r) => r.actor_id).sort(),
+      ['s2', 's3'],
     );
   });
 });
 
-test('ON: cap presentazione = tier (Escalated 3), attack prioritari', () => {
+test('ON: cap presentazione = tier (Escalated 3); oltre-cap downgrade a hidden senza leak', () => {
   withFlag('true', () => {
     const s = fakeSession();
     s.roundState.pending_intents = [1, 2, 3, 4, 5].map((i) => ({
@@ -85,21 +130,43 @@ test('ON: cap presentazione = tier (Escalated 3), attack prioritari', () => {
       })),
       { id: 'p1', controlled_by: 'player', hp: 9, position: { x: 5, y: 5 } },
     ];
-    assert.equal(buildThreatPreview(s).length, 3);
+    const rows = buildThreatPreview(s);
+    const threats = rows.filter((r) => !isHidden(r));
+    assert.equal(threats.length, 3, 'cap tier Escalated = 3 righe threat');
+    const hidden = rows.filter(isHidden);
+    assert.equal(hidden.length, 2, 'attack oltre-cap presenti come hidden, non droppati');
+    // Leak check: erano attack con target_id p1 -- il downgrade li azzera.
+    for (const row of hidden) assertMasked(row);
   });
 });
 
-test('ON: retreat mai telegrafato anche in zona', () => {
+test('ON: retreat mai telegrafato -> riga hidden mascherata', () => {
   withFlag('true', () => {
     const s = fakeSession();
     s.roundState.pending_intents = [
       { unit_id: 's1', action: { type: 'retreat', move_to: { x: 8, y: 8 } } },
     ];
-    assert.equal(buildThreatPreview(s).length, 0);
+    const rows = buildThreatPreview(s);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].actor_id, 's1');
+    assertMasked(rows[0]);
   });
 });
 
-test('ON: attack sopravvive al taglio anche se dichiarato ULTIMO', () => {
+test('ON: unita SIS morta -> nessuna riga (neanche hidden)', () => {
+  withFlag('true', () => {
+    const s = fakeSession();
+    s.units.find((u) => u.id === 's3').hp = 0;
+    const rows = buildThreatPreview(s);
+    assert.deepEqual(
+      rows.map((r) => r.actor_id).sort(),
+      ['s1', 's2'],
+      'dead unit fuori dal preview in ogni forma',
+    );
+  });
+});
+
+test('ON: attack sopravvive al taglio anche se dichiarato ULTIMO; zone-move tagliato -> hidden', () => {
   withFlag('true', () => {
     // 3 zone-entry dichiarate PRIMA + 1 attack dichiarato ULTIMO, cap tier 3
     // (pressure 50, Escalated): senza la sort attack-first la slice(0, 3)
@@ -121,7 +188,11 @@ test('ON: attack sopravvive al taglio anche se dichiarato ULTIMO', () => {
       { unit_id: 's4', action: { type: 'attack', target_id: 'p1' } },
     ];
     const rows = buildThreatPreview(s);
-    assert.equal(rows.length, 3, 'cap tier Escalated = 3');
-    assert.equal(rows[0].intent_type, 'attack', 'attack prioritario sopravvive alla slice');
+    const threats = rows.filter((r) => !isHidden(r));
+    assert.equal(threats.length, 3, 'cap tier Escalated = 3');
+    assert.equal(threats[0].intent_type, 'attack', 'attack prioritario sopravvive alla slice');
+    const hidden = rows.filter(isHidden);
+    assert.equal(hidden.length, 1, 'zone-move tagliato dal cap presente come hidden');
+    assertMasked(hidden[0]);
   });
 });

--- a/tests/ai/threatPreviewThreatsOnly.test.js
+++ b/tests/ai/threatPreviewThreatsOnly.test.js
@@ -108,7 +108,10 @@ test('ON: objective non zone-based -> solo attack threat, resto hidden', () => {
       'niente zona -> solo attack telegrafato',
     );
     assert.deepEqual(
-      rows.filter(isHidden).map((r) => r.actor_id).sort(),
+      rows
+        .filter(isHidden)
+        .map((r) => r.actor_id)
+        .sort(),
       ['s2', 's3'],
     );
   });


### PR DESCRIPTION
## Contesto

Codex P2 su PR merged #3258 (thread su `apps/backend/services/ai/threatPreview.js:117`): con `SISTEMA_TELEGRAPH_THREATS_ONLY=true` il filtro faceva `continue` sulle intents non-threat e la riga spariva da `threat_preview`. Il consumer legacy (`apps/play`, archiviato ma di riferimento) tratta la riga assente di un'unita' Sistema viva come fallback attacco (`Intento: attacco` + icona fist) -- il telegraph mentiva proprio nel caso che il flag vuole nascondere. Pre-condizione (1) del flip (ADR-2026-07-10-sistema-action-symmetry).

## Contratto deciso: marker esplicito

Sotto threats-only **ogni unita' SIS viva con intent pendente ha SEMPRE una riga**:
- intent non-threat o tagliato dal cap -> riga mascherata `intent_type: "hidden"` (icon `?`, `target_id` null, `threat_tiles` [], `expected_damage`/`hit_pct` null);
- riga assente = solo "preview non disponibile" (pre-declare / legacy flow), mai "intent filtrato";
- il downgrade oltre-cap RICOSTRUISCE la riga da zero (mascherare una riga attack esistente conserverebbe `expected_damage` = leak);
- il cap resta il tetto delle sole minacce telegrafate; flag OFF byte-identical.

Scelto vs "assenza = nessun telegraph" perche': (a) il fallback legacy scatta proprio su riga assente; (b) payload self-describing per il futuro consumer Godot; (c) pattern StS gia' nel codebase (icona intent sempre presente, `?` = ignoto).

## Verifica frontend canonico Godot (punto 2 del task)

`Game-Godot-v2` oggi NON consuma `threat_preview` backend: `scripts/ai/threat_preview.gd` e' un port locale **senza consumer surface** (deferred-roadmap.md: "ThreatPreview -- no consumer surface") e `sistema_api.gd` non chiama `begin-planning`. Nessun fallback-attacco lato Godot. Contratto documentato nell'addendum ADR per il wiring futuro.

## Modifiche

- `threatPreview.js`: righe `hidden` per non-threat + oltre-cap; contratto nel header.
- `tests/ai/threatPreviewThreatsOnly.test.js`: 8 test (17/17 verdi con `threatPreview.test.js`), incluso leak-check sul downgrade e dead-unit.
- `apps/play/src/main.js`: labelMap `hidden: 'nascosto'` (reference consumer).
- ADR symmetry: addendum contratto pre-flip.

## Test

```
node --test tests/ai/threatPreviewThreatsOnly.test.js tests/ai/threatPreview.test.js
# tests 17 / pass 17 / fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)