### PR TITLE
fix(traits): model koppen rules, kill the species-affinity backfill, honest gate at 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,10 +585,25 @@ jobs:
           # combos carry a non-null biome. The runtime generator already skipped the rule
           # outright (`const classId = rule.when?.biome_class; if (!classId) return;`),
           # so it was dead data that only inflated the coverage metric.
-          # Removing that rule takes this to a measured 0 with no fabricated affinities.
-          # The debt it was masking is real but different, and is now visible as the
-          # advisory `traits_missing_rules` (71 traits that no biome rule suggests).
-          max_missing = 0
+          # Removing that rule took this to a measured 0 -- but that 0 was STILL propped up
+          # by a second crutch one layer down: report_trait_coverage defaulted to
+          # --species-affinity, and trait_coverage.py injected EVERY affinity species into
+          # any uncovered rule combo with zero biome grounding. That backfill is now deleted,
+          # and climate-scoped rules (koppen_in / koppen_any) are expanded onto the biome
+          # classes they actually apply to (biome_classes.yaml koppen_examples) instead of
+          # collapsing to the unsatisfiable (biome=None, morphotype=None) combo that a
+          # biome-less global keeper stub was "covering".
+          #
+          # With both crutches gone the honest number is 9. Unlike the phantom 73, each of
+          # these is a concrete, checkable claim -- "rule says climate BSk yields pelli_cave;
+          # badlands IS a BSk biome; no badlands species carries pelli_cave":
+          #   pelli_cave        -> badlands, steppe_algoritmiche
+          #   pigmenti_aurorali -> badlands, steppe_algoritmiche
+          #   grassi_termici    -> badlands, steppe_algoritmiche
+          #   pelli_fitte       -> canopia_ionica, rovine_planari
+          #   cuticole_cerose   -> pianura_salina_iperarida
+          # Real content debt, Species Curator-gated. Ratchet DOWN only, never up.
+          max_missing = 9
 
           traits_with_species = summary.get('traits_with_species')
           rules_missing = summary.get('rules_missing_species_total')

--- a/data/derived/analysis/README.md
+++ b/data/derived/analysis/README.md
@@ -23,10 +23,10 @@ Report derivati rigenerabili dal core e dal pack Evo Tactics.
 
 | File | sha256 |
 | --- | --- |
-| `data/derived/analysis/trait_coverage_report.json` | `137f4bb5131349830cf1e7b4984f48e54dc193cd264ed97e684933bd185870c3` |
-| `data/derived/analysis/trait_coverage_matrix.csv` | `4e774b8edf1f040b7773f61d74dc2694fda62ad40219ab4f6e8bdcae27956246` |
+| `data/derived/analysis/trait_coverage_report.json` | `7be99fb5f83aa69c0d9e53b3bed1d0f74658d09830ddae2a739b2dfdfb64d6bb` |
+| `data/derived/analysis/trait_coverage_matrix.csv` | `4c4005bbfbd67212b7a00f88267f355f050a1f809276ef2798a3c4482162f784` |
 | `data/derived/analysis/trait_gap_report.json` | `a0ef558023bba99f39cdd6c8c173c7e77d60a8ede00b16cf4225a7ad693227c2` |
-| `data/derived/analysis/trait_baseline.yaml` | `aed250a6acea20688471470c466f599e8aa4d8dd5d92c74860f6e8763c5ce4ee` |
+| `data/derived/analysis/trait_baseline.yaml` | `029076d96a7ee93dcab610d77a64be4ff9ab0e0b317af72b5666f23b808c78f5` |
 | `data/derived/analysis/trait_env_mapping.json` | `8b0c0e07c8fca118707efe948092992d2dece80996ad9c270a6a56b3ba851ddc` |
 | `data/derived/analysis/progression/skydock_siege_xp.json` | `71abfef29be8df51f6ea7534de92b3d7a4b829057bb9a054da4d51ab22cf8ae9` |
 | `data/derived/analysis/progression/skydock_siege_xp_summary.csv` | `b80cca96f619946293a3600c1a42245f8a9996f6c4a1c518b3249db16bd781b9` |

