### PR TITLE
feat(traits): author difensivo design-stubs (R1, 3 stubs)

### DIFF
--- a/data/traits/difensivo/armatura_pietra_planare.json
+++ b/data/traits/difensivo/armatura_pietra_planare.json
@@ -26,7 +26,9 @@
     }
   ],
   "sinergie": [
-    "carapace_fase_variabile"
+    "carapace_fase_variabile",
+    "corteccia_memetica",
+    "radici_ancora_planare"
   ],
   "sinergie_pi": {
     "co_occorrenze": [],

--- a/data/traits/difensivo/corteccia_memetica.json
+++ b/data/traits/difensivo/corteccia_memetica.json
@@ -10,13 +10,17 @@
     "complementare": "protezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "radici_ancora_planare",
+    "armatura_pietra_planare",
+    "pelli_cave"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.corteccia_memetica.mutazione_indotta",
   "uso_funzione": "i18n:traits.corteccia_memetica.uso_funzione",
   "spinta_selettiva": "i18n:traits.corteccia_memetica.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/difensivo/corteccia_memetica.json
+++ b/data/traits/difensivo/corteccia_memetica.json
@@ -22,5 +22,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.corteccia_memetica.debolezza"
 }

--- a/data/traits/difensivo/pelli_cave.json
+++ b/data/traits/difensivo/pelli_cave.json
@@ -10,13 +10,15 @@
     "complementare": "protezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "corteccia_memetica"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pelli_cave.mutazione_indotta",
   "uso_funzione": "i18n:traits.pelli_cave.uso_funzione",
   "spinta_selettiva": "i18n:traits.pelli_cave.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/difensivo/pelli_cave.json
+++ b/data/traits/difensivo/pelli_cave.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.pelli_cave.debolezza"
 }

--- a/data/traits/difensivo/radici_ancora_planare.json
+++ b/data/traits/difensivo/radici_ancora_planare.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.radici_ancora_planare.debolezza"
 }

--- a/data/traits/difensivo/radici_ancora_planare.json
+++ b/data/traits/difensivo/radici_ancora_planare.json
@@ -10,13 +10,16 @@
     "complementare": "protezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "corteccia_memetica",
