### PR TITLE
feat(traits): author all 46 design-stubs (R1 complete)

### DIFF
--- a/data/traits/cognitivo/artigli_psionici.json
+++ b/data/traits/cognitivo/artigli_psionici.json
@@ -10,13 +10,16 @@
     "complementare": "cognizione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "corna_psico_conduttive",
+    "cervello_a_bassa_latenza"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.artigli_psionici.mutazione_indotta",
   "uso_funzione": "i18n:traits.artigli_psionici.uso_funzione",
   "spinta_selettiva": "i18n:traits.artigli_psionici.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/cognitivo/cervello_predittivo.json
+++ b/data/traits/cognitivo/cervello_predittivo.json
@@ -10,13 +10,16 @@
     "complementare": "cognizione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "cervello_a_bassa_latenza",
+    "corna_psico_conduttive"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.cervello_predittivo.mutazione_indotta",
   "uso_funzione": "i18n:traits.cervello_predittivo.uso_funzione",
   "spinta_selettiva": "i18n:traits.cervello_predittivo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/cognitivo/mente_lucida.json
+++ b/data/traits/cognitivo/mente_lucida.json
@@ -10,13 +10,16 @@
     "complementare": "cognizione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "sonno_emisferico_alternato",
+    "coscienza_d_alveare_diffusa"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.mente_lucida.mutazione_indotta",
   "uso_funzione": "i18n:traits.mente_lucida.uso_funzione",
   "spinta_selettiva": "i18n:traits.mente_lucida.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/difensivo/corteccia_memetica.json
+++ b/data/traits/difensivo/corteccia_memetica.json
@@ -10,13 +10,15 @@
     "complementare": "protezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "campo_di_interferenza_acustica"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.corteccia_memetica.mutazione_indotta",
   "uso_funzione": "i18n:traits.corteccia_memetica.uso_funzione",
   "spinta_selettiva": "i18n:traits.corteccia_memetica.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/difensivo/pelli_cave.json
+++ b/data/traits/difensivo/pelli_cave.json
@@ -10,13 +10,15 @@
     "complementare": "protezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "cute_resistente_sali"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pelli_cave.mutazione_indotta",
   "uso_funzione": "i18n:traits.pelli_cave.uso_funzione",
   "spinta_selettiva": "i18n:traits.pelli_cave.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/difensivo/radici_ancora_planare.json
+++ b/data/traits/difensivo/radici_ancora_planare.json
@@ -10,13 +10,15 @@
     "complementare": "protezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "armatura_pietra_planare"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.radici_ancora_planare.mutazione_indotta",
   "uso_funzione": "i18n:traits.radici_ancora_planare.uso_funzione",
   "spinta_selettiva": "i18n:traits.radici_ancora_planare.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/aculei_velenosi.json
+++ b/data/traits/fisiologico/aculei_velenosi.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "pungiglione_paralizzante"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.aculei_velenosi.mutazione_indotta",
   "uso_funzione": "i18n:traits.aculei_velenosi.uso_funzione",
   "spinta_selettiva": "i18n:traits.aculei_velenosi.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/adattamento_volo.json
+++ b/data/traits/fisiologico/adattamento_volo.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "equilibrio_vestibolare"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.adattamento_volo.mutazione_indotta",
   "uso_funzione": "i18n:traits.adattamento_volo.uso_funzione",
   "spinta_selettiva": "i18n:traits.adattamento_volo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/aura_glaciale.json
+++ b/data/traits/fisiologico/aura_glaciale.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "siero_anti_gelo_naturale"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.aura_glaciale.mutazione_indotta",
   "uso_funzione": "i18n:traits.aura_glaciale.uso_funzione",
   "spinta_selettiva": "i18n:traits.aura_glaciale.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/cuore_in_furia.json
+++ b/data/traits/fisiologico/cuore_in_furia.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ipertrofia_muscolare_massiva"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.cuore_in_furia.mutazione_indotta",
   "uso_funzione": "i18n:traits.cuore_in_furia.uso_funzione",
   "spinta_selettiva": "i18n:traits.cuore_in_furia.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/denti_seghettati.json
+++ b/data/traits/fisiologico/denti_seghettati.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "aculei_velenosi"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.denti_seghettati.mutazione_indotta",
   "uso_funzione": "i18n:traits.denti_seghettati.uso_funzione",
   "spinta_selettiva": "i18n:traits.denti_seghettati.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/filtri_bioattivi.json
+++ b/data/traits/fisiologico/filtri_bioattivi.json
@@ -10,13 +10,16 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "filtrazione_osmotica",
+    "rete_filtro_polmonare"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.filtri_bioattivi.mutazione_indotta",
   "uso_funzione": "i18n:traits.filtri_bioattivi.uso_funzione",
   "spinta_selettiva": "i18n:traits.filtri_bioattivi.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/membrane_osmotiche.json
+++ b/data/traits/fisiologico/membrane_osmotiche.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "filtrazione_osmotica"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.membrane_osmotiche.mutazione_indotta",
   "uso_funzione": "i18n:traits.membrane_osmotiche.uso_funzione",
   "spinta_selettiva": "i18n:traits.membrane_osmotiche.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/pelle_elastomera.json