--- a/data/derived/analysis/manifest.json
+++ b/data/derived/analysis/manifest.json
@@ -4,10 +4,10 @@
   "command": "python scripts/generate_derived_analysis.py --core-root data/core --pack-root packs/evo_tactics_pack --update-readme",
   "log_tag": null,
   "artifacts": {
-    "data/derived/analysis/trait_coverage_report.json": "137f4bb5131349830cf1e7b4984f48e54dc193cd264ed97e684933bd185870c3",
-    "data/derived/analysis/trait_coverage_matrix.csv": "4e774b8edf1f040b7773f61d74dc2694fda62ad40219ab4f6e8bdcae27956246",
+    "data/derived/analysis/trait_coverage_report.json": "7be99fb5f83aa69c0d9e53b3bed1d0f74658d09830ddae2a739b2dfdfb64d6bb",
+    "data/derived/analysis/trait_coverage_matrix.csv": "4c4005bbfbd67212b7a00f88267f355f050a1f809276ef2798a3c4482162f784",
     "data/derived/analysis/trait_gap_report.json": "a0ef558023bba99f39cdd6c8c173c7e77d60a8ede00b16cf4225a7ad693227c2",
-    "data/derived/analysis/trait_baseline.yaml": "aed250a6acea20688471470c466f599e8aa4d8dd5d92c74860f6e8763c5ce4ee",
+    "data/derived/analysis/trait_baseline.yaml": "029076d96a7ee93dcab610d77a64be4ff9ab0e0b317af72b5666f23b808c78f5",
     "data/derived/analysis/trait_env_mapping.json": "8b0c0e07c8fca118707efe948092992d2dece80996ad9c270a6a56b3ba851ddc",
     "data/derived/analysis/progression/skydock_siege_xp.json": "71abfef29be8df51f6ea7534de92b3d7a4b829057bb9a054da4d51ab22cf8ae9",
     "data/derived/analysis/progression/skydock_siege_xp_summary.csv": "b80cca96f619946293a3600c1a42245f8a9996f6c4a1c518b3249db16bd781b9",

--- a/data/derived/analysis/trait_baseline.yaml
+++ b/data/derived/analysis/trait_baseline.yaml
@@ -4,7 +4,7 @@ source:
   trait_reference: packs\evo_tactics_pack\docs\catalog\trait_reference.json
   trait_glossary: data\core\traits\glossary.json
 summary:
-  total_traits: 436
+  total_traits: 435
   missing_metadata: 128
 traits:
   aculei_velenosi:
@@ -48,7 +48,7 @@ traits:
     description_en: Generate a wide sonic band while flying.
     tier: T3
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Aereo
     fattore_mantenimento_energetico: Medio (risonanza ad ampio spettro)
     sinergie:
@@ -122,7 +122,7 @@ traits:
       shielding.
     tier: T2
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Aereo
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -217,7 +217,7 @@ traits:
     description_en: Channels storm lightning into psionic strikes or shields.
     tier: T3
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Offensivo
     fattore_mantenimento_energetico: Alto (Canalizzazione costante di plasma atmosferico)
     sinergie:
@@ -373,7 +373,7 @@ traits:
       shockwaves.
     tier: T2
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difesa/Strutturale
     fattore_mantenimento_energetico: Basso (Risonanza geodetica stabile)
     sinergie:
@@ -390,7 +390,7 @@ traits:
     description_en: Amplify leaps and leg thrusts.
     tier: T3
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Terrestre
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -406,7 +406,7 @@ traits:
     description_en: Rotate limbs for tight maneuvers.
     tier: T3
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Terrestre
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -459,7 +459,7 @@ traits:
     description_en: Induce localized cold shock.
     tier: T3
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Termico
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -570,7 +570,7 @@ traits:
     description_en: Cryogenic claws that freeze and pin targets on contact.
     tier: T2
     archetype: locomozione
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotorio/Predatorio
     fattore_mantenimento_energetico: Medio (Raffreddamento endogeno controllato)
     sinergie:
@@ -606,7 +606,7 @@ traits:
     description_en: Deliver shockwaves that fracture targets.
     tier: T4
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Contusivo
     fattore_mantenimento_energetico: Alto (apporto costante o consumo continuo)
     sinergie:
@@ -625,7 +625,7 @@ traits:
       in predators.
     tier: T3
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Controllo
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -662,7 +662,7 @@ traits:
       vitals.
     tier: T3
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Supporto/Difesa
     fattore_mantenimento_energetico: Alto (Canalizzazione fotonica continua)
     sinergie:
@@ -774,7 +774,7 @@ traits:
     description_en: Antennae reading gravitic shear and converting to signals.
     tier: T3
     archetype: sensore
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensore/Gravitazionale
     fattore_mantenimento_energetico: i18n:traits.bioantenne_gravitiche.fattore_mantenimento_energetico
     sinergie: []
@@ -848,7 +848,7 @@ traits:
     description_en: Shield against external electromagnetic fields.
     tier: T2
     archetype: difensivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difensivo/Resistenze
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -940,7 +940,7 @@ traits:
     description_en: Psionic gills filtering salts and toxins in shifting waters.
     tier: T2
     archetype: sopravvivenza
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Respiratorio/Osmoregolazione
     fattore_mantenimento_energetico: Medio (Pompe ioniche attive)
     sinergie:
@@ -995,7 +995,7 @@ traits:
     description_en: Root bulbs releasing heat and stores to linked allies.
     tier: T2
     archetype: simbiotico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Simbiotico/Nutrizione
     fattore_mantenimento_energetico: Medio (Accumulo e rilascio lento di nutrienti)
     sinergie:
@@ -1071,7 +1071,7 @@ traits:
     description_en: Internal caverns amplifying electric/gravitational waves.
     tier: T3
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Supporto/Risonanza
     fattore_mantenimento_energetico: i18n:traits.camere_risonanza_abyssal.fattore_mantenimento_energetico
     sinergie: []
@@ -1085,7 +1085,7 @@ traits:
     description_en: Mask position and velocity.
     tier: T3
     archetype: difensivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difensivo/Camuffamento
     fattore_mantenimento_energetico: Basso (rumore bianco a fase variabile)
     sinergie:
@@ -1104,7 +1104,7 @@ traits:
     description_en: Stun or injure targets with a sonic beam.
     tier: T4
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Controllo
     fattore_mantenimento_energetico: Medio (scarica focalizzata con ricarica)
     sinergie:
@@ -1139,7 +1139,7 @@ traits:
     description_en: Disorient predators and communicate at range.
     tier: T4
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Controllo
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -1154,7 +1154,7 @@ traits:
     description_en: Frequencies harmonising the squad and reducing stress (temp).
     tier: T3
     archetype: temporaneo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Temporaneo/Risonanza
     fattore_mantenimento_energetico: i18n:traits.canto_risonante.fattore_mantenimento_energetico
     sinergie: []
@@ -1277,7 +1277,7 @@ traits:
     description_en: Bioluminescent shell confusing predators in abyssal dark.
     tier: T3
     archetype: struttura
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Strutturale/Sensoriale
     fattore_mantenimento_energetico: Alto (Bioluminescenza controllata)
     sinergie:
@@ -1332,7 +1332,7 @@ traits:
     description_en: Thermo-reactive cartilage optimizing aerial turns.
     tier: T2
     archetype: locomozione
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotorio/Adattivo
     fattore_mantenimento_energetico: Medio (Richiede frequenti riallineamenti fibrosi)
     sinergie:
@@ -1427,7 +1427,7 @@ traits:
     description_en: Chest chambers projecting long-range calls through tundra frost.
     tier: T1
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Supporto
     fattore_mantenimento_energetico: Basso (Camere di risonanza statiche)
     sinergie:
@@ -1464,7 +1464,7 @@ traits:
     description_en: Execute high-frequency maneuvers.
     tier: T3
     archetype: cognitivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Cognitivo/Apprendimento
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -1519,7 +1519,7 @@ traits:
     description_en: Parasitic tendrils weaving energy lanes through canopy.
     tier: T1
     archetype: simbiotico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Simbiotico/Utility
     fattore_mantenimento_energetico: Medio (Nutrimento condiviso con l'ospite arboreo)
     sinergie:
@@ -1535,7 +1535,7 @@ traits:
     description_en: Translate the body across smooth or rough ground.
     tier: T3
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Terrestre
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -1571,7 +1571,7 @@ traits:
       wetlands.
     tier: T2
     archetype: metabolismo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Metabolico/Resilienza
     fattore_mantenimento_energetico: Medio (Doppio circuito emolinfa/linfa)
     sinergie:
@@ -1683,7 +1683,7 @@ traits:
     description_en: Enter stasis under harsh conditions.
     tier: T2
     archetype: difensivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difensivo/Resistenze
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -1840,7 +1840,7 @@ traits:
     description_en: Hang and counterbalance weight.
     tier: T3
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Arboricolo
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -1936,7 +1936,7 @@ traits:
     description_en: Exchange tactile light pulses.
     tier: T2
     archetype: cognitivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Cognitivo/Sociale
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -1970,7 +1970,7 @@ traits:
     description_en: Bioelectric coral ridges channeling light and impulses.
     tier: T1
     archetype: ambiente
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Ambiente/Supporto
     fattore_mantenimento_energetico: i18n:traits.coralli_sinaptici_fotofase.fattore_mantenimento_energetico
     sinergie: []
@@ -1984,7 +1984,7 @@ traits:
     description_en: Iron plates guiding deep magnetic fields.
     tier: T3
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difesa/Magnetico
     fattore_mantenimento_energetico: i18n:traits.corazze_ferro_magnetico.fattore_mantenimento_energetico
     sinergie: []
@@ -2000,7 +2000,7 @@ traits:
       for pack alerts.
     tier: T3
     archetype: cognitivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Cognitivo/Sociale
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -2040,7 +2040,7 @@ traits:
       short-term memory.
     tier: T4
     archetype: cognitivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Cognitivo/Sociale
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -2376,7 +2376,7 @@ traits:
       for performance peaks in cool climates.
     tier: T3
     archetype: fisiologico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Fisiologico/Termico
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -2392,7 +2392,7 @@ traits:
     description_en: Disrupt prey nervous systems.
     tier: T4
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Elettrico
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -2409,7 +2409,7 @@ traits:
     description_en: Organs emitting deep choruses to stabilise shear.
     tier: T3
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Supporto/Anomalia
     fattore_mantenimento_energetico: i18n:traits.emettitori_voidsong.fattore_mantenimento_energetico
     sinergie: []
@@ -2423,7 +2423,7 @@ traits:
     description_en: Fluid storing charge and draining enemy energy.
     tier: T3
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Supporto/Energetico
     fattore_mantenimento_energetico: i18n:traits.emolinfa_conducente.fattore_mantenimento_energetico
     sinergie: []
@@ -2618,7 +2618,7 @@ traits:
     description_en: Change sex after one or two incubations.
     tier: T3
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Riproduttivo/Cicli
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -2634,7 +2634,7 @@ traits:
     description_en: Liquefy tissues on contact and siphon them.
     tier: T4
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Chimico
     fattore_mantenimento_energetico: Alto (apporto costante o consumo continuo)
     sinergie:
@@ -2649,7 +2649,7 @@ traits:
     description_en: Engulf and digest entire biomass.
     tier: T3
     archetype: alimentazione
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Alimentazione/Digestione
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -2716,7 +2716,7 @@ traits:
     description_en: Filaments relaying squad frequencies and softening shear.
     tier: T3
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Supporto/Risonanza
     fattore_mantenimento_energetico: i18n:traits.filamenti_echo.fattore_mantenimento_energetico
     sinergie: []
@@ -2730,7 +2730,7 @@ traits:
     description_en: Filaments plotting safe routes through currents.
     tier: T1
     archetype: locomozione
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Mobilità/Logistica
     fattore_mantenimento_energetico: i18n:traits.filamenti_guidalampo.fattore_mantenimento_energetico
     sinergie: []
@@ -2802,7 +2802,7 @@ traits:
     description_en: Neutralize self-generated toxins.
     tier: T2
     archetype: fisiologico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Fisiologico/Idrico
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -2854,7 +2854,7 @@ traits:
     description_en: Sustain electrogenic organs.
     tier: T2
     archetype: alimentazione
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Alimentazione/Digestione
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -2889,7 +2889,7 @@ traits:
     description_en: Slide or climb along smooth surfaces.
     tier: T2
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Terrestre
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -3001,7 +3001,7 @@ traits:
     description_en: Bound plasma appendage that can hook and ignite targets.
     tier: T2
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Controllo
     fattore_mantenimento_energetico: Medio (Filamenti di plasma vincolato)
     sinergie:
@@ -3229,7 +3229,7 @@ traits:
     description_en: Secretions holding attenuated buff copies.
     tier: T2
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Supporto/Copia
     fattore_mantenimento_energetico: i18n:traits.ghiandole_mnemoniche.fattore_mantenimento_energetico
     sinergie: []
@@ -3394,7 +3394,7 @@ traits:
     description_en: Rhythmic flashes that dazzle foes and sync allies.
     tier: T1
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Illuminazione
     fattore_mantenimento_energetico: i18n:traits.impulsi_bioluminescenti.fattore_mantenimento_energetico
     sinergie: []
@@ -3408,7 +3408,7 @@ traits:
     description_en: Orient along magnetic field lines.
     tier: T3
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Magneto-ricettivo
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -3445,7 +3445,7 @@ traits:
       acceleration while enduring short bursts.
     tier: T3
     archetype: fisiologico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Fisiologico/Metabolico
     fattore_mantenimento_energetico: Alto (apporto costante o consumo continuo)
     sinergie:
@@ -3500,7 +3500,7 @@ traits:
     description_en: Respiratory lamellae deflect extreme gases via heat gradients.
     tier: T2
     archetype: sopravvivenza
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Respiratorio/Termoregolazione
     fattore_mantenimento_energetico: Medio (Flusso continuo di fluidi caldi)
     sinergie:
@@ -3625,7 +3625,7 @@ traits:
     description_en: Resonant chambers filtering unstable signals.
     tier: T2
     archetype: risonanza
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Risonanza/Crepuscolo
     fattore_mantenimento_energetico: i18n:traits.lobi_risonanti_crepuscolo.fattore_mantenimento_energetico
     sinergie: []
@@ -3639,7 +3639,7 @@ traits:
     description_en: Grip and climb on nearly any surface.
     tier: T3
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Terrestre
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -3717,7 +3717,7 @@ traits:
       pulses.
     tier: T3
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difesa/Termoregolazione
     fattore_mantenimento_energetico: Alto (Rivestimento ablativo rigenerante)
     sinergie:
@@ -3787,7 +3787,7 @@ traits:
     description_en: Adopt different shapes and densities.
     tier: T3
     archetype: difensivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difensivo/Camuffamento
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -3825,7 +3825,7 @@ traits:
     description_en: Translucent membranes screening radiation and airborne pathogens.
     tier: T2
     archetype: sopravvivenza
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Respiratorio/Protezione
     fattore_mantenimento_energetico: Basso (Auto-riparazione lenta)
     sinergie:
@@ -3841,7 +3841,7 @@ traits:
     description_en: Tissues that ferry luminous charge between synaptic nodes.
     tier: T1
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difesa/Elettrico
     fattore_mantenimento_energetico: i18n:traits.membrane_fotoconvoglianti.fattore_mantenimento_energetico
     sinergie: []
@@ -3929,7 +3929,7 @@ traits:
       a collective reserve.
     tier: T3
     archetype: fisiologico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Fisiologico/Metabolico
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -4015,7 +4015,7 @@ traits:
     description_en: Grow mass and intellect by merging units.
     tier: T2
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Riproduttivo/Cicli
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -4031,7 +4031,7 @@ traits:
     description_en: Maintain extended flight at ultra-low sound pressure.
     tier: T2
     archetype: fisiologico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Fisiologico/Metabolico
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -4046,7 +4046,7 @@ traits:
     description_en: Symbiotic mucus absorbing poisons and sealing swamp wounds.
     tier: T1
     archetype: simbiotico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Simbiotico/Difensivo
     fattore_mantenimento_energetico: Medio (Coltura simbiotica costante)
     sinergie:
@@ -4189,7 +4189,7 @@ traits:
     description_en: Psionic mist that blurs memory and orientation.
     tier: T2
     archetype: controllo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Controllo/Memoria
     fattore_mantenimento_energetico: i18n:traits.nebbia_mnesica.fattore_mantenimento_energetico
     sinergie: []
@@ -4234,7 +4234,7 @@ traits:
     description_en: Mycorrhizal nodes foreseeing threats via fungal signals.
     tier: T3
     archetype: simbiotico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Simbiotico/Nervoso
     fattore_mantenimento_energetico: Medio (Scambio continuo di segnali con simbionti)
     sinergie:
@@ -4279,7 +4279,7 @@ traits:
     description_en: Node lattice amplifying surface signals.
     tier: T1
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Supporto/Sensore
     fattore_mantenimento_energetico: i18n:traits.nodi_sinaptici_superficiali.fattore_mantenimento_energetico
     sinergie: []
@@ -4360,7 +4360,7 @@ traits:
     description_en: Read strand tension and stress patterns.
     tier: T2
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Visivo
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -4392,7 +4392,7 @@ traits:
     description_en: See sound as patterns in the air.
     tier: T2
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Visivo
     fattore_mantenimento_energetico: Basso (micro-attuatori oculari)
     sinergie:
@@ -4412,7 +4412,7 @@ traits:
       useful in variable microgravity.
     tier: T2
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Visivo
     fattore_mantenimento_energetico: Moderato (Attivo)
     sinergie:
@@ -4559,7 +4559,7 @@ traits:
     description_en: Organs sequencing chained buff thefts.
     tier: T2
     archetype: supporto
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Supporto/Sequenziamento
     fattore_mantenimento_energetico: i18n:traits.organi_metacronici.fattore_mantenimento_energetico
     sinergie: []
@@ -4575,7 +4575,7 @@ traits:
       and hidden movements.
     tier: T2
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Tatto-Vibro
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -4717,7 +4717,7 @@ traits:
     description_en: Insulate the body and stay afloat.
     tier: T2
     archetype: difensivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difensivo/Termoregolazione
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -4856,7 +4856,7 @@ traits:
     description_en: Dermis storing piezo charge and reflecting blows (temp).
     tier: T3
     archetype: temporaneo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Temporaneo/Difesa
     fattore_mantenimento_energetico: i18n:traits.pelle_piezo_satura.fattore_mantenimento_energetico
     sinergie: []
@@ -5380,7 +5380,7 @@ traits:
     description_en: Photovoltaic plumage storing sunlight for long sorties.
     tier: T2
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Tegumentario/Energetico
     fattore_mantenimento_energetico: Alto (Richiede manutenzione delle lamine fotoreattive)
     sinergie:
@@ -5396,7 +5396,7 @@ traits:
     description_en: Plates diffusing and attenuating erratic charges.
     tier: T2
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difesa/Foschia
     fattore_mantenimento_energetico: i18n:traits.placca_diffusione_foschia.fattore_mantenimento_energetico
     sinergie: []
@@ -5440,7 +5440,7 @@ traits:
     description_en: Layers dispersing abyssal pressure and reducing trauma.
     tier: T3
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difesa/Pressione
     fattore_mantenimento_energetico: i18n:traits.placche_pressioniche.fattore_mantenimento_energetico
     sinergie: []
@@ -5484,7 +5484,7 @@ traits:
     description_en: Crystalline lungs concentrating thin high-altitude oxygen.
     tier: T2
     archetype: sopravvivenza
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Respiratorio/Aerobico
     fattore_mantenimento_energetico: Medio (Pulizia periodica dei cristalli)
     sinergie:
@@ -5610,7 +5610,7 @@ traits:
     description_en: Experimental slot drawing random traits from a curated pool.
     tier: T1
     archetype: adattivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Flessibile/Generico
     fattore_mantenimento_energetico: Variabile (Dipende dal tratto estratto)
     sinergie:
@@ -5664,7 +5664,7 @@ traits:
     description_en: Absorb nutrients suspended in the air.
     tier: T3
     archetype: fisiologico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Fisiologico/Respiratorio
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -5899,7 +5899,7 @@ traits:
     description_en: Cognitive echo duplicating buffs at reduced power (temp).
     tier: T3
     archetype: temporaneo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Temporaneo/Memoria
     fattore_mantenimento_energetico: i18n:traits.riverbero_memetico.fattore_mantenimento_energetico
     sinergie: []
@@ -5915,7 +5915,7 @@ traits:
       draws fluids after impact.
     tier: T4
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Perforante
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -5932,7 +5932,7 @@ traits:
     description_en: Grab and manipulate at long reach.
     tier: T3
     archetype: manipolativo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Manipolativo/Alimentare
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -6093,7 +6093,7 @@ traits:
     description_en: Stratospheric vesicles dispersing long-range support spores.
     tier: T3
     archetype: simbiotico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Simbiotico/Supporto
     fattore_mantenimento_energetico: Alto (Coltura continua di spore portanti)
     sinergie:
@@ -6188,7 +6188,7 @@ traits:
       projectile blows.
     tier: T4
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Balistico
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -6255,7 +6255,7 @@ traits:
     description_en: Lighten the load for slow, steady travel.
     tier: T3
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Terrestre
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -6273,7 +6273,7 @@ traits:
     description_en: Light discharge illuminating connections and reflexes (temp).
     tier: T2
     archetype: temporaneo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Temporaneo/Scarica
     fattore_mantenimento_energetico: i18n:traits.scintilla_sinaptica.fattore_mantenimento_energetico
     sinergie: []
@@ -6287,7 +6287,7 @@ traits:
     description_en: Reduce friction to glide.
     tier: T3
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Terrestre
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -6302,7 +6302,7 @@ traits:
     description_en: Absorb impacts from the rear.
     tier: T3
     archetype: difensivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difensivo/Corazza
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -6336,7 +6336,7 @@ traits:
     description_en: Protective film dispersing electrical build-up.
     tier: T2
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difesa/Antistatico
     fattore_mantenimento_energetico: i18n:traits.secrezioni_antistatiche.fattore_mantenimento_energetico
     sinergie: []
@@ -6429,7 +6429,7 @@ traits:
     description_en: Cranial crystals mapping invisible geomagnetic corridors.
     tier: T1
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Navigazione
     fattore_mantenimento_energetico: Basso (Ricettori passivi)
     sinergie:
@@ -6507,7 +6507,7 @@ traits:
     description_en: Distributed sensors reading memetic plankton patterns.
     tier: T1
     archetype: analisi
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Analisi/Sensori Planctonici
     fattore_mantenimento_energetico: i18n:traits.sensori_planctonici.fattore_mantenimento_energetico
     sinergie: []
@@ -6599,7 +6599,7 @@ traits:
     description_en: Stun prey with charges woven into the web.
     tier: T4
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Elettrico
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -6615,7 +6615,7 @@ traits:
     description_en: Prevent crystallization at low temperatures.
     tier: T2
     archetype: fisiologico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Fisiologico/Termico
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -6690,7 +6690,7 @@ traits:
     description_en: Coralline synapses relaying orders through marine harmonics.
     tier: T2
     archetype: simbiotico
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Simbiotico/Comunicazione
     fattore_mantenimento_energetico: Medio (Scambio continuo di impulsi corallini)
     sinergie:
@@ -6798,7 +6798,7 @@ traits:
     description_en: Map space and airflow without sight.
     tier: T3
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Uditivo-Olfattivo
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -6832,7 +6832,7 @@ traits:
     description_en: Spines absorbing buffs and redirecting them.
     tier: T2
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Assorbimento
     fattore_mantenimento_energetico: i18n:traits.spicole_canalizzatrici.fattore_mantenimento_energetico
     sinergie: []
@@ -6933,7 +6933,7 @@ traits:
     description_en: Scales dispersing charge and reducing glare.
     tier: T1
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difesa/Elettrico
     fattore_mantenimento_energetico: i18n:traits.squame_diffusori_ionici.fattore_mantenimento_energetico
     sinergie: []
@@ -6947,7 +6947,7 @@ traits:
     description_en: Crystal scales diffusing heat and casting mirages.
     tier: T2
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Tegumentario/Difensivo
     fattore_mantenimento_energetico: Medio (Richiede riallineamento delle placche)
     sinergie:
@@ -7254,22 +7254,6 @@ traits:
     biomi:
       abisso_vulcanico: 1
     missing_metadata: true
-  traits_aggregate:
-    label: Aggregato tratti Evo
-    label_en: Evo Traits Aggregate
-    description_it: Dump normalizzato dei trait Evo (TR-*) per allineare indice legacy
-      e QA.
-    description_en: Normalized Evo trait dump (TR-*) used to align legacy index and
-      QA.
-    tier: T1
-    archetype: meta
-    occurrences: 1
-    famiglia_tipologia: Meta/Dataset
-    fattore_mantenimento_energetico: N/A
-    sinergie: []
-    conflitti: []
-    biomi: {}
-    missing_metadata: false
   unghie_a_micro_adesione:
     label: Unghie a Micro-Adesione
     label_en: Micro-Adhesion Claws
@@ -7279,7 +7263,7 @@ traits:
       escapes and browsing.
     tier: T2
     archetype: locomotivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotivo/Arboricolo
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -7369,7 +7353,7 @@ traits:
     description_en: Capillary fleece condensing fog into mobile water reserves.
     tier: T1
     archetype: difesa
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Tegumentario/Idratazione
     fattore_mantenimento_energetico: Basso (Strutture passive a microfilo)
     sinergie:
@@ -7384,7 +7368,7 @@ traits:
     description_en: Absorb nearly all incoming light.
     tier: T3
     archetype: difensivo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Difensivo/Camuffamento
     fattore_mantenimento_energetico: Basso (mantenimento passivo o trascurabile)
     sinergie:
@@ -7506,7 +7490,7 @@ traits:
     description_en: See under extremely low luminance.
     tier: T3
     archetype: sensoriale
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Sensoriale/Visivo
     fattore_mantenimento_energetico: Medio (manutenzione periodica o situazionale)
     sinergie:
@@ -7557,7 +7541,7 @@ traits:
     description_en: Luminous implosion followed by void and short teleport (temp).
     tier: T3
     archetype: temporaneo
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Temporaneo/Traslazione
     fattore_mantenimento_energetico: i18n:traits.vortice_nera_flash.fattore_mantenimento_energetico
     sinergie: []
@@ -7633,7 +7617,7 @@ traits:
     description_en: Corrode tissues and even metals.
     tier: T4
     archetype: offensiva
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Offensivo/Chimico
     fattore_mantenimento_energetico: Alto (apporto costante o consumo continuo)
     sinergie:
@@ -7665,7 +7649,7 @@ traits:
     description_en: Hollow hooves sending rhythmic waves across the steppe pack.
     tier: T1
     archetype: locomozione
-    occurrences: 1
+    occurrences: 0
     famiglia_tipologia: Locomotorio/Supporto
     fattore_mantenimento_energetico: Basso (Vibrazione passiva del suolo)
     sinergie:
@@ -7855,10 +7839,6 @@ archetypes:
     - artigli_psionici
     - cervello_predittivo
     - mente_lucida
-  meta:
-    total: 1
-    traits:
-    - traits_aggregate
   metabolismo:
     total: 19
     traits:

--- a/data/derived/analysis/trait_coverage_matrix.csv
+++ b/data/derived/analysis/trait_coverage_matrix.csv
@@ -33,9 +33,9 @@ artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,caverna_risonante,,1,2
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,caverna_risonante,bipede_agile,0,1
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,cryosteppe,cursoriale_quadrupede,0,1
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,dorsale_termale_tropicale,,0,1
-artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,dorsale_termale_tropicale,cursoriale_quadrupede,1,10
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,mezzanotte_orbitale,,0,1
-artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,mezzanotte_orbitale,cursoriale_quadrupede,1,10
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,mezzanotte_orbitale,cursoriale_quadrupede,1,0
 artigli_sghiaccio_glaciale,Artigli Sghiaccio Glaciale,Artigli Sghiaccio Glaciale,,,0,1
 artigli_vetrificati,Artigli Vetrificati,Artigli Vetrificati,caldera_glaciale,,1,1
 aura_scudo_radianza,Aura Scudo di Radianza,Radiant Shield Aura,,,0,1
@@ -67,7 +67,7 @@ carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,ba
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,caverna,costrutto_corazzato,0,1
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,cryosteppe,cursoriale_quadrupede,0,1
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,mezzanotte_orbitale,,0,1
-carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,mezzanotte_orbitale,cursoriale_quadrupede,1,9
+carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,mezzanotte_orbitale,cursoriale_quadrupede,1,0
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,palude,bipede_filtratore,0,1
 carapace_luminiscente_abissale,Carapace Luminiscente Abissale,Carapace Luminiscente Abissale,,,0,1
 carapace_segmenti_logici,Carapace Segmenti Logici,Carapace Segmenti Logici,steppe_algoritmiche,,1,1
@@ -94,7 +94,7 @@ coda_contrappeso,Coda Contrappeso,Coda Contrappeso,mangrovieto_cinetico,,1,1
 coda_coppia_retroattiva,Coda Coppia Retroattiva,Coda Coppia Retroattiva,steppe_algoritmiche,,1,1
 coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,badlands,scavatore_corazzato,0,1
 coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,dorsale_termale_tropicale,,0,1
-coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,dorsale_termale_tropicale,cursoriale_quadrupede,1,4
+coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
 coda_stabilizzatrice_filo,Coda Stabilizzatrice Filo,Coda Stabilizzatrice Filo,canopia_ionica,,1,1
 coda_stabilizzatrice_geiser,Coda Stabilizzatrice Geiser,Coda Stabilizzatrice Geiser,dorsale_termale_tropicale,,1,1
 coda_stabilizzatrice_vortex,Coda Stabilizzatrice Vortex,Coda Stabilizzatrice Vortex,stratosfera_tempestosa,,1,1
@@ -103,19 +103,20 @@ coralli_partner,Coralli Partner,Coralli Partner,reef_luminescente,,1,1
 corteccia_memetica,Corteccia Memetica,Corteccia Memetica,foresta_miceliale,flora_radicata,0,1
 criostasi_adattiva,Criostasi,Adaptive Cryostasis,cryosteppe,volatore_planatore,0,1
 criostasi_adattiva,Criostasi,Adaptive Cryostasis,mezzanotte_orbitale,,0,1
-criostasi_adattiva,Criostasi,Adaptive Cryostasis,mezzanotte_orbitale,volatore_planatore,1,6
+criostasi_adattiva,Criostasi,Adaptive Cryostasis,mezzanotte_orbitale,volatore_planatore,1,0
 cromofori_alert_acido,Cromofori Alert Acido,Cromofori Alert Acido,foresta_acida,,1,1
 cuore_multicamera_bassa_pressione,Cuore Multicamera Bassa Pressione,Cuore Multicamera Bassa Pressione,stratosfera_tempestosa,,1,1
 cuscinetti_elettrostatici,Cuscinetti Elettrostatici,Cuscinetti Elettrostatici,pianura_salina_iperarida,,1,1
 cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,,,1,1
 cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,badlands,,1,2
 cute_resistente_sali,Cute Resistente Sali,Cute Resistente Sali,badlands,volatore_planatore,0,1
-cuticole_cerose,Cuticole Cerose,Cuticole Cerose,,,1,1
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,,,0,1
 cuticole_cerose,Cuticole Cerose,Cuticole Cerose,cryosteppe,volatore_planatore,0,1
 cuticole_cerose,Cuticole Cerose,Cuticole Cerose,deserto_caldo,cursoriale_quadrupede,0,1
 cuticole_cerose,Cuticole Cerose,Cuticole Cerose,deserto_caldo,ingegnere_radicante,0,1
 cuticole_cerose,Cuticole Cerose,Cuticole Cerose,deserto_caldo,scavenger_corazzato,0,1
 cuticole_cerose,Cuticole Cerose,Cuticole Cerose,deserto_caldo,volatore_planatore,0,2
+cuticole_cerose,Cuticole Cerose,Cuticole Cerose,pianura_salina_iperarida,,1,0
 cuticole_neutralizzanti,Cuticole Neutralizzanti,Cuticole Neutralizzanti,foresta_acida,,1,1
 denti_chelatanti,Denti Chelatanti,Denti Chelatanti,foresta_acida,,1,1
 denti_ossidoferro,Denti Ossidoferro,Denti Ossidoferro,abisso_vulcanico,,1,1
@@ -128,9 +129,9 @@ eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,FORESTA_TEMP
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,badlands,volatore_planatore,0,1
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,cryosteppe,volatore_planatore,0,1
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,dorsale_termale_tropicale,,0,1
-eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,dorsale_termale_tropicale,volatore_planatore,1,6
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,dorsale_termale_tropicale,volatore_planatore,1,0
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_orbitale,,0,1
-eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_orbitale,volatore_planatore,1,6
+eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_orbitale,volatore_planatore,1,0
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,canopia_ionica,serpentiforme_alato,0,1
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_miceliale,,1,1
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_temperata,,0,1
@@ -146,11 +147,11 @@ epitelio_fosforescente,Epitelio Fosforescente,Epitelio Fosforescente,reef_lumine
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,badlands,scavenger_corazzato,0,2
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,cryosteppe,scavenger_corazzato,0,1
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,dorsale_termale_tropicale,,0,1
-filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,dorsale_termale_tropicale,scavenger_corazzato,1,10
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,dorsale_termale_tropicale,scavenger_corazzato,1,0
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,falde_magnetiche_psioniche,,1,1
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,foresta_miceliale,,1,1
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,mezzanotte_orbitale,,0,1
-filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,mezzanotte_orbitale,scavenger_corazzato,1,10
+filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,mezzanotte_orbitale,scavenger_corazzato,1,0
 filamenti_digestivi_compattanti,Filamenti Digestivi Compattanti,Digestive Compaction Filaments,reef_luminescente,amorfo,0,1
 filamenti_magnetotrofi,Filamenti Magnetotrofi,Filamenti Magnetotrofi,abisso_vulcanico,,1,1
 filamenti_superconduttivi,Filamenti Superconduttivi,Filamenti Superconduttivi,caldera_glaciale,,1,1
@@ -184,12 +185,15 @@ ghiandole_nebbia_ionica,Ghiandole Nebbia Ionica,Ghiandole Nebbia Ionica,canopia_
 ghiandole_resina_conduttiva,Ghiandole Resina Conduttiva,Ghiandole Resina Conduttiva,canopia_ionica,,1,1
 ghiandole_ventosa,Ghiandole Ventosa,Ghiandole Ventosa,caldera_glaciale,,1,1
 giunti_antitorsione,Giunti Antitorsione,Giunti Antitorsione,mangrovieto_cinetico,,1,1
-grassi_termici,Grassi Termici,Grassi Termici,,,1,1
+grassi_termici,Grassi Termici,Grassi Termici,,,0,1
+grassi_termici,Grassi Termici,Grassi Termici,badlands,,1,0
+grassi_termici,Grassi Termici,Grassi Termici,cryosteppe,,1,1
 grassi_termici,Grassi Termici,Grassi Termici,cryosteppe,volatore_planatore,0,1
 grassi_termici,Grassi Termici,Grassi Termici,deserto_caldo,cursoriale_quadrupede,0,1
 grassi_termici,Grassi Termici,Grassi Termici,deserto_caldo,ingegnere_radicante,0,1
 grassi_termici,Grassi Termici,Grassi Termici,deserto_caldo,scavenger_corazzato,0,1
 grassi_termici,Grassi Termici,Grassi Termici,deserto_caldo,volatore_planatore,0,2
+grassi_termici,Grassi Termici,Grassi Termici,steppe_algoritmiche,,1,0
 gusci_criovetro,Gusci Criovetro,Gusci Criovetro,caldera_glaciale,,1,1
 gusci_magnesio,Gusci Magnesio,Gusci Magnesio,dorsale_termale_tropicale,,1,1
 lamelle_shear,Lamelle Shear,Lamelle Shear,stratosfera_tempestosa,,1,1
@@ -218,9 +222,9 @@ mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chr
 mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,canopia_ionica,aliante_mimetico,0,1
 mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,canopia_psionica_leggera,,1,1
 mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,dorsale_termale_tropicale,,0,1
-mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,dorsale_termale_tropicale,ingegnere_radicante,1,6
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,dorsale_termale_tropicale,ingegnere_radicante,1,0
 mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,mezzanotte_orbitale,,0,1
-mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,mezzanotte_orbitale,volatore_planatore,1,6
+mimetismo_cromatico_passivo,Ghiandole di Mimetismo Cromatico Passivo,Passive Chromatic Mimicry,mezzanotte_orbitale,volatore_planatore,1,0
 mucillagine_simbionte_mangrovie,Mucillagine Simbionte delle Mangrovie,Mucillagine Simbionte delle Mangrovie,,,0,1
 mucose_aderenza_sonica,Mucose Aderenza Sonica,Mucose Aderenza Sonica,caverna_risonante,,1,1
 mucose_barofile,Mucose Barofile,Mucose Barofile,abisso_vulcanico,,1,1
@@ -228,7 +232,7 @@ nodi_micorrizici_oracolari,Nodi Micorrizici Oracolari,Nodi Micorrizici Oracolari
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,abisso_vulcanico,multi_arto_rotante,0,1
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,badlands,cursoriale_quadrupede,0,1
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,dorsale_termale_tropicale,,0,1
-nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,dorsale_termale_tropicale,cursoriale_quadrupede,1,7
+nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,falde_magnetiche_psioniche,,1,1
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,orbita_psionica_inversa,,1,1
 occhi_cristallo_modulare,Occhi a Cristallo Modulare,Modular Crystal Eyes,stratosfera_tempestosa,fluttuatore,0,1
@@ -237,13 +241,13 @@ occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,DE
 occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,FORESTA_TEMPERATA,volatore_planatore,0,1
 occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,badlands,volatore_planatore,0,1
 occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,dorsale_termale_tropicale,,0,1
-occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,dorsale_termale_tropicale,volatore_planatore,1,4
+occhi_infrarosso_composti,Occhi Composti ad Infrarosso,Infrared Compound Eyes,dorsale_termale_tropicale,volatore_planatore,1,0
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,cryosteppe,cursoriale_quadrupede,0,1
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,dorsale_termale_tropicale,,0,1
-olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,dorsale_termale_tropicale,cursoriale_quadrupede,1,9
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,falde_magnetiche_psioniche,,1,1
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,mezzanotte_orbitale,,0,1
-olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,mezzanotte_orbitale,cursoriale_quadrupede,1,9
+olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,mezzanotte_orbitale,cursoriale_quadrupede,1,0
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,orbita_psionica_inversa,,1,1
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,reef_luminescente,amorfo,0,1
 olfatto_risonanza_magnetica,Olfatto di Risonanza Magnetica,Magnetic Resonance Scent,stratosfera_tempestosa,fluttuatore,0,1
@@ -251,23 +255,28 @@ pathfinder,Pathfinder,Pathfinder,foresta_miceliale,,1,1
 pathfinder,Pathfinder,Pathfinder,foresta_temperata,,0,1
 pelli_anti_ustione,Pelli Anti-Ustione,Burn-Resistant Skins,badlands,,1,1
 pelli_anti_ustione,Pelli Anti-Ustione,Burn-Resistant Skins,badlands,volatore_planatore,0,1
-pelli_cave,pelli_cave,Hollow Skins,,,1,6
+pelli_cave,pelli_cave,Hollow Skins,badlands,,1,0
+pelli_cave,pelli_cave,Hollow Skins,cryosteppe,,1,1
 pelli_cave,pelli_cave,Hollow Skins,cryosteppe,volatore_planatore,0,1
 pelli_cave,pelli_cave,Hollow Skins,deserto_caldo,cursoriale_quadrupede,0,1
 pelli_cave,pelli_cave,Hollow Skins,deserto_caldo,ingegnere_radicante,0,1
 pelli_cave,pelli_cave,Hollow Skins,deserto_caldo,scavenger_corazzato,0,1
 pelli_cave,pelli_cave,Hollow Skins,deserto_caldo,volatore_planatore,0,2
-pelli_fitte,Pelli Fitte,Dense Skins,,,1,1
-pelli_fitte,Pelli Fitte,Dense Skins,foresta_temperata,,0,1
+pelli_cave,pelli_cave,Hollow Skins,steppe_algoritmiche,,1,0
+pelli_fitte,Pelli Fitte,Dense Skins,canopia_ionica,,1,0
+pelli_fitte,Pelli Fitte,Dense Skins,foresta_temperata,,1,1
+pelli_fitte,Pelli Fitte,Dense Skins,rovine_planari,,1,0
 pianificatore,Pianificatore,Strategic Planner,foresta_miceliale,,1,1
 pianificatore,Pianificatore,Strategic Planner,foresta_temperata,,0,1
-pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,,,1,7
+pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,badlands,,1,0
+pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,cryosteppe,,1,1
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,cryosteppe,volatore_planatore,0,1
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,deserto_caldo,cursoriale_quadrupede,0,1
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,deserto_caldo,ingegnere_radicante,0,1
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,deserto_caldo,scavenger_corazzato,0,1
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,deserto_caldo,volatore_planatore,0,2
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,foresta_miceliale,flora_radicata,0,1
+pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,steppe_algoritmiche,,1,0
 piume_solari_fotovoltaiche,Piume Solari Fotovoltaiche,Piume Solari Fotovoltaiche,,,0,1
 polmoni_cristallini_alta_quota,Polmoni Cristallini d'Alta Quota,Polmoni Cristallini d'Alta Quota,,,0,1
 radici_ancora_planare,Radici Ancora Planare,Radici Ancora Planare,foresta_miceliale,flora_radicata,0,1
@@ -275,9 +284,9 @@ random,Trait Random,Trait Random,,,0,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,badlands,scavenger_corazzato,0,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,cryosteppe,cursoriale_quadrupede,0,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,dorsale_termale_tropicale,,0,1
-respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,dorsale_termale_tropicale,scavenger_corazzato,1,6
+respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,dorsale_termale_tropicale,scavenger_corazzato,1,0
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,,0,1
-respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,cursoriale_quadrupede,1,6
+respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,cursoriale_quadrupede,1,0
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,canyons_risonanti,alato_spettrale,0,1
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_miceliale,,1,1
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_temperata,,0,1
@@ -285,29 +294,29 @@ sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoy
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_ionica,aliante_mimetico,0,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,,1,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,dorsale_termale_tropicale,,0,1
-sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,dorsale_termale_tropicale,cursoriale_quadrupede,1,12
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,mezzanotte_orbitale,,0,1
-sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,mezzanotte_orbitale,volatore_planatore,1,12
+sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,mezzanotte_orbitale,volatore_planatore,1,0
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,orbita_psionica_inversa,,1,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,stratosfera_tempestosa,fluttuatore,0,1
 sacche_spore_stratosferiche,Sacche di Spore Stratosferiche,Sacche di Spore Stratosferiche,,,0,1
 sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,badlands,ingegnere_radicante,0,1
 sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,cryosteppe,scavenger_corazzato,0,1
 sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,dorsale_termale_tropicale,,0,1
-sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,dorsale_termale_tropicale,ingegnere_radicante,1,5
+sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,dorsale_termale_tropicale,ingegnere_radicante,1,0
 sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,mezzanotte_orbitale,,0,1
-sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,mezzanotte_orbitale,scavenger_corazzato,1,5
+sangue_piroforico,Sangue che prende fuoco a contatto con l'ossigeno,Pyrophoric Blood,mezzanotte_orbitale,scavenger_corazzato,1,0
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,badlands,cursoriale_quadrupede,0,2
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,badlands,scavenger_corazzato,0,1
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,cryosteppe,cursoriale_quadrupede,0,1
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,,0,1
-scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,cursoriale_quadrupede,1,9
-scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,scavenger_corazzato,1,9
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,scavenger_corazzato,1,0
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,mezzanotte_orbitale,,0,1
-scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,mezzanotte_orbitale,cursoriale_quadrupede,1,9
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,mezzanotte_orbitale,cursoriale_quadrupede,1,0
 secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,badlands,ingegnere_radicante,0,1
 secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,dorsale_termale_tropicale,,0,1
-secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,dorsale_termale_tropicale,ingegnere_radicante,1,3
+secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,dorsale_termale_tropicale,ingegnere_radicante,1,0
 sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,,,0,1
 sensori_sismici,Sensori Sismici,Seismic Sensors,caverna_risonante,bipede_agile,0,1
 sinapsi_coraline_polifoniche,Sinapsi Coraline Polifoniche,Sinapsi Coraline Polifoniche,,,0,1
@@ -317,23 +326,23 @@ sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemisph
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,badlands,volatore_planatore,0,1
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,cryosteppe,volatore_planatore,0,1
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,dorsale_termale_tropicale,,0,1
-sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,dorsale_termale_tropicale,volatore_planatore,1,4
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,dorsale_termale_tropicale,volatore_planatore,1,0
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,mezzanotte_orbitale,,0,1
-sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,mezzanotte_orbitale,volatore_planatore,1,4
+sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,mezzanotte_orbitale,volatore_planatore,1,0
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,badlands,scavenger_corazzato,0,1
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,cryosteppe,scavenger_corazzato,0,1
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,dorsale_termale_tropicale,,0,1
-spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,dorsale_termale_tropicale,scavenger_corazzato,1,8
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,dorsale_termale_tropicale,scavenger_corazzato,1,0
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,foresta_miceliale,,1,1
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,foresta_temperata,,0,1
 spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,mezzanotte_orbitale,,0,1
-spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,mezzanotte_orbitale,scavenger_corazzato,1,8
+spore_psichiche_silenziate,Spora Psichica Silenziosa,Silent Psychic Spores,mezzanotte_orbitale,scavenger_corazzato,1,0
 squame_rifrangenti_deserto,Squame Rifrangenti del Deserto,Squame Rifrangenti del Deserto,,,0,1
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,badlands,cursoriale_quadrupede,0,1
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,canopia_ionica,aliante_mimetico,0,1
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,canopia_psionica_leggera,,1,1
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,dorsale_termale_tropicale,,0,1
-struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,dorsale_termale_tropicale,cursoriale_quadrupede,1,7
+struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,falde_magnetiche_psioniche,,1,1
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,foresta_miceliale,,1,1
 struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",Elastic Amorphous Frame,reef_luminescente,amorfo,0,1
@@ -344,7 +353,7 @@ vello_condensatore_nebbie,Vello Condensatore di Nebbie,Vello Condensatore di Neb
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,badlands,scavenger_corazzato,0,1
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,cryosteppe,cursoriale_quadrupede,0,1
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,dorsale_termale_tropicale,,0,1
-ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,dorsale_termale_tropicale,scavenger_corazzato,1,6
+ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,dorsale_termale_tropicale,scavenger_corazzato,1,0
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,mezzanotte_orbitale,,0,1
-ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,mezzanotte_orbitale,cursoriale_quadrupede,1,6
+ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,mezzanotte_orbitale,cursoriale_quadrupede,1,0
 zoccoli_risonanti_steppe,Zoccoli Risonanti delle Steppe,Zoccoli Risonanti delle Steppe,,,0,1

--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -12,12 +12,18 @@
     "traits_with_rules": 151,
     "traits_with_species": 189,
     "traits_with_affinity": 200,
-    "rule_combos_total": 181,
-    "species_combos_total": 349,
-    "rules_missing_species_total": 0,
+    "rule_combos_total": 189,
+    "species_combos_total": 317,
+    "rules_missing_species_total": 9,
     "affinity_missing_species_total": 0,
-    "affinity_missing_matrix_total": 48,
-    "traits_missing_species": [],
+    "affinity_missing_matrix_total": 89,
+    "traits_missing_species": [
+      "cuticole_cerose",
+      "grassi_termici",
+      "pelli_cave",
+      "pelli_fitte",
+      "pigmenti_aurorali"
+    ],
     "traits_missing_rules": [
       "adattamento_volo",
       "ali_fono_risonanti",
@@ -64,7 +70,6 @@
       "olfatto_risonanza_magnetica",
       "pathfinder",
       "pelli_cave",
-      "pelli_fitte",
       "pianificatore",
       "pigmenti_aurorali",
       "piume_solari_fotovoltaiche",
@@ -1341,7 +1346,7 @@
         ]
       },
       "species": {
-        "total": 27,
+        "total": 7,
         "coverage": [
           {
             "biome": "badlands",
@@ -1385,35 +1390,11 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 10,
-            "examples": [
-              "caverna-risonante-trait-keeper",
-              "cryo-lynx",
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker",
-              "ferrimordax-rutilus"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 10,
-            "examples": [
-              "caverna-risonante-trait-keeper",
-              "cryo-lynx",
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker",
-              "ferrimordax-rutilus"
             ]
           }
         ]
@@ -1431,7 +1412,12 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "ferrimordax-rutilus",
+          "pyroflagellum_meteoriticum",
+          "rotabrachium_ferox",
+          "rubrospina-velox"
+        ]
       },
       "affinity": {
         "total_species": 10,
@@ -2866,7 +2852,7 @@
         ]
       },
       "species": {
-        "total": 14,
+        "total": 5,
         "coverage": [
           {
             "biome": "badlands",
@@ -2901,18 +2887,6 @@
             ]
           },
           {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 9,
-            "examples": [
-              "cryo-lynx",
-              "filtrophagus_custos",
-              "lithoconstructus_inhibens",
-              "mezzanotte-orbitale-trait-keeper",
-              "nano-rust-bloom"
-            ]
-          },
-          {
             "biome": "palude",
             "morphotype": "bipede_filtratore",
             "count": 1,
@@ -2943,7 +2917,12 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "nano-rust-bloom",
+          "pyroflagellum_meteoriticum",
+          "sand-burrower",
+          "steppe-bison-mini"
+        ]
       },
       "affinity": {
         "total_species": 9,
@@ -4071,7 +4050,7 @@
         ]
       },
       "species": {
-        "total": 6,
+        "total": 2,
         "coverage": [
           {
             "biome": "badlands",
@@ -4088,17 +4067,6 @@
             "examples": [
               "dorsale-termale-tropicale-trait-keeper"
             ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 4,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker",
-              "rotabrachium_ferox",
-              "tellurmordax_phasicus"
-            ]
           }
         ]
       },
