### PR TITLE
feat(traits): author fisiologico design-stubs (R1, 15 stubs) + debolezza

### DIFF
--- a/data/traits/fisiologico/aculei_velenosi.json
+++ b/data/traits/fisiologico/aculei_velenosi.json
@@ -10,13 +10,16 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "denti_seghettati"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.aculei_velenosi.mutazione_indotta",
   "uso_funzione": "i18n:traits.aculei_velenosi.uso_funzione",
   "spinta_selettiva": "i18n:traits.aculei_velenosi.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.aculei_velenosi.debolezza"
 }

--- a/data/traits/fisiologico/adattamento_volo.json
+++ b/data/traits/fisiologico/adattamento_volo.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "zampe_radianti",
+    "sensori_sismici"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.adattamento_volo.mutazione_indotta",
   "uso_funzione": "i18n:traits.adattamento_volo.uso_funzione",
   "spinta_selettiva": "i18n:traits.adattamento_volo.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.adattamento_volo.debolezza"
 }

--- a/data/traits/fisiologico/aura_glaciale.json
+++ b/data/traits/fisiologico/aura_glaciale.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "tela_appiccicosa",
+    "tentacoli_uncinati"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.aura_glaciale.mutazione_indotta",
   "uso_funzione": "i18n:traits.aura_glaciale.uso_funzione",
   "spinta_selettiva": "i18n:traits.aura_glaciale.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.aura_glaciale.debolezza"
 }

--- a/data/traits/fisiologico/cuore_in_furia.json
+++ b/data/traits/fisiologico/cuore_in_furia.json
@@ -10,13 +10,16 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "denti_seghettati"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.cuore_in_furia.mutazione_indotta",
   "uso_funzione": "i18n:traits.cuore_in_furia.uso_funzione",
   "spinta_selettiva": "i18n:traits.cuore_in_furia.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.cuore_in_furia.debolezza"
 }

--- a/data/traits/fisiologico/denti_seghettati.json
+++ b/data/traits/fisiologico/denti_seghettati.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "aculei_velenosi",
+    "cuore_in_furia"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.denti_seghettati.mutazione_indotta",
   "uso_funzione": "i18n:traits.denti_seghettati.uso_funzione",
   "spinta_selettiva": "i18n:traits.denti_seghettati.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.denti_seghettati.debolezza"
 }

--- a/data/traits/fisiologico/filtri_bioattivi.json
+++ b/data/traits/fisiologico/filtri_bioattivi.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "membrane_osmotiche",
+    "tessuti_adattivi"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.filtri_bioattivi.mutazione_indotta",
   "uso_funzione": "i18n:traits.filtri_bioattivi.uso_funzione",
   "spinta_selettiva": "i18n:traits.filtri_bioattivi.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.filtri_bioattivi.debolezza"
 }

--- a/data/traits/fisiologico/membrane_osmotiche.json
+++ b/data/traits/fisiologico/membrane_osmotiche.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "filtri_bioattivi",
+    "tessuti_adattivi"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.membrane_osmotiche.mutazione_indotta",
   "uso_funzione": "i18n:traits.membrane_osmotiche.uso_funzione",
   "spinta_selettiva": "i18n:traits.membrane_osmotiche.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.membrane_osmotiche.debolezza"
 }

--- a/data/traits/fisiologico/pelle_elastomera.json
+++ b/data/traits/fisiologico/pelle_elastomera.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "pelli_fitte",
+    "pelli_anti_ustione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pelle_elastomera.mutazione_indotta",
   "uso_funzione": "i18n:traits.pelle_elastomera.uso_funzione",
   "spinta_selettiva": "i18n:traits.pelle_elastomera.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.pelle_elastomera.debolezza"
 }

--- a/data/traits/fisiologico/pelli_anti_ustione.json
+++ b/data/traits/fisiologico/pelli_anti_ustione.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "pelle_elastomera",
+    "pelli_fitte"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pelli_anti_ustione.mutazione_indotta",
   "uso_funzione": "i18n:traits.pelli_anti_ustione.uso_funzione",
   "spinta_selettiva": "i18n:traits.pelli_anti_ustione.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.pelli_anti_ustione.debolezza"
 }

