### PR TITLE
feat(traits): author offensivo design-stubs (R1, 4 stubs)

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -17905,7 +17905,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.arco_voltaico.debolezza"
     },
     "martello_osseo": {
       "schema_version": "2.0",
@@ -17945,7 +17946,8 @@
           ],
           "weight": 1
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.martello_osseo.debolezza"
     },
     "pungiglione_paralizzante": {
       "schema_version": "2.0",
@@ -17970,7 +17972,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.pungiglione_paralizzante.debolezza"
     },
     "scarica_ionica": {
       "schema_version": "2.0",
@@ -17995,7 +17998,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.scarica_ionica.debolezza"
     },
     "risonanza_magnetica": {
       "schema_version": "2.0",

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -7553,7 +7553,8 @@
       "slot": [],
       "sinergie": [
         "locomozione_miriapode_ibrida",
-        "estroflessione_gastrica_acida"
+        "estroflessione_gastrica_acida",
+        "martello_osseo"
       ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.artiglio_cinetico_a_urto.mutazione_indotta",
@@ -17893,14 +17894,17 @@
         "complementare": "offesa"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "scarica_ionica",
+        "pungiglione_paralizzante"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.arco_voltaico.mutazione_indotta",
       "uso_funzione": "i18n:traits.arco_voltaico.uso_funzione",
       "spinta_selettiva": "i18n:traits.arco_voltaico.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "martello_osseo": {
@@ -17915,14 +17919,16 @@
         "complementare": "offesa"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "artiglio_cinetico_a_urto"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.martello_osseo.mutazione_indotta",
       "uso_funzione": "i18n:traits.martello_osseo.uso_funzione",
       "spinta_selettiva": "i18n:traits.martello_osseo.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17953,14 +17959,17 @@
         "complementare": "offesa"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "arco_voltaico",
+        "scarica_ionica"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.pungiglione_paralizzante.mutazione_indotta",
       "uso_funzione": "i18n:traits.pungiglione_paralizzante.uso_funzione",
       "spinta_selettiva": "i18n:traits.pungiglione_paralizzante.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "scarica_ionica": {
@@ -17975,14 +17984,17 @@
         "complementare": "offesa"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "arco_voltaico",
+        "pungiglione_paralizzante"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.scarica_ionica.mutazione_indotta",
       "uso_funzione": "i18n:traits.scarica_ionica.uso_funzione",
       "spinta_selettiva": "i18n:traits.scarica_ionica.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "risonanza_magnetica": {

--- a/data/traits/offensivo/arco_voltaico.json
+++ b/data/traits/offensivo/arco_voltaico.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.arco_voltaico.debolezza"
 }

--- a/data/traits/offensivo/arco_voltaico.json
+++ b/data/traits/offensivo/arco_voltaico.json
@@ -10,13 +10,16 @@
     "complementare": "offesa"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "scarica_ionica",
+    "pungiglione_paralizzante"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.arco_voltaico.mutazione_indotta",
   "uso_funzione": "i18n:traits.arco_voltaico.uso_funzione",
   "spinta_selettiva": "i18n:traits.arco_voltaico.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/offensivo/artiglio_cinetico_a_urto.json
+++ b/data/traits/offensivo/artiglio_cinetico_a_urto.json
@@ -9,7 +9,8 @@
   "slot": [],
   "sinergie": [
     "locomozione_miriapode_ibrida",
-    "estroflessione_gastrica_acida"
+    "estroflessione_gastrica_acida",
+    "martello_osseo"
   ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.artiglio_cinetico_a_urto.mutazione_indotta",

--- a/data/traits/offensivo/martello_osseo.json
+++ b/data/traits/offensivo/martello_osseo.json
@@ -10,13 +10,15 @@
     "complementare": "offesa"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "artiglio_cinetico_a_urto"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.martello_osseo.mutazione_indotta",
   "uso_funzione": "i18n:traits.martello_osseo.uso_funzione",
   "spinta_selettiva": "i18n:traits.martello_osseo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/offensivo/martello_osseo.json
+++ b/data/traits/offensivo/martello_osseo.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.martello_osseo.debolezza"
 }

--- a/data/traits/offensivo/pungiglione_paralizzante.json
+++ b/data/traits/offensivo/pungiglione_paralizzante.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.pungiglione_paralizzante.debolezza"
 }

--- a/data/traits/offensivo/pungiglione_paralizzante.json
+++ b/data/traits/offensivo/pungiglione_paralizzante.json
@@ -10,13 +10,16 @@
     "complementare": "offesa"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "arco_voltaico",