@@ -4111,7 +4079,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "dune-stalker",
+          "rotabrachium_ferox"
+        ]
       },
       "affinity": {
         "total_species": 4,
@@ -4547,7 +4518,7 @@
         ]
       },
       "species": {
-        "total": 8,
+        "total": 2,
         "coverage": [
           {
             "biome": "cryosteppe",
@@ -4564,18 +4535,6 @@
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
             ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 6,
-            "examples": [
-              "aerostatocyon_altivolans",
-              "aurora-gull",
-              "cryo-lynx",
-              "dune-stalker",
-              "mezzanotte-orbitale-trait-keeper"
-            ]
           }
         ]
       },
@@ -4588,7 +4547,12 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "aerostatocyon_altivolans",
+          "cryo-lynx",
+          "dune-stalker",
+          "rubrospina-velox"
+        ]
       },
       "affinity": {
         "total_species": 6,
@@ -4856,7 +4820,7 @@
         "total": 1,
         "coverage": [
           {
-            "biome": null,
+            "biome": "pianura_salina_iperarida",
             "morphotype": null,
             "count": 1
           }
@@ -4917,8 +4881,17 @@
         ]
       },
       "diff": {
-        "missing_in_species": [],
+        "missing_in_species": [
+          {
+            "biome": "pianura_salina_iperarida",
+            "morphotype": null
+          }
+        ],
         "missing_in_rules": [
+          {
+            "biome": null,
+            "morphotype": null
+          },
           {
             "biome": "cryosteppe",
             "morphotype": "volatore_planatore"
@@ -5271,7 +5244,7 @@
         ]
       },
       "species": {
-        "total": 19,
+        "total": 7,
         "coverage": [
           {
             "biome": "CRYOSTEPPE",
@@ -5322,34 +5295,10 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore",
-            "count": 6,
-            "examples": [
-              "aerostatocyon_altivolans",
-              "aurora-gull",
-              "dorsale-termale-tropicale-trait-keeper",
-              "echo-wing",
-              "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
-              "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 6,
-            "examples": [
-              "aerostatocyon_altivolans",
-              "aurora-gull",
-              "dorsale-termale-tropicale-trait-keeper",
-              "echo-wing",
               "mezzanotte-orbitale-trait-keeper"
             ]
           }
@@ -5380,7 +5329,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "aerostatocyon_altivolans",
+          "thaw-rot"
+        ]
       },
       "affinity": {
         "total_species": 6,
@@ -6062,7 +6014,7 @@
         ]
       },
       "species": {
-        "total": 28,
+        "total": 8,
         "coverage": [
           {
             "biome": "badlands",
@@ -6090,18 +6042,6 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 10,
-            "examples": [
-              "amorphovenator_magneticus",
-              "blight-micotico",
-              "dorsale-termale-tropicale-trait-keeper",
-              "falde-magnetiche-psioniche-trait-keeper",
-              "ferriscroba-detrita"
-            ]
-          },
-          {
             "biome": "falde_magnetiche_psioniche",
             "morphotype": null,
             "count": 1,
@@ -6123,18 +6063,6 @@
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato",
-            "count": 10,
-            "examples": [
-              "amorphovenator_magneticus",
-              "blight-micotico",
-              "dorsale-termale-tropicale-trait-keeper",
-              "falde-magnetiche-psioniche-trait-keeper",
-              "ferriscroba-detrita"
             ]
           },
           {
@@ -6164,7 +6092,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "blight-micotico",
+          "ferriscroba-detrita"
+        ]
       },
       "affinity": {
         "total_species": 10,
@@ -7575,17 +7506,27 @@
       "description_it": "Grassi Termici permette alle squadre di stabilizzare assorbimento e conversione energetica multi-fonte all'interno di ambienti dinamici.",
       "description_en": "Grassi Termici allow squads to stabilise multi-source energy absorption and conversion within ambienti dinamici.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
           {
-            "biome": null,
+            "biome": "badlands",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "steppe_algoritmiche",
             "morphotype": null,
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 7,
+        "total": 8,
         "coverage": [
           {
             "biome": null,
@@ -7593,6 +7534,14 @@
             "count": 1,
             "examples": [
               "global-trait-keeper"
+            ]
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": null,
+            "count": 1,
+            "examples": [
+              "evento-brinastorm"
             ]
           },
           {
@@ -7639,11 +7588,20 @@
         ]
       },
       "diff": {
-        "missing_in_species": [],
+        "missing_in_species": [
+          {
+            "biome": "badlands",
+            "morphotype": null
+          },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
         "missing_in_rules": [
           {
-            "biome": "cryosteppe",
-            "morphotype": "volatore_planatore"
+            "biome": null,
+            "morphotype": null
           },
           {
             "biome": "deserto_caldo",
@@ -8998,7 +8956,7 @@
         ]
       },
       "species": {
-        "total": 17,
+        "total": 5,
         "coverage": [
           {
             "biome": "badlands",
@@ -9033,35 +8991,11 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante",
-            "count": 6,
-            "examples": [
-              "blight-micotico",
-              "canopia-psionica-leggera-trait-keeper",
-              "cryptopennatus_psionicus",
-              "dorsale-termale-tropicale-trait-keeper",
-              "ferrocolonia-magnetotattica"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 6,
-            "examples": [
-              "blight-micotico",
-              "canopia-psionica-leggera-trait-keeper",
-              "cryptopennatus_psionicus",
-              "dorsale-termale-tropicale-trait-keeper",
-              "ferrocolonia-magnetotattica"
             ]
           }
         ]
@@ -9079,7 +9013,9 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "blight-micotico"
+        ]
       },
       "affinity": {
         "total_species": 6,
@@ -9428,7 +9364,7 @@
         ]
       },
       "species": {
-        "total": 12,
+        "total": 5,
         "coverage": [
           {
             "biome": "abisso_vulcanico",
@@ -9452,18 +9388,6 @@
             "count": 1,
             "examples": [
               "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 7,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "falde-magnetiche-psioniche-trait-keeper",
-              "ferriscroba-detrita",
-              "orbita-psionica-inversa-trait-keeper",
-              "rotabrachium_ferox"
             ]
           },
           {
@@ -9497,7 +9421,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "ferriscroba-detrita",
+          "rust-scavenger"
+        ]
       },
       "affinity": {
         "total_species": 7,
@@ -9619,7 +9546,7 @@
         ]
       },
       "species": {
-        "total": 9,
+        "total": 5,
         "coverage": [
           {
             "biome": "CRYOSTEPPE",
@@ -9660,17 +9587,6 @@
             "examples": [
               "dorsale-termale-tropicale-trait-keeper"
             ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore",
-            "count": 4,
-            "examples": [
-              "aurora-gull",
-              "dorsale-termale-tropicale-trait-keeper",
-              "echo-wing",
-              "lupus-temperatus"
-            ]
           }
         ]
       },
@@ -9695,7 +9611,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "aurora-gull",
+          "lupus-temperatus"
+        ]
       },
       "affinity": {
         "total_species": 4,
@@ -9742,7 +9661,7 @@
         ]
       },
       "species": {
-        "total": 25,
+        "total": 7,
         "coverage": [
           {
             "biome": "cryosteppe",
@@ -9761,18 +9680,6 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 9,
-            "examples": [
-              "aerostatocyon_altivolans",
-              "amorphovenator_magneticus",
-              "cryo-lynx",
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker"
-            ]
-          },
-          {
             "biome": "falde_magnetiche_psioniche",
             "morphotype": null,
             "count": 1,
@@ -9786,18 +9693,6 @@
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 9,
-            "examples": [
-              "aerostatocyon_altivolans",
-              "amorphovenator_magneticus",
-              "cryo-lynx",
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker"
             ]
           },
           {
@@ -9843,7 +9738,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "dune-stalker",
+          "ferrimordax-rutilus"
+        ]
       },
       "affinity": {
         "total_species": 9,
@@ -10110,28 +10008,34 @@
       "description_it": "Tessuti cutanei porosi con sacche d'aria interne che fungono da barriera termica leggera riducendo il trasferimento di calore in condizioni aride.",
       "description_en": "Porous skin tissues with internal air pockets acting as a lightweight thermal barrier, reducing heat transfer under arid conditions.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
           {
-            "biome": null,
+            "biome": "badlands",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "steppe_algoritmiche",
             "morphotype": null,
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 12,
+        "total": 7,
         "coverage": [
           {
-            "biome": null,
+            "biome": "cryosteppe",
             "morphotype": null,
-            "count": 6,
+            "count": 1,
             "examples": [
-              "cactus-weaver",
-              "evento-brinastorm",
-              "evento-ondata-termica",
-              "noctule-termico",
-              "silica-bloom"
+              "evento-brinastorm"
             ]
           },
           {
@@ -10178,12 +10082,17 @@
         ]
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "cryosteppe",
-            "morphotype": "volatore_planatore"
+            "biome": "badlands",
+            "morphotype": null
           },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [
           {
             "biome": "deserto_caldo",
             "morphotype": "cursoriale_quadrupede"
@@ -10225,26 +10134,28 @@
       "description_it": "Derma a densità elevata con fibre intrecciate che assorbe microimpatti e riduce la perdita idrica per evaporazione in ambienti ventosi.",
       "description_en": "High-density derma with interwoven fibers that absorbs microimpacts and reduces water loss by evaporation in windy environments.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
           {
-            "biome": null,
+            "biome": "canopia_ionica",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "foresta_temperata",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "rovine_planari",
             "morphotype": null,
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 2,
+        "total": 1,
         "coverage": [
-          {
-            "biome": null,
-            "morphotype": null,
-            "count": 1,
-            "examples": [
-              "evento-seme-uragano"
-            ]
-          },
           {
             "biome": "foresta_temperata",
             "morphotype": null,
@@ -10256,13 +10167,17 @@
         ]
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "foresta_temperata",
+            "biome": "canopia_ionica",
+            "morphotype": null
+          },
+          {
+            "biome": "rovine_planari",
             "morphotype": null
           }
         ],
+        "missing_in_rules": [],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
@@ -10340,28 +10255,34 @@
       "description_it": "Cromofori dermici che fluorescono sotto luce polare o tempesta magnetica: finche' il portatore e' in forze, il bagliore pulsa a fine scontro e abbaglia i nemici ravvicinati.",
       "description_en": "Dermal chromophores fluorescing under polar light or magnetic storms; while the bearer stays hale the glow pulses at battle's end to dazzle nearby foes.",
       "rules": {
-        "total": 1,
+        "total": 3,
         "coverage": [
           {
-            "biome": null,
+            "biome": "badlands",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "cryosteppe",
+            "morphotype": null,
+            "count": 1
+          },
+          {
+            "biome": "steppe_algoritmiche",
             "morphotype": null,
             "count": 1
           }
         ]
       },
       "species": {
-        "total": 14,
+        "total": 8,
         "coverage": [
           {
-            "biome": null,
+            "biome": "cryosteppe",
             "morphotype": null,
-            "count": 7,
+            "count": 1,
             "examples": [
-              "cactus-weaver",
-              "evento-brinastorm",
-              "evento-ondata-termica",
-              "noctule-termico",
-              "radiciforma_ancorans"
+              "evento-brinastorm"
             ]
           },
           {
@@ -10416,12 +10337,17 @@
         ]
       },
       "diff": {
-        "missing_in_species": [],
-        "missing_in_rules": [
+        "missing_in_species": [
           {
-            "biome": "cryosteppe",
-            "morphotype": "volatore_planatore"
+            "biome": "badlands",
+            "morphotype": null
           },
+          {
+            "biome": "steppe_algoritmiche",
+            "morphotype": null
+          }
+        ],
+        "missing_in_rules": [
           {
             "biome": "deserto_caldo",
             "morphotype": "cursoriale_quadrupede"
@@ -10740,7 +10666,7 @@
         ]
       },
       "species": {
-        "total": 16,
+        "total": 4,
         "coverage": [
           {
             "biome": "badlands",
@@ -10767,35 +10693,11 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 6,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker",
-              "ferriscroba-detrita",
-              "mezzanotte-orbitale-trait-keeper",
-              "rust-scavenger"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 6,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker",
-              "ferriscroba-detrita",
-              "mezzanotte-orbitale-trait-keeper",
-              "rust-scavenger"
             ]
           }
         ]
@@ -10813,7 +10715,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "dune-stalker",
+          "ferriscroba-detrita"
+        ]
       },
       "affinity": {
         "total_species": 6,
@@ -11062,7 +10967,7 @@
         ]
       },
       "species": {
-        "total": 31,
+        "total": 7,
         "coverage": [
           {
             "biome": "badlands",
@@ -11097,35 +11002,11 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 12,
-            "examples": [
-              "aerostatocyon_altivolans",
-              "arboryxis-lenis",
-              "aurora-gull",
-              "canopia-psionica-leggera-trait-keeper",
-              "cryptopennatus_psionicus"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 12,
-            "examples": [
-              "aerostatocyon_altivolans",
-              "arboryxis-lenis",
-              "aurora-gull",
-              "canopia-psionica-leggera-trait-keeper",
-              "cryptopennatus_psionicus"
             ]
           },
           {
@@ -11163,7 +11044,13 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "arboryxis-lenis",
+          "aurora-gull",
+          "dune-stalker",
+          "echo-wing",
+          "steppe-bison-mini"
+        ]
       },
       "affinity": {
         "total_species": 12,
@@ -11269,7 +11156,7 @@
         ]
       },
       "species": {
-        "total": 14,
+        "total": 4,
         "coverage": [
           {
             "biome": "badlands",
@@ -11296,35 +11183,11 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante",
-            "count": 5,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "ferrocolonia-magnetotattica",
-              "mezzanotte-orbitale-trait-keeper",
-              "nano-rust-bloom",
-              "thaw-rot"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato",
-            "count": 5,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "ferrocolonia-magnetotattica",
-              "mezzanotte-orbitale-trait-keeper",
-              "nano-rust-bloom",
-              "thaw-rot"
             ]
           }
         ]
@@ -11342,7 +11205,9 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "nano-rust-bloom"
+        ]
       },
       "affinity": {
         "total_species": 5,
@@ -11425,7 +11290,7 @@
         ]
       },
       "species": {
-        "total": 33,
+        "total": 6,
         "coverage": [
           {
             "biome": "badlands",
@@ -11461,47 +11326,11 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 9,
-            "examples": [
-              "amorphovenator_magneticus",
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker",
-              "mezzanotte-orbitale-trait-keeper",
-              "nano-rust-bloom"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 9,
-            "examples": [
-              "amorphovenator_magneticus",
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker",
-              "mezzanotte-orbitale-trait-keeper",
-              "nano-rust-bloom"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 9,
-            "examples": [
-              "amorphovenator_magneticus",
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker",
-              "mezzanotte-orbitale-trait-keeper",
-              "nano-rust-bloom"
             ]
           }
         ]
@@ -11523,7 +11352,11 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "amorphovenator_magneticus",
+          "rust-scavenger",
+          "tellurmordax_phasicus"
+        ]
       },
       "affinity": {
         "total_species": 9,
@@ -11671,7 +11504,7 @@
         ]
       },
       "species": {
-        "total": 5,
+        "total": 2,
         "coverage": [
           {
             "biome": "badlands",
@@ -11688,16 +11521,6 @@
             "examples": [
               "dorsale-termale-tropicale-trait-keeper"
             ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "ingegnere_radicante",
-            "count": 3,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "ferrocolonia-magnetotattica",
-              "thaw-rot"
-            ]
           }
         ]
       },
@@ -11710,7 +11533,9 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "thaw-rot"
+        ]
       },
       "affinity": {
         "total_species": 3,
@@ -12016,7 +11841,7 @@
         ]
       },
       "species": {
-        "total": 15,
+        "total": 7,
         "coverage": [
           {
             "biome": "CRYOSTEPPE",
@@ -12067,32 +11892,10 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "volatore_planatore",
-            "count": 4,
-            "examples": [
-              "aurora-gull",
-              "dorsale-termale-tropicale-trait-keeper",
-              "echo-wing",
-              "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
-              "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "volatore_planatore",
-            "count": 4,
-            "examples": [
-              "aurora-gull",
-              "dorsale-termale-tropicale-trait-keeper",
-              "echo-wing",
               "mezzanotte-orbitale-trait-keeper"
             ]
           }
@@ -12225,7 +12028,7 @@
         ]
       },
       "species": {
-        "total": 22,
+        "total": 6,
         "coverage": [
           {
             "biome": "badlands",
@@ -12252,18 +12055,6 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 8,
-            "examples": [
-              "blight-micotico",
-              "cryptopennatus_psionicus",
-              "dorsale-termale-tropicale-trait-keeper",
-              "foresta-miceliale-trait-keeper",
-              "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
             "biome": "foresta_miceliale",
             "morphotype": null,
             "count": 1,
@@ -12286,18 +12077,6 @@
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
             ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "scavenger_corazzato",
-            "count": 8,
-            "examples": [
-              "blight-micotico",
-              "cryptopennatus_psionicus",
-              "dorsale-termale-tropicale-trait-keeper",
-              "foresta-miceliale-trait-keeper",
-              "mezzanotte-orbitale-trait-keeper"
-            ]
           }
         ]
       },
@@ -12318,7 +12097,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "cryptopennatus_psionicus",
+          "sonovespera_lamentans"
+        ]
       },
       "affinity": {
         "total_species": 8,
@@ -12432,7 +12214,7 @@
         ]
       },
       "species": {
-        "total": 14,
+        "total": 7,
         "coverage": [
           {
             "biome": "badlands",
@@ -12464,18 +12246,6 @@
             "count": 1,
             "examples": [
               "dorsale-termale-tropicale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 7,
-            "examples": [
-              "amorphovenator_magneticus",
-              "canopia-psionica-leggera-trait-keeper",
-              "cryptopennatus_psionicus",
-              "dorsale-termale-tropicale-trait-keeper",
-              "dune-stalker"
             ]
           },
           {
@@ -12890,7 +12660,7 @@
         ]
       },
       "species": {
-        "total": 16,
+        "total": 4,
         "coverage": [
           {
             "biome": "badlands",
@@ -12917,35 +12687,11 @@
             ]
           },
           {
-            "biome": "dorsale_termale_tropicale",
-            "morphotype": "scavenger_corazzato",
-            "count": 6,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "ferriscroba-detrita",
-              "ferrocolonia-magnetotattica",
-              "mezzanotte-orbitale-trait-keeper",
-              "rust-scavenger"
-            ]
-          },
-          {
             "biome": "mezzanotte_orbitale",
             "morphotype": null,
             "count": 1,
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
-            ]
-          },
-          {
-            "biome": "mezzanotte_orbitale",
-            "morphotype": "cursoriale_quadrupede",
-            "count": 6,
-            "examples": [
-              "dorsale-termale-tropicale-trait-keeper",
-              "ferriscroba-detrita",
-              "ferrocolonia-magnetotattica",
-              "mezzanotte-orbitale-trait-keeper",
-              "rust-scavenger"
             ]
           }
         ]
@@ -12963,7 +12709,10 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "ferriscroba-detrita",
+          "ferrocolonia-magnetotattica"
+        ]
       },
       "affinity": {
         "total_species": 6,

--- a/docs/ops/backend-components-inventory.md
+++ b/docs/ops/backend-components-inventory.md
@@ -1,0 +1,111 @@
+---
+title: Backend "Idea Engine" -- inventario componenti + stato runtime
+doc_status: active
+doc_owner: platform-docs
+workstream: ops-qa
+last_verified: 2026-06-28
+source_of_truth: false
+language: it-en
+review_cycle_days: 90
+---
+
+# Backend "Idea Engine" -- inventario componenti + stato runtime
+
+Snapshot dei componenti del backend (`apps/backend`) emersi dal log di boot, con
+cosa fanno, se sono online, e come verificarli. Probe live eseguiti contro prod
+`http://localhost:3334` (host Lenovo CODEMASTERDD) il 2026-06-28.
+
+> NB: "Idea Engine" e' il nome **legacy** del backend (nato come API di raccolta
+> idee/feedback con tassonomia; vedi `docs/tutorials/idea-engine.md`,
+> `historical_ref`). Oggi e' il backend di gioco completo (combat / session /
+> co-op / meta-loop). Compare ancora nei log di boot e in `GET /api/health`
+> (`service: idea-engine`).
+
+## Legenda stato
+
+- 🟢 online + serve (handler root 200)
+- 🔒 online ma auth-gated (401 senza token)
+- ⚪ in-process, caricato (no handler root / superficie solo sub-path o on-demand)
+- 🟡 online ma su sorgenti fallback/statiche
+- 🔴 offline
+
+## Core
+
+| Componente  | Cosa fa                                        | Stato | Verifica                                               |
+| ----------- | ---------------------------------------------- | ----- | ------------------------------------------------------ |
+| idea-engine | Server Express (entry `index.js` -> `app.js`). | 🟢    | `GET /api/health` -> `{status:ok,service:idea-engine}` |
+
+## Motori combat/session (in-process, caricati al boot)
+
+| Componente    | Cosa fa                                                                           | Stato                                   |
+| ------------- | --------------------------------------------------------------------------------- | --------------------------------------- |
+| trait-effects | Risolve 503 trait attivi (`data/core/traits/active_effects.yaml`) nel combat.     | ⚪ caricato                             |
+| fairness      | Cap economia PT (`cap_pt_max=1`, `data/packs.yaml`) anti-snowball.                | ⚪ caricato                             |
+| vc-scoring    | Profiling comportamentale: 6 indici + 4 MBTI + 9 Ennea su eventi sessione.        | ⚪ caricato                             |
+| ai-profiles   | 7 profili AI nemica; `utility_brain` (decisione a utility-score) su 4 aggressivi. | ⚪ caricato                             |
+| combat        | Rules engine d20 (`services/combat/*` + roundOrchestrator).                       | 🟢 sub-path (`/api/combat/*`, root 404) |
+
+## Plugin (8, via `services/pluginLoader.js` -> montano `/api/<nome>`)
+
+| Plugin      | Cosa fa                                             | Stato live                                    |
+| ----------- | --------------------------------------------------- | --------------------------------------------- |
+| jobs        | 12 classi/ruoli (`data/core/jobs.yaml`).            | 🟢 `/api/jobs` -> `count:11` (vedi nota jobs) |
+| tutorial    | Scenari onboarding.                                 | 🟢 `/api/tutorial`                            |
+| narrative   | Testi/eventi narrativi.                             | ⚪ `/api/v1/narrative/*` (root 404)           |
+| meta        | Meta-progressione (NPG, nido, trust, mating).       | ⚪ `/api/v1/meta/*` (es. `/npg`)              |
+| forms       | Form-evolution engine (M12).                        | ⚪ `/api/v1/forms/*`                          |
+| progression | XP + perk-pair (M13).                               | ⚪ `/api/v1/progression/*`                    |
+| mutations   | Catalogo mutazioni post-encounter (M14).            | ⚪ `/api/v1/mutations/*`                      |
+| lineage     | Propagazione generazionale (eredita 1-2 mutazioni). | ⚪ `/api/v1/lineage/*`                        |
+
+## Networking / esterni / telemetria
+
+| Componente        | Cosa fa                                                                                 | Stato                        | Note                                                                                                                             |
+| ----------------- | --------------------------------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| lobby-ws          | WebSocket co-op (TV+phone). Prod = porta dedicata :3341; playtest = shared `/ws`.       | 🟢 :3341 LISTEN              | `services/network/wsSession.js`                                                                                                  |
+| traits API        | CRUD trait + glossary + ermes-suggestions.                                              | 🔒 401                       | token `TRAIT_EDITOR_TOKEN`/JWT                                                                                                   |
+| game-database     | Fetch trait glossary HTTP dal repo sibling :3333 (Alt B, OD-030).                       | 🔴 offline                   | :3333 giu' -> fallback file locale (funziona, solo rumore log). Default flag = ON (`index.js:30`).                               |
+| nebula-aggregator | Telemetria dashboard "Nebula"/Atlas (coverage specie, timeline incidenti, generatore).  | 🟡 online, sorgenti fallback | `/api/v1/atlas/{dataset,telemetry,generator}` 200; feed live non configurati -> dataset statico (`data/nebula/atlasDataset.js`). |
+| ermes             | Simulatore eco-pressure per bioma (Node -> Python `prototypes/ermes_lab/ermes_sim.py`). | 🟢 boot report fresh         | Nessun endpoint dedicato; lazy-spawn on trait-edit + export co-op debrief; suggestions via `/api/traits/suggestions`.            |
+
+## Note runtime
+
+### jobs: 11 vs 12 (NON e' un bug)
+
+`jobs.yaml` ha 12 entry (8 base + 4 expansion). Una e' `trait_native`, uno
+**pseudo-job** auto-generato da `scripts/generate_trait_native_abilities.py`
+(indice delle ability native dei trait, esposto solo a `abilityExecutor`),
+`status: pseudo`. `apps/backend/routes/jobs.js` lo **filtra** -> `/api/jobs`
+ritorna 11 classi giocabili. Comportamento documentato in `jobs.yaml:625-628`.
+
+### Sintesi "online"
+
+- Tutto in-process e' **online** (backend su). I `404` al root = modulo caricato
+  senza handler root (solo sub-path), NON "giu'".
+- Unico realmente **offline**: game-database :3333 (fallback locale copre).
+- Nebula: API su, ma serve dati statici/mock (feed telemetria live non agganciati).
+- ERMES: report a disco, processo Python solo on-demand (no daemon).
+
+### Contesto persistenza (vedi memory `project_backend_db_topology_imprint_playtest`)
+
+- Prod gira dal worktree `C:\dev\_gamewt-lenovo-host` (il suo `.env` ha
+  `DATABASE_URL` -> Postgres :5432 schema `public`) -> persiste (`Prisma hydrate`).
+- Il repo dev `C:\dev\Game` non ha `DATABASE_URL` -> stub in-memory.
+- Launcher playtest isolato: `C:\Users\edusc\run-imprint-playtest.cmd`
+  (schema `playtest_imprint`, PORT 3400, WS shared, `GAME_DATABASE_ENABLED=false`).
+
+### Incidente prod 2026-06-24 (risolto)
+
+Crash-loop `prisma:error Can't reach database server :5432`: PG con shutdown
+sporco ha fatto crash-recovery in 37s, ma il launcher prod aspettava
+`pg_isready` solo 30s -> backend partito a DB non pronta. Fix: attesa 30 -> 90s
+in `start-evo-backend.cmd` (e nel launcher playtest). Resilienza task
+(RestartCount=999 + BootTrigger) gia' presente (#2965/#2966).
+
+## Follow-up aperti
+
+- Audit "quali componenti usiamo davvero / cosa cambiare/migliorare/sostituire":
+  issue su `MasterDD-L34D/codemasterdd-ai-station` (2026-06-28).
+- Nebula: feed telemetria live mai configurati -> valutare se cablare o ritirare.
+- game-database: default ON ma :3333 spesso giu' -> valutare default o health-gate.
+- Doc-drift `GAME_DATABASE_ENABLED=false` (`.env.example:51` + CLAUDE.md) vs default ON.

