### PR TITLE
feat(traits): author sensoriale design-stubs (R1, 8 stubs)

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -18102,7 +18102,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.senso_magnetico.debolezza"
     },
     "sintonia_magnetica": {
       "schema_version": "2.0",
@@ -18127,7 +18128,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.sintonia_magnetica.debolezza"
     },
     "nocicezione": {
       "schema_version": "2.0",
@@ -18151,7 +18153,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.nocicezione.debolezza"
     },
     "propriocezione": {
       "schema_version": "2.0",
@@ -18176,7 +18179,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.propriocezione.debolezza"
     },
     "equilibrio_vestibolare": {
       "schema_version": "2.0",
@@ -18200,7 +18204,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.equilibrio_vestibolare.debolezza"
     },
     "termocezione": {
       "schema_version": "2.0",
@@ -18224,7 +18229,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.termocezione.debolezza"
     },
     "matrice_antimagia": {
       "schema_version": "2.0",
@@ -18523,7 +18529,8 @@
           ],
           "weight": 1
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.pigmenti_aurorali.debolezza"
     },
     "adattamento_volo": {
       "schema_version": "2.0",
@@ -18636,7 +18643,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.eco_sismico.debolezza"
     },
     "artigli_sette_vie_2": {
       "schema_version": "2.0",

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -10437,7 +10437,8 @@
       "sinergie": [
         "cavita_risonanti_tundra",
         "olfatto_risonanza_magnetica",
-        "sensori_geomagnetici"
+        "sensori_geomagnetici",
+        "eco_sismico"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -11230,7 +11231,8 @@
         }
       ],
       "sinergie": [
-        "sonno_emisferico_alternato"
+        "sonno_emisferico_alternato",
+        "termocezione"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -11435,7 +11437,8 @@
       "tier": "T2",
       "slot": [],
       "sinergie": [
-        "rostro_emostatico_litico"
+        "rostro_emostatico_litico",
+        "eco_sismico"
       ],
       "conflitti": [
         "ipertrofia_muscolare_massiva"
@@ -11517,7 +11520,9 @@
       ],
       "sinergie": [
         "carapace_fase_variabile",
-        "eco_interno_riflesso"
+        "eco_interno_riflesso",
+        "senso_magnetico",
+        "sintonia_magnetica"
       ],
       "sinergie_pi": {
         "co_occorrenze": [],
@@ -18085,14 +18090,18 @@
         "complementare": "percezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "sintonia_magnetica",
+        "sensori_geomagnetici",
+        "pigmenti_aurorali"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.senso_magnetico.mutazione_indotta",
       "uso_funzione": "i18n:traits.senso_magnetico.uso_funzione",
       "spinta_selettiva": "i18n:traits.senso_magnetico.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "sintonia_magnetica": {
@@ -18107,14 +18116,17 @@
         "complementare": "percezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "senso_magnetico",
+        "sensori_geomagnetici"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.sintonia_magnetica.mutazione_indotta",
       "uso_funzione": "i18n:traits.sintonia_magnetica.uso_funzione",
       "spinta_selettiva": "i18n:traits.sintonia_magnetica.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "nocicezione": {
@@ -18129,14 +18141,16 @@
         "complementare": "percezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "propriocezione"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.nocicezione.mutazione_indotta",
       "uso_funzione": "i18n:traits.nocicezione.uso_funzione",
       "spinta_selettiva": "i18n:traits.nocicezione.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "propriocezione": {
@@ -18151,14 +18165,17 @@
         "complementare": "percezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "equilibrio_vestibolare",
+        "nocicezione"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.propriocezione.mutazione_indotta",
       "uso_funzione": "i18n:traits.propriocezione.uso_funzione",
       "spinta_selettiva": "i18n:traits.propriocezione.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "equilibrio_vestibolare": {
@@ -18173,14 +18190,16 @@
         "complementare": "percezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "propriocezione"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.equilibrio_vestibolare.mutazione_indotta",
       "uso_funzione": "i18n:traits.equilibrio_vestibolare.uso_funzione",
       "spinta_selettiva": "i18n:traits.equilibrio_vestibolare.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "termocezione": {
@@ -18195,14 +18214,16 @@
         "complementare": "percezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "occhi_infrarosso_composti"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.termocezione.mutazione_indotta",
       "uso_funzione": "i18n:traits.termocezione.uso_funzione",
       "spinta_selettiva": "i18n:traits.termocezione.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "matrice_antimagia": {
@@ -18440,14 +18461,16 @@
         "complementare": "percezione"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "senso_magnetico"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.pigmenti_aurorali.mutazione_indotta",
       "uso_funzione": "i18n:traits.pigmenti_aurorali.uso_funzione",
       "spinta_selettiva": "i18n:traits.pigmenti_aurorali.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -18602,14 +18625,17 @@
         "complementare": "risonanza"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "organi_sismici_cutanei",
+        "eco_interno_riflesso"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.eco_sismico.mutazione_indotta",
       "uso_funzione": "i18n:traits.eco_sismico.uso_funzione",
       "spinta_selettiva": "i18n:traits.eco_sismico.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "artigli_sette_vie_2": {

--- a/data/traits/sensoriale/eco_interno_riflesso.json
+++ b/data/traits/sensoriale/eco_interno_riflesso.json
@@ -36,7 +36,8 @@
   "sinergie": [
     "cavita_risonanti_tundra",
     "olfatto_risonanza_magnetica",
-    "sensori_geomagnetici"
+    "sensori_geomagnetici",
+    "eco_sismico"
   ],
   "sinergie_pi": {
     "co_occorrenze": [],

--- a/data/traits/sensoriale/eco_sismico.json
+++ b/data/traits/sensoriale/eco_sismico.json
@@ -10,13 +10,16 @@
     "complementare": "risonanza"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "organi_sismici_cutanei",
+    "eco_interno_riflesso"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.eco_sismico.mutazione_indotta",
   "uso_funzione": "i18n:traits.eco_sismico.uso_funzione",
   "spinta_selettiva": "i18n:traits.eco_sismico.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/eco_sismico.json
+++ b/data/traits/sensoriale/eco_sismico.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.eco_sismico.debolezza"
 }

--- a/data/traits/sensoriale/equilibrio_vestibolare.json
+++ b/data/traits/sensoriale/equilibrio_vestibolare.json
@@ -10,13 +10,15 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "propriocezione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.equilibrio_vestibolare.mutazione_indotta",
   "uso_funzione": "i18n:traits.equilibrio_vestibolare.uso_funzione",
   "spinta_selettiva": "i18n:traits.equilibrio_vestibolare.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/equilibrio_vestibolare.json
+++ b/data/traits/sensoriale/equilibrio_vestibolare.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.equilibrio_vestibolare.debolezza"
 }

--- a/data/traits/sensoriale/nocicezione.json
+++ b/data/traits/sensoriale/nocicezione.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.nocicezione.debolezza"
 }