+++ b/data/traits/fisiologico/pelle_elastomera.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "pelli_fitte"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pelle_elastomera.mutazione_indotta",
   "uso_funzione": "i18n:traits.pelle_elastomera.uso_funzione",
   "spinta_selettiva": "i18n:traits.pelle_elastomera.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/pelli_anti_ustione.json
+++ b/data/traits/fisiologico/pelli_anti_ustione.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ectotermia_dinamica"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pelli_anti_ustione.mutazione_indotta",
   "uso_funzione": "i18n:traits.pelli_anti_ustione.uso_funzione",
   "spinta_selettiva": "i18n:traits.pelli_anti_ustione.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/pelli_fitte.json
+++ b/data/traits/fisiologico/pelli_fitte.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "pelle_elastomera"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pelli_fitte.mutazione_indotta",
   "uso_funzione": "i18n:traits.pelli_fitte.uso_funzione",
   "spinta_selettiva": "i18n:traits.pelli_fitte.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/sensori_sismici.json
+++ b/data/traits/fisiologico/sensori_sismici.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "eco_sismico"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.sensori_sismici.mutazione_indotta",
   "uso_funzione": "i18n:traits.sensori_sismici.uso_funzione",
   "spinta_selettiva": "i18n:traits.sensori_sismici.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/tela_appiccicosa.json
+++ b/data/traits/fisiologico/tela_appiccicosa.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "tentacoli_uncinati"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.tela_appiccicosa.mutazione_indotta",
   "uso_funzione": "i18n:traits.tela_appiccicosa.uso_funzione",
   "spinta_selettiva": "i18n:traits.tela_appiccicosa.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/tentacoli_uncinati.json
+++ b/data/traits/fisiologico/tentacoli_uncinati.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "tela_appiccicosa"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.tentacoli_uncinati.mutazione_indotta",
   "uso_funzione": "i18n:traits.tentacoli_uncinati.uso_funzione",
   "spinta_selettiva": "i18n:traits.tentacoli_uncinati.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/tessuti_adattivi.json
+++ b/data/traits/fisiologico/tessuti_adattivi.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "pelle_elastomera"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.tessuti_adattivi.mutazione_indotta",
   "uso_funzione": "i18n:traits.tessuti_adattivi.uso_funzione",
   "spinta_selettiva": "i18n:traits.tessuti_adattivi.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/fisiologico/zampe_radianti.json
+++ b/data/traits/fisiologico/zampe_radianti.json
@@ -10,13 +10,15 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ectotermia_dinamica"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.zampe_radianti.mutazione_indotta",
   "uso_funzione": "i18n:traits.zampe_radianti.uso_funzione",
   "spinta_selettiva": "i18n:traits.zampe_radianti.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/nervoso/matrice_antimagia.json
+++ b/data/traits/nervoso/matrice_antimagia.json
@@ -10,13 +10,15 @@
     "complementare": "sistema_nervoso"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "coscienza_d_alveare_diffusa"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.matrice_antimagia.mutazione_indotta",
   "uso_funzione": "i18n:traits.matrice_antimagia.uso_funzione",
   "spinta_selettiva": "i18n:traits.matrice_antimagia.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/nervoso/nuclei_di_controllo.json
+++ b/data/traits/nervoso/nuclei_di_controllo.json
@@ -10,13 +10,16 @@
     "complementare": "sistema_nervoso"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "cervello_a_bassa_latenza",
+    "sonno_emisferico_alternato"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.nuclei_di_controllo.mutazione_indotta",
   "uso_funzione": "i18n:traits.nuclei_di_controllo.uso_funzione",
   "spinta_selettiva": "i18n:traits.nuclei_di_controllo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/nervoso/risonanza_magnetica.json
+++ b/data/traits/nervoso/risonanza_magnetica.json
@@ -10,13 +10,16 @@
     "complementare": "sistema_nervoso"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "elettromagnete_biologico",
+    "bozzolo_magnetico"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.risonanza_magnetica.mutazione_indotta",
   "uso_funzione": "i18n:traits.risonanza_magnetica.uso_funzione",
   "spinta_selettiva": "i18n:traits.risonanza_magnetica.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/offensivo/arco_voltaico.json
+++ b/data/traits/offensivo/arco_voltaico.json
@@ -10,13 +10,16 @@
     "complementare": "offesa"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "elettromagnete_biologico",
+    "artigli_induzione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.arco_voltaico.mutazione_indotta",
   "uso_funzione": "i18n:traits.arco_voltaico.uso_funzione",
   "spinta_selettiva": "i18n:traits.arco_voltaico.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/offensivo/martello_osseo.json
+++ b/data/traits/offensivo/martello_osseo.json
@@ -10,13 +10,15 @@
     "complementare": "offesa"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "artiglio_cinetico_a_urto"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.martello_osseo.mutazione_indotta",
   "uso_funzione": "i18n:traits.martello_osseo.uso_funzione",
   "spinta_selettiva": "i18n:traits.martello_osseo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/offensivo/pungiglione_paralizzante.json
+++ b/data/traits/offensivo/pungiglione_paralizzante.json
@@ -10,13 +10,15 @@
     "complementare": "offesa"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "denti_chelatanti"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pungiglione_paralizzante.mutazione_indotta",
   "uso_funzione": "i18n:traits.pungiglione_paralizzante.uso_funzione",
   "spinta_selettiva": "i18n:traits.pungiglione_paralizzante.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/offensivo/scarica_ionica.json
