### PR TITLE
docs(balance): promote flag-ON bands -- fourth grid_sized ratify at flip

### DIFF
--- a/docs/core/15-LEVEL_DESIGN.md
+++ b/docs/core/15-LEVEL_DESIGN.md
@@ -129,22 +129,23 @@ NON si trasferisce a una nuova taglia (la geometria muove la difficolta' reale).
 advisory: `tools/js/validate_encounter_grid_ratify.js` + baseline `data/core/balance/grid_ratify_baseline.json`.
 Aggiorna il baseline (grid_size + evidence_ref) solo dopo l'evidence N=40.
 
-**Bande pace RATIFICATE N=40 -- board grid_sized (terza ratifica 2026-07-10 sera,
-post-fix stepTowards #3253).** Semantica banda = completion + pace +
-reinforcement-liveness. Nota storica sulla letalita': il "ceiling strutturale WR 1.0"
-delle ratifiche precedenti era il comportamento del Sistema (ritirate utility + cap
-globale + clamp stepTowards), NON un limite del driver -- coi flag simmetria (arm
-gate+AP, misurato N=40, flag OFF in prod) il driver produce sconfitte del party
-(dorsale WR 0.925, CI95 [0.801, 0.974]; evidence nel doc sotto). Le bande QUI restano
-flag-OFF = semantica prod corrente (`MOVE_TERRAIN_COST_ENABLED=true` + stepTowards con
-bounds reali #3253). L-069: NON trasferiscono fra semantiche (il fix stepTowards ha
-mosso il pace dorsale 14.1 -> 18.8: movimento reale al posto del teleport-clamp).
+**Bande pace RATIFICATE N=40 -- board grid_sized (quarta ratifica 2026-07-10 sera,
+FLAG-ON = prod dal flip ADR-2026-07-10 sistema-action-symmetry).** Semantica banda =
+completion + pace + reinforcement-liveness. Con i flag simmetria attivi la completion
+NON e' piu' WR 1.0 strutturale: le sconfitte del party sono parte della semantica
+ratificata (dorsale WR 0.925 CI95 [0.801, 0.974], abisso 0.975, canyon 1.0 -- N=40
+arm gate+AP). Bande derivate dall'arm gateap-stepfix N=40 e verificate pre-flip sul
+main post-#3264: probe N=10 paired (seeds 1..10) bit-exact 30/30 vs il control,
+incluse le 2 sconfitte dorsale -- telegraph threats-only confermato presentation-only.
+Storia flag-OFF (terza ratifica: bande [14,25]/[15,21]/[13,21], WR 1.0, avg
+18.82/17.45/16.05) = semantica pre-flip, evidence nel doc factorial sez. 2.
+L-069: le bande NON trasferiscono fra semantiche.
 
-| Board                        | Encounter esemplare (`docs/planning/encounters/`) | Banda pace (avg_rounds) | N=40 misurato (stepfix 07-10 sera)     | Evidence                                                 |
-| ---------------------------- | ------------------------------------------------- | ----------------------- | -------------------------------------- | --------------------------------------------------------- |
-| 16x12                        | `enc_badlands_dorsale_ferrosa_01`                 | [14, 25]                | avg 18.82 (sd 2.07), WR 1.0, reinf 4/4 | `docs/research/2026-07-10-sistema-symmetry-factorial.md` |
-| 20x12 (cap larghezza schema) | `enc_badlands_canyon_lungo_01`                    | [15, 21]                | avg 17.45 (sd 1.08), WR 1.0, reinf 4/4 | `docs/research/2026-07-10-sistema-symmetry-factorial.md` |
-| 18x10                        | `enc_abisso_colata_basaltica_01`                  | [13, 21]                | avg 16.05 (sd 1.50), WR 1.0, reinf 4/4 | `docs/research/2026-07-10-sistema-symmetry-factorial.md` |
+| Board                        | Encounter esemplare (`docs/planning/encounters/`) | Banda pace (avg_rounds) | N=40 misurato (gateap stepfix)                     | Evidence                                                 |
+| ---------------------------- | ------------------------------------------------- | ----------------------- | -------------------------------------------------- | -------------------------------------------------------- |
+| 16x12                        | `enc_badlands_dorsale_ferrosa_01`                 | [11, 23]                | avg 16.73 (sd 2.61), WR 0.925, ko 0.275, reinf 4/4 | `docs/research/2026-07-10-sistema-symmetry-factorial.md` |
+| 20x12 (cap larghezza schema) | `enc_badlands_canyon_lungo_01`                    | [13, 20]                | avg 16.07 (sd 1.58), WR 1.0, ko 0.113, reinf 4/4   | `docs/research/2026-07-10-sistema-symmetry-factorial.md` |
+| 18x10                        | `enc_abisso_colata_basaltica_01`                  | [12, 25]                | avg 14.95 (sd 2.33), WR 0.975, ko 0.175, reinf 4/4 | `docs/research/2026-07-10-sistema-symmetry-factorial.md` |
 
 Probe generico riusabile: `tools/sim/grid-band-probe.js --encounter <id>` (#3230).
 

--- a/docs/research/2026-07-10-sistema-symmetry-factorial.md
+++ b/docs/research/2026-07-10-sistema-symmetry-factorial.md
@@ -146,3 +146,28 @@ seed di grid-band-probe EFFETTIVI (riproduzione deterministica in un run indipen
 post-merge, stessa toolchain Node v24.11.0; il full-loop driver resta unseeded).
 Output: `reports/sim/*-n10-postmerge-0710/` | log
 `Extras/ollama-runs/2026-07-10-grid-band-reprobe-postmerge.log` (cdd).
+
+## Addendum 2 -- 2026-07-10 sera: FLIP eseguito, bande flag-ON promosse
+
+- **Pre-flip probe flag-ON** (main `d9fd2f0ca` post-#3264, env gate+AP+telegraph ON):
+  N=10 paired (seeds 1..10) vs `reports/sim/*-n40-gateap-stepfix` = **bit-exact 30/30**
+  (incluse le 2 sconfitte dorsale seed 5 e 10, kos 4/4). Doppia conferma: il contratto
+  hidden-row (#3264) e' presentation-only, e le misure N=40 gateap descrivono ESATTAMENTE
+  il comportamento prod flag-ON. Evidence: `reports/sim/*-n10-flagon-preflip-0710/` |
+  log `Extras/ollama-runs/2026-07-10-flagon-preflip-probe.log` (cdd).
+- **FLIP eseguito** (owner-authorized in-session, da Ryzen via SSH): checkout prod
+  Lenovo `_gamewt-lenovo-host` `dc0de487` -> `d9fd2f0ca` (nessun delta lockfile o
+  migrazioni sui 141 file); keys.env + `SISTEMA_RETREAT_GATE_ENABLED=true` +
+  `SISTEMA_PER_UNIT_AP_ENABLED=true` + `SISTEMA_TELEGRAPH_THREATS_ONLY=true`;
+  restart task (pid nuovo, `/api/health` ok, boot log pulito). Rollback: flag via
+  da keys.env (+ eventuale `git checkout --detach dc0de487`) + restart.
+- **Bande flag-ON promosse** in `docs/core/15-LEVEL_DESIGN.md` (quarta ratifica,
+  min-1/max+1 su N=40 gateap): dorsale [11,23], canyon [13,20], abisso [12,25].
+  Completion: sconfitte by-design (dorsale WR 0.925 CI95 [0.801,0.974]).
+- **xpBudget `action_economy`**: decisione owner = DEFER (warn /start accettato;
+  neutralizzazione in PR dedicato quando esistono misure in banda, come da sez. 7).
+- **D2 widening 1.2x** (deciso nell'ADR): implementazione nel gate PENDENTE -- il
+  threshold a `declareSistemaIntents.js` non applica il fattore che il legacy ha in
+  `policy.js` (`LOW_HP_RETREAT_THRESHOLD * 1.2` sotto persistent-threat). Non blocca
+  ne' flip ne' bande (nessun encounter di misura ha `persistent_high_threat`);
+  follow-up TDD dedicato.

--- a/reports/sim/abisso-colata-n10-flagon-preflip-0710/runs.jsonl
+++ b/reports/sim/abisso-colata-n10-flagon-preflip-0710/runs.jsonl
@@ -1,0 +1,10 @@
+{"seed":1,"outcome":"victory","rounds":13,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":2,"outcome":"victory","rounds":16,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":3,"outcome":"victory","rounds":14,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":4,"outcome":"victory","rounds":13,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":5,"outcome":"victory","rounds":15,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":6,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":7,"outcome":"victory","rounds":16,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":8,"outcome":"victory","rounds":15,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":9,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":10,"outcome":"victory","rounds":20,"kos":1,"rosterN":4,"reinforcements":4}

--- a/reports/sim/abisso-colata-n10-flagon-preflip-0710/summary.json
+++ b/reports/sim/abisso-colata-n10-flagon-preflip-0710/summary.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "enc_abisso_colata_basaltica_01",
+  "grid": "18x10 (board_scale=grid_sized)",
+  "party_source": "enc_badlands_pilot_01",
+  "pressure_start": 50,
+  "scaling": {
+    "hpAdd": 0,
+    "modAdd": 0,
+    "dcAdd": 0,
+    "countMult": 1,
+    "rangeAdd": 0
+  },
+  "objective": "elimination",
+  "band_semantics": "completion+pace+liveness (L-069)",
+  "wiring_proof": {
+    "grid_width": 18,
+    "grid_height": 10,
+    "terrain_features": 26,
+    "combat_los_enabled_env": "(unset -> default ON #3226)"
+  },
+  "N": 10,
+  "wins": 10,
+  "defeats": 0,
+  "timeouts": 0,
+  "win_rate": 1,
+  "wr_ci95_wilson": [
+    0.722,
+    1
+  ],
+  "creature_ko_rate": 0.175,
+  "avg_rounds": 15,
+  "rounds_sd": 2.05,
+  "rounds_min": 13,
+  "rounds_max": 20,
+  "avg_reinforcements": 4,
+  "node": "v24.11.0"
+}

--- a/reports/sim/canyon-lungo-n10-flagon-preflip-0710/runs.jsonl
+++ b/reports/sim/canyon-lungo-n10-flagon-preflip-0710/runs.jsonl
@@ -1,0 +1,10 @@
+{"seed":1,"outcome":"victory","rounds":15,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":2,"outcome":"victory","rounds":16,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":3,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":4,"outcome":"victory","rounds":18,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":5,"outcome":"victory","rounds":15,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":6,"outcome":"victory","rounds":14,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":7,"outcome":"victory","rounds":15,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":8,"outcome":"victory","rounds":14,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":9,"outcome":"victory","rounds":16,"kos":0,"rosterN":4,"reinforcements":4}
+{"seed":10,"outcome":"victory","rounds":19,"kos":1,"rosterN":4,"reinforcements":4}

--- a/reports/sim/canyon-lungo-n10-flagon-preflip-0710/summary.json
+++ b/reports/sim/canyon-lungo-n10-flagon-preflip-0710/summary.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "enc_badlands_canyon_lungo_01",
+  "grid": "20x12 (board_scale=grid_sized)",
+  "party_source": "enc_badlands_pilot_01",
+  "pressure_start": 50,
+  "scaling": {
+    "hpAdd": 0,
+    "modAdd": 0,
+    "dcAdd": 0,
+    "countMult": 1,
+    "rangeAdd": 0
+  },
+  "objective": "elimination",
+  "band_semantics": "completion+pace+liveness (L-069)",
+  "wiring_proof": {
+    "grid_width": 20,
+    "grid_height": 12,
+    "terrain_features": 34,
+    "combat_los_enabled_env": "(unset -> default ON #3226)"
+  },
+  "N": 10,
+  "wins": 10,
+  "defeats": 0,
+  "timeouts": 0,
+  "win_rate": 1,
+  "wr_ci95_wilson": [
+    0.722,
+    1
+  ],
+  "creature_ko_rate": 0.1,
+  "avg_rounds": 15.6,
+  "rounds_sd": 1.71,
+  "rounds_min": 14,
+  "rounds_max": 19,
+  "avg_reinforcements": 4,
+  "node": "v24.11.0"
+}

--- a/reports/sim/dorsale-ferrosa-n10-flagon-preflip-0710/runs.jsonl
+++ b/reports/sim/dorsale-ferrosa-n10-flagon-preflip-0710/runs.jsonl
@@ -1,0 +1,10 @@
+{"seed":1,"outcome":"victory","rounds":19,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":2,"outcome":"victory","rounds":13,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":3,"outcome":"victory","rounds":13,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":4,"outcome":"victory","rounds":16,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":5,"outcome":"defeat","rounds":22,"kos":4,"rosterN":4,"reinforcements":4}
+{"seed":6,"outcome":"victory","rounds":19,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":7,"outcome":"victory","rounds":18,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":8,"outcome":"victory","rounds":14,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":9,"outcome":"victory","rounds":18,"kos":1,"rosterN":4,"reinforcements":4}
+{"seed":10,"outcome":"defeat","rounds":15,"kos":4,"rosterN":4,"reinforcements":4}

--- a/reports/sim/dorsale-ferrosa-n10-flagon-preflip-0710/summary.json
+++ b/reports/sim/dorsale-ferrosa-n10-flagon-preflip-0710/summary.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "enc_badlands_dorsale_ferrosa_01",
+  "grid": "16x12 (board_scale=grid_sized)",
+  "party_source": "enc_badlands_pilot_01",
+  "pressure_start": 50,
+  "scaling": {
+    "hpAdd": 0,
+    "modAdd": 0,
+    "dcAdd": 0,
+    "countMult": 1,
+    "rangeAdd": 0
+  },
+  "objective": "elimination",
+  "band_semantics": "completion+pace+liveness (L-069)",
+  "wiring_proof": {
+    "grid_width": 16,
+    "grid_height": 12,
+    "terrain_features": 36,
+    "combat_los_enabled_env": "(unset -> default ON #3226)"
+  },
+  "N": 10,
+  "wins": 8,
+  "defeats": 2,
+  "timeouts": 0,
+  "win_rate": 0.8,
+  "wr_ci95_wilson": [
+    0.49,
+    0.943
+  ],
+  "creature_ko_rate": 0.4,
+  "avg_rounds": 16.7,
+  "rounds_sd": 2.98,
+  "rounds_min": 13,
+  "rounds_max": 22,
+  "avg_reinforcements": 4,
+  "node": "v24.11.0"
+}


### PR DESCRIPTION
## Cosa

Quarta ratifica bande grid_sized: promozione delle misure N=40 arm gate+AP a bande FLAG-ON (= semantica prod dal flip ADR-2026-07-10).

## Evidence

- Pre-flip probe su main post-#3264 (env gate+AP+telegraph ON): N=10 paired seeds 1..10 **bit-exact 30/30** vs `reports/sim/*-n40-gateap-stepfix` (incluse le 2 sconfitte dorsale seed 5/10) -> telegraph presentation-only confermato, le misure N=40 gateap = comportamento prod. Evidence committata: `reports/sim/*-n10-flagon-preflip-0710/`.
- Bande (min-1/max+1 su N=40): dorsale [11,23], canyon [13,20], abisso [12,25]. Completion: sconfitte by-design (dorsale WR 0.925 CI95 [0.801,0.974]).
- Addendum 2 nel doc factorial: record del flip (checkout prod dc0de487 -> d9fd2f0ca + 3 flag keys.env + restart verificato), decisioni owner (xpBudget DEFER; D2 gate widening = follow-up TDD).

Nessun cambio runtime in questa PR (docs + evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)