### PR TITLE
chore(traits): refresh trait completion dashboard (J2, 251->308)

### DIFF
--- a/logs/trait_audit/trait_progress_history.json
+++ b/logs/trait_audit/trait_progress_history.json
@@ -62,6 +62,16 @@
   {
     "timestamp": "2025-12-02T02:04:09.412975+00:00",
     "metrics": {
+      "completion_flags": {
+        "total_traits": 251,
+        "traits_with_value": 201,
+        "percent": 80.0796812749004
+      },
+      "data_origin": {
+        "total_traits": 251,
+        "traits_with_value": 251,
+        "percent": 100.0
+      },
       "species_affinity": {
         "total_traits": 251,
         "traits_with_value": 8,
@@ -76,15 +86,35 @@
         "total_traits": 251,
         "traits_with_value": 225,
         "percent": 89.64143426294821
+      }
+    }
+  },
+  {
+    "timestamp": "2026-07-14T00:15:32.655701+00:00",
+    "metrics": {
+      "species_affinity": {
+        "total_traits": 308,
+        "traits_with_value": 200,
+        "percent": 64.93506493506493
+      },
+      "biome_tags": {
+        "total_traits": 308,
+        "traits_with_value": 175,
+        "percent": 56.81818181818182
+      },
+      "usage_tags": {
+        "total_traits": 308,
+        "traits_with_value": 227,
+        "percent": 73.7012987012987
       },
       "completion_flags": {
-        "total_traits": 251,
-        "traits_with_value": 201,
-        "percent": 80.0796812749004
+        "total_traits": 308,
+        "traits_with_value": 257,
+        "percent": 83.44155844155844
       },
       "data_origin": {
-        "total_traits": 251,
-        "traits_with_value": 251,
+        "total_traits": 308,
+        "traits_with_value": 308,
         "percent": 100.0
       }
     }

--- a/reports/trait_progress.md
+++ b/reports/trait_progress.md
@@ -1,33 +1,23 @@
----
-title: Trait Completion Dashboard
-doc_status: generated
-doc_owner: platform-docs
-workstream: cross-cutting
-last_verified: 2026-05-06
-source_of_truth: false
-language: it-en
-review_cycle_days: 14
----
 # Trait Completion Dashboard
 
-_Aggiornato al 2025-12-02 02:04 UTC, totale tratti: 251_
+_Aggiornato al 2026-07-14 00:15 UTC, totale tratti: 308_
 
 ## KPI principali
 
 | Indicatore | Tratti con dato | Totale | Copertura |
 | --- | ---: | ---: | --- |
-| Specie collegate | 8 | 251 | 3.2% |
-| Tag bioma | 174 | 251 | 69.3% |
-| Tag d'uso | 225 | 251 | 89.6% |
-| Flag completamento | 201 | 251 | 80.1% |
-| Origine dati | 251 | 251 | 100.0% |
+| Specie collegate | 200 | 308 | 64.9% |
+| Tag bioma | 175 | 308 | 56.8% |
+| Tag d'uso | 227 | 308 | 73.7% |
+| Flag completamento | 257 | 308 | 83.4% |
+| Origine dati | 308 | 308 | 100.0% |
 
 ### Gap principali
 
-- **Specie collegate**: 243 tratti senza dato → `ali_fulminee, ali_ioniche, ali_membrana_sonica, antenne_dustsense, antenne_eco_turbina` … (+238 altri)
-- **Tag bioma**: 77 tratti senza dato → `ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto` … (+72 altri)
-- **Tag d'uso**: 26 tratti senza dato → `bioantenne_gravitiche, camere_risonanza_abyssal, canto_risonante, coralli_sinaptici_fotofase, corazze_ferro_magnetico` … (+21 altri)
-- **Flag completamento**: 50 tratti senza dato → `ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto` … (+45 altri)
+- **Specie collegate**: 108 tratti senza dato → `arco_voltaico, articolazioni_multiassiali, artigli_ipo_termici, artigli_sette_vie_2, artiglio_cinetico_a_urto` … (+103 altri)
+- **Tag bioma**: 133 tratti senza dato → `aculei_velenosi, adattamento_volo, ali_fono_risonanti, arco_voltaico, articolazioni_a_leva_idraulica` … (+128 altri)
+- **Tag d'uso**: 81 tratti senza dato → `aculei_velenosi, adattamento_volo, arco_voltaico, artigli_psionici, artigli_sette_vie_2` … (+76 altri)
+- **Flag completamento**: 51 tratti senza dato → `ali_fono_risonanti, articolazioni_a_leva_idraulica, articolazioni_multiassiali, artigli_ipo_termici, artiglio_cinetico_a_urto` … (+46 altri)
 - **Origine dati**: copertura completa ✅
 
 ## Trend storico
@@ -37,6 +27,7 @@ _Aggiornato al 2025-12-02 02:04 UTC, totale tratti: 251_
 | 2025-11-01 | 99.4% | 0.6% | 0.6% | 0.6% | 0.6% |
 | 2025-11-03 | 100.0% | 0.6% | 100.0% | 100.0% | 100.0% |
 | 2025-12-02 | 3.2% | 69.3% | 89.6% | 80.1% | 100.0% |
+| 2026-07-14 | 64.9% | 56.8% | 73.7% | 83.4% | 100.0% |
 
 ## Interpretazione
 


### PR DESCRIPTION
## What (J2 -- trait-hygiene batch)
Regenerate `reports/trait_progress.md` via `tools/py/trait_completion_dashboard.py`. The committed dashboard was stale: `last_verified 2026-05-06`, snapshot **251** traits; now **308** post-dedup. Species-affinity coverage jumped 3.2% -> 64.9% (real data, was a stale snapshot).

## Scope
Only the dashboard + its history file. `index.csv`, `data/derived/analysis/*`, and QA baselines were already refreshed on main (shipped in J3 #3278); `check_derived_reproducible.py --deep` = OK.

Draft -- merge = master-dd.