+++ b/data/traits/offensivo/scarica_ionica.json
@@ -10,13 +10,16 @@
     "complementare": "offesa"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "elettromagnete_biologico",
+    "artigli_induzione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.scarica_ionica.mutazione_indotta",
   "uso_funzione": "i18n:traits.scarica_ionica.uso_funzione",
   "spinta_selettiva": "i18n:traits.scarica_ionica.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/eco_sismico.json
+++ b/data/traits/sensoriale/eco_sismico.json
@@ -10,13 +10,16 @@
     "complementare": "risonanza"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ghiandole_eco_mappanti",
+    "echi_risonanti"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.eco_sismico.mutazione_indotta",
   "uso_funzione": "i18n:traits.eco_sismico.uso_funzione",
   "spinta_selettiva": "i18n:traits.eco_sismico.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/equilibrio_vestibolare.json
+++ b/data/traits/sensoriale/equilibrio_vestibolare.json
@@ -10,13 +10,16 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "cervelletto_equilibrio_statico",
+    "propriocezione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.equilibrio_vestibolare.mutazione_indotta",
   "uso_funzione": "i18n:traits.equilibrio_vestibolare.uso_funzione",
   "spinta_selettiva": "i18n:traits.equilibrio_vestibolare.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/nocicezione.json
+++ b/data/traits/sensoriale/nocicezione.json
@@ -10,13 +10,15 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "propriocezione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.nocicezione.mutazione_indotta",
   "uso_funzione": "i18n:traits.nocicezione.uso_funzione",
   "spinta_selettiva": "i18n:traits.nocicezione.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/pigmenti_aurorali.json
+++ b/data/traits/sensoriale/pigmenti_aurorali.json
@@ -10,13 +10,15 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "capillari_fluoridici"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pigmenti_aurorali.mutazione_indotta",
   "uso_funzione": "i18n:traits.pigmenti_aurorali.uso_funzione",
   "spinta_selettiva": "i18n:traits.pigmenti_aurorali.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/propriocezione.json
+++ b/data/traits/sensoriale/propriocezione.json
@@ -10,13 +10,16 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "cervelletto_equilibrio_statico",
+    "equilibrio_vestibolare"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.propriocezione.mutazione_indotta",
   "uso_funzione": "i18n:traits.propriocezione.uso_funzione",
   "spinta_selettiva": "i18n:traits.propriocezione.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/senso_magnetico.json
+++ b/data/traits/sensoriale/senso_magnetico.json
@@ -10,13 +10,16 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "sintonia_magnetica",
+    "antenne_waveguide"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.senso_magnetico.mutazione_indotta",
   "uso_funzione": "i18n:traits.senso_magnetico.uso_funzione",
   "spinta_selettiva": "i18n:traits.senso_magnetico.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/sintonia_magnetica.json
+++ b/data/traits/sensoriale/sintonia_magnetica.json
@@ -10,13 +10,16 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "senso_magnetico",
+    "antenne_plasmatiche_tempesta"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.sintonia_magnetica.mutazione_indotta",
   "uso_funzione": "i18n:traits.sintonia_magnetica.uso_funzione",
   "spinta_selettiva": "i18n:traits.sintonia_magnetica.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/termocezione.json
+++ b/data/traits/sensoriale/termocezione.json
@@ -10,13 +10,15 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "nocicezione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.termocezione.mutazione_indotta",
   "uso_funzione": "i18n:traits.termocezione.uso_funzione",
   "spinta_selettiva": "i18n:traits.termocezione.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/canto_di_richiamo.json
+++ b/data/traits/strategia/canto_di_richiamo.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "legame_di_branco",
+    "voce_imperiosa"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.canto_di_richiamo.mutazione_indotta",
   "uso_funzione": "i18n:traits.canto_di_richiamo.uso_funzione",
   "spinta_selettiva": "i18n:traits.canto_di_richiamo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/ferocia.json
+++ b/data/traits/strategia/ferocia.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "spirito_combattivo",
+    "marchio_predatorio"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.ferocia.mutazione_indotta",
   "uso_funzione": "i18n:traits.ferocia.uso_funzione",
   "spinta_selettiva": "i18n:traits.ferocia.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/intimidatore.json
+++ b/data/traits/strategia/intimidatore.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "voce_imperiosa",
+    "marchio_predatorio"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.intimidatore.mutazione_indotta",
   "uso_funzione": "i18n:traits.intimidatore.uso_funzione",
   "spinta_selettiva": "i18n:traits.intimidatore.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/legame_di_branco.json
+++ b/data/traits/strategia/legame_di_branco.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "coscienza_d_alveare_diffusa",
+    "canto_di_richiamo"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.legame_di_branco.mutazione_indotta",
   "uso_funzione": "i18n:traits.legame_di_branco.uso_funzione",
   "spinta_selettiva": "i18n:traits.legame_di_branco.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/marchio_predatorio.json
+++ b/data/traits/strategia/marchio_predatorio.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ferocia",
+    "intimidatore"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.marchio_predatorio.mutazione_indotta",
   "uso_funzione": "i18n:traits.marchio_predatorio.uso_funzione",
   "spinta_selettiva": "i18n:traits.marchio_predatorio.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/midollo_iperattivo.json
