### PR TITLE
feat(traits): author strategia design-stubs (R1, 10 stubs)

### DIFF
--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -17657,7 +17657,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.canto_di_richiamo.debolezza"
     },
     "ferocia": {
       "schema_version": "2.0",
@@ -17693,7 +17694,8 @@
           ],
           "weight": 5
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.ferocia.debolezza"
     },
     "intimidatore": {
       "schema_version": "2.0",
@@ -17718,7 +17720,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.intimidatore.debolezza"
     },
     "legame_di_branco": {
       "schema_version": "2.0",
@@ -17752,7 +17755,8 @@
           ],
           "weight": 2
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.legame_di_branco.debolezza"
     },
     "marchio_predatorio": {
       "schema_version": "2.0",
@@ -17785,7 +17789,8 @@
           ],
           "weight": 2
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.marchio_predatorio.debolezza"
     },
     "midollo_iperattivo": {
       "schema_version": "2.0",
@@ -17810,7 +17815,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.midollo_iperattivo.debolezza"
     },
     "spirito_combattivo": {
       "schema_version": "2.0",
@@ -17834,7 +17840,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.spirito_combattivo.debolezza"
     },
     "spore_paniche": {
       "schema_version": "2.0",
@@ -17859,7 +17866,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.spore_paniche.debolezza"
     },
     "sussurro_psichico": {
       "schema_version": "2.0",
@@ -17883,7 +17891,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.sussurro_psichico.debolezza"
     },
     "voce_imperiosa": {
       "schema_version": "2.0",
@@ -17909,7 +17918,8 @@
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
         "design_stub": false
-      }
+      },
+      "debolezza": "i18n:traits.voce_imperiosa.debolezza"
     },
     "arco_voltaico": {
       "schema_version": "2.0",

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -14269,7 +14269,8 @@
         "lamelle_shear",
         "membrane_captura_rugiada",
         "random",
-        "spore_psichiche_silenziate"
+        "spore_psichiche_silenziate",
+        "legame_di_branco"
       ],
       "sinergie_pi": {
         "co_occorrenze": [
@@ -17645,14 +17646,17 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "ferocia",
+        "midollo_iperattivo"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.canto_di_richiamo.mutazione_indotta",
       "uso_funzione": "i18n:traits.canto_di_richiamo.uso_funzione",
       "spinta_selettiva": "i18n:traits.canto_di_richiamo.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "ferocia": {
@@ -17667,14 +17671,18 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "midollo_iperattivo",
+        "canto_di_richiamo",
+        "spirito_combattivo"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.ferocia.mutazione_indotta",
       "uso_funzione": "i18n:traits.ferocia.uso_funzione",
       "spinta_selettiva": "i18n:traits.ferocia.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17699,14 +17707,17 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "voce_imperiosa",
+        "spore_paniche"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.intimidatore.mutazione_indotta",
       "uso_funzione": "i18n:traits.intimidatore.uso_funzione",
       "spinta_selettiva": "i18n:traits.intimidatore.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "legame_di_branco": {
@@ -17721,14 +17732,17 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "marchio_predatorio",
+        "tattiche_di_branco"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.legame_di_branco.mutazione_indotta",
       "uso_funzione": "i18n:traits.legame_di_branco.uso_funzione",
       "spinta_selettiva": "i18n:traits.legame_di_branco.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17752,14 +17766,16 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "legame_di_branco"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.marchio_predatorio.mutazione_indotta",
       "uso_funzione": "i18n:traits.marchio_predatorio.uso_funzione",
       "spinta_selettiva": "i18n:traits.marchio_predatorio.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17783,14 +17799,17 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "ferocia",
+        "canto_di_richiamo"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.midollo_iperattivo.mutazione_indotta",
       "uso_funzione": "i18n:traits.midollo_iperattivo.uso_funzione",
       "spinta_selettiva": "i18n:traits.midollo_iperattivo.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "spirito_combattivo": {
@@ -17805,14 +17824,16 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "ferocia"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.spirito_combattivo.mutazione_indotta",
       "uso_funzione": "i18n:traits.spirito_combattivo.uso_funzione",
       "spinta_selettiva": "i18n:traits.spirito_combattivo.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "spore_paniche": {
@@ -17827,14 +17848,17 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "intimidatore",
+        "voce_imperiosa"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.spore_paniche.mutazione_indotta",
       "uso_funzione": "i18n:traits.spore_paniche.uso_funzione",
       "spinta_selettiva": "i18n:traits.spore_paniche.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "sussurro_psichico": {
@@ -17849,14 +17873,16 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "voce_imperiosa"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.sussurro_psichico.mutazione_indotta",
       "uso_funzione": "i18n:traits.sussurro_psichico.uso_funzione",
       "spinta_selettiva": "i18n:traits.sussurro_psichico.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "voce_imperiosa": {
@@ -17871,14 +17897,18 @@
         "complementare": "istinto"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "intimidatore",
+        "spore_paniche",
+        "sussurro_psichico"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.voce_imperiosa.mutazione_indotta",
       "uso_funzione": "i18n:traits.voce_imperiosa.uso_funzione",
       "spinta_selettiva": "i18n:traits.voce_imperiosa.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       }
     },
     "arco_voltaico": {

--- a/data/traits/strategia/canto_di_richiamo.json
+++ b/data/traits/strategia/canto_di_richiamo.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.canto_di_richiamo.debolezza"
 }

--- a/data/traits/strategia/canto_di_richiamo.json
+++ b/data/traits/strategia/canto_di_richiamo.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ferocia",
+    "midollo_iperattivo"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.canto_di_richiamo.mutazione_indotta",
   "uso_funzione": "i18n:traits.canto_di_richiamo.uso_funzione",
   "spinta_selettiva": "i18n:traits.canto_di_richiamo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/ferocia.json
+++ b/data/traits/strategia/ferocia.json
@@ -10,13 +10,17 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "midollo_iperattivo",
+    "canto_di_richiamo",
+    "spirito_combattivo"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.ferocia.mutazione_indotta",
   "uso_funzione": "i18n:traits.ferocia.uso_funzione",
   "spinta_selettiva": "i18n:traits.ferocia.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/ferocia.json
+++ b/data/traits/strategia/ferocia.json
@@ -22,5 +22,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.ferocia.debolezza"
 }