--- a/logs/monitor_map_elites.py
+++ b/logs/monitor_map_elites.py
@@ -1,0 +1,158 @@
+# Live monitor for the MAP-Elites overnight run (read-only, stdlib only).
+# v2: + progress bar totale + barra iterazione in corso (righe jsonl / 40).
+# Scans the trial dir every 60s and regenerates monitor.html (meta-refresh 60s).
+# Kill anytime: it never touches the run, the backend, or production files.
+import glob
+import json
+import os
+import time
+from datetime import datetime
+
+TRIAL_DIR = r"C:\dev\Game\docs\playtest\map-elites-hardcore_06-overnight-20260702"
+OUT_HTML = r"C:\dev\Game\logs\map_elites_monitor.html"
+TOTAL_ITER = 50
+N_PER_TRIAL = 40
+WR_B = [(0, .10), (.10, .20), (.20, .30), (.30, .40), (.40, 1.0)]
+DF_B = [(0, .30), (.30, .50), (.50, .70), (.70, .90), (.90, 1.0)]
+
+
+def bucket(v, bands):
+    for i, (lo, hi) in enumerate(bands):
+        if lo <= v < hi or (i == len(bands) - 1 and v >= lo):
+            return i
+    return None
+
+
+def scan():
+    iters = []
+    for fp in sorted(glob.glob(os.path.join(TRIAL_DIR, "iter-*.json"))):
+        try:
+            with open(fp, encoding="utf-8") as fh:
+                agg = json.load(fh).get("aggregate") or {}
+            iters.append({
+                "i": int(os.path.basename(fp)[5:8]),
+                "wr": agg.get("win_rate"), "df": agg.get("defeat_rate"),
+                "to": agg.get("timeout_rate"), "n": agg.get("N"),
+                "verdict": agg.get("verdict"), "turns": agg.get("turns_avg"),
+                "mtime": os.path.getmtime(fp),
+            })
+        except (json.JSONDecodeError, OSError, ValueError):
+            continue
+    return iters
+
+
+def current_iter_progress(iters):
+    done_ids = {x["i"] for x in iters}
+    best = None
+    for fp in glob.glob(os.path.join(TRIAL_DIR, "iter-*.jsonl")):
+        try:
+            i = int(os.path.basename(fp)[5:8])
+        except ValueError:
+            continue
+        if i not in done_ids and (best is None or i > best[0]):
+            best = (i, fp)
+    if best is None:
+        return None
+    try:
+        with open(best[1], encoding="utf-8") as fh:
+            lines = sum(1 for ln in fh if ln.strip())
+    except OSError:
+        return None
+    return {"i": best[0], "runs": lines, "of": N_PER_TRIAL}
+
+
+def bar(pct, label, color="#4C72B0"):
+    pct = max(0.0, min(1.0, pct))
+    return ("<div style='margin:6px 0 14px'>"
+            f"<div style='font-size:13px;margin-bottom:3px'>{label}</div>"
+            "<div style='background:#e9ecef;border-radius:6px;height:22px;width:560px;overflow:hidden'>"
+            f"<div style='background:{color};height:100%;width:{pct*100:.1f}%;border-radius:6px;"
+            "color:#fff;font-size:12px;font-weight:700;line-height:22px;padding-left:8px;white-space:nowrap'>"
+            f"{pct*100:.1f}%</div></div></div>")
+
+
+def render(iters):
+    now = time.time()
+    done = len(iters)
+    cur = current_iter_progress(iters)
+    frac = done + (cur["runs"] / cur["of"] if cur else 0)
+    bars = bar(frac / TOTAL_ITER,
+               f"Run totale: {done}/{TOTAL_ITER} iterazioni complete"
+               + (f" + iter-{cur['i']:03d} in corso" if cur else ""),
+               "#4C72B0")
+    if cur:
+        bars += bar(cur["runs"] / cur["of"],
+                    f"Iterazione in corso (iter-{cur['i']:03d}): "
+                    f"{cur['runs']}/{cur['of']} battaglie simulate", "#55A868")
+    all_files = glob.glob(os.path.join(TRIAL_DIR, "*"))
+    newest = max((os.path.getmtime(f) for f in all_files), default=0)
+    age_min = (now - newest) / 60
+    status = "RUNNING" if age_min < 90 else "STALLED?"
+    scolor = "#28a745" if age_min < 90 else "#dc3545"
+    eta = ""
+    if done >= 2:
+        ts = sorted(x["mtime"] for x in iters)
+        gaps = [b - a for a, b in zip(ts, ts[1:])][-5:]
+        per_iter = sum(gaps) / len(gaps)
+        remaining = (TOTAL_ITER - frac) * per_iter
+        eta = (f"{per_iter/60:.0f} min/iter (media ultime {len(gaps)}) -> "
+               f"~{remaining/3600:.1f}h residue, fine ~"
+               f"{datetime.fromtimestamp(now + remaining).strftime('%d/%m %H:%M')}")
+    grid = {}
+    for x in iters:
+        if x["wr"] is None or x["df"] is None:
+            continue
+        c = (bucket(x["wr"], WR_B), bucket(x["df"], DF_B))
+        grid.setdefault(c, []).append(x["i"])
+    cells = ""
+    for dj in range(4, -1, -1):
+        cells += "<tr>"
+        cells += f"<th>df {DF_B[dj][0]:.0%}-{DF_B[dj][1]:.0%}</th>"
+        for wi in range(5):
+            hits = grid.get((wi, dj), [])
+            if hits:
+                cells += (f"<td class='on'>{len(hits)}<br>"
+                          f"<small>iter {min(hits)}..{max(hits)}</small></td>")
+            else:
+                cells += "<td class='off'>-</td>"
+        cells += "</tr>"
+    hdr = "".join(f"<th>wr {lo:.0%}-{hi:.0%}</th>" for lo, hi in WR_B)
+    rows = ""
+    for x in iters[-8:][::-1]:
+        v = x["verdict"] or "?"
+        vc = "#28a745" if v == "GREEN" else "#6c757d"
+        rows += (f"<tr><td>{x['i']:03d}</td><td>{x['wr']:.1%}</td>"
+                 f"<td>{x['df']:.1%}</td><td>{x['to']:.1%}</td><td>{x['n']}</td>"
+                 f"<td style='color:{vc}'>{v}</td><td>{x['turns']:.1f}</td></tr>")
+    low_n = sum(1 for x in iters if (x["n"] or 0) < N_PER_TRIAL)
+    return f"""<!DOCTYPE html><html><head><meta charset="utf-8">
+<meta http-equiv="refresh" content="60"><title>MAP-Elites monitor</title>
+<style>body{{font-family:Segoe UI,sans-serif;background:#f8f9fa;margin:24px;color:#212529}}
+.k{{display:inline-block;background:#fff;border-radius:8px;padding:12px 20px;margin:0 10px 14px 0;box-shadow:0 1px 3px rgba(0,0,0,.1)}}
+.k b{{font-size:22px}} table{{border-collapse:collapse;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.1)}}
+td,th{{border:1px solid #dee2e6;padding:8px 12px;text-align:center;font-size:13px}}
+.on{{background:#55A868;color:#fff;font-weight:700}} .off{{background:#f1f3f5;color:#adb5bd}}
+h3{{margin:18px 0 8px}}</style></head><body>
+<h2>MAP-Elites hardcore_06 -- overnight 20260702</h2>
+{bars}
+<div class="k">stato <b style="color:{scolor}">{status}</b><br><small>ultimo file {age_min:.0f} min fa</small></div>
+<div class="k">iterazioni <b>{done}/{TOTAL_ITER}</b></div>
+<div class="k">celle popolate <b>{len(grid)}/25</b></div>
+<div class="k">ETA <b style="font-size:14px">{eta or 'n/d'}</b></div>
+<div class="k">iter con N&lt;{N_PER_TRIAL} <b>{low_n}</b><br><small>run parziali (da indagare nel report)</small></div>
+<h3>Mappa QD (win-rate x defeat-rate) -- celle raggiunte</h3>
+<table><tr><th></th>{hdr}</tr>{cells}</table>
+<h3>Ultime iterazioni</h3>
+<table><tr><th>iter</th><th>WR</th><th>defeat</th><th>timeout</th><th>N</th><th>verdict</th><th>turns avg</th></tr>{rows}</table>
+<p><small>aggiornato {datetime.now().strftime('%H:%M:%S')} -- auto-refresh 60s -- read-only, non tocca la run</small></p>
+</body></html>"""
+
+
+while True:
+    try:
+        with open(OUT_HTML, "w", encoding="utf-8") as fh:
+            fh.write(render(scan()))
+        print(f"refresh {datetime.now().strftime('%H:%M:%S')}", flush=True)
+    except Exception as e:
+        print(f"warn: {e}", flush=True)
+    time.sleep(60)

