### PR TITLE
fix(traits): drop dead coscienza_dalveare_diffusa ref from env_traits catalog

### DIFF
--- a/packs/evo_tactics_pack/docs/catalog/env_traits.json
+++ b/packs/evo_tactics_pack/docs/catalog/env_traits.json
@@ -1011,7 +1011,6 @@
           "corazze_ferro_magnetico",
           "corna_psico_conduttive",
           "coscienza_d_alveare_diffusa",
-          "coscienza_dalveare_diffusa",
           "ectotermia_dinamica",
           "elettromagnete_biologico",
           "emettitori_voidsong",


### PR DESCRIPTION
Resolves the Codex P2 on #3278 (merged J3 dedup). The pack env-trait suggestion catalog `packs/evo_tactics_pack/docs/catalog/env_traits.json` still listed the deleted slug `coscienza_dalveare_diffusa`; canonical `coscienza_d_alveare_diffusa` is already on the adjacent line -> pure dedup leftover, removed. JSON valid, `check_derived_reproducible --deep` clean. Draft -- merge = master-dd.