--- a/data/traits/sensoriale/nocicezione.json
+++ b/data/traits/sensoriale/nocicezione.json
@@ -10,13 +10,15 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "propriocezione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.nocicezione.mutazione_indotta",
   "uso_funzione": "i18n:traits.nocicezione.uso_funzione",
   "spinta_selettiva": "i18n:traits.nocicezione.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/occhi_infrarosso_composti.json
+++ b/data/traits/sensoriale/occhi_infrarosso_composti.json
@@ -22,7 +22,8 @@
     }
   ],
   "sinergie": [
-    "sonno_emisferico_alternato"
+    "sonno_emisferico_alternato",
+    "termocezione"
   ],
   "sinergie_pi": {
     "co_occorrenze": [],

--- a/data/traits/sensoriale/organi_sismici_cutanei.json
+++ b/data/traits/sensoriale/organi_sismici_cutanei.json
@@ -8,7 +8,8 @@
   "tier": "T2",
   "slot": [],
   "sinergie": [
-    "rostro_emostatico_litico"
+    "rostro_emostatico_litico",
+    "eco_sismico"
   ],
   "conflitti": [
     "ipertrofia_muscolare_massiva"

--- a/data/traits/sensoriale/pigmenti_aurorali.json
+++ b/data/traits/sensoriale/pigmenti_aurorali.json
@@ -10,13 +10,15 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "senso_magnetico"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pigmenti_aurorali.mutazione_indotta",
   "uso_funzione": "i18n:traits.pigmenti_aurorali.uso_funzione",
   "spinta_selettiva": "i18n:traits.pigmenti_aurorali.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/pigmenti_aurorali.json
+++ b/data/traits/sensoriale/pigmenti_aurorali.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.pigmenti_aurorali.debolezza"
 }

--- a/data/traits/sensoriale/propriocezione.json
+++ b/data/traits/sensoriale/propriocezione.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.propriocezione.debolezza"
 }

