### PR TITLE
fix(traits): reconcile pigmenti_aurorali glossary to dazzle mechanic

### DIFF
--- a/data/core/traits/glossary.json
+++ b/data/core/traits/glossary.json
@@ -2408,8 +2408,8 @@
     "pigmenti_aurorali": {
       "label_it": "pigmenti_aurorali",
       "label_en": "Auroral Pigments",
-      "description_it": "Cromofori dermici che fluorescono sotto luce polare o tempesta magnetica, mimetizzando il soggetto tra bagliori atmosferici.",
-      "description_en": "Dermal chromophores fluorescing under polar light or magnetic storms, blending the subject into atmospheric glows."
+      "description_it": "Cromofori dermici che fluorescono sotto luce polare o tempesta magnetica: finche' il portatore e' in forze, il bagliore pulsa a fine scontro e abbaglia i nemici ravvicinati.",
+      "description_en": "Dermal chromophores fluorescing under polar light or magnetic storms; while the bearer stays hale the glow pulses at battle's end to dazzle nearby foes."
     },
     "pigmenti_termici": {
       "label_it": "Pigmenti Termici",

--- a/data/derived/analysis/README.md
+++ b/data/derived/analysis/README.md
@@ -23,7 +23,7 @@ Report derivati rigenerabili dal core e dal pack Evo Tactics.
 
 | File | sha256 |
 | --- | --- |
-| `data/derived/analysis/trait_coverage_report.json` | `893d912ca2b63b65f1ab012f70cce9fa0b81cfbb61937575ba27e77f52e06149` |
+| `data/derived/analysis/trait_coverage_report.json` | `6895464e7c184b668556b138442c2be7c4bdab866a700e354455a9c3aa43b3fc` |
 | `data/derived/analysis/trait_coverage_matrix.csv` | `ebe5ee5fc17ba57cb4d2454907b63b6bb3ff83a2006af9eaff074776289891d9` |
 | `data/derived/analysis/trait_gap_report.json` | `a0ef558023bba99f39cdd6c8c173c7e77d60a8ede00b16cf4225a7ad693227c2` |
 | `data/derived/analysis/trait_baseline.yaml` | `1b7658a544435d522bda9e119ee6959f0b6b65a70bcf09665bec9d5cf2a23254` |

--- a/data/derived/analysis/manifest.json
+++ b/data/derived/analysis/manifest.json
@@ -4,7 +4,7 @@
   "command": "python scripts/generate_derived_analysis.py --core-root data/core --pack-root packs/evo_tactics_pack --update-readme",
   "log_tag": null,
   "artifacts": {
-    "data/derived/analysis/trait_coverage_report.json": "893d912ca2b63b65f1ab012f70cce9fa0b81cfbb61937575ba27e77f52e06149",
+    "data/derived/analysis/trait_coverage_report.json": "6895464e7c184b668556b138442c2be7c4bdab866a700e354455a9c3aa43b3fc",
     "data/derived/analysis/trait_coverage_matrix.csv": "ebe5ee5fc17ba57cb4d2454907b63b6bb3ff83a2006af9eaff074776289891d9",
     "data/derived/analysis/trait_gap_report.json": "a0ef558023bba99f39cdd6c8c173c7e77d60a8ede00b16cf4225a7ad693227c2",
     "data/derived/analysis/trait_baseline.yaml": "1b7658a544435d522bda9e119ee6959f0b6b65a70bcf09665bec9d5cf2a23254",

--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -11027,8 +11027,8 @@
     "pigmenti_aurorali": {
       "label_it": "pigmenti_aurorali",
       "label_en": "Auroral Pigments",
-      "description_it": "Cromofori dermici che fluorescono sotto luce polare o tempesta magnetica, mimetizzando il soggetto tra bagliori atmosferici.",
-      "description_en": "Dermal chromophores fluorescing under polar light or magnetic storms, blending the subject into atmospheric glows.",
+      "description_it": "Cromofori dermici che fluorescono sotto luce polare o tempesta magnetica: finche' il portatore e' in forze, il bagliore pulsa a fine scontro e abbaglia i nemici ravvicinati.",
+      "description_en": "Dermal chromophores fluorescing under polar light or magnetic storms; while the bearer stays hale the glow pulses at battle's end to dazzle nearby foes.",
       "rules": {
         "total": 1,
         "coverage": [


### PR DESCRIPTION
## What

`data/core/traits/glossary.json` described `pigmenti_aurorali` as **camouflage**
("mimetizzando il soggetto tra bagliori atmosferici" / "blending the subject into
atmospheric glows"), contradicting the authoritative engine-coded mechanic in
`data/core/traits/active_effects.yaml`.

The coded `active_effect` (Slice 7, `combat/pigmentiAurorali`) is an **offensive
end-of-round dazzle**: while the bearer is at `HP >= 50%`, at end of round it dazzles
adjacent enemies (`-1` attack). R1 i18n authoring correctly follows the dazzle
mechanic, which amplified the stale glossary flavor into player-facing copy.

## Change

Text-only. Glossary `description_it` / `description_en` rewritten to reflect the
HP-gated end-of-round dazzle, keeping the biological flavor stem. **No mechanic
change.**

## Design note

No genuine fork: mechanic is intentionally engine-coded, name = "auroral pigments"
(glow), and i18n already follows dazzle. Camouflage was stale flavor written
pre-implementation, not intended design. Glossary was the drifted artifact.

Surfaced by lore-consistency-checker during R1 i18n authoring (2026-07-14). Not
urgent; no gate depends on it.