--- a/data/traits/strategia/intimidatore.json
+++ b/data/traits/strategia/intimidatore.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.intimidatore.debolezza"
 }

--- a/data/traits/strategia/intimidatore.json
+++ b/data/traits/strategia/intimidatore.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "voce_imperiosa",
+    "spore_paniche"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.intimidatore.mutazione_indotta",
   "uso_funzione": "i18n:traits.intimidatore.uso_funzione",
   "spinta_selettiva": "i18n:traits.intimidatore.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/legame_di_branco.json
+++ b/data/traits/strategia/legame_di_branco.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.legame_di_branco.debolezza"
 }

--- a/data/traits/strategia/legame_di_branco.json
+++ b/data/traits/strategia/legame_di_branco.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "marchio_predatorio",
+    "tattiche_di_branco"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.legame_di_branco.mutazione_indotta",
   "uso_funzione": "i18n:traits.legame_di_branco.uso_funzione",
   "spinta_selettiva": "i18n:traits.legame_di_branco.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/marchio_predatorio.json
+++ b/data/traits/strategia/marchio_predatorio.json
@@ -10,13 +10,15 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "legame_di_branco"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.marchio_predatorio.mutazione_indotta",
   "uso_funzione": "i18n:traits.marchio_predatorio.uso_funzione",
   "spinta_selettiva": "i18n:traits.marchio_predatorio.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/marchio_predatorio.json
+++ b/data/traits/strategia/marchio_predatorio.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.marchio_predatorio.debolezza"
 }