--- a/data/traits/sensoriale/propriocezione.json
+++ b/data/traits/sensoriale/propriocezione.json
@@ -10,13 +10,16 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "equilibrio_vestibolare",
+    "nocicezione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.propriocezione.mutazione_indotta",
   "uso_funzione": "i18n:traits.propriocezione.uso_funzione",
   "spinta_selettiva": "i18n:traits.propriocezione.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/senso_magnetico.json
+++ b/data/traits/sensoriale/senso_magnetico.json
@@ -10,13 +10,17 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "sintonia_magnetica",
+    "sensori_geomagnetici",
+    "pigmenti_aurorali"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.senso_magnetico.mutazione_indotta",
   "uso_funzione": "i18n:traits.senso_magnetico.uso_funzione",
   "spinta_selettiva": "i18n:traits.senso_magnetico.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/senso_magnetico.json
+++ b/data/traits/sensoriale/senso_magnetico.json
@@ -22,5 +22,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.senso_magnetico.debolezza"
 }

--- a/data/traits/sensoriale/sensori_geomagnetici.json
+++ b/data/traits/sensoriale/sensori_geomagnetici.json
@@ -23,7 +23,9 @@
   ],
   "sinergie": [
     "carapace_fase_variabile",
-    "eco_interno_riflesso"
+    "eco_interno_riflesso",
+    "senso_magnetico",
+    "sintonia_magnetica"
   ],
   "sinergie_pi": {
     "co_occorrenze": [],

--- a/data/traits/sensoriale/sintonia_magnetica.json
+++ b/data/traits/sensoriale/sintonia_magnetica.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.sintonia_magnetica.debolezza"
 }

--- a/data/traits/sensoriale/sintonia_magnetica.json
+++ b/data/traits/sensoriale/sintonia_magnetica.json
@@ -10,13 +10,16 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "senso_magnetico",
+    "sensori_geomagnetici"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.sintonia_magnetica.mutazione_indotta",
   "uso_funzione": "i18n:traits.sintonia_magnetica.uso_funzione",
   "spinta_selettiva": "i18n:traits.sintonia_magnetica.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/termocezione.json
+++ b/data/traits/sensoriale/termocezione.json
@@ -10,13 +10,15 @@
     "complementare": "percezione"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "occhi_infrarosso_composti"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.termocezione.mutazione_indotta",
   "uso_funzione": "i18n:traits.termocezione.uso_funzione",
   "spinta_selettiva": "i18n:traits.termocezione.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/sensoriale/termocezione.json
+++ b/data/traits/sensoriale/termocezione.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.termocezione.debolezza"
 }

--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,22 +1,14 @@
 # QA export changelog
 
-Generato: 2026-07-14T00:03:24.248947Z
-Baseline precedente: 2026-06-28T13:37:48.320348Z
+Generato: 2026-07-14T01:56:28.882226Z
+Baseline precedente: 2026-07-14T00:03:24.248947Z
 
 ## Metriche baseline
-- Tratti totali: 308 (-1 vs precedente)
-- Glossario OK: 308 (-1 vs precedente)
+- Tratti totali: 308 (0 vs precedente)
+- Glossario OK: 308 (0 vs precedente)
 - Glossario mancanti: 0 (0 vs precedente)