--- a/tools/py/game_utils/trait_coverage.py
+++ b/tools/py/game_utils/trait_coverage.py
@@ -71,6 +71,33 @@ def _resolve_path(hint: str | Path | None, *anchors: Path) -> Path | None:
     return fallback if fallback.exists() else None
 
 
+def _load_koppen_biomes(env_traits_path: Path) -> dict[str, list[str]]:
+    """Invert `biome_classes.yaml` -> {koppen_code: [biome_class, ...]}.
+
+    Authoritative source for mapping a climate-scoped env rule onto the biome classes
+    it actually applies to. Codes marked 'n/a' (biomes with no real-world analogue,
+    e.g. abisso_vulcanico) are skipped rather than mapped.
+    """
+    registry = (
+        env_traits_path.parent.parent.parent
+        / "tools"
+        / "config"
+        / "registries"
+        / "biome_classes.yaml"
+    )
+    if not registry.exists():
+        return {}
+    data = _load_yaml(registry)
+    if not isinstance(data, Mapping):
+        return {}
+    inverted: dict[str, list[str]] = {}
+    for biome_class, codes in (data.get("koppen_examples") or {}).items():
+        for code in _ensure_list(codes):
+            if code and code != "n/a":
+                inverted.setdefault(code, []).append(biome_class)
+    return inverted
+
+
 def _format_combo_key(combo: tuple[str | None, str | None]) -> dict[str, str | None]:
     biome, morph = combo
     return {"biome": biome, "morphotype": morph}