--- a/data/traits/fisiologico/pelli_fitte.json
+++ b/data/traits/fisiologico/pelli_fitte.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "pelle_elastomera",
+    "pelli_anti_ustione"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.pelli_fitte.mutazione_indotta",
   "uso_funzione": "i18n:traits.pelli_fitte.uso_funzione",
   "spinta_selettiva": "i18n:traits.pelli_fitte.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.pelli_fitte.debolezza"
 }

--- a/data/traits/fisiologico/sensori_sismici.json
+++ b/data/traits/fisiologico/sensori_sismici.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "adattamento_volo",
+    "zampe_radianti"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.sensori_sismici.mutazione_indotta",
   "uso_funzione": "i18n:traits.sensori_sismici.uso_funzione",
   "spinta_selettiva": "i18n:traits.sensori_sismici.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.sensori_sismici.debolezza"
 }

--- a/data/traits/fisiologico/tela_appiccicosa.json
+++ b/data/traits/fisiologico/tela_appiccicosa.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "aura_glaciale",
+    "tentacoli_uncinati"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.tela_appiccicosa.mutazione_indotta",
   "uso_funzione": "i18n:traits.tela_appiccicosa.uso_funzione",
   "spinta_selettiva": "i18n:traits.tela_appiccicosa.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.tela_appiccicosa.debolezza"
 }

--- a/data/traits/fisiologico/tentacoli_uncinati.json
+++ b/data/traits/fisiologico/tentacoli_uncinati.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "aura_glaciale",
+    "tela_appiccicosa"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.tentacoli_uncinati.mutazione_indotta",
   "uso_funzione": "i18n:traits.tentacoli_uncinati.uso_funzione",
   "spinta_selettiva": "i18n:traits.tentacoli_uncinati.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.tentacoli_uncinati.debolezza"
 }

--- a/data/traits/fisiologico/tessuti_adattivi.json
+++ b/data/traits/fisiologico/tessuti_adattivi.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "filtri_bioattivi",
+    "membrane_osmotiche"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.tessuti_adattivi.mutazione_indotta",
   "uso_funzione": "i18n:traits.tessuti_adattivi.uso_funzione",
   "spinta_selettiva": "i18n:traits.tessuti_adattivi.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.tessuti_adattivi.debolezza"
 }

--- a/data/traits/fisiologico/zampe_radianti.json
+++ b/data/traits/fisiologico/zampe_radianti.json
@@ -10,13 +10,17 @@
     "complementare": "morfologia"
   },
   "slot": [],