-- Mismatch matrice: 116 (-1 vs precedente)
+- Mismatch matrice: 116 (0 vs precedente)
 - Tratti con conflitti: 28 (0 vs precedente)
-
-### tratti con mismatch matrice
-- Risolti:
-  - coscienza_dalveare_diffusa
-
-### tratti senza copertura QA
-- Risolti:
-  - coscienza_dalveare_diffusa
 
 ## Highlights UI
 - Solo matrice: Strategist, architetto, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, fisiologia_predatoria, fotosintesi_bifase, ghiandole_nettare_memetico, intangibilita_parziale
@@ -40,7 +32,7 @@ Baseline precedente: 2026-06-28T13:37:48.320348Z
 - Tratti validati: 0 (0 vs precedente)
 
 ## Badge QA
-- Tratti passed: 308 (-1 vs precedente)
+- Tratti passed: 308 (0 vs precedente)
 - Conflitti badge: 28 (0 vs precedente)
 
 _Report generato da scripts/export-qa-report.js_

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T00:03:24.248947Z",
+  "generated_at": "2026-07-14T01:56:28.882226Z",
   "summary": {
     "total_traits": 308,
     "glossary_ok": 308,
@@ -14442,7 +14442,8 @@
       "synergies": [
         "cavita_risonanti_tundra",
         "olfatto_risonanza_magnetica",
-        "sensori_geomagnetici"
+        "sensori_geomagnetici",
+        "eco_sismico"
       ],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -14556,7 +14557,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "organi_sismici_cutanei",
+        "eco_interno_riflesso"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -16070,7 +16074,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "propriocezione"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -25600,7 +25606,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "propriocezione"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -26546,7 +26554,8 @@
       },
       "conflicts": [],
       "synergies": [
-        "sonno_emisferico_alternato"
+        "sonno_emisferico_alternato",
+        "termocezione"
       ],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -26892,7 +26901,8 @@
         "ipertrofia_muscolare_massiva"
       ],
       "synergies": [
-        "rostro_emostatico_litico"
+        "rostro_emostatico_litico",
+        "eco_sismico"
       ],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -27935,7 +27945,9 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "senso_magnetico"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -28509,7 +28521,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "equilibrio_vestibolare",
+        "nocicezione"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -31550,7 +31565,11 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "sintonia_magnetica",
+        "sensori_geomagnetici",
+        "pigmenti_aurorali"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -31665,7 +31684,9 @@
       "conflicts": [],
       "synergies": [
         "carapace_fase_variabile",
-        "eco_interno_riflesso"
+        "eco_interno_riflesso",
+        "senso_magnetico",
+        "sintonia_magnetica"
       ],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -32368,7 +32389,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "senso_magnetico",
+        "sensori_geomagnetici"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -34231,7 +34255,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "occhi_infrarosso_composti"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",


### PR DESCRIPTION
## R1 design-stub authoring -- sensoriale family (5/7)

Completes the 8 sensoriale design-stubs. Methodology per #3285.

## Clusters (all reciprocal, grounded on sensory sub-domains)
| cluster | edges |
|---|---|
| magnetic sensing | senso_magnetico <-> sintonia_magnetica <-> sensori_geomagnetici(auth); pigmenti_aurorali <-> senso_magnetico |
| body-awareness | equilibrio_vestibolare <-> propriocezione <-> nocicezione |
| thermal | termocezione <-> occhi_infrarosso_composti(auth, infrared trails) |
| seismic/echo | eco_sismico <-> organi_sismici_cutanei(auth) + eco_interno_riflesso(auth) |

Full-cascade back-links into 4 authored traits (per-file + index.json).

## Gate (all green)
- trait_template_validator exit 0; trait_audit --check exit 0 + zero reciprocity warnings
- check_derived_reproducible --deep OK (8/8), count 308
- lore + harsh cluster-review before merge (5/7)

Scope: design fields only (7 of these also need data/i18n -> separate PR). Branch `r1iso/*` = isolated worktree. merge = master-dd.