--- a/data/traits/strategia/midollo_iperattivo.json
+++ b/data/traits/strategia/midollo_iperattivo.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ferocia",
+    "canto_di_richiamo"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.midollo_iperattivo.mutazione_indotta",
   "uso_funzione": "i18n:traits.midollo_iperattivo.uso_funzione",
   "spinta_selettiva": "i18n:traits.midollo_iperattivo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/midollo_iperattivo.json
+++ b/data/traits/strategia/midollo_iperattivo.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.midollo_iperattivo.debolezza"
 }

--- a/data/traits/strategia/spirito_combattivo.json
+++ b/data/traits/strategia/spirito_combattivo.json
@@ -10,13 +10,15 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "ferocia"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.spirito_combattivo.mutazione_indotta",
   "uso_funzione": "i18n:traits.spirito_combattivo.uso_funzione",
   "spinta_selettiva": "i18n:traits.spirito_combattivo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/spirito_combattivo.json
+++ b/data/traits/strategia/spirito_combattivo.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.spirito_combattivo.debolezza"
 }

--- a/data/traits/strategia/spore_paniche.json
+++ b/data/traits/strategia/spore_paniche.json
@@ -10,13 +10,16 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "intimidatore",
+    "voce_imperiosa"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.spore_paniche.mutazione_indotta",
   "uso_funzione": "i18n:traits.spore_paniche.uso_funzione",
   "spinta_selettiva": "i18n:traits.spore_paniche.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/spore_paniche.json
+++ b/data/traits/strategia/spore_paniche.json
@@ -21,5 +21,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.spore_paniche.debolezza"
 }

--- a/data/traits/strategia/sussurro_psichico.json
+++ b/data/traits/strategia/sussurro_psichico.json
@@ -10,13 +10,15 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "voce_imperiosa"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.sussurro_psichico.mutazione_indotta",
   "uso_funzione": "i18n:traits.sussurro_psichico.uso_funzione",
   "spinta_selettiva": "i18n:traits.sussurro_psichico.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/sussurro_psichico.json
+++ b/data/traits/strategia/sussurro_psichico.json
@@ -20,5 +20,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.sussurro_psichico.debolezza"
 }

--- a/data/traits/strategia/tattiche_di_branco.json
+++ b/data/traits/strategia/tattiche_di_branco.json
@@ -37,7 +37,8 @@
     "lamelle_shear",
     "membrane_captura_rugiada",
     "random",
-    "spore_psichiche_silenziate"
+    "spore_psichiche_silenziate",
+    "legame_di_branco"
   ],
   "sinergie_pi": {
     "co_occorrenze": [

--- a/data/traits/strategia/voce_imperiosa.json
+++ b/data/traits/strategia/voce_imperiosa.json
@@ -10,13 +10,17 @@
     "complementare": "istinto"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "intimidatore",
+    "spore_paniche",
+    "sussurro_psichico"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.voce_imperiosa.mutazione_indotta",
   "uso_funzione": "i18n:traits.voce_imperiosa.uso_funzione",
   "spinta_selettiva": "i18n:traits.voce_imperiosa.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
+    "design_stub": false
   }
 }

--- a/data/traits/strategia/voce_imperiosa.json
+++ b/data/traits/strategia/voce_imperiosa.json
@@ -22,5 +22,6 @@
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
     "design_stub": false
-  }
+  },
+  "debolezza": "i18n:traits.voce_imperiosa.debolezza"
 }

--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,22 +1,14 @@
 # QA export changelog
 
-Generato: 2026-07-14T00:03:24.248947Z
-Baseline precedente: 2026-06-28T13:37:48.320348Z
+Generato: 2026-07-14T01:57:28.254324Z
+Baseline precedente: 2026-07-14T00:03:24.248947Z
 
 ## Metriche baseline