+    "armatura_pietra_planare"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.radici_ancora_planare.mutazione_indotta",
   "uso_funzione": "i18n:traits.radici_ancora_planare.uso_funzione",
   "spinta_selettiva": "i18n:traits.radici_ancora_planare.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -18075,7 +18075,8 @@
           ],
           "weight": 1
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.pelli_cave.debolezza"
     },
     "senso_magnetico": {
       "schema_version": "2.0",
@@ -18306,7 +18307,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.corteccia_memetica.debolezza"
     },
     "artigli_psionici": {
       "schema_version": "2.0",
@@ -18599,7 +18601,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.radici_ancora_planare.debolezza"
     },
     "eco_sismico": {
       "schema_version": "2.0",

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -1825,7 +1825,9 @@
         }
       ],
       "sinergie": [
-        "carapace_fase_variabile"
+        "carapace_fase_variabile",
+        "corteccia_memetica",
+        "radici_ancora_planare"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -18019,14 +18021,16 @@
         "complementare": "protezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "corteccia_memetica"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.pelli_cave.mutazione_indotta",
       "uso_funzione": "i18n:traits.pelli_cave.uso_funzione",
       "spinta_selettiva": "i18n:traits.pelli_cave.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -18280,14 +18284,18 @@
         "complementare": "protezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "radici_ancora_planare",
+        "armatura_pietra_planare",
+        "pelli_cave"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.corteccia_memetica.mutazione_indotta",
       "uso_funzione": "i18n:traits.corteccia_memetica.uso_funzione",
       "spinta_selettiva": "i18n:traits.corteccia_memetica.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -18570,14 +18578,17 @@
         "complementare": "protezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "corteccia_memetica",
+        "armatura_pietra_planare"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.radici_ancora_planare.mutazione_indotta",
       "uso_funzione": "i18n:traits.radici_ancora_planare.uso_funzione",
       "spinta_selettiva": "i18n:traits.radici_ancora_planare.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {

--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,22 +1,14 @@
 # QA export changelog
 
-Generato: 2026-07-14T00:03:24.248947Z
-Baseline precedente: 2026-06-28T13:37:48.320348Z
+Generato: 2026-07-14T01:50:46.715317Z
+Baseline precedente: 2026-07-14T00:03:24.248947Z
 
 ## Metriche baseline
-- Tratti totali: 308 (-1 vs precedente)
-- Glossario OK: 308 (-1 vs precedente)
+- Tratti totali: 308 (0 vs precedente)
+- Glossario OK: 308 (0 vs precedente)
 - Glossario mancanti: 0 (0 vs precedente)
-- Mismatch matrice: 116 (-1 vs precedente)
+- Mismatch matrice: 116 (0 vs precedente)
 - Tratti con conflitti: 28 (0 vs precedente)
-
-### tratti con mismatch matrice
-- Risolti:
-  - coscienza_dalveare_diffusa
-
-### tratti senza copertura QA
-- Risolti:
-  - coscienza_dalveare_diffusa
 
 ## Highlights UI
 - Solo matrice: Strategist, architetto, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, fisiologia_predatoria, fotosintesi_bifase, ghiandole_nettare_memetico, intangibilita_parziale
@@ -40,7 +32,7 @@ Baseline precedente: 2026-06-28T13:37:48.320348Z
 - Tratti validati: 0 (0 vs precedente)
 
 ## Badge QA
-- Tratti passed: 308 (-1 vs precedente)
+- Tratti passed: 308 (0 vs precedente)
 - Conflitti badge: 28 (0 vs precedente)
 
 _Report generato da scripts/export-qa-report.js_

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T00:03:24.248947Z",
+  "generated_at": "2026-07-14T01:50:46.715317Z",
   "summary": {
     "total_traits": 308,
     "glossary_ok": 308,
@@ -2230,7 +2230,9 @@
         "frusta_fiammeggiante"
       ],
       "synergies": [
-        "carapace_fase_variabile"
+        "carapace_fase_variabile",
+        "corteccia_memetica",
+        "radici_ancora_planare"
       ],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -12477,7 +12479,11 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "radici_ancora_planare",
+        "armatura_pietra_planare",
+        "pelli_cave"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -27581,7 +27587,9 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "corteccia_memetica"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -28735,7 +28743,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "corteccia_memetica",
+        "armatura_pietra_planare"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",


### PR DESCRIPTION
## R1 design-stub authoring -- difensivo family (2/7)

Completes the 3 difensivo design-stubs. Same validated methodology as cognitivo #3285.

## What
- Populated `sinergie` for **corteccia_memetica**, **radici_ancora_planare**, **pelli_cave**, grounded on the family's protective/tanky theme.
- Flipped `design_stub` -> false on all 3.
- Full-cascade reciprocity: back-links corteccia_memetica + radici_ancora_planare into authored `armatura_pietra_planare` (per-file + index.json).
- Hand-synced index.json; regenerated derived (index.csv unchanged, derived/analysis, QA baseline).

| edge | grounding |
|---|---|
| corteccia_memetica <-> radici_ancora_planare | both treant defensive (harden / anchor tanky) |
| corteccia_memetica <-> armatura_pietra_planare | hardening + shockwave-damping armor |
| corteccia_memetica <-> pelli_cave | protective integument layers |
| radici_ancora_planare <-> armatura_pietra_planare | planar-anchored tanky + planar stone armor |

## Gate (all green)
- trait_template_validator exit 0
- trait_audit --check exit 0 + zero new reciprocity warnings
- check_derived_reproducible --deep OK (8/8), count 308
- lore + harsh cluster-review before merge (2/7)

Scope: design fields only. Branch `r1iso/*` = authored in an isolated git worktree (shared-clone concurrency hygiene). merge = master-dd.