-  "sinergie": [],
+  "sinergie": [
+    "adattamento_volo",
+    "sensori_sismici"
+  ],
   "conflitti": [],
   "mutazione_indotta": "i18n:traits.zampe_radianti.mutazione_indotta",
   "uso_funzione": "i18n:traits.zampe_radianti.uso_funzione",
   "spinta_selettiva": "i18n:traits.zampe_radianti.spinta_selettiva",
   "data_origin": "gap1_salvage_2026_06_22",
   "completion_flags": {
-    "design_stub": true
-  }
+    "design_stub": false
+  },
+  "debolezza": "i18n:traits.zampe_radianti.debolezza"
 }

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -17349,14 +17349,16 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "denti_seghettati"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.aculei_velenosi.mutazione_indotta",
       "uso_funzione": "i18n:traits.aculei_velenosi.uso_funzione",
       "spinta_selettiva": "i18n:traits.aculei_velenosi.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17366,7 +17368,8 @@
           ],
           "weight": 3
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.aculei_velenosi.debolezza"
     },
     "aura_glaciale": {
       "schema_version": "2.0",
@@ -17380,15 +17383,19 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "tela_appiccicosa",
+        "tentacoli_uncinati"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.aura_glaciale.mutazione_indotta",
       "uso_funzione": "i18n:traits.aura_glaciale.uso_funzione",
       "spinta_selettiva": "i18n:traits.aura_glaciale.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
-      }
+        "design_stub": false
+      },
+      "debolezza": "i18n:traits.aura_glaciale.debolezza"
     },
     "cuore_in_furia": {
       "schema_version": "2.0",
@@ -17402,15 +17409,18 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "denti_seghettati"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.cuore_in_furia.mutazione_indotta",
       "uso_funzione": "i18n:traits.cuore_in_furia.uso_funzione",
       "spinta_selettiva": "i18n:traits.cuore_in_furia.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
-      }
+        "design_stub": false
+      },
+      "debolezza": "i18n:traits.cuore_in_furia.debolezza"
     },
     "denti_seghettati": {
       "schema_version": "2.0",
@@ -17424,15 +17434,19 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "aculei_velenosi",
+        "cuore_in_furia"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.denti_seghettati.mutazione_indotta",
       "uso_funzione": "i18n:traits.denti_seghettati.uso_funzione",
       "spinta_selettiva": "i18n:traits.denti_seghettati.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
-      }
+        "design_stub": false
+      },
+      "debolezza": "i18n:traits.denti_seghettati.debolezza"
     },
     "pelle_elastomera": {
       "schema_version": "2.0",
@@ -17446,14 +17460,17 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "pelli_fitte",
+        "pelli_anti_ustione"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.pelle_elastomera.mutazione_indotta",
       "uso_funzione": "i18n:traits.pelle_elastomera.uso_funzione",
       "spinta_selettiva": "i18n:traits.pelle_elastomera.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17470,7 +17487,8 @@
           ],
           "weight": 3
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.pelle_elastomera.debolezza"
     },
     "pelli_anti_ustione": {
       "schema_version": "2.0",
@@ -17484,14 +17502,17 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "pelle_elastomera",
+        "pelli_fitte"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.pelli_anti_ustione.mutazione_indotta",
       "uso_funzione": "i18n:traits.pelli_anti_ustione.uso_funzione",
       "spinta_selettiva": "i18n:traits.pelli_anti_ustione.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17502,7 +17523,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.pelli_anti_ustione.debolezza"
     },
     "pelli_fitte": {
       "schema_version": "2.0",
@@ -17516,14 +17538,17 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "pelle_elastomera",
+        "pelli_anti_ustione"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.pelli_fitte.mutazione_indotta",
       "uso_funzione": "i18n:traits.pelli_fitte.uso_funzione",
       "spinta_selettiva": "i18n:traits.pelli_fitte.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17533,7 +17558,8 @@
           ],
           "weight": 1
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.pelli_fitte.debolezza"
     },
     "sensori_sismici": {
       "schema_version": "2.0",
@@ -17547,14 +17573,17 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "adattamento_volo",
+        "zampe_radianti"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.sensori_sismici.mutazione_indotta",
       "uso_funzione": "i18n:traits.sensori_sismici.uso_funzione",
       "spinta_selettiva": "i18n:traits.sensori_sismici.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -17565,7 +17594,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.sensori_sismici.debolezza"
     },
     "tela_appiccicosa": {
       "schema_version": "2.0",
@@ -17579,15 +17609,19 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "aura_glaciale",
+        "tentacoli_uncinati"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.tela_appiccicosa.mutazione_indotta",
       "uso_funzione": "i18n:traits.tela_appiccicosa.uso_funzione",
       "spinta_selettiva": "i18n:traits.tela_appiccicosa.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
-      }
+        "design_stub": false
+      },
+      "debolezza": "i18n:traits.tela_appiccicosa.debolezza"
     },
     "tentacoli_uncinati": {
       "schema_version": "2.0",
@@ -17601,15 +17635,19 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "aura_glaciale",
+        "tela_appiccicosa"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.tentacoli_uncinati.mutazione_indotta",
       "uso_funzione": "i18n:traits.tentacoli_uncinati.uso_funzione",
       "spinta_selettiva": "i18n:traits.tentacoli_uncinati.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
-      }
+        "design_stub": false
+      },
+      "debolezza": "i18n:traits.tentacoli_uncinati.debolezza"
     },
     "zampe_radianti": {
       "schema_version": "2.0",
@@ -17623,15 +17661,19 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "adattamento_volo",
+        "sensori_sismici"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.zampe_radianti.mutazione_indotta",
       "uso_funzione": "i18n:traits.zampe_radianti.uso_funzione",
       "spinta_selettiva": "i18n:traits.zampe_radianti.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
-      }
+        "design_stub": false
+      },
+      "debolezza": "i18n:traits.zampe_radianti.debolezza"
     },
     "canto_di_richiamo": {
       "schema_version": "2.0",
@@ -18344,14 +18386,17 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "filtri_bioattivi",
+        "membrane_osmotiche"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.tessuti_adattivi.mutazione_indotta",
       "uso_funzione": "i18n:traits.tessuti_adattivi.uso_funzione",
       "spinta_selettiva": "i18n:traits.tessuti_adattivi.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -18362,7 +18407,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.tessuti_adattivi.debolezza"
     },
     "filtri_bioattivi": {
       "schema_version": "2.0",
@@ -18376,14 +18422,17 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "membrane_osmotiche",
+        "tessuti_adattivi"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.filtri_bioattivi.mutazione_indotta",
       "uso_funzione": "i18n:traits.filtri_bioattivi.uso_funzione",
       "spinta_selettiva": "i18n:traits.filtri_bioattivi.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -18394,7 +18443,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.filtri_bioattivi.debolezza"
     },
     "membrane_osmotiche": {
       "schema_version": "2.0",
@@ -18408,14 +18458,17 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "filtri_bioattivi",
+        "tessuti_adattivi"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.membrane_osmotiche.mutazione_indotta",
       "uso_funzione": "i18n:traits.membrane_osmotiche.uso_funzione",
       "spinta_selettiva": "i18n:traits.membrane_osmotiche.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -18426,7 +18479,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.membrane_osmotiche.debolezza"
     },
     "pigmenti_aurorali": {
       "schema_version": "2.0",
@@ -18514,14 +18568,17 @@
         "complementare": "morfologia"
       },
       "slot": [],