-- Tratti totali: 308 (-1 vs precedente)
-- Glossario OK: 308 (-1 vs precedente)
+- Tratti totali: 308 (0 vs precedente)
+- Glossario OK: 308 (0 vs precedente)
 - Glossario mancanti: 0 (0 vs precedente)
-- Mismatch matrice: 116 (-1 vs precedente)
+- Mismatch matrice: 116 (0 vs precedente)
 - Tratti con conflitti: 28 (0 vs precedente)
-
-### tratti con mismatch matrice
-- Risolti:
-  - coscienza_dalveare_diffusa
-
-### tratti senza copertura QA
-- Risolti:
-  - coscienza_dalveare_diffusa
 
 ## Highlights UI
 - Solo matrice: Strategist, architetto, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, fisiologia_predatoria, fotosintesi_bifase, ghiandole_nettare_memetico, intangibilita_parziale
@@ -40,7 +32,7 @@ Baseline precedente: 2026-06-28T13:37:48.320348Z
 - Tratti validati: 0 (0 vs precedente)
 
 ## Badge QA
-- Tratti passed: 308 (-1 vs precedente)
+- Tratti passed: 308 (0 vs precedente)
 - Conflitti badge: 28 (0 vs precedente)
 
 _Report generato da scripts/export-qa-report.js_

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T00:03:24.248947Z",
+  "generated_at": "2026-07-14T01:57:28.254324Z",
   "summary": {
     "total_traits": 308,
     "glossary_ok": 308,
@@ -6983,7 +6983,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "ferocia",
+        "midollo_iperattivo"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -16532,7 +16535,11 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "midollo_iperattivo",
+        "canto_di_richiamo",
+        "spirito_combattivo"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -21186,7 +21193,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "voce_imperiosa",
+        "spore_paniche"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -21999,7 +22009,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "marchio_predatorio",
+        "tattiche_di_branco"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -23156,7 +23169,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "legame_di_branco"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -24649,7 +24664,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "ferocia",
+        "canto_di_richiamo"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -32828,7 +32846,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "ferocia"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -32941,7 +32961,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "intimidatore",
+        "voce_imperiosa"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -33649,7 +33672,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "voce_imperiosa"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -33778,7 +33803,8 @@
         "lamelle_shear",
         "membrane_captura_rugiada",
         "random",
-        "spore_psichiche_silenziate"
+        "spore_psichiche_silenziate",
+        "legame_di_branco"
       ],
       "dataset_sources": [
         "data/core/species.yaml",
@@ -35162,7 +35188,11 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "intimidatore",
+        "spore_paniche",
+        "sussurro_psichico"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",


### PR DESCRIPTION
## R1 design-stub authoring -- strategia family (6/7)

Completes the 10 strategia design-stubs -- the last synergy family. Methodology per #3285.

## Clusters (all reciprocal, behavioral combat sub-domains)
| cluster | edges |
|---|---|
| rage/fury | ferocia <-> midollo_iperattivo <-> canto_di_richiamo; spirito_combattivo <-> ferocia |
| fear/panic | intimidatore <-> voce_imperiosa <-> spore_paniche; sussurro_psichico <-> voce_imperiosa |
| pack coordination | marchio_predatorio <-> legame_di_branco <-> tattiche_di_branco(auth) |

Full-cascade back-link legame_di_branco into authored tattiche_di_branco.

## Gate (all green)
- trait_template_validator exit 0; trait_audit --check exit 0 + zero reciprocity warnings
- check_derived_reproducible --deep OK (8/8), count 308
- lore + harsh cluster-review before merge (6/7)

Scope: design fields only (this family already has curated data/i18n). Branch `r1iso/*` = isolated worktree. merge = master-dd.

---
**R1 synergy authoring complete across all 7 families** (cognitivo #3285, difensivo #3287, nervoso #3288, offensivo #3289, sensoriale #3290, strategia this). All 46 design-stubs now have grounded reciprocal synergies + design_stub=false. Remaining R1 residual: the 14 missing data/i18n entries (separate PR).