### PR TITLE
feat(traits): author nervoso design-stubs (R1, 3 stubs)

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -17997,14 +17997,17 @@
         "complementare": "sistema_nervoso"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "matrice_antimagia",
+        "nuclei_di_controllo"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.risonanza_magnetica.mutazione_indotta",
       "uso_funzione": "i18n:traits.risonanza_magnetica.uso_funzione",
       "spinta_selettiva": "i18n:traits.risonanza_magnetica.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "pelli_cave": {
@@ -18217,14 +18220,17 @@
         "complementare": "sistema_nervoso"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "nuclei_di_controllo",
+        "risonanza_magnetica"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.matrice_antimagia.mutazione_indotta",
       "uso_funzione": "i18n:traits.matrice_antimagia.uso_funzione",
       "spinta_selettiva": "i18n:traits.matrice_antimagia.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -18249,14 +18255,17 @@
         "complementare": "sistema_nervoso"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "matrice_antimagia",
+        "risonanza_magnetica"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.nuclei_di_controllo.mutazione_indotta",
       "uso_funzione": "i18n:traits.nuclei_di_controllo.uso_funzione",
       "spinta_selettiva": "i18n:traits.nuclei_di_controllo.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -18008,7 +18008,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.risonanza_magnetica.debolezza"
     },
     "pelli_cave": {
       "schema_version": "2.0",
@@ -18241,7 +18242,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.matrice_antimagia.debolezza"
     },
     "nuclei_di_controllo": {
       "schema_version": "2.0",
@@ -18275,7 +18277,8 @@
           ],
           "weight": 3
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.nuclei_di_controllo.debolezza"
     },
     "corteccia_memetica": {
       "schema_version": "2.0",

--- a/data/traits/nervoso/matrice_antimagia.json
+++ b/data/traits/nervoso/matrice_antimagia.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.matrice_antimagia.debolezza"
 }

--- a/data/traits/nervoso/matrice_antimagia.json
+++ b/data/traits/nervoso/matrice_antimagia.json
@@ -10,13 +10,16 @@
     "complementare": "sistema_nervoso"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "nuclei_di_controllo",
+    "risonanza_magnetica"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.matrice_antimagia.mutazione_indotta",
   "uso_funzione": "i18n:traits.matrice_antimagia.uso_funzione",
   "spinta_selettiva": "i18n:traits.matrice_antimagia.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/nervoso/nuclei_di_controllo.json
+++ b/data/traits/nervoso/nuclei_di_controllo.json
@@ -10,13 +10,16 @@
     "complementare": "sistema_nervoso"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "matrice_antimagia",
+    "risonanza_magnetica"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.nuclei_di_controllo.mutazione_indotta",
   "uso_funzione": "i18n:traits.nuclei_di_controllo.uso_funzione",
   "spinta_selettiva": "i18n:traits.nuclei_di_controllo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/nervoso/nuclei_di_controllo.json
+++ b/data/traits/nervoso/nuclei_di_controllo.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.nuclei_di_controllo.debolezza"
 }

--- a/data/traits/nervoso/risonanza_magnetica.json
+++ b/data/traits/nervoso/risonanza_magnetica.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.risonanza_magnetica.debolezza"
 }

--- a/data/traits/nervoso/risonanza_magnetica.json
+++ b/data/traits/nervoso/risonanza_magnetica.json
@@ -10,13 +10,16 @@
     "complementare": "sistema_nervoso"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "matrice_antimagia",
+    "nuclei_di_controllo"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.risonanza_magnetica.mutazione_indotta",
   "uso_funzione": "i18n:traits.risonanza_magnetica.uso_funzione",
   "spinta_selettiva": "i18n:traits.risonanza_magnetica.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,22 +1,14 @@
 # QA export changelog
 
-Generato: 2026-07-14T00:03:24.248947Z
-Baseline precedente: 2026-06-28T13:37:48.320348Z
+Generato: 2026-07-14T01:52:34.462209Z
+Baseline precedente: 2026-07-14T00:03:24.248947Z
 
 ## Metriche baseline
-- Tratti totali: 308 (-1 vs precedente)
-- Glossario OK: 308 (-1 vs precedente)
+- Tratti totali: 308 (0 vs precedente)
+- Glossario OK: 308 (0 vs precedente)
 - Glossario mancanti: 0 (0 vs precedente)
-- Mismatch matrice: 116 (-1 vs precedente)
+- Mismatch matrice: 116 (0 vs precedente)
 - Tratti con conflitti: 28 (0 vs precedente)
-
-### tratti con mismatch matrice
-- Risolti:
-  - coscienza_dalveare_diffusa
-
-### tratti senza copertura QA
-- Risolti:
-  - coscienza_dalveare_diffusa
 
 ## Highlights UI
 - Solo matrice: Strategist, architetto, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, fisiologia_predatoria, fotosintesi_bifase, ghiandole_nettare_memetico, intangibilita_parziale
@@ -40,7 +32,7 @@ Baseline precedente: 2026-06-28T13:37:48.320348Z
 - Tratti validati: 0 (0 vs precedente)
 
 ## Badge QA
-- Tratti passed: 308 (-1 vs precedente)
+- Tratti passed: 308 (0 vs precedente)
 - Conflitti badge: 28 (0 vs precedente)
 
 _Report generato da scripts/export-qa-report.js_

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T00:03:24.248947Z",
+  "generated_at": "2026-07-14T01:52:34.462209Z",
   "summary": {
     "total_traits": 308,
     "glossary_ok": 308,
@@ -23382,7 +23382,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "nuclei_di_controllo",
+        "risonanza_magnetica"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -25958,7 +25961,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "matrice_antimagia",
+        "risonanza_magnetica"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -29444,7 +29450,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "matrice_antimagia",
+        "nuclei_di_controllo"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",


### PR DESCRIPTION
## R1 design-stub authoring -- nervoso family (3/7)

Completes the 3 nervoso design-stubs. Same methodology as #3285/#3287.

## What
- Populated `sinergie` for **matrice_antimagia**, **nuclei_di_controllo**, **risonanza_magnetica**; flipped `design_stub` -> false.
- No distinct authored traits in-family to ground against, so the 3 form a self-contained reciprocal triad around the **runic-golem / magnetic-field** archetype. matrice_antimagia framing is bio-mechanical field-inhibition, **not literal high-fantasy magic** (per the R1-v2 plan lore anchor).
- Hand-synced index.json; regenerated derived.

| edge | grounding |
|---|---|
| matrice_antimagia <-> nuclei_di_controllo | same runic-golem body (antimagia matrix + control core) |
| matrice_antimagia <-> risonanza_magnetica | field inhibition + field reading (EM/magnetic domain) |
| nuclei_di_controllo <-> risonanza_magnetica | coordinated strikes guided by magnetic-field sensing |

## Gate (all green)
- trait_template_validator exit 0; trait_audit --check exit 0 + zero reciprocity warnings
- check_derived_reproducible --deep OK (8/8), count 308
- lore + harsh cluster-review before merge (3/7)

Scope: design fields only (i18n for these 3 pending the separate data/i18n PR). Branch `r1iso/*` = isolated worktree. merge = master-dd.