+++ b/data/traits/strategia/midollo_iperattivo.json
@@ -10,13 +10,15 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "focus_frazionato"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.midollo_iperattivo.mutazione_indotta",
   "uso_funzione": "i18n:traits.midollo_iperattivo.uso_funzione",
   "spinta_selettiva": "i18n:traits.midollo_iperattivo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/spirito_combattivo.json
+++ b/data/traits/strategia/spirito_combattivo.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ferocia",
+    "marchio_predatorio"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.spirito_combattivo.mutazione_indotta",
   "uso_funzione": "i18n:traits.spirito_combattivo.uso_funzione",
   "spinta_selettiva": "i18n:traits.spirito_combattivo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/spore_paniche.json
+++ b/data/traits/strategia/spore_paniche.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "sussurro_psichico",
+    "intimidatore"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.spore_paniche.mutazione_indotta",
   "uso_funzione": "i18n:traits.spore_paniche.uso_funzione",
   "spinta_selettiva": "i18n:traits.spore_paniche.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/sussurro_psichico.json
+++ b/data/traits/strategia/sussurro_psichico.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "coscienza_d_alveare_diffusa",
+    "corna_psico_conduttive"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.sussurro_psichico.mutazione_indotta",
   "uso_funzione": "i18n:traits.sussurro_psichico.uso_funzione",
   "spinta_selettiva": "i18n:traits.sussurro_psichico.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/voce_imperiosa.json
+++ b/data/traits/strategia/voce_imperiosa.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "intimidatore",
+    "canto_di_richiamo"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.voce_imperiosa.mutazione_indotta",
   "uso_funzione": "i18n:traits.voce_imperiosa.uso_funzione",
   "spinta_selettiva": "i18n:traits.voce_imperiosa.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -1949,6 +1949,76 @@
       "mutazione_indotta": "Regolazione neurochimica che sopprime rumore ed affaticamento cognitivo.",
       "spinta_selettiva": "Scenari di conflitto prolungato dove il collasso cognitivo e' la vera causa di morte.",
       "uso_funzione": "Mantenimento della decisione ottimale sotto stress o interferenza mentale."
+    },
+    "arco_voltaico": {
+      "description": "Scarica elettrica ad arco proiettata tra appendici conduttive per colpire a distanza ravvicinata.",
+      "label": "Arco Voltaico",
+      "mutazione_indotta": "Organi elettrogeni specializzati che accumulano e scaricano potenziale lungo un arco conduttivo.",
+      "spinta_selettiva": "Prede rapide o sfuggenti dove il contatto diretto e' difficile.",
+      "uso_funzione": "Colpire con una scarica ad arco che salta tra bersagli vicini."
+    },
+    "martello_osseo": {
+      "description": "Escrescenza ossea massiccia usata come arma contundente ad alto impatto.",
+      "label": "Martello Osseo",
+      "mutazione_indotta": "Ispessimento e fusione di segmenti ossei in una massa d'urto compatta.",
+      "spinta_selettiva": "Prede corazzate o riparate dietro strutture dure.",
+      "uso_funzione": "Frantumare corazze e strutture con colpi contundenti."
+    },
+    "pungiglione_paralizzante": {
+      "description": "Aculeo inoculatore che rilascia una neurotossina paralizzante.",
+      "label": "Pungiglione Paralizzante",
+      "mutazione_indotta": "Ghiandole velenifere connesse a un aculeo cavo inoculatore.",
+      "spinta_selettiva": "Prede piu' grandi o veloci da sottomettere senza lotta prolungata.",
+      "uso_funzione": "Immobilizzare la preda con una singola inoculazione mirata."
+    },
+    "scarica_ionica": {
+      "description": "Emissione di un fronte di particelle cariche che disturba tessuti e conduzione nervosa.",
+      "label": "Scarica Ionica",
+      "mutazione_indotta": "Membrane elettrogeniche che ionizzano l'aria o l'acqua circostante.",
+      "spinta_selettiva": "Ambienti conduttivi umidi dove la carica si propaga con efficacia.",
+      "uso_funzione": "Sprigionare una scarica ionizzante ad area ravvicinata."
+    },
+    "corteccia_memetica": {
+      "description": "Strato dermico che archivia e ripropone schemi difensivi appresi da minacce precedenti.",
+      "label": "Corteccia Memetica",
+      "mutazione_indotta": "Reti neurali dermiche capaci di registrare e richiamare pattern di aggressione.",
+      "spinta_selettiva": "Predatori ricorrenti con schemi d'attacco riconoscibili.",
+      "uso_funzione": "Anticipare un attacco gia' subito adattando la risposta difensiva."
+    },
+    "pelli_cave": {
+      "description": "Tegumento a camere cave che assorbe e dissipa gli urti restando leggero.",
+      "label": "Pelli Cave",
+      "mutazione_indotta": "Formazione di camere d'aria stratificate nel derma.",
+      "spinta_selettiva": "Cadute, urti o colpi contundenti frequenti nell'habitat.",
+      "uso_funzione": "Attutire l'impatto distribuendolo nelle camere cave."
+    },
+    "radici_ancora_planare": {
+      "description": "Appendici radicali che ancorano il corpo al substrato resistendo a spostamenti e prese.",
+      "label": "Radici Ancora Planare",
+      "mutazione_indotta": "Estroflessioni radicali capaci di aggrapparsi e fissarsi al terreno.",
+      "spinta_selettiva": "Correnti, venti forti o predatori che afferrano e trascinano.",
+      "uso_funzione": "Resistere a trascinamenti, ribaltamenti e prese avversarie."
+    },
+    "matrice_antimagia": {
+      "description": "Rete neurale che smorza e disperde interferenze mentali ed energetiche esterne.",
+      "label": "Matrice Antimagia",
+      "mutazione_indotta": "Reticolo di fibre isolanti che schermano il sistema nervoso centrale.",
+      "spinta_selettiva": "Ambienti o creature che sfruttano interferenza mentale.",
+      "uso_funzione": "Ridurre l'efficacia di controlli mentali e scariche energetiche."
+    },
+    "nuclei_di_controllo": {
+      "description": "Gangli accessori che coordinano appendici multiple con precisione indipendente.",
+      "label": "Nuclei di Controllo",
+      "mutazione_indotta": "Sviluppo di nuclei nervosi ausiliari distribuiti lungo il corpo.",
+      "spinta_selettiva": "Corpi con molte appendici o manipolatori da gestire in parallelo.",
+      "uso_funzione": "Governare piu' appendici simultaneamente senza perdita di coordinazione."
+    },
+    "risonanza_magnetica": {
+      "description": "Organi che percepiscono e modulano campi magnetici per orientarsi e segnalare.",
+      "label": "Risonanza Magnetica",
+      "mutazione_indotta": "Cristalli biomagnetici accoppiati a terminazioni nervose sensibili.",
+      "spinta_selettiva": "Ambienti con forti gradienti magnetici o scarsa visibilita'.",
+      "uso_funzione": "Rilevare e sfruttare i campi magnetici circostanti."
     }
   }
 }

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -1928,6 +1928,27 @@
       "mutazione_indotta": "Placche cornee cave che emettono onde sismiche ritmiche al contatto con il terreno.",
       "spinta_selettiva": "Mantenere coesione di branchi su grandi distanze e rilevare predatori sotterranei.",
       "uso_funzione": "Propaga segnali ritmici che sincronizzano movimenti e abilità di squadra."