@@ -159,15 +186,49 @@ def generate_trait_coverage(
         lambda: defaultdict(set)
     )
 
-    for rule in env_data.get("rules", []):
+    koppen_biomes = _load_koppen_biomes(env_traits_path)
+
+    for index, rule in enumerate(env_data.get("rules", [])):
         conditions = rule.get("when") or {}
         biome = conditions.get("biome_class")
         morph = conditions.get("morphotype")
         traits = _ensure_list((rule.get("suggest") or {}).get("traits"))
+
+        # A rule that suggests traits but constrains NOTHING is a coverage-backfill in
+        # disguise: it makes every trait it lists *count* as covered while the runtime
+        # generator skips it outright (indexTraitRegistry bails on a missing biome_class).
+        # One such rule (meta.category=coverage_backfill, 105 traits) had to be removed in
+        # #3298 after it hid a real gap for 7 months. Reject the pattern at the source so
+        # it cannot be reintroduced. Rules scoped on a non-biome axis (salinita_in,
+        # hazard_any, ...) are legitimate and unaffected -- only a truly empty `when` fails.
+        if traits and not conditions:
+            raise ValueError(
+                f"env_traits rule[{index}] suggests {len(traits)} trait(s) with an empty "
+                "`when` -- an unconditioned rule fakes coverage without producing anything "
+                "at runtime. Scope it (biome_class / morphotype / koppen_* / hazard_any / "
+                "salinita_in) or remove it. See PR #3298."
+            )
+
+        # A climate-scoped rule (koppen_in / koppen_any) declares no biome_class, so
+        # it used to collapse to the degenerate (None, None) combo -- which NO species
+        # can ever satisfy, because species are keyed by (biome, morphotype). That made
+        # the coverage question structurally unanswerable and it was being papered over
+        # by the species_affinity backfill. Expand such a rule to the biome classes whose
+        # canonical koppen codes it matches, so the question becomes real.
+        rule_biomes: list[str | None] = [biome]
+        if biome is None:
+            codes = _ensure_list(conditions.get("koppen_in")) + _ensure_list(
+                conditions.get("koppen_any")
+            )
+            expanded = sorted({b for c in codes for b in koppen_biomes.get(c, [])})
+            if expanded:
+                rule_biomes = list(expanded)
+
         for trait_id in traits:
             if trait_id not in target_traits:
                 continue