+    "scarica_ionica"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pungiglione_paralizzante.mutazione_indotta",
   "uso_funzione": "i18n:traits.pungiglione_paralizzante.uso_funzione",
   "spinta_selettiva": "i18n:traits.pungiglione_paralizzante.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/offensivo/scarica_ionica.json
+++ b/data/traits/offensivo/scarica_ionica.json
@@ -10,13 +10,16 @@
     "complementare": "offesa"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "arco_voltaico",
+    "pungiglione_paralizzante"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.scarica_ionica.mutazione_indotta",
   "uso_funzione": "i18n:traits.scarica_ionica.uso_funzione",
   "spinta_selettiva": "i18n:traits.scarica_ionica.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/offensivo/scarica_ionica.json
+++ b/data/traits/offensivo/scarica_ionica.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.scarica_ionica.debolezza"
 }

--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,22 +1,14 @@
 # QA export changelog
 
-Generato: 2026-07-14T00:03:24.248947Z
-Baseline precedente: 2026-06-28T13:37:48.320348Z
+Generato: 2026-07-14T01:53:41.789311Z
+Baseline precedente: 2026-07-14T00:03:24.248947Z
 
 ## Metriche baseline
-- Tratti totali: 308 (-1 vs precedente)
-- Glossario OK: 308 (-1 vs precedente)
+- Tratti totali: 308 (0 vs precedente)
+- Glossario OK: 308 (0 vs precedente)
 - Glossario mancanti: 0 (0 vs precedente)
-- Mismatch matrice: 116 (-1 vs precedente)
+- Mismatch matrice: 116 (0 vs precedente)
 - Tratti con conflitti: 28 (0 vs precedente)
-
-### tratti con mismatch matrice
-- Risolti:
-  - coscienza_dalveare_diffusa
-
-### tratti senza copertura QA
-- Risolti:
-  - coscienza_dalveare_diffusa
 
 ## Highlights UI
 - Solo matrice: Strategist, architetto, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, fisiologia_predatoria, fotosintesi_bifase, ghiandole_nettare_memetico, intangibilita_parziale
@@ -40,7 +32,7 @@ Baseline precedente: 2026-06-28T13:37:48.320348Z
 - Tratti validati: 0 (0 vs precedente)
 
 ## Badge QA
-- Tratti passed: 308 (-1 vs precedente)
+- Tratti passed: 308 (0 vs precedente)
 - Conflitti badge: 28 (0 vs precedente)
 
 _Report generato da scripts/export-qa-report.js_

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T00:03:24.248947Z",
+  "generated_at": "2026-07-14T01:53:41.789311Z",
   "summary": {
     "total_traits": 308,
     "glossary_ok": 308,
@@ -2114,7 +2114,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "scarica_ionica",
+        "pungiglione_paralizzante"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -3733,7 +3736,8 @@
       "conflicts": [],
       "synergies": [
         "locomozione_miriapode_ibrida",
-        "estroflessione_gastrica_acida"
+        "estroflessione_gastrica_acida",
+        "martello_osseo"
       ],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -23269,7 +23273,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "artiglio_cinetico_a_urto"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -28622,7 +28628,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "arco_voltaico",
+        "scarica_ionica"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -30381,7 +30390,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "arco_voltaico",
+        "pungiglione_paralizzante"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",


### PR DESCRIPTION
## R1 design-stub authoring -- offensivo family (4/7)

Completes the 4 offensivo design-stubs. Methodology per #3285.

## What
- Populated `sinergie` for **arco_voltaico**, **scarica_ionica**, **pungiglione_paralizzante**, **martello_osseo**; flipped `design_stub` -> false.
- Full-cascade reciprocity: back-link martello_osseo into authored `artiglio_cinetico_a_urto`.

| cluster | edges | grounding |
|---|---|---|
| electric/ionic disrupt | arco_voltaico <-> scarica_ionica <-> pungiglione_paralizzante | voltaic/ionic/neurotoxin -- all disrupt the nervous system |
| concussive | martello_osseo <-> artiglio_cinetico_a_urto | bony mass impact + kinetic shockwave/fracture |

## Gate (all green)
- trait_template_validator exit 0; trait_audit --check exit 0 + zero reciprocity warnings
- check_derived_reproducible --deep OK (8/8), count 308
- lore + harsh cluster-review before merge (4/7)

Scope: design fields only. **All 4 stubs are also among the 14 needing data/i18n entries** -> handled in the separate i18n PR after synergies. Branch `r1iso/*` = isolated worktree. merge = master-dd.