+    },
+    "artigli_psionici": {
+      "description": "Artigli attraversati da un campo psicocinetico, estensione fisica dell'intento predatorio.",
+      "label": "Artigli Psionici",
+      "mutazione_indotta": "Ipertrofia dei fasci neurali motori che estendono un campo psicocinetico lungo gli artigli.",
+      "spinta_selettiva": "Ambienti dove la sola forza fisica dell'artiglio non basta contro prede corazzate.",
+      "uso_funzione": "Manifestazione ravvicinata dell'intento predatorio come estensione fisica della mente."
+    },
+    "cervello_predittivo": {
+      "description": "Cortecce associative espanse che modellano gli esiti probabili prima che accadano.",
+      "label": "Cervello Predittivo",
+      "mutazione_indotta": "Espansione delle cortecce associative che modellano traiettorie probabili prima che accadano.",
+      "spinta_selettiva": "Pressione da prede o predatori rapidi dove reagire non basta e serve prevedere.",
+      "uso_funzione": "Anticipazione del movimento avversario leggendo micro-segnali ambientali."
+    },
+    "mente_lucida": {
+      "description": "Regolazione neurochimica che tiene la cognizione limpida sotto stress e interferenza.",
+      "label": "Mente Lucida",
+      "mutazione_indotta": "Regolazione neurochimica che sopprime rumore ed affaticamento cognitivo.",
+      "spinta_selettiva": "Scenari di conflitto prolungato dove il collasso cognitivo e' la vera causa di morte.",
+      "uso_funzione": "Mantenimento della decisione ottimale sotto stress o interferenza mentale."
     }
   }
 }

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -2019,6 +2019,62 @@
       "mutazione_indotta": "Cristalli biomagnetici accoppiati a terminazioni nervose sensibili.",
       "spinta_selettiva": "Ambienti con forti gradienti magnetici o scarsa visibilita'.",
       "uso_funzione": "Rilevare e sfruttare i campi magnetici circostanti."