-            rule_matrix[trait_id][(biome, morph)] += 1
+            for rule_biome in rule_biomes:
+                rule_matrix[trait_id][(rule_biome, morph)] += 1
 
     foodweb_roles: dict[str, dict[str, list[dict[str, Any]]]] = defaultdict(
         lambda: defaultdict(list)
@@ -285,14 +346,14 @@ def generate_trait_coverage(
                         "top_species": affinity_species_ids[:10],
                     }
 
-        if affinity_species_ids and rule_counter:
-            for combo in rule_counter.keys():
-                if species_counter.get(combo, 0):
-                    continue
-                species_counter[combo] += len(affinity_species_ids)
-                for species_id in affinity_species_ids:
-                    species_examples[trait_id][combo].add(species_id)
-                    species_seen[trait_id].add(species_id)
+        # REMOVED: an unconditional species_affinity backfill used to live here. For any
+        # rule combo lacking species coverage it injected EVERY affinity species into that
+        # combo -- with no biome grounding whatsoever, so a species that does not live in
+        # the biome still "covered" it. That silently held rules_missing_species_total at
+        # 0 and made the gate meaningless: it is the same trick as the `coverage_backfill`
+        # env rule removed in #3298, one layer down. Coverage must be earned by a species
+        # that actually lives in the rule's biome. `affinity_map` is still reported below
+        # as the advisory `missing_in_affinity` diff -- it just no longer fakes coverage.
 
         if rule_counter:
             summary["traits_with_rules"] += 1


### PR DESCRIPTION
## #3298 removed one crutch. There was a second one underneath.

#3298 correctly deleted the synthetic `coverage_backfill` env rule and took the gate to a **measured 0**. That 0 was still propped up.

### 1. The species-affinity backfill (removed)
`report_trait_coverage.py` defaults to `--species-affinity`; **CI never passes the flag**, so it silently gets the default. `trait_coverage.py` then did:

```python
if affinity_species_ids and rule_counter:
    for combo in rule_counter.keys():
        if species_counter.get(combo, 0): continue
        species_counter[combo] += len(affinity_species_ids)   # <-- zero biome grounding
```

It injected **every** affinity species into **any** uncovered rule combo -- a species that does not live in the biome still "covered" it. **Same trick as the coverage_backfill rule, one layer down.** Coverage must be earned by a species that actually lives in the rule's biome. (`affinity_map` is still reported as the advisory `missing_in_affinity` diff -- it just no longer fakes coverage.)

### 2. Climate-scoped rules (now modelled -- this was the ask on #3299)
A `koppen_in` / `koppen_any` rule declares no `biome_class`, so it collapsed to the **(biome=None, morphotype=None)** combo -- **unsatisfiable by construction**, since species are keyed by (biome, morphotype). It was being "covered" by a biome-less `global-trait-keeper` stub.

Such rules are now expanded onto the biome classes whose canonical koppen codes they match, using **the registry that already exists** -- `biome_classes.yaml` -> `koppen_examples`. **No map was invented.**

```
koppen_in  [Cfb, Cfa] -> canopia_ionica, foresta_temperata, rovine_planari
koppen_any [BSk, Dfc] -> badlands, cryosteppe, steppe_algoritmiche
```

### 3. The backfill pattern is now rejected at the source
A rule that suggests traits with an **empty `when`** raises. It fakes coverage while the runtime generator skips it outright (`indexTraitRegistry` bails on a missing `biome_class`) -- exactly the rule that hid a real gap for 7 months. Rules scoped on a non-biome axis (`salinita_in`, `hazard_any`) are legitimate and unaffected.
**Negative control run:** a poisoned `env_traits` with an empty-`when` rule is rejected; the real file still passes.

## The honest number is 9

Unlike the phantom 73 I nearly baselined, **each of these is a concrete, checkable claim** -- *"the rule says climate BSk yields pelli_cave; badlands IS a BSk biome; no badlands species carries pelli_cave"*:

| trait | missing in |
|---|---|
| pelli_cave | badlands, steppe_algoritmiche |
| pigmenti_aurorali | badlands, steppe_algoritmiche |
| grassi_termici | badlands, steppe_algoritmiche |
| pelli_fitte | canopia_ionica, rovine_planari |
| cuticole_cerose | pianura_salina_iperarida |

(`cryosteppe` does **not** appear -- its species genuinely carry those traits. The gaps are real and specific.)

`max_missing` baselined at **9** as REAL, ratchet-DOWN-only debt. Follow-up chip authors the species-trait links (Species Curator-gated). Derived artifacts re-baselined -- `check_derived_reproducible` correctly flagged this as an **owner-gated generator change**.

## Gate
coverage **PASS** (189>=27, 9<=9) · validator 0 · trait_audit 0 · `check_derived_reproducible --deep` OK · canon OK · `sync:evo-pack` no-drift PASS

Refs #3299. merge = master-dd.