### PR TITLE
fix(ai): widen Sistema retreat gate 1.2x under M1 persistent threat (ADR-2026-07-10 D2)

### DIFF
--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -569,7 +569,13 @@ function createDeclareSistemaIntents(deps) {
           // scoring (utilityBrain PERSISTENT_THREAT_RETREAT_BONUS) puo' vincere.
           // Deterministico; nessun encounter di misura ha persistent_high_threat ->
           // bande flag-ON invariate.
-          if (threatCtx && threatCtx.persistent_high_threat) {
+          // Precedenza legacy: l'escalation passive/critical forza engage/all-in
+          // (REGOLA_004_THREAT) PRIMA della soglia, quindi il widening NON scatta
+          // sotto escalation attiva (invariante pinnato in sistemaDefendBias.test.js).
+          const escalationAllIn =
+            threatCtx &&
+            (threatCtx.escalation_tier === 'passive' || threatCtx.escalation_tier === 'critical');
+          if (threatCtx && threatCtx.persistent_high_threat && !escalationAllIn) {
             threshold *= 1.2;
           }
           const hpRatio =

--- a/apps/backend/services/ai/declareSistemaIntents.js
+++ b/apps/backend/services/ai/declareSistemaIntents.js
@@ -559,9 +559,19 @@ function createDeclareSistemaIntents(deps) {
               ? aiProfiles.profiles[actor.ai_profile]
               : null;
           const gateOverrides = (gateProf && gateProf.overrides) || {};
-          const threshold = Number(
+          let threshold = Number(
             gateOverrides.retreat_hp_pct ?? retreatGateBaseCfg.LOW_HP_RETREAT_THRESHOLD,
           );
+          // D2 (ADR-2026-07-10) -- M1 persistent-threat widening. Mirror del path
+          // legacy (policy.js REGOLA_002: LOW_HP_RETREAT_THRESHOLD * 1.2): quando un
+          // PG persistent-high-threat e' sul campo, la soglia di ritirata si allarga
+          // del 20% cosi' la ritirata resta legale a HP piu' alti e l'overlay di
+          // scoring (utilityBrain PERSISTENT_THREAT_RETREAT_BONUS) puo' vincere.
+          // Deterministico; nessun encounter di misura ha persistent_high_threat ->
+          // bande flag-ON invariate.
+          if (threatCtx && threatCtx.persistent_high_threat) {
+            threshold *= 1.2;
+          }
           const hpRatio =
             Number(actor.max_hp) > 0 ? Number(actor.hp || 0) / Number(actor.max_hp) : 1;
           retreatGated = hpRatio > threshold;

--- a/tests/ai/sistemaRetreatGate.test.js
+++ b/tests/ai/sistemaRetreatGate.test.js
@@ -140,3 +140,104 @@ test('gate OFF: determinismo baseline (flag unset)', () => {
   const off2 = withFlag(undefined, () => declareFor(woundedSession()));
   assert.deepEqual(off1.decisions, off2.decisions, 'determinismo baseline');
 });
+
+// ---------------------------------------------------------------------------
+// D2 (ADR-2026-07-10) -- M1 persistent-threat widening. Il path legacy allarga la
+// soglia di ritirata a 1.2x quando c'e' un PG persistent-high-threat sul campo
+// (policy.js REGOLA_002: LOW_HP_RETREAT_THRESHOLD * 1.2). Il gate utility deve
+// fare lo stesso: nella banda (soglia, soglia*1.2] la ritirata torna legale e
+// l'overlay PERSISTENT_THREAT_RETREAT_BONUS (utilityBrain) la fa vincere. Senza il
+// fattore la ritirata resta gated e quel bonus di scoring e' dead-code nella banda.
+// ---------------------------------------------------------------------------
+const HIGH_THREAT = { kills_vs_sistema: 3, sightings: 5, threat_level: 'high' };
+const NORMAL_THREAT = { kills_vs_sistema: 1, sightings: 2, threat_level: 'normal' };
+
+// declareFor con computeThreatIndex iniettato: senza un threatCtx non-null
+// declareSistemaIntents non calcola persistent_high_threat (resterebbe assente) e
+// il widening non potrebbe mai scattare. L'oggetto tornato e' indifferente --
+// declareSistemaIntents vi scrive persistent_high_threat = computePersistentHighThreat(session).
+function declareWithThreat(session) {
+  const declare = createDeclareSistemaIntents({
+    pickLowestHpEnemy,
+    stepTowards,
+    manhattanDistance: manhattan,
+    gridSize: 16,
+    aiProfiles: {
+      profiles: {
+        aggressive: { use_utility_brain: true, overrides: { retreat_hp_pct: 0.15 } },
+      },
+    },
+    computeThreatIndex: () => ({}),
+  });
+  return declare(session);
+}
+
+// SIS ferita a hpRatio 0.16 -- DENTRO la banda (0.15, 0.18]: gated senza widening,
+// libera con widening. playerThreat pilota computePersistentHighThreat (high -> true).
+function bandSession(playerThreat) {
+  return {
+    units: [
+      {
+        id: 'sis_w',
+        controlled_by: 'sistema',
+        hp: 16,
+        max_hp: 100,
+        ap: 2,
+        ap_max: 2,
+        mod: 2,
+        dc: 12,
+        attack_range: 1,
+        initiative: 10,
+        position: { x: 10, y: 5 },
+        status: {},
+        ai_profile: 'aggressive',
+        damage: { min: 1, max: 3 },
+      },
+      {
+        id: 'p1',
+        controlled_by: 'player',
+        hp: 12,
+        max_hp: 12,
+        ap: 2,
+        ap_max: 2,
+        mod: 2,
+        dc: 12,
+        attack_range: 1,
+        initiative: 12,
+        position: { x: 2, y: 5 },
+        status: {},
+      },
+    ],
+    grid: { width: 16, height: 12 },
+    sistema_pressure: 50,
+    sistema_state: { units_observed: { p1: playerThreat } },
+  };
+}
+
+test('gate ON + persistent_high_threat: nella banda (soglia, soglia*1.2] la ritirata NON e gated e vince', () => {
+  withFlag('true', () => {
+    const { decisions } = declareWithThreat(bandSession(HIGH_THREAT));
+    const d = decisions.find((x) => x.unit_id === 'sis_w');
+    assert.ok(d, 'decisione emessa');
+    assert.match(d.rule, /^UTILITY/, `atteso rule utility, avuto ${d.rule}`);
+    assert.equal(
+      d.intent,
+      'retreat',
+      `widening 1.2x: a hpRatio 0.16 sotto persistent threat la ritirata torna legale e vince (avuto ${d.intent})`,
+    );
+  });
+});
+
+test('gate ON senza persistent threat: stesso HP nella banda resta gated', () => {
+  withFlag('true', () => {
+    const { decisions } = declareWithThreat(bandSession(NORMAL_THREAT));
+    const d = decisions.find((x) => x.unit_id === 'sis_w');
+    assert.ok(d, 'decisione emessa');
+    assert.match(d.rule, /^UTILITY/, `atteso rule utility, avuto ${d.rule}`);
+    assert.notEqual(
+      d.intent,
+      'retreat',
+      `senza persistent threat la soglia resta 0.15: a hpRatio 0.16 la ritirata e gated (avuto ${d.intent})`,
+    );
+  });
+});

--- a/tests/ai/sistemaRetreatGate.test.js
+++ b/tests/ai/sistemaRetreatGate.test.js
@@ -156,7 +156,7 @@ const NORMAL_THREAT = { kills_vs_sistema: 1, sightings: 2, threat_level: 'normal
 // declareSistemaIntents non calcola persistent_high_threat (resterebbe assente) e
 // il widening non potrebbe mai scattare. L'oggetto tornato e' indifferente --
 // declareSistemaIntents vi scrive persistent_high_threat = computePersistentHighThreat(session).
-function declareWithThreat(session) {
+function declareWithThreat(session, extraThreat = {}) {
   const declare = createDeclareSistemaIntents({
     pickLowestHpEnemy,
     stepTowards,
@@ -167,7 +167,9 @@ function declareWithThreat(session) {
         aggressive: { use_utility_brain: true, overrides: { retreat_hp_pct: 0.15 } },
       },
     },
-    computeThreatIndex: () => ({}),
+    // extraThreat permette di iniettare escalation_tier et al. nel threatCtx
+    // (declareSistemaIntents vi sovrascrive solo persistent_high_threat).
+    computeThreatIndex: () => ({ ...extraThreat }),
   });
   return declare(session);
 }
@@ -238,6 +240,43 @@ test('gate ON senza persistent threat: stesso HP nella banda resta gated', () =>
       d.intent,
       'retreat',
       `senza persistent threat la soglia resta 0.15: a hpRatio 0.16 la ritirata e gated (avuto ${d.intent})`,
+    );
+  });
+});
+
+// Precedenza legacy (policy.js REGOLA_004_THREAT): l'escalation passive/critical
+// forza engage/all-in PRIMA della soglia di ritirata, quindi il widening +20% non
+// deve trasformare quel round in una ritirata (invariante pinnato dal path legacy in
+// sistemaDefendBias.test.js). Il gate deve onorare la stessa precedenza: nella banda
+// (0.15, 0.18] con persistent threat MA escalation attiva la ritirata resta gated.
+test('gate ON + persistent + escalation critical: widening soppresso, retreat resta gated', () => {
+  withFlag('true', () => {
+    const { decisions } = declareWithThreat(bandSession(HIGH_THREAT), {
+      escalation_tier: 'critical',
+    });
+    const d = decisions.find((x) => x.unit_id === 'sis_w');
+    assert.ok(d, 'decisione emessa');
+    assert.match(d.rule, /^UTILITY/, `atteso rule utility, avuto ${d.rule}`);
+    assert.notEqual(
+      d.intent,
+      'retreat',
+      `escalation critical: l'all-in vince sul widening, retreat gated (avuto ${d.intent})`,
+    );
+  });
+});
+
+test('gate ON + persistent + escalation passive: widening soppresso, retreat resta gated', () => {
+  withFlag('true', () => {
+    const { decisions } = declareWithThreat(bandSession(HIGH_THREAT), {
+      escalation_tier: 'passive',
+    });
+    const d = decisions.find((x) => x.unit_id === 'sis_w');
+    assert.ok(d, 'decisione emessa');
+    assert.match(d.rule, /^UTILITY/, `atteso rule utility, avuto ${d.rule}`);
+    assert.notEqual(
+      d.intent,
+      'retreat',
+      `escalation passive: engage forzato, retreat gated (avuto ${d.intent})`,
     );
   });
 });


### PR DESCRIPTION
## Cosa

Implementa **D2** dell'ADR merged `docs/adr/ADR-2026-07-10-sistema-action-symmetry.md`
(checkbox `[x] widening 1.2x`, ratifica owner in-session 2026-07-10): il retreat gate
utility-brain allarga la soglia a **1.2x** sotto M1 `persistent_high_threat`, come il path
rule-based legacy.

## Perche'

`declareSistemaIntents.js` (blocco `retreatGateOn`) risolveva `threshold` direttamente da
`retreat_hp_pct` (override profilo o config base) **senza** il fattore persistent-threat,
mentre il path legacy (`policy.js` REGOLA_002) allarga gia' `LOW_HP_RETREAT_THRESHOLD * 1.2`
quando un PG persistent-high-threat e' sul campo. Nella banda `(threshold, threshold*1.2]`
la ritirata veniva tolta dalle azioni legali **prima** che l'overlay di scoring
`PERSISTENT_THREAT_RETREAT_BONUS` (utilityBrain) potesse agire -> quel bonus era dead-code
in quella banda. Asimmetria fra i due cervelli sullo stesso profilo.

## Fix

Widening del `threshold` risolto x1.2 quando `threatCtx.persistent_high_threat`, mirror del
contratto legacy. La ritirata resta legale a HP piu' alti e lo scoring overlay puo' vincere.
Deterministico.

## TDD

- **RED**: `gate ON + persistent_high_threat: nella banda la ritirata NON e gated e vince`
  falliva (`intent=approach`, retreat gated a hpRatio 0.16 con soglia 0.15).
- **Controllo (verde prima e dopo)**: `gate ON senza persistent threat: stesso HP resta gated`
  -- previene un fix che allarga incondizionatamente.
- **GREEN**: 7/7 `sistemaRetreatGate.test.js`; full suite `tests/ai/*.test.js` = **614 pass / 0 fail**
  (inclusi i test persistent-threat e utility scoring esistenti).

## Impatto bande

Nessun encounter di misura ha `persistent_high_threat` (cfr. ADR D2 + addendum 2 di
`docs/research/2026-07-10-sistema-symmetry-factorial.md`): le **bande pace flag-ON (#3265)
non sono impattate**. Widening OFF-path invariato (flag `SISTEMA_RETREAT_GATE_ENABLED`
default OFF -> byte-identical).

## Ref

- ADR-2026-07-10 D2 (widening 1.2x)
- Follow-up flaggato in `docs/research/2026-07-10-sistema-symmetry-factorial.md` (addendum 2)
- Arco: #3251 apLedger, #3254 flag, #3258 telegraph, #3264 telegraph-contract, #3265 bands