+    },
+    "eco_sismico": {
+      "description": "Percezione delle vibrazioni trasmesse dal substrato per mappare l'ambiente.",
+      "label": "Eco Sismico",
+      "mutazione_indotta": "Recettori meccanici accoppiati allo scheletro che leggono onde sismiche.",
+      "spinta_selettiva": "Ambienti bui o sepolti dove la vista e' inutile.",
+      "uso_funzione": "Localizzare movimenti e strutture tramite le vibrazioni del terreno."
+    },
+    "equilibrio_vestibolare": {
+      "description": "Organo dell'equilibrio che stabilizza postura e movimento in terreni instabili.",
+      "label": "Equilibrio Vestibolare",
+      "mutazione_indotta": "Canali semicircolari sviluppati con fluido e cristalli sensori.",
+      "spinta_selettiva": "Terreni irregolari, arrampicata o volo dove cadere e' letale.",
+      "uso_funzione": "Mantenere assetto e coordinazione durante manovre rapide."
+    },
+    "nocicezione": {
+      "description": "Sistema di recettori del dolore che segnala danno tissutale imminente o in corso.",
+      "label": "Nocicezione",
+      "mutazione_indotta": "Terminazioni nervose specializzate nel rilevare stimoli nocivi.",
+      "spinta_selettiva": "Ambienti ricchi di minacce fisiche o chimiche ravvicinate.",
+      "uso_funzione": "Innescare ritrazione e protezione immediata dal danno."
+    },
+    "pigmenti_aurorali": {
+      "description": "Cellule pigmentate che emettono bagliori cangianti per segnale o inganno.",
+      "label": "Pigmenti Aurorali",
+      "mutazione_indotta": "Cromatofori bioluminescenti a modulazione rapida.",
+      "spinta_selettiva": "Ambienti oscuri o sociali dove il segnale visivo e' vantaggioso.",
+      "uso_funzione": "Comunicare, abbagliare o confondere tramite pattern luminosi."
+    },
+    "propriocezione": {
+      "description": "Senso interno della posizione e del movimento delle proprie appendici.",
+      "label": "Propriocezione",
+      "mutazione_indotta": "Recettori di stiramento distribuiti in muscoli e articolazioni.",
+      "spinta_selettiva": "Manipolazione fine o movimento in spazi angusti e bui.",
+      "uso_funzione": "Controllare con precisione il corpo senza feedback visivo."
+    },
+    "senso_magnetico": {
+      "description": "Percezione del campo magnetico terrestre per orientamento a lunga distanza.",
+      "label": "Senso Magnetico",
+      "mutazione_indotta": "Depositi di biomagnetite accoppiati a terminazioni nervose.",
+      "spinta_selettiva": "Migrazioni o territori vasti privi di riferimenti visivi.",
+      "uso_funzione": "Orientarsi e migrare seguendo le linee del campo magnetico."
+    },
+    "sintonia_magnetica": {
+      "description": "Modulazione fine della sensibilita' magnetica per leggere anomalie locali.",
+      "label": "Sintonia Magnetica",
+      "mutazione_indotta": "Affinamento dei recettori magnetici con filtraggio del rumore.",
+      "spinta_selettiva": "Ambienti con gradienti magnetici complessi da interpretare.",
+      "uso_funzione": "Distinguere sorgenti e anomalie magnetiche ravvicinate."
+    },
+    "termocezione": {
+      "description": "Percezione delle differenze di temperatura per rilevare prede o correnti.",
+      "label": "Termocezione",
+      "mutazione_indotta": "Fossette termosensibili con recettori a infrarosso.",
+      "spinta_selettiva": "Caccia notturna o ambienti dove il calore rivela la preda.",
+      "uso_funzione": "Individuare corpi caldi o correnti termiche al buio."
     }
   }
 }

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -2075,6 +2075,76 @@
       "mutazione_indotta": "Fossette termosensibili con recettori a infrarosso.",
       "spinta_selettiva": "Caccia notturna o ambienti dove il calore rivela la preda.",
       "uso_funzione": "Individuare corpi caldi o correnti termiche al buio."
+    },
+    "canto_di_richiamo": {
+      "description": "Vocalizzo che richiama e coordina i membri del branco a distanza.",
+      "label": "Canto di Richiamo",
+      "mutazione_indotta": "Sacche vocali risonanti capaci di emettere richiami a lungo raggio.",
+      "spinta_selettiva": "Specie sociali che cacciano o si difendono in gruppo.",
+      "uso_funzione": "Radunare o segnalare al branco tramite un richiamo riconoscibile."
+    },
+    "ferocia": {
+      "description": "Predisposizione all'aggressione intensa e sostenuta nel confronto diretto.",
+      "label": "Ferocia",
+      "mutazione_indotta": "Regolazione ormonale che amplifica l'aggressivita' sotto minaccia.",
+      "spinta_selettiva": "Competizione diretta per prede, territorio o accoppiamento.",
+      "uso_funzione": "Sostenere un assalto deciso senza esitazione."
+    },
+    "intimidatore": {
+      "description": "Esibizione di segnali di minaccia che scoraggiano l'avversario prima dello scontro.",
+      "label": "Intimidatore",
+      "mutazione_indotta": "Strutture e posture amplificate per apparire piu' grandi e pericolosi.",
+      "spinta_selettiva": "Conflitti dove evitare lo scontro fisico e' vantaggioso.",
+      "uso_funzione": "Dissuadere rivali e predatori con una dimostrazione di forza."
+    },
+    "legame_di_branco": {
+      "description": "Coesione sociale che sincronizza comportamento e difesa collettiva.",
+      "label": "Legame di Branco",
+      "mutazione_indotta": "Circuiti neurali e feromonali che rafforzano il riconoscimento di gruppo.",
+      "spinta_selettiva": "Sopravvivenza in gruppo contro minacce superiori al singolo.",
+      "uso_funzione": "Agire in modo coordinato con i membri del branco."
+    },
+    "marchio_predatorio": {
+      "description": "Segnale che identifica e marca una preda designata per la caccia coordinata.",
+      "label": "Marchio Predatorio",
+      "mutazione_indotta": "Ghiandole segnalatrici che depositano una traccia riconoscibile.",
+      "spinta_selettiva": "Caccia cooperativa su prede grandi o sfuggenti.",
+      "uso_funzione": "Designare e inseguire una preda condivisa dal gruppo."
+    },
+    "midollo_iperattivo": {
+      "description": "Produzione accelerata di cellule che sostiene sforzo e recupero prolungati.",
+      "label": "Midollo Iperattivo",
+      "mutazione_indotta": "Midollo osseo iperfunzionante con turnover cellulare elevato.",
+      "spinta_selettiva": "Ambienti che richiedono sforzo fisico ripetuto e resistenza.",
+      "uso_funzione": "Sostenere attivita' intensa recuperando piu' in fretta."
+    },
+    "spirito_combattivo": {
+      "description": "Determinazione che mantiene l'efficacia anche in condizioni di svantaggio.",
+      "label": "Spirito Combattivo",
+      "mutazione_indotta": "Assetto neuroendocrino che ritarda cedimento e resa.",
+      "spinta_selettiva": "Scontri prolungati dove la tenuta mentale decide l'esito.",
+      "uso_funzione": "Continuare a combattere efficacemente sotto stress e danno."
+    },
+    "spore_paniche": {
+      "description": "Rilascio di spore che inducono disorientamento e fuga negli avversari.",
+      "label": "Spore Paniche",
+      "mutazione_indotta": "Sporangi che disperdono composti neuroattivi volatili.",
+      "spinta_selettiva": "Difesa contro branchi o predatori numerosi.",
+      "uso_funzione": "Disperdere un gruppo nemico seminando panico."
+    },
+    "sussurro_psichico": {
+      "description": "Trasmissione mentale sottile che semina dubbio o suggestione nell'avversario.",
+      "label": "Sussurro Psichico",
+      "mutazione_indotta": "Emissione di deboli campi psichici modulati.",
+      "spinta_selettiva": "Confronti dove destabilizzare la mente rivale e' decisivo.",
+      "uso_funzione": "Interferire con la decisione avversaria a corto raggio."
+    },
+    "voce_imperiosa": {
+      "description": "Vocalizzo dominante che impone gerarchia e sottomissione nel gruppo.",
+      "label": "Voce Imperiosa",
+      "mutazione_indotta": "Apparato vocale capace di toni a bassa frequenza autorevoli.",
+      "spinta_selettiva": "Strutture sociali gerarchiche con competizione per il rango.",
+      "uso_funzione": "Affermare dominanza e dirigere il comportamento altrui."
     }
   }
 }