-      "sinergie": [],
+      "sinergie": [
+        "zampe_radianti",
+        "sensori_sismici"
+      ],
       "conflitti": [],
       "mutazione_indotta": "i18n:traits.adattamento_volo.mutazione_indotta",
       "uso_funzione": "i18n:traits.adattamento_volo.uso_funzione",
       "spinta_selettiva": "i18n:traits.adattamento_volo.spinta_selettiva",
       "data_origin": "gap1_salvage_2026_06_22",
       "completion_flags": {
-        "design_stub": true
+        "design_stub": false
       },
       "species_affinity": [
         {
@@ -18556,7 +18613,8 @@
           ],
           "weight": 4
         }
-      ]
+      ],
+      "debolezza": "i18n:traits.adattamento_volo.debolezza"
     },
     "radici_ancora_planare": {
       "schema_version": "2.0",

--- a/reports/qa-changelog.md
+++ b/reports/qa-changelog.md
@@ -1,22 +1,14 @@
 # QA export changelog
 
-Generato: 2026-07-14T00:03:24.248947Z
-Baseline precedente: 2026-06-28T13:37:48.320348Z
+Generato: 2026-07-14T09:29:07.806345Z
+Baseline precedente: 2026-07-14T00:03:24.248947Z
 
 ## Metriche baseline
-- Tratti totali: 308 (-1 vs precedente)
-- Glossario OK: 308 (-1 vs precedente)
+- Tratti totali: 308 (0 vs precedente)
+- Glossario OK: 308 (0 vs precedente)
 - Glossario mancanti: 0 (0 vs precedente)
-- Mismatch matrice: 116 (-1 vs precedente)
+- Mismatch matrice: 116 (0 vs precedente)
 - Tratti con conflitti: 28 (0 vs precedente)
-
-### tratti con mismatch matrice
-- Risolti:
-  - coscienza_dalveare_diffusa
-
-### tratti senza copertura QA
-- Risolti:
-  - coscienza_dalveare_diffusa
 
 ## Highlights UI
 - Solo matrice: Strategist, architetto, assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo, fisiologia_predatoria, fotosintesi_bifase, ghiandole_nettare_memetico, intangibilita_parziale
@@ -40,7 +32,7 @@ Baseline precedente: 2026-06-28T13:37:48.320348Z
 - Tratti validati: 0 (0 vs precedente)
 
 ## Badge QA
-- Tratti passed: 308 (-1 vs precedente)
+- Tratti passed: 308 (0 vs precedente)
 - Conflitti badge: 28 (0 vs precedente)
 
 _Report generato da scripts/export-qa-report.js_

--- a/reports/trait_baseline.json
+++ b/reports/trait_baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T00:03:24.248947Z",
+  "generated_at": "2026-07-14T09:29:07.806345Z",
   "summary": {
     "total_traits": 308,
     "glossary_ok": 308,
@@ -25,7 +25,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "denti_seghettati"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -138,7 +140,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "zampe_radianti",
+        "sensori_sismici"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -3962,7 +3967,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "tela_appiccicosa",
+        "tentacoli_uncinati"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -13052,7 +13060,9 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "denti_seghettati"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -13977,7 +13987,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "aculei_velenosi",
+        "cuore_in_furia"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -17463,7 +17476,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "membrane_osmotiche",
+        "tessuti_adattivi"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -23959,7 +23975,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "filtri_bioattivi",
+        "tessuti_adattivi"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -27242,7 +27261,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "pelli_fitte",
+        "pelli_anti_ustione"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -27468,7 +27490,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "pelle_elastomera",
+        "pelli_fitte"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -27694,7 +27719,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "pelle_elastomera",
+        "pelli_anti_ustione"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -31892,7 +31920,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "adattamento_volo",
+        "zampe_radianti"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -34005,7 +34036,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "aura_glaciale",
+        "tentacoli_uncinati"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -34118,7 +34152,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "aura_glaciale",
+        "tela_appiccicosa"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -34344,7 +34381,10 @@
         "matrix": "ok"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "filtri_bioattivi",
+        "membrane_osmotiche"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",
@@ -35517,7 +35557,10 @@
         "matrix": "mismatch"
       },
       "conflicts": [],
-      "synergies": [],
+      "synergies": [
+        "adattamento_volo",
+        "sensori_sismici"
+      ],
       "dataset_sources": [
         "data/core/species.yaml",
         "data/core/telemetry.yaml",


### PR DESCRIPTION
## R1 design-stub authoring -- fisiologico family (7/7, the missed family)

Completes the 15 fisiologico design-stubs -- **the family missed in the first R1 pass**. This closes **46/46 stubs**. Same methodology as #3285.

## What
- `sinergie` for all 15, grounded on physiological sub-domains (5 reciprocal intra-family clusters, no authored back-links needed).
- **`debolezza` i18n ref added** (Codex C fix): un-stubbed traits now carry `debolezza` like 85% of the catalog + the trait_data_reference required-fields list.
- `design_stub` -> false. All 15 already have curated data/i18n (incl. debolezza IT+EN) -> refs resolve, renders curated text.

| cluster | edges |
|---|---|
| bleed/predation | aculei_velenosi <-> denti_seghettati <-> cuore_in_furia |
| control/slow | aura_glaciale <-> tela_appiccicosa <-> tentacoli_uncinati |
| defensive dermis | pelle_elastomera <-> pelli_fitte <-> pelli_anti_ustione |
| status sustain | filtri_bioattivi <-> membrane_osmotiche <-> tessuti_adattivi |
| mobility/position | adattamento_volo <-> zampe_radianti <-> sensori_sismici |

## Gate (all green)
- trait_template_validator exit 0; trait_audit --check exit 0 + zero reciprocity warnings
- check_derived_reproducible --deep OK (8/8), count 308
- lore + harsh cluster-review before merge

Scope: design fields + debolezza ref. Branch `r1iso/*` = isolated worktree. merge = master-dd.