--- a/locales/it/traits.json
+++ b/locales/it/traits.json
@@ -2145,6 +2145,111 @@
       "mutazione_indotta": "Apparato vocale capace di toni a bassa frequenza autorevoli.",
       "spinta_selettiva": "Strutture sociali gerarchiche con competizione per il rango.",
       "uso_funzione": "Affermare dominanza e dirigere il comportamento altrui."
+    },
+    "aculei_velenosi": {
+      "description": "Spine cutanee che iniettano una tossina difensiva al contatto.",
+      "label": "Aculei Velenosi",
+      "mutazione_indotta": "Spine cave collegate a ghiandole velenifere sottocutanee.",
+      "spinta_selettiva": "Predatori che afferrano o mordono prede piccole.",
+      "uso_funzione": "Punire con veleno chi tenta il contatto ravvicinato."
+    },
+    "adattamento_volo": {
+      "description": "Insieme di modifiche corporee che rendono possibile il volo sostenuto.",
+      "label": "Adattamento al Volo",
+      "mutazione_indotta": "Alleggerimento scheletrico e superfici portanti sviluppate.",
+      "spinta_selettiva": "Ambienti tridimensionali dove il volo apre nicchie irraggiungibili.",
+      "uso_funzione": "Spostarsi in volo per fuga, caccia o esplorazione."
+    },
+    "aura_glaciale": {
+      "description": "Emissione di freddo intenso che rallenta e irrigidisce cio' che e' vicino.",
+      "label": "Aura Glaciale",
+      "mutazione_indotta": "Tessuti criogenici che sottraggono calore all'ambiente immediato.",
+      "spinta_selettiva": "Climi rigidi o prede vulnerabili al freddo.",
+      "uso_funzione": "Raffreddare l'area ravvicinata ostacolando l'avversario."
+    },
+    "cuore_in_furia": {
+      "description": "Sistema cardiaco potenziato che sostiene picchi di sforzo esplosivo.",
+      "label": "Cuore in Furia",
+      "mutazione_indotta": "Miocardio ipertrofico con gittata amplificata su richiesta.",
+      "spinta_selettiva": "Caccia d'agguato o fughe che richiedono esplosivita'.",
+      "uso_funzione": "Erogare scatti di potenza fisica improvvisa."
+    },
+    "denti_seghettati": {
+      "description": "Dentatura a margini seghettati che lacera invece di forare.",
+      "label": "Denti Seghettati",
+      "mutazione_indotta": "Bordi dentali serrati con smalto rinforzato.",
+      "spinta_selettiva": "Prede grandi o dalla pelle coriacea.",
+      "uso_funzione": "Recidere carne e tessuti fibrosi con morsi laceranti."
+    },
+    "filtri_bioattivi": {
+      "description": "Organi che filtrano e neutralizzano tossine e agenti nocivi ingeriti.",
+      "label": "Filtri Bioattivi",
+      "mutazione_indotta": "Membrane filtranti con enzimi detossificanti.",
+      "spinta_selettiva": "Ambienti o prede ricchi di sostanze tossiche.",
+      "uso_funzione": "Alimentarsi in sicurezza da fonti contaminate."
+    },
+    "membrane_osmotiche": {
+      "description": "Superfici che regolano il bilancio idrico e salino con l'ambiente.",
+      "label": "Membrane Osmotiche",
+      "mutazione_indotta": "Epiteli specializzati nel controllo osmotico attivo.",
+      "spinta_selettiva": "Ambienti a salinita' variabile o estrema.",
+      "uso_funzione": "Mantenere l'equilibrio interno in acque o suoli salini."
+    },
+    "pelle_elastomera": {
+      "description": "Tegumento elastico che assorbe deformazioni e torna alla forma.",
+      "label": "Pelle Elastomera",
+      "mutazione_indotta": "Fibre elastiche dermiche ad alta resilienza.",
+      "spinta_selettiva": "Ambienti con impatti, compressioni o passaggi angusti.",
+      "uso_funzione": "Assorbire urti e stiramenti senza lacerarsi."
+    },
+    "pelli_anti_ustione": {
+      "description": "Strato cutaneo resistente al calore e alle scottature chimiche.",
+      "label": "Pelli Anti-Ustione",
+      "mutazione_indotta": "Cheratine termoresistenti e strati isolanti sottocutanei.",
+      "spinta_selettiva": "Ambienti vulcanici, aridi o chimicamente ostili.",
+      "uso_funzione": "Resistere a fonti di calore e agenti corrosivi."
+    },
+    "pelli_fitte": {
+      "description": "Tegumento denso e stratificato che resiste a morsi e abrasioni.",
+      "label": "Pelli Fitte",
+      "mutazione_indotta": "Ispessimento dermico con strati fibrosi compatti.",
+      "spinta_selettiva": "Predatori con morsi o artigli penetranti.",
+      "uso_funzione": "Ridurre il danno da contatto e perforazione."
+    },
+    "sensori_sismici": {
+      "description": "Recettori che avvertono vibrazioni del terreno per allerta precoce.",
+      "label": "Sensori Sismici",
+      "mutazione_indotta": "Meccanocettori accoppiati agli arti a contatto col suolo.",
+      "spinta_selettiva": "Ambienti aperti o bui dove sentire prima e' sopravvivere.",
+      "uso_funzione": "Rilevare l'avvicinarsi di minacce dal movimento del terreno."
+    },
+    "tela_appiccicosa": {
+      "description": "Secrezione adesiva usata per intrappolare prede o ancorarsi.",
+      "label": "Tela Appiccicosa",
+      "mutazione_indotta": "Ghiandole seriche che producono filamenti vischiosi.",
+      "spinta_selettiva": "Cattura di prede agili senza inseguimento.",
+      "uso_funzione": "Immobilizzare prede o fissarsi alle superfici."
+    },
+    "tentacoli_uncinati": {
+      "description": "Appendici prensili munite di uncini per afferrare e trattenere.",
+      "label": "Tentacoli Uncinati",
+      "mutazione_indotta": "Tentacoli muscolari con uncini cheratinizzati.",
+      "spinta_selettiva": "Prede sfuggenti o substrati difficili da tenere.",
+      "uso_funzione": "Agganciare e trattenere prede o appigli."
+    },
+    "tessuti_adattivi": {
+      "description": "Tessuti che rimodellano struttura e funzione in risposta allo stress.",
+      "label": "Tessuti Adattivi",
+      "mutazione_indotta": "Cellule plastiche capaci di ridifferenziarsi secondo necessita'.",
+      "spinta_selettiva": "Ambienti instabili che premiano la flessibilita' fisiologica.",
+      "uso_funzione": "Adattare il corpo a carichi e ambienti mutevoli."
+    },
+    "zampe_radianti": {
+      "description": "Arti vascolarizzati che dissipano o irradiano calore per termoregolazione.",
+      "label": "Zampe Radianti",
+      "mutazione_indotta": "Reti capillari superficiali negli arti a funzione radiante.",
+      "spinta_selettiva": "Climi caldi dove smaltire calore in eccesso e' vitale.",
+      "uso_funzione": "Regolare la temperatura corporea scambiando calore dagli arti."
     }
   }
 }


### PR DESCRIPTION
## What -- R1 complete (46/46 design-stubs authored)
Author design fields (`sinergie`) + IT lore prose (label/description/mutazione_indotta/uso_funzione/spinta_selettiva) for every `completion_flags.design_stub` trait, flipping the flag to false. Per-family commits:
- cognitivo 3, offensivo/difensivo/nervoso 10, sensoriale 8, strategia 10, fisiologico 15.

## Grounding (anti-fabrication)
Sinergie grounded on existing authored traits per family + intra-family thematic pairings (all ids resolve to real trait files). Prose is **lore-level only** -- biological/behavioural flavour, NO combat mechanics (those are R2 / trait_mechanics.yaml, behaviour-critical, separate). Master-dd ratified the cognitivo pattern in-session before scaling.

## Verify (all pass, every batch)
trait_template_validator + trait_audit --check + check_missing_traits + check_derived_reproducible --deep. **No derived-artifact drift** (design/prose don't move coverage/qa bundles). 0 design_stub remaining.

## Scope boundary
Design + lore only. NOT authored here: combat mechanics (R2), the index.json schema_version cosmetic (unenforced). Istruttoria: docs/planning/2026-07-14-r1-trait-stub-authoring-istruttoria.md (#3277).

Draft -- merge = master-dd.