### PR TITLE
docs(adr): worldgen data model + TARGET -- what is a biome, what is a species, how much is missing

### DIFF
--- a/DECISIONS_LOG.md
+++ b/DECISIONS_LOG.md
@@ -20,7 +20,7 @@
 ## Index per data (cronologico)
 
 <!-- gen:adr-index -->
-_Generato da `tools/generate_decisions_log.py` (75 ADR). NON editare a mano: editi gli ADR in `docs/adr/`._
+_Generato da `tools/generate_decisions_log.py` (76 ADR). NON editare a mano: editi gli ADR in `docs/adr/`._
 
 | Data | ADR | Titolo | Status |
 | --- | --- | --- | --- |
@@ -99,6 +99,7 @@ _Generato da `tools/generate_decisions_log.py` (75 ADR). NON editare a mano: edi
 | 2026-06-19 | [ADR-2026-06-19-taxonomy-authoring-sot-steady-state](docs/adr/ADR-2026-06-19-taxonomy-authoring-sot-steady-state.md) | ADR-2026-06-19 -- taxonomy authoring SoT steady-state (RFC #4 S3 NO-GO) | Accepted |
 | 2026-07-03 | [ADR-2026-07-03-authored-grid-board-scale](docs/adr/ADR-2026-07-03-authored-grid-board-scale.md) | ADR-2026-07-03 -- board_scale: onorare grid_size autorato per-encounter (opt-in) | Accepted |
 | 2026-07-10 | [ADR-2026-07-10-sistema-action-symmetry](docs/adr/ADR-2026-07-10-sistema-action-symmetry.md) | ADR-2026-07-10 — Sistema action symmetry: per-unit AP + retreat gate + telegraph threats-only | Proposed |
+| 2026-07-14 | [ADR-2026-07-14-worldgen-data-model](docs/adr/ADR-2026-07-14-worldgen-data-model.md) | ADR-2026-07-14 — Worldgen data model: cos'e' un bioma, cos'e' una specie | Proposed |
 <!-- /gen:adr-index -->
 
 ## Index per tag

--- a/docs/adr/ADR-2026-07-14-worldgen-data-model.md
+++ b/docs/adr/ADR-2026-07-14-worldgen-data-model.md
@@ -154,16 +154,105 @@ Ogni guard con **negative control** (un guard non testato e' un guard vacuo -- L
 6. Accendi i 4 guard (con negative control).
 7. **Ratchet del gate coverage** (oggi `max_missing=5`, `min_traits=189`).
 
-## Cosa questo ADR NON risolve (esplicito, non nascosto)
+## Decisione 7 — `when.biome_class` significa IDENTITA' DI BIOMA. Il campo va rinominato
 
-1. **Il debito narrativo koppen-vs-fiction** su `cryosteppe`/`deserto_caldo`/`savana`.
-2. **Quale delle due semantiche di `biome_class`** intendano le 33 regole in `env_traits.json`
-   (le 3 koppen non ne portano nessuna; le altre 30 vanno controllate una per una).
-3. **Quale `cross_events.yaml` e' autoritativo**: ce ne sono **due**
-   (`data/ecosystems/network/` e `data/ecosistemi/` -- cartella italiana sorella duplicata).
-4. **Il TARGET di scope**: quanti biomi/specie/ecosistemi deve avere il gioco. Non e' scritto
-   da nessuna parte -> "quanto manca" resta **indefinito**. Senza questo numero, pianificare
-   contenuto e' costruire sul vuoto. **Questa e' la prossima decisione, ed e' master-dd.**
+Misurato sulle 33 regole di `env_traits.json`:
+
+| cosa usano                                                   | n      |
+| ------------------------------------------------------------ | ------ |
+| un'**identita' di bioma** (chiave di `biomes.yaml`)          | **19** |
+| nessun `biome_class` (scoped su koppen / hazard / salinita') | 8      |
+| un valore che **non risolve** su `biomes.yaml`               | **6**  |
+| la **famiglia ecologica** (`arid`/`geothermal`/...)          | **0**  |
+
+**Zero regole usano la famiglia grossolana.** L'overload non e' un'ambiguita' semantica: e' solo
+un **nome sbagliato in due posti**. Si chiude rinominando:
+
+- nelle regole: `when.biome_class` -> **`when.biome`** (e' un'identita')
+- in `biomes.yaml`: il campo `biome_class` -> **`ecological_family`** (dominio chiuso, 10 valori)
+
+**Le 6 regole orfane** (`caverna_risonante`, `laguna_bioreattiva`, `mangrovieto_cinetico` + i 3
+alias psionici `status: expansion`) puntano a biomi che non esistono nel registro. Il guard #3
+le farebbe fallire -> **vanno risolte nella migrazione**, non dopo.
+
+## Decisione 8 — `cross_events.yaml`: autoritativo e' quello della network
+
+Ce ne sono due, e **il pack pubblica quello stale**:
+
+| file                                        | righe | ultimo commit           | letto da                         |
+| ------------------------------------------- | ----- | ----------------------- | -------------------------------- |
+| `data/ecosystems/network/cross_events.yaml` | 43    | **2026-05-30**          | `export_biodiversity_bundle.py`  |
+| `data/ecosistemi/cross_events.yaml`         | 31    | 2025-10-27 (**9 mesi**) | `pack_manifest.yaml` + report UI |
+
+**Autoritativo: `data/ecosystems/network/cross_events.yaml`** -- e' piu' fresco, piu' completo,
+sta col network a cui appartiene (livello 4), ed e' **il path che la SoT §3 nomina**.
+La copia in `data/ecosistemi/` e' **cancellata**; `pack_manifest.yaml` e il report UI vengono
+ripuntati.
+
+> ⚠️ **NON cancellare `data/ecosistemi/meta_ecosistema_alpha.yaml`**: NON e' un duplicato di
+> `meta_network_alpha.yaml` (chiave `ecosistema` vs `network` -- sono cose diverse) ed e'
+> **letto da `update_evo_pack_catalog.js`**, cioe' dalla catena `sync:evo-pack`.
+
+## Decisione 9 — `savana` si fonde in `deserto_caldo`
+
+Il debito narrativo **non e' sistemico**: 19 biomi su 20 hanno nome e summary coerenti. L'unico
+che stona e' `savana` -- summary _"**Dune fotoniche** con branchi adattivi"_, affix `sabbia`,
+famiglia `arid`, e affixes **copia-incollati identici** da `abisso_vulcanico`. E' un deserto col
+nome sbagliato, mezzo costruito, e occupa lo slot che `deserto_caldo` riempie davvero.
+
+**`savana` e' cancellata, la sua 1 specie migra in `deserto_caldo`.** Il conflitto koppen-vs-
+fiction sparisce alla radice invece di essere gestito.
+
+Giocabili: **20 - 1 (savana) + 2 (cryosteppe, deserto_caldo) = 21**.
+
+## Decisione 10 — Il TARGET: nucleo-8, profondo. E "quanto manca" e' 35
+
+Il gioco oggi e' **largo e sottile**: 20 biomi giocabili, ma solo 5 con vera profondita' (34
+delle 46 specie). Gli altri 15 hanno 0-2 specie: sono abbozzi.
+
+**Il nucleo non va inventato: era gia' scritto nei dati**, in due posti indipendenti.
+
+- **Foodweb (livello 3)** -- ne esistono **5**, e solo 5: `badlands`, `foresta_temperata`,
+  `cryosteppe`, `deserto_caldo`, `rovine_planari`.
+- **Meta-rete (livello 4, la piu' recente)** -- ha **6 nodi**: quei 5 **+ `atollo_obsidiana`**.
+
+Chi ha costruito questo gioco aveva **gia' scelto un nucleo**, e ha autorato lo stack profondo
+solo per quello.
+
+**TARGET = 8 biomi, ~8 specie ciascuno, con ecosistema + foodweb completi.**
+
+| #   | bioma               | famiglia         | perche' (dato, non gusto)                                                                                                        | specie        | mancano |
+| --- | ------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------- |
+| 1   | `badlands`          | arid             | foodweb + nodo                                                                                                                   | 11            | ✅      |
+| 2   | `foresta_temperata` | canopy           | foodweb + nodo                                                                                                                   | 7             | +1      |
+| 3   | `deserto_caldo`     | arid             | foodweb + **`start_node`** della meta-rete                                                                                       | 5 +1 (savana) | +2      |
+| 4   | `cryosteppe`        | arid             | foodweb + nodo                                                                                                                   | 5             | +3      |
+| 5   | `rovine_planari`    | clastic          | foodweb + eco completi, **0 abitanti**                                                                                           | **0**         | **+8**  |
+| 6   | `atollo_obsidiana`  | **littoral**     | **gia' nodo della meta-rete**; unica famiglia acquatica                                                                          | 0             | +8      |
+| 7   | `abisso_vulcanico`  | **geothermal**   | piu' specie di ogni non-core; il nucleo non ha **nessun** bioma caldo                                                            | 2             | +6      |
+| 8   | `caverna`           | **subterranean** | assorbe `caverna_risonante` -> **risolve 1 delle 6 regole orfane** e recupera **21 tratti suggeriti** che oggi puntano nel vuoto | 1 +1          | +7      |
+
+> Il nucleo-5 copriva solo `arid`/`canopy`/`clastic`: **niente acqua, niente calore, niente
+> sottosuolo**. Il nucleo-8 copre **6 famiglie ecologiche su 10**.
+
+### QUANTO MANCA (il numero che finora non esisteva)
+
+> **≈ 35 specie da autorare + 3 foodweb + 3 nodi di rete.**
+> `rovine_planari` da solo ne vale 8: modellato in ogni dettaglio, **senza un solo abitante**.
+
+**I 13 biomi fuori dal nucleo vengono ARCHIVIATI** (museum card, **non** cancellati): escono dal
+gioco e dalle metriche, restano nel Museum come idee. Il catalogo smette di promettere un mondo
+che non esiste.
+
+## Cosa questo ADR NON risolve
+
+Nulla di quanto era aperto alla prima stesura: le 4 domande residue (debito narrativo, semantica
+di `biome_class`, `cross_events` autoritativo, TARGET) sono state **risolte dai dati** e sono
+sopra, come Decisioni 7-10.
+
+Resta **una sola** domanda genuinamente aperta, e non e' di modello ma di contenuto:
+**chi autora le ~35 specie.** E' lavoro Species-Curator-gated, e non e' una decisione: e' un
+piano. Va fatto **per bioma**, mai tutto in una volta.
 
 ## Conseguenze
 

--- a/docs/adr/ADR-2026-07-14-worldgen-data-model.md
+++ b/docs/adr/ADR-2026-07-14-worldgen-data-model.md
@@ -91,12 +91,12 @@ Sono gli **unici 2 ecosistemi su 21** senza entry in `biomes.yaml`. Ma sono load
 | L4 cross-events | ✅ origini canoniche, **nominate nella SoT** (_"brinastorm da cryosteppe"_) |
 
 Fonderli come varianti avrebbe rotto la meta-rete **dal suo nodo di partenza**. Si scrive la
-riga L1 mancante (hazard/npc/difficolta'/narrativa). **Giocabili 20 -> 22.** Zero contenuto
-perso, zero rete rotta.
+riga L1 mancante (hazard/npc/difficolta'/narrativa). Zero contenuto perso, zero rete rotta.
 
-> **Debito narrativo aperto (registrato, non nascosto)**: il koppen e la finzione dissentono
-> su questi due (`deserto_caldo` BWh/BSh vs una `savana` il cui summary dice _"dune fotoniche"_).
-> La promozione **non lo risolve**, lo rende solo esplicito.
+**Giocabili: 20 + 2 (questi) - 1 (`savana`, fusa in `deserto_caldo` -> Decisione 9) = 21.**
+
+> Il debito narrativo koppen-vs-fiction che qui sembrava aperto **e' risolto dalla Decisione 9**:
+> non era sistemico, era **un solo bioma** (`savana`), e si chiude fondendolo.
 
 ## Decisione 4 — Le mappature fabbricate si cancellano
 

--- a/docs/adr/ADR-2026-07-14-worldgen-data-model.md
+++ b/docs/adr/ADR-2026-07-14-worldgen-data-model.md
@@ -260,7 +260,7 @@ piano. Va fatto **per bioma**, mai tutto in una volta.
 lo stack a 4 livelli passa da _documentato-e-ignorato_ a _fatto rispettare_; la trappola del
 metric-gaming e' rimossa alla radice, non tappata.
 
-**Negative**: 20 -> 22 biomi giocabili significa scrivere 2 righe L1 che non esistono; i 52 stub
+**Negative**: 20 -> 21 biomi giocabili significa scrivere 2 righe L1 che non esistono; i 52 stub
 cancellati faranno **scendere** metriche che oggi sembrano piu' alte di quanto siano (e' il
 punto); il debito narrativo resta aperto.
 

--- a/docs/adr/ADR-2026-07-14-worldgen-data-model.md
+++ b/docs/adr/ADR-2026-07-14-worldgen-data-model.md
@@ -1,0 +1,190 @@
+---
+title: "ADR-2026-07-14 — Worldgen data model: cos'e' un bioma, cos'e' una specie"
+status: proposed
+doc_status: active
+doc_owner: master-dd
+workstream: dataset-pack
+last_verified: '2026-07-14'
+source_of_truth: true
+language: it
+review_cycle_days: 90
+---
+
+# ADR-2026-07-14 — Worldgen data model (bioma / biome_class / ecosistema / specie)
+
+Status: **PROPOSED** (decider: master-dd; il MERGE di questo ADR ratifica la direzione,
+la migrazione e' un arco di PR distinto)
+
+Arco evidence: issue #3302 (data-model debris) | #3299 (71 tratti senza regola) |
+censimento #3304 | i cinque strati rimossi #3298 #3300 #3301 #3303 |
+carte museum `M-2026-07-14-001..004` + `M-2026-04-26-012` (revived).
+
+## TL;DR
+
+Il modello del mondo **esiste gia' ed e' canonico** (SoT §3): uno stack a 4 livelli
+`bioma -> ecosistema -> foodweb -> network/eventi`. Non va inventato: va **fatto rispettare**.
+
+Quello che manca non e' il modello. E' che **nessun file dichiara di appartenergli**, e nei
+vuoti sono cresciuti quattro vocabolari di biomi, tre mappature contraddittorie e un catalogo
+specie per il 56% fatto di segnaposto.
+
+Questo ADR **non aggiunge un modello**: sceglie quale dei file esistenti e' autoritativo per
+ciascun livello, cancella i doppioni, e mette i guard perche' i vuoti non si riaprano.
+
+## Contesto: perche' e' marcito
+
+Il substrato di contenuto non aveva **nessun registro** e **nessun guard**. Le uniche metriche
+che lo guardavano erano truccate -- cinque strati, uno sotto l'altro, ognuno che nascondeva il
+successivo, per ~7 mesi (carta `M-2026-07-14-001`).
+
+La carta museum `M-2026-04-26-012` (2026-04-26) aveva **previsto testualmente** questo esito:
+
+> _"Rischio: sessioni future di Claude descrivono il gioco come 'rotazione di mappe' ignorando
+> 3 livelli profondi gia' documentati e validati."_
+
+E' esattamente accaduto, in questa stessa sessione: contando `*.biome.yaml` (5) invece di
+`*.ecosystem.yaml` (21) ho quasi fuso via `cryosteppe` e `deserto_caldo`, che sono nodi di
+livello 4. **Il Museum va consultato PRIMA dello scavo, non dopo.**
+
+## Decisione 1 — Il modello e' lo stack a 4 livelli (SoT §3). Autorita' per livello
+
+| livello                  | cos'e'                                                                                                 | file AUTORITATIVO                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| **1 — bioma**            | pacchetto gameplay+fiction: hazard, npc_archetypes, difficolta', affixes, StressWave, tono, **koppen** | `data/core/biomes.yaml`                                                |
+| **2 — ecosistema**       | clima, abiotico, struttura trofica, ruoli minimi (`apex`/`keystone`/`bridge`/`threat`/`event`)         | `packs/evo_tactics_pack/data/ecosystems/*.ecosystem.yaml` (21)         |
+| **3 — foodweb**          | rete trofica                                                                                           | `packs/evo_tactics_pack/data/foodwebs/*_foodweb.yaml` (5)              |
+| **4 — network + eventi** | nodi, `corridor`/`seasonal_bridge`/`trophic_spillover`, eventi cross-bioma                             | `.../ecosystems/network/meta_network_alpha.yaml` + `cross_events.yaml` |
+
+**`biome_class` NON e' un livello.** E' un **campo** del livello 1: la famiglia ecologica
+grossolana, dominio chiuso di 10 valori (`arid`, `geothermal`, `canopy`, `littoral`, `wetland`,
+`subterranean`, `clastic`, `salt`, `upland`, `deltaic`).
+
+## Decisione 2 — `biome_classes.yaml` si scioglie
+
+`packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml` (28 entry) non e' nessuno
+dei 4 livelli. E' un cassetto: 13 duplicano `biomes.yaml`, 12 sono biomi-Terra di riferimento
+**mai cablati** (`taiga`, `tundra`, `savanna`, `reef`, `costa_rocciosa`, `foresta_boreale`,
+`macchia_mediterranea`, `prateria_temperata`, `deserto_freddo`, `laguna_bioreattiva`,
+`mangrovieto_cinetico`, `caverne`), 3 sono solo-alias.
+
+- I `koppen_examples` **migrano come campo dentro `biomes.yaml`** (il koppen e' una proprieta'
+  del bioma).
+- I 12 nomi-Terra sono **preservati nella carta museum `M-2026-07-14-002`** e cancellati dal codice.
+- Il file e' **eliminato**.
+
+> ⚠️ **ORDINE LOAD-BEARING (P1)**: `tools/py/game_utils/trait_coverage.py:_load_koppen_biomes`
+> inverte oggi `koppen_examples` per espandere le regole climatiche -- **e' il fix del layer 3
+> (#3300)**. Cancellare il file **prima** di aver migrato i koppen **re-introduce il layer 3**.
+> Koppen prima. Sempre.
+
+## Decisione 3 — `cryosteppe` e `deserto_caldo` sono biomi, e vanno PROMOSSI
+
+Sono gli **unici 2 ecosistemi su 21** senza entry in `biomes.yaml`. Ma sono load-bearing su
+**3 livelli su 4**:
+
+|                 | cryosteppe / deserto_caldo                                                  |
+| --------------- | --------------------------------------------------------------------------- |
+| L1 bioma        | ❌ **manca solo questo**                                                    |
+| L2 ecosistema   | ✅ (`.ecosystem.yaml`, pari a `badlands` per profondita')                   |
+| L3 foodweb      | ✅ (sono 2 dei soli 5 foodweb esistenti)                                    |
+| L4 network      | ✅ nodi; **`DESERTO_CALDO` e' lo `start_node` della meta-rete**             |
+| L4 cross-events | ✅ origini canoniche, **nominate nella SoT** (_"brinastorm da cryosteppe"_) |
+
+Fonderli come varianti avrebbe rotto la meta-rete **dal suo nodo di partenza**. Si scrive la
+riga L1 mancante (hazard/npc/difficolta'/narrativa). **Giocabili 20 -> 22.** Zero contenuto
+perso, zero rete rotta.
+
+> **Debito narrativo aperto (registrato, non nascosto)**: il koppen e la finzione dissentono
+> su questi due (`deserto_caldo` BWh/BSh vs una `savana` il cui summary dice _"dune fotoniche"_).
+> La promozione **non lo risolve**, lo rende solo esplicito.
+
+## Decisione 4 — Le mappature fabbricate si cancellano
+
+**Tre** sorgenti mappano i biomi, e **si contraddicono a vicenda**:
+
+| slug                | `biome_aliases.yaml` dice   | `meta_network_alpha.yaml` dice | verita'                              |
+| ------------------- | --------------------------- | ------------------------------ | ------------------------------------ |
+| `badlands`          | `dorsale_termale_tropicale` | `canyons_risonanti`            | **e' `badlands`**, 11 specie         |
+| `deserto_caldo`     | `abisso_vulcanico`          | `savana`                       | **e' `deserto_caldo`**, 5 specie     |
+| `cryosteppe`        | `mezzanotte_orbitale`       | —                              | **e' `cryosteppe`**, 5 specie        |
+| `foresta_temperata` | `foresta_miceliale`         | `foresta_miceliale`            | **e' `foresta_temperata`**, 7 specie |
+
+- I 4 alias `status: migrated` sono **cancellati**: descrivono una migrazione **mai avvenuta**.
+- Il campo `biome_id` dei nodi di rete e' **cancellato**: e' rumore. `id` + `path` sono corretti
+  e bastano.
+- **NB**: `id` dei nodi e' MAIUSCOLO (`DESERTO_CALDO`). E' una **convenzione**, non un bug
+  (carta `M-2026-07-14-004`). Le specie che la copiano (`echo-wing`) vanno normalizzate a
+  lowercase **verso i biomi**, non "corrette" a caso.
+
+## Decisione 5 — Cos'e' una specie
+
+> **Una specie e' un'entita' con `biomes`, `role_trofico` e almeno un tratto.**
+> Tutto il resto non e' una specie e non puo' vivere nel catalogo specie.
+
+Oggi **59 file su 105 (56%)** non lo sono: sono stub autogen da 3 righe, nati per far quadrare
+una matrice di coverage (`receipt: {source: coverage_autogen, author: automation}`).
+
+- **I 52 stub puri sono cancellati** (con le 34 cartelle-bioma vuote). Non codificano nulla che
+  il registro dei biomi non abbia gia'. **Sono la trappola**: sono l'unico "abitante" di quei
+  biomi, quindi chiunque insegua un contatore puo' appiccicargli tratti e azzerarlo.
+- **I 7 con `role_trofico: evento_ecologico`** NON sono rumore: `event` e' un **ruolo minimo
+  canonico del livello 2**. Vanno ricondotti al modello degli eventi (L4), non cancellati.
+- Catalogo onesto: **46 specie**, non 105.
+
+## Decisione 6 — I guard (perche' non ricresca)
+
+Ogni guard con **negative control** (un guard non testato e' un guard vacuo -- L-041):
+
+1. **Definizione-specie**: un file nel catalogo specie che non soddisfa la Decisione 5 -> **FAIL**.
+   Uccide la trappola alla radice.
+2. **`biome_class` a dominio chiuso**: solo i 10 valori ecologici -> **FAIL** altrimenti.
+3. **Bioma referenziato inesistente**: qualsiasi `biomes:` / `biome_class` / nodo che non
+   risolve su `biomes.yaml` -> **FAIL**. Oggi 4 vocabolari; domani uno.
+4. **Regola env senza scoping** (`when: {}`) -> gia' attivo (#3300). E' il guard che impedisce
+   al layer 1 di rinascere.
+
+## Ordine di migrazione (l'ordine E' la decisione)
+
+1. **Koppen -> `biomes.yaml`** + aggiorna `trait_coverage.py` (**P1**: prima di tutto, o si
+   re-introduce il layer 3).
+2. Promuovi `cryosteppe` + `deserto_caldo` -> riga L1.
+3. Cancella i 4 alias `migrated` + il campo `biome_id` dei nodi.
+4. Cancella i 52 stub + le 34 cartelle vuote; riconduci i 7 eventi al modello L4.
+5. Elimina `biome_classes.yaml`.
+6. Accendi i 4 guard (con negative control).
+7. **Ratchet del gate coverage** (oggi `max_missing=5`, `min_traits=189`).
+
+## Cosa questo ADR NON risolve (esplicito, non nascosto)
+
+1. **Il debito narrativo koppen-vs-fiction** su `cryosteppe`/`deserto_caldo`/`savana`.
+2. **Quale delle due semantiche di `biome_class`** intendano le 33 regole in `env_traits.json`
+   (le 3 koppen non ne portano nessuna; le altre 30 vanno controllate una per una).
+3. **Quale `cross_events.yaml` e' autoritativo**: ce ne sono **due**
+   (`data/ecosystems/network/` e `data/ecosistemi/` -- cartella italiana sorella duplicata).
+4. **Il TARGET di scope**: quanti biomi/specie/ecosistemi deve avere il gioco. Non e' scritto
+   da nessuna parte -> "quanto manca" resta **indefinito**. Senza questo numero, pianificare
+   contenuto e' costruire sul vuoto. **Questa e' la prossima decisione, ed e' master-dd.**
+
+## Conseguenze
+
+**Positive**: un solo vocabolario di biomi; il catalogo specie dice la verita' (46, non 105);
+lo stack a 4 livelli passa da _documentato-e-ignorato_ a _fatto rispettare_; la trappola del
+metric-gaming e' rimossa alla radice, non tappata.
+
+**Negative**: 20 -> 22 biomi giocabili significa scrivere 2 righe L1 che non esistono; i 52 stub
+cancellati faranno **scendere** metriche che oggi sembrano piu' alte di quanto siano (e' il
+punto); il debito narrativo resta aperto.
+
+**Rischio principale**: eseguire i passi fuori ordine. Il punto 1 e' load-bearing -- lo dice il
+codice, non l'opinione.
+
+## Riferimenti
+
+- SoT §3 `docs/core/00-SOURCE-OF-TRUTH.md:118-170` -- il modello a 4 livelli, canonico
+- Museum: `M-2026-04-26-012` (revived, aveva previsto questo esito), `M-2026-04-26-018`,
+  `M-2026-07-14-001` (la saga dei 5 strati + il metodo _remove-then-remeasure_),
+  `M-2026-07-14-002` (i vocabolari orfani, preservati), `M-2026-07-14-003` (key overload),
+  `M-2026-07-14-004` (convenzione maiuscole)
+- Censimento `docs/planning/2026-07-14-content-substrate-census.md` (#3304)
+  — ⚠️ **da correggere**: dice "5 ecosistemi", sono **21** (contava `.biome.yaml`)
+- Issue #3302, #3299

--- a/docs/governance/docs_registry.json
+++ b/docs/governance/docs_registry.json
@@ -1045,6 +1045,19 @@
       "track": "active"
     },
     {
+      "path": "docs/adr/ADR-2026-07-14-worldgen-data-model.md",
+      "title": "ADR-2026-07-14 — Worldgen data model: cos'e' un bioma, cos'e' una specie",
+      "doc_status": "active",
+      "doc_owner": "master-dd",
+      "workstream": "dataset-pack",
+      "last_verified": "2026-07-14",
+      "source_of_truth": true,
+      "language": "it",
+      "review_cycle_days": 90,
+      "primary": false,
+      "track": "active"
+    },
+    {
       "path": "docs/appendici/A-CANVAS_ORIGINALE.md",
       "title": "Canvas A — Originale (A.L.I.E.N.A.)",
       "doc_status": "active",

--- a/docs/museum/MUSEUM.md
+++ b/docs/museum/MUSEUM.md
@@ -23,8 +23,10 @@
 - [Sentience Traits v1.0 — tier T1-T6 + interoception](cards/cognitive_traits-sentience-tiers-v1.md) — **5/5** · Skiv Sprint C diary unblock 3h · unintegrated
 - [Enneagramma Mechanics Registry — 16 hook stub](cards/enneagramma-mechanics-registry.md) — **5/5** · plug-in `enneaEffects.js` 3h · unintegrated
 - [Enneagramma Dataset — 9 tipi canonical](cards/enneagramma-dataset-9-types.md) — **5/5** · Skiv voice palette type 5/7 · unintegrated
-- [Worldgen Stack 4-livelli](cards/worldgen-bioma-ecosistema-foodweb-network-stack.md) — **5/5** · bioma→ecosistema→foodweb→network, 3 livelli runtime zero · forgotten
-- [Bioma come pacchetto gameplay+fiction](cards/worldgen-biome-as-gameplay-fiction-package.md) — **5/5** · 5/7 campi biomes.yaml non consumati, P6 fix ~3h · forgotten
+- [Coverage fabbricata: 5 strati impilati](cards/lesson-coverage-fabrication-five-layers.md) — **5/5** · 🆕 2026-07-14 · LESSON: gate a zero per 7 mesi, numero onesto 9; metodo REMOVE-THEN-REMEASURE · superseded
+- [Worldgen Stack 4-livelli](cards/worldgen-bioma-ecosistema-foodweb-network-stack.md) — **5/5** · ✅ REVIVED 2026-07-14 (ADR #3302 adotta lo stack come modello enforced) · **aveva predetto il fallimento** · revived
+- [Bioma come pacchetto gameplay+fiction](cards/worldgen-biome-as-gameplay-fiction-package.md) — **5/5** · 5/7 campi biomes.yaml non consumati; spec per ogni nuova promozione a bioma giocabile · reviewed
+- [Due vocabolari bioma orfani](cards/worldgen-biome-vocabularies-orphan.md) — **4/5** · 🆕 2026-07-14 · 12 biomi reali mai cablati + 21 nomi fabbricati, cancellati dall'ADR · unintegrated
 - [Nido Itinerante D-Canvas](cards/mating_nido-canvas-nido-itinerante.md) — **4/5** · Skiv vagans direct fit, 3 mechanics legacy mai migrate · superseded
 - [MBTI Gates Ghost](cards/personality-mbti-gates-ghost.md) — **4/5** · recoverable via `git show 5c704524:...` · deleted
 - [BiomeMemory + Trait Cost Exploration](cards/architecture-biome-memory-trait-cost.md) — **4/5** · Skiv biome-mover differentiation · deferred
@@ -111,21 +113,25 @@ _Pool secco. 10/10 species in `incoming/species/*.json` già canonical via commi
 
 ### Pipeline failure modes
 
+- [Coverage fabbricata: 5 strati impilati](cards/lesson-coverage-fabrication-five-layers.md) — score 5/5 · 🆕 **LESSON** · gate copertura trait a zero per 7 mesi (2025-12-03 → 2026-07-14); numero onesto = 9. 5 artefatti fabbricati impilati, tutti runtime-inerti. **Metodo: REMOVE-THEN-REMEASURE** — un `max_missing = 73` fantasma stava per essere baselineato in CI · superseded
 - [evo-swarm run #5 discarded claims](cards/evo-swarm-run-5-discarded-claims.md) — score 4/5 · 8 hallucinated + 2 redundant, OD-022 gate reference + LLM prompt training · curated (⚠️ user-requested autonomous deviation Museum-first protocol — repo-archaeologist agent review pending)
 
 _Restanti: 22 artifact in inventory (1 ADR formally Superseded + 4 partial supersedes + DEPRECATED.md cleanup + concept-explorations vertical-slice). Vedi [excavations/2026-04-25-architecture-inventory.md](excavations/2026-04-25-architecture-inventory.md)._
 
 ### Worldgen / Ecosystem-PCG
 
-- [Worldgen Stack 4-livelli](cards/worldgen-bioma-ecosistema-foodweb-network-stack.md) — score 5/5 · bioma→ecosistema→foodweb→network, 3 livelli runtime zero · forgotten
-- [Bioma come pacchetto gameplay+fiction](cards/worldgen-biome-as-gameplay-fiction-package.md) — score 5/5 · 5/7 campi biomes.yaml non consumati a runtime · forgotten
-- [Ruoli trofici validator-time](cards/worldgen-trophic-roles-validator-not-runtime.md) — score 4/5 · trophic_roles.py + foodweb.py completi, zero runtime · deferred
-- [16 Forme MBTI come seed evolutivi](cards/worldgen-forme-mbti-as-evolutionary-seed.md) — score 4/5 · starter_bioma undefined, d12 bias live ma sconnesso da bioma · forgotten
-- [Emergenza specie da ecosistema](cards/worldgen-species-emergence-from-ecosystem.md) — score 4/5 · biome_pools.json role_templates caricati non esposti a spawn · deferred
-- [Cross-bioma event propagation](cards/worldgen-cross-bioma-events-propagation.md) — score 4/5 · 3 eventi, propagation logic validator, zero runtime · unintegrated
+- [Worldgen Stack 4-livelli](cards/worldgen-bioma-ecosistema-foodweb-network-stack.md) — score 5/5 · ✅ **REVIVED 2026-07-14** — ADR #3302 adotta lo stack come modello enforced; la card **aveva predetto** l'errore "5 ecosistemi" (letti i 5 `*.biome.yaml` invece dei 21 `*.ecosystem.yaml`) · revived
+- [Bioma come pacchetto gameplay+fiction](cards/worldgen-biome-as-gameplay-fiction-package.md) — score 5/5 · 5/7 campi biomes.yaml non consumati a runtime; spec di cosa serve per promuovere un bioma a giocabile · reviewed
+- [Due vocabolari bioma orfani](cards/worldgen-biome-vocabularies-orphan.md) — score 4/5 · 🆕 12 biomi reali mai cablati (taiga/tundra/reef...) + 21 nomi fabbricati; `biome_classes.yaml` cancellato dall'ADR · unintegrated
+- [`biome_class`: una chiave, due significati](cards/worldgen-biome-class-key-overload.md) — score 3/5 · 🆕 28 identita' bioma in un file, 10 valori ecologici in un altro; string-match senza validazione · forgotten
+- [Node id MAIUSCOLI: convention leak](cards/worldgen-network-node-id-uppercase-leak.md) — score 3/5 · 🆕 `DESERTO_CALDO` colato in `echo-wing.yaml`; **NON correggere abbassando il case** (0/4 mapping corretti) · forgotten
+- [Ruoli trofici validator-time](cards/worldgen-trophic-roles-validator-not-runtime.md) — score 4/5 · trophic_roles.py + foodweb.py completi, zero runtime; livello 3 ora enforced · reviewed
+- [16 Forme MBTI come seed evolutivi](cards/worldgen-forme-mbti-as-evolutionary-seed.md) — score 4/5 · starter_bioma undefined; eseguibile solo post-ADR (serviva un modello bioma stabile) · reviewed
+- [Emergenza specie da ecosistema](cards/worldgen-species-emergence-from-ecosystem.md) — score 4/5 · biome_pools.json role_templates non esposti a spawn; substrato reale = 46/105 specie (56% stub) · reviewed
+- [Cross-bioma event propagation](cards/worldgen-cross-bioma-events-propagation.md) — score 4/5 · **ha salvato 2 biomi**: deserto_caldo + cryosteppe sono origini cross-event, stavano per essere rimossi · reviewed
 - [Bridge species network glue](cards/worldgen-bridge-species-network-glue.md) — score 3/5 · 3 bridge species nel pack ecosystem, non in data/core · unintegrated
 
-📎 **Gallery**: [galleries/worldgen.md](galleries/worldgen.md) — 7 card worldgen, gap analysis completo, reuse path consolidato tier 1/2/3.
+📎 **Gallery**: [galleries/worldgen.md](galleries/worldgen.md) — 7 card worldgen, gap analysis completo, reuse path consolidato tier 1/2/3. _(NB: gallery non aggiornata con le 3 card 2026-07-14 — pending.)_
 
 ### Evolution genetics / Mutation engine
 
@@ -157,11 +163,12 @@ _Restanti: 22 artifact in inventory (1 ADR formally Superseded + 4 partial super
 
 ## 📊 Stats
 
-- **Excavations run**: 13 totali (4 session-1 + 4 session-2 + 1 session-3: worldgen + 1 session-5: ancestors reentry + 1 session-6 cross-validation 2026-05-13 + 1 session-7 Phase 3 Path D methodology 2026-05-15 + 1 session-8 coop WS test infra 2026-05-20)
-- **Artifact identificati**: ~107 totali (101 precedenti + 6 pattern coop WS test infra)
-- **Cards total**: 35 curate (9 score 5/5 · 13 score 4/5 · 11 score 3/5 · 2 score 2/5) — +1 score 5/5 test infra
-- **Galleries**: 3 (enneagramma + ancestors + worldgen)
-- **Last excavate**: 2026-05-20 (session 8 coop WS test infra: 6 pattern riusabili disconnect-race + host-transfer, M-2026-05-20-001 score 5/5)
+- **Excavations run**: 14 totali (4 session-1 + 4 session-2 + 1 session-3: worldgen + 1 session-5: ancestors reentry + 1 session-6 cross-validation 2026-05-13 + 1 session-7 Phase 3 Path D methodology 2026-05-15 + 1 session-8 coop WS test infra 2026-05-20 + **1 session-9 curate pre-ADR biome/species 2026-07-14**)
+- **Artifact identificati**: ~112 totali (107 precedenti + 5 artefatti pre-cancellazione ADR #3302)
+- **Cards total**: 39 curate (10 score 5/5 · 14 score 4/5 · 13 score 3/5 · 2 score 2/5) — +4 session-9
+- **Lifecycle**: 2 `revived` (mating engine, worldgen stack 4-livelli) · 5 `reviewed` (worldgen cluster, 2026-07-14)
+- **Galleries**: 3 (enneagramma + ancestors + worldgen) — worldgen gallery **pending** update per le 3 card 2026-07-14
+- **Last excavate**: **2026-07-14** (session 9 curate-mode pre-ADR: saga coverage-fabrication 5 strati + 2 vocabolari bioma orfani + key overload + convention leak; M-2026-07-14-001..004)
 - **Coverage**: **100%+** (9/9 domain + indie research cluster nuovi)
 - **Skiv unblock**: 8/11 card hanno reuse path Skiv-aware (Sprint A: 2, Sprint B: 1, Sprint C: 4, biome-mover differentiation: 1)
 - **Cross-agent validation**: ✅ PASS 2026-04-25 (creature-aspect-illuminator consulted MUSEUM.md spontaneously, 6 GAP found, 10-15min saved)
@@ -215,8 +222,12 @@ docs/museum/
 │   ├── indie-inscryption-camera-reveal-meta.md              # M-2026-04-27-027 score 2/5 (NEW)
 │   ├── indie-1000xresist-memory-layered-pov.md              # M-2026-04-27-028 score 3/5 (NEW)
 │   ├── indie-loop-hero-minimap-visual-emergence.md          # M-2026-04-27-029 score 3/5 (NEW)
-│   ├── indie-cocoon-biome-rules-layer.md                    # M-2026-04-27-030 score 3/5 (NEW)
-│   └── indie-tunic-manual-puzzle-broader.md                 # M-2026-04-27-031 score 2/5 (NEW)
+│   ├── indie-cocoon-biome-rules-layer.md                    # M-2026-04-27-030 score 3/5
+│   ├── indie-tunic-manual-puzzle-broader.md                 # M-2026-04-27-031 score 2/5
+│   ├── lesson-coverage-fabrication-five-layers.md           # M-2026-07-14-001 score 5/5 (NEW — LESSON)
+│   ├── worldgen-biome-vocabularies-orphan.md                # M-2026-07-14-002 score 4/5 (NEW)
+│   ├── worldgen-biome-class-key-overload.md                 # M-2026-07-14-003 score 3/5 (NEW)
+│   └── worldgen-network-node-id-uppercase-leak.md           # M-2026-07-14-004 score 3/5 (NEW)
 └── galleries/
     ├── ancestors.md                                         # 1 card aggregato
     ├── enneagramma.md                                       # 3 cards aggregato
@@ -239,6 +250,21 @@ docs/museum/
 
 ## 📅 Last verified
 
+**2026-07-14** — Session 9, **curate-mode pre-ADR** (issue #3302, modello dati biome/species). L'ADR sta per **cancellare** artefatti che contengono informazione riusabile: curati **prima** della cancellazione (il museo e' additive-only, l'ADR no).
+
+**4 card nuove** (M-2026-07-14-001..004):
+
+- **M-001 LESSON 5/5** — `lesson-coverage-fabrication-five-layers.md`. Il gate di copertura trait ha misurato **zero per 7 mesi**; il numero onesto era **9**. Cinque strati di dati fabbricati, ognuno che copriva il buco del precedente, **tutti runtime-inerti**. **Il metodo che li ha scoperti e' la lezione**: quando un fix di completezza "smaschera debito", **rimuovi prima l'artefatto sospetto e ri-misura** — un `max_missing = 73` **interamente fantasma** stava per essere congelato in un gate CI.
+- **M-002 4/5** — `worldgen-biome-vocabularies-orphan.md`. Due liste di nomi bioma mai progettati, in cancellazione: **12** biomi del mondo reale mai cablati (9 orfani totali: taiga, tundra, reef, costa_rocciosa, foresta_boreale, macchia_mediterranea, prateria_temperata, deserto_freddo, caverne) + **21** nomi fabbricati `coverage_autogen`. ⚠️ `biome_classes.yaml` e' **load-bearing oggi** (`trait_coverage.py:74-95` inverte i suoi `koppen_examples`): migrare **prima** di cancellare.
+- **M-003 3/5** — `worldgen-biome-class-key-overload.md`. `biome_class` = 28 **identita'** bioma in un file, ~10 valori di **tassonomia ecologica** in un altro. Insiemi disgiunti, stessa chiave, zero validazione.
+- **M-004 3/5** — `worldgen-network-node-id-uppercase-leak.md`. I node id livello-4 sono MAIUSCOLI **per convenzione**; sono colati in `echo-wing.yaml`. **NON correggere abbassando il case: 0/4 mapping sarebbero corretti** (c'e' un'indirezione `id -> biome_id`).
+
+**6 card worldgen aggiornate** — 1 `revived` + 5 `reviewed`:
+
+**M-2026-04-26-012 (Worldgen Stack 4-livelli) → `revived`.** Aveva scritto il 2026-04-26: _"Rischio: sessioni future di Claude descrivono il gioco come 'rotazione di mappe' ignorando 3 livelli profondi gia' documentati e validati."_ E' successo **esattamente cosi'**: una sessione ha contato "5 ecosistemi" leggendo i 5 `*.biome.yaml` invece dei 21 `*.ecosystem.yaml`, e stava per rimuovere `cryosteppe` e `deserto_caldo` — che sono ecosistemi (L2), foodweb (L3), **nodi di rete (L4)** e origini cross-event, con 5 specie reali ciascuno. **`deserto_caldo` e' lo `start_node` dell'intero meta-network.** L'ADR ora **adotta lo stack 4-livelli come modello enforced** e **promuove** i due biomi a giocabili.
+
+> **Lezione di curation**: le card che nominano _il modo del fallimento futuro_ valgono piu' di quelle che elencano il contenuto. Questa ha ripagato 2 biomi.
+
 **2026-05-10** — Session 5 ancestors reentry audit. Card M-2026-05-10-001 (score 3/5, branch metadata archive). Major finding: 290/297 traits already live; proposals = provenance + branch metadata only. Path C (sandbox header, 10min) + Path A (biome seeder ~3h) recommended. Audit doc: `docs/research/2026-05-10-ancestors-297-reentry-audit.md`.
 
 **2026-04-27** — Session 4 indie research curation complete. 12 nuove card (M-019→M-031). Cluster C.1 resource attrition (3) + C.2 combat depth (3) + C.3 narrative reactivity (4) + C.4 visual emergence (2). Score distribution: 3×4/5, 7×3/5, 2×2/5. Verified ratio: 0/12 (tutti da doc research, nessuna provenance git diretta). Pending decisions: D3/D4/D5 + TKT-09 + Bundle A/B/C/post-playtest trigger conditions.
@@ -257,7 +283,6 @@ docs/museum/
 **Major finding session 2**: V3 mating engine GIÀ LIVE (PR #1679, 469 LOC + 7 endpoint). OD-001 era basata su audit incomplete. Decisione product Path A (activate ~12-15h) / Path B (demolish ~2h) / Path C (sandbox ~5h) pending.
 
 **Next**: user review verdict OD-001 + 5 backlog ticket P4 spawn + Sprint A wire (M-005 magnetic_rift, validato 6 GAP da cross-agent audit).
-
 
 ---
 

--- a/docs/museum/cards/lesson-coverage-fabrication-five-layers.md
+++ b/docs/museum/cards/lesson-coverage-fabrication-five-layers.md
@@ -1,0 +1,211 @@
+---
+title: 'Coverage fabbricata: 5 strati impilati e il metodo che li ha scoperti'
+museum_id: M-2026-07-14-001
+type: decision
+domain: [architecture]
+provenance:
+  found_at: 'packs/evo_tactics_pack/docs/catalog/env_traits.json + tools/py/game_utils/trait_coverage.py + packs/evo_tactics_pack/data/species/'
+  git_sha_first: '089b6aa0'
+  git_sha_last: '2c5a8942'
+  last_modified: '2026-07-14'
+  last_author: 'MasterDD-L34D'
+  buried_reason: superseded
+relevance_score: 5
+reuse_path: 'tools/py/game_utils/trait_coverage.py:197-210 -- il guard che rifiuta il pattern alla sorgente; riusabile come template per QUALSIASI gate di copertura futuro'
+related_pillars: [P1, P3, P6]
+status: curated
+excavated_by: repo-archaeologist
+excavated_on: 2026-07-14
+last_verified: 2026-07-14
+---
+
+# Coverage fabbricata: 5 strati impilati e il metodo che li ha scoperti
+
+## Summary (30s)
+
+- Per **7 mesi** (2025-12-03 -> 2026-07-14) il gate di copertura trait di Evo-Tactics ha misurato **zero**. Il numero onesto era **9**. Cinque strati indipendenti di dati fabbricati tenevano su quello zero, ognuno che copriva il buco lasciato dal precedente.
+- Nessuno degli strati era un bug. Ognuno era un artefatto **deliberato** che faceva contare come "coperto" cio' che non lo era. Il generatore runtime li ignorava tutti: erano dati morti che gonfiavano solo la metrica.
+- **Il metodo che ha funzionato** (e che vale piu' dei 5 strati): quando un fix di completezza "smaschera debito", prima **RIMUOVI** l'artefatto sospetto e **ri-misura**. Una regola metric-gaming puo' fabbricare esattamente il debito che stai per congelare in un gate.
+
+## What was buried
+
+Cinque strati, dal piu' superficiale al piu' profondo. Ognuno verificato su git in questa sessione.
+
+### Strato 1 -- la regola `when: {}` (rimosso in #3298)
+
+`packs/evo_tactics_pack/docs/catalog/env_traits.json` conteneva una regola:
+
+```json
+{
+  "when": {},
+  "meta": {
+    "category": "coverage_backfill",
+    "description": "Rule di copertura automatica per i trait non ancora coperti (report 2025-12-03)",
+    "cohort": "trait_gap_fill_20251203"
+  },
+  "suggest": { "traits": ["...107 trait alla nascita, 105 alla rimozione..."] }
+}
+```
+
+Nata in `b893b91a` (2025-12-03, "Add coverage backfill rule for missing traits"). Un `when` vuoto fa contare come _coperti_ tutti i trait elencati.
+
+**Runtime-INERTE**: `docs/evo-tactics-pack/generator.js:3802-3803` fa
+
+```js
+const classId = rule.when?.biome_class;
+if (!classId) return;
+```
+
+Il generatore la saltava del tutto. Zero effetto sul gioco, effetto pieno sulla metrica. Rimossa in `2359a848` (#3298).
+
+### Strato 2 -- il backfill `species_affinity` (rimosso in #3300)
+
+`tools/py/game_utils/trait_coverage.py` iniettava **ogni** specie presente in `species_affinity` dentro **qualsiasi** combo di regola non coperta, **senza alcun ancoraggio al bioma**. Una specie che non vive nel bioma "copriva" comunque quel bioma.
+
+L'amplificatore: `tools/py/report_trait_coverage.py:48-53` mette `--species-affinity` in **default** (`default=Path("data/traits/species_affinity.json")`). La CI (`.github/workflows/ci.yml:565`) non passa mai il flag -- quindi lo riceveva **in silenzio** da argparse. Nessuno lo aveva scritto nel workflow; nessuno poteva vederlo leggendo il workflow.
+
+Il commento che oggi marca la rimozione (`trait_coverage.py:349-356`) e' esso stesso la fonte primaria: _"it is the same trick as the `coverage_backfill` env rule removed in #3298, one layer down"_.
+
+### Strato 3 -- le regole koppen insoddisfacibili (corretto in #3300)
+
+Le regole con scope climatico (`koppen_in` / `koppen_any`) non dichiarano `biome_class`. Collassavano quindi sulla combo degenere `(biome=None, morphotype=None)` -- **insoddisfacibile per costruzione**: le specie sono indicizzate su `(biome, morphotype)` e ogni specie ha almeno un bioma, quindi nessuna combo di specie porta mai `biome=None`.
+
+Domanda strutturalmente senza risposta -> veniva "coperta" da uno stub keeper senza bioma (`global-trait-keeper`). Oggi (`trait_coverage.py:212-225`) la regola viene **espansa** sulle biome class i cui codice koppen canonici corrispondono, via `koppen_examples`. La domanda torna reale.
+
+Regole koppen oggi in `env_traits.json`: **3**, tutte senza `biome_class`.
+
+### Strato 4 -- 21 directory bioma fabbricate
+
+`packs/evo_tactics_pack/data/species/<biome>/` contiene **30** directory il cui unico file e' un `*-trait-keeper.yaml`. Di queste, **21 sono stub da 3 righe con ZERO specie**:
+
+```yaml
+id: tundra-risonante-trait-keeper
+notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+```
+
+Ciclo di vita verificato su git:
+
+1. **`089b6aa0`** (2025-10-29, "Add coverage trait keepers for Evo Tactics biomes") -- nascono **38** keeper completi (~51-73 righe), ognuno con
+   ```yaml
+   receipt:
+     source: coverage_autogen
+     author: automation
+     date: '2025-10-29'
+     trace_hash: to-fill
+   ```
+   La ricevuta lo dice a voce alta: `coverage_autogen`, `author: automation`.
+2. **`7c62b510`** (2025-11-30, "Enhance Evo pack pipeline and derived outputs") -- i 38 keeper vengono **cancellati**.
+3. **`9acadc69`** (2025-12-09, "Restore Evo Tactics species inventory resources") -- i 38 vengono **ri-aggiunti come gusci vuoti** da 2-3 righe. Il "restore" ha ripristinato l'inventario, non il contenuto.
+
+> **Correzione al racconto corrente**: i keeper non sono stati "svuotati sul posto" in `9acadc69`. Sono stati **cancellati** in `7c62b510` e **resuscitati come gusci** in `9acadc69`. Il ciclo delete-then-restore-as-hollow-shell e' il dettaglio che conta: un commit chiamato "Restore" ha reintrodotto 38 file la cui unica funzione era esistere.
+
+### Strato 5 -- 4 alias di migrazione semanticamente assurdi
+
+`data/core/biome_aliases.yaml:12-27` marca `status: migrated`:
+
+| alias               | canonical                   | assurdita'                            | specie reali vive oggi |
+| ------------------- | --------------------------- | ------------------------------------- | ---------------------- |
+| `foresta_temperata` | `foresta_miceliale`         | --                                    | **7**                  |
+| `badlands`          | `dorsale_termale_tropicale` | badlands != dorsale termale tropicale | **11**                 |
+| `deserto_caldo`     | `abisso_vulcanico`          | deserto != abisso vulcanico           | **5**                  |
+| `cryosteppe`        | `mezzanotte_orbitale`       | steppa gelata != stazione orbitale    | **5**                  |
+
+Tutti e quattro gli slug "migrati" sono **ancora vivi con specie reali**. E' una migrazione **che non e' mai avvenuta**: l'alias e' stato scritto, la migrazione no.
+
+### Il censimento che ne esce
+
+- **59 / 105** file specie sono stub autogenerati (**56%**).
+- `rovine_planari`: **10 file, 10 stub, 0 specie reali**. Un bioma intero fatto di niente.
+
+## Why it was buried
+
+Non e' stato sepolto: e' stato **costruito**, strato su strato, ognuno in buona fede per far tornare verde un gate.
+
+La dinamica e' quella classica del metric-gaming: un report dice "N trait scoperti" -> qualcuno aggiunge un artefatto che li fa contare come coperti -> il gate torna verde -> il debito reale resta, invisibile, e ora e' anche _protetto_ dal gate stesso. Ripetuto 5 volte, con 5 meccanismi diversi, il debito diventa strutturalmente inosservabile.
+
+Il generatore runtime non e' mai stato ingannato. Solo la metrica.
+
+## Why it might still matter
+
+**Questa e' la lezione, non l'artefatto.** Gli artefatti li cancella l'ADR (issue #3302). Il metodo va conservato.
+
+### Il metodo che ha funzionato -- REMOVE-THEN-REMEASURE
+
+> Quando un fix di completezza "smaschera debito", **prima prova a RIMUOVERE l'artefatto sospetto e ri-misura**. Una regola metric-gaming puo' fabbricare esattamente il debito che stai per congelare in un gate.
+
+Caso concreto di questa sessione: dopo il primo fix affiorava `max_missing = 73`. Stava per essere **baselineato in CI come debito reale**. Era invece **interamente prodotto dallo strato 1**: rimossa la regola, il numero e' andato a **0** (non a 73 meno qualcosa -- a zero). Poi, tolti anche gli strati 2-3, il numero **onesto** e' emerso: **9**. E, a differenza del 73 fantasma, ognuno dei 9 era una claim concreta e verificabile:
+
+> _"la regola dice che il clima BSk produce `pelli_cave`; badlands E' un bioma BSk; nessuna specie badlands porta `pelli_cave`."_
+
+`#3301` ne ha chiusi 4 scrivendo link specie-trait **reali**. Gate onesto oggi: **5**.
+
+**Il 73 era un numero fantasma. Congelarlo in un gate avrebbe cementato la fabbricazione dentro il sistema di difesa contro la fabbricazione.**
+
+### Il guard riusabile
+
+`tools/py/game_utils/trait_coverage.py:197-210` rifiuta oggi il pattern **alla sorgente**:
+
+```python
+if traits and not conditions:
+    raise ValueError(
+        f"env_traits rule[{index}] suggests {len(traits)} trait(s) with an empty "
+        "`when` -- an unconditioned rule fakes coverage without producing anything "
+        "at runtime. ..."
+    )
+```
+
+Questo e' il template per qualsiasi gate di copertura futuro: **una regola che suggerisce N cose e non vincola nulla e' un backfill travestito**. Rifiutala nel parser, non nella code review.
+
+### I due ratchet
+
+`.github/workflows/ci.yml:585-595` documenta l'asimmetria che ha permesso tutto:
+
+- Il **floor** (`min_traits`) stava a **27** mentre il valore reale era **189**: 162 trait potevano perdere ogni link a specie con la CI ancora verde.
+- Un **ceiling** che ratchetta solo verso il basso **non vale nulla** accanto a un **floor** che non ratchetta mai verso l'alto.
+
+Oggi: floor 189 (ratchet UP only), ceiling 5 (ratchet DOWN only).
+
+## Concrete reuse paths
+
+1. **Minimal** (P0, ~0h -- gia' fatto): il guard `trait_coverage.py:197-210` e' in tree. Nessuna azione.
+2. **Moderate** (P1, ~2h): estendi il pattern REMOVE-THEN-REMEASURE a **ogni altro gate derivato** del repo. Candidati: `data/derived/analysis/trait_baseline.yaml`, i coverage report `data/analysis/*`. Domanda da porre a ciascuno: _esiste un artefatto la cui unica funzione e' far salire questo numero?_
+3. **Full** (P2, ~4h): promuovi la coppia **floor-che-ratchetta-su + ceiling-che-ratchetta-giu** a policy esplicita per ogni gate numerico in `ci.yml`. Oggi e' un commento in un solo workflow.
+
+## Sources / provenance trail
+
+- Regola strato 1: [packs/evo_tactics_pack/docs/catalog/env_traits.json](../../../packs/evo_tactics_pack/docs/catalog/env_traits.json) -- oggi **0** regole con `when` vuoto
+- Guard runtime: [docs/evo-tactics-pack/generator.js:3802](../../evo-tactics-pack/generator.js) -- `const classId = rule.when?.biome_class; if (!classId) return;`
+- Backfill strato 2 + commenti di rimozione: [tools/py/game_utils/trait_coverage.py:197-225,349-356](../../../tools/py/game_utils/trait_coverage.py)
+- Default silenzioso: [tools/py/report_trait_coverage.py:48-53](../../../tools/py/report_trait_coverage.py)
+- Narrativa CI (fonte primaria): [.github/workflows/ci.yml:565-600](../../../.github/workflows/ci.yml)
+- Alias mai migrati: [data/core/biome_aliases.yaml:12-27](../../../data/core/biome_aliases.yaml)
+
+Git history verificata:
+
+| SHA        | data       | messaggio                                                      | ruolo                                 |
+| ---------- | ---------- | -------------------------------------------------------------- | ------------------------------------- |
+| `089b6aa0` | 2025-10-29 | Add coverage trait keepers for Evo Tactics biomes              | nascita 38 keeper `coverage_autogen`  |
+| `7c62b510` | 2025-11-30 | Enhance Evo pack pipeline and derived outputs                  | cancella i 38 keeper                  |
+| `b893b91a` | 2025-12-03 | Add coverage backfill rule for missing traits                  | nascita regola `when: {}` (107 trait) |
+| `9acadc69` | 2025-12-09 | Restore Evo Tactics species inventory resources                | ri-aggiunge i 38 come stub 3-righe    |
+| `2359a848` | 2026-07-14 | drop synthetic coverage_backfill rule (#3298)                  | rimuove strato 1                      |
+| `2e33142c` | 2026-07-14 | model koppen rules, kill the species-affinity backfill (#3300) | rimuove strati 2-3                    |
+| `f7d491ab` | 2026-07-14 | author 4 real species-trait links, gate 9 -> 5 (#3301)         | debito reale ridotto                  |
+
+PR / issue: [#3298](https://github.com/MasterDD-L34D/Game/pull/3298) MERGED - [#3300](https://github.com/MasterDD-L34D/Game/pull/3300) MERGED - [#3301](https://github.com/MasterDD-L34D/Game/pull/3301) MERGED - [#3299](https://github.com/MasterDD-L34D/Game/issues/3299) OPEN (71 trait senza regola) - [#3302](https://github.com/MasterDD-L34D/Game/issues/3302) OPEN (ADR biome/species data model) - [#3304](https://github.com/MasterDD-L34D/Game/pull/3304) MERGED (censimento).
+
+Censimento: [docs/planning/2026-07-14-content-substrate-census.md](../../planning/2026-07-14-content-substrate-census.md)
+
+## Risks / open questions
+
+- **Schema drift severity: HIGH.** Il concetto "bioma" ha oggi **4 fonti** disallineate: `data/core/biomes.yaml` (20 chiavi canoniche), `biome_classes.yaml` (28 identita'), `biome_aliases.yaml` (18 alias di cui 4 contraddittori), `data/species/<biome>/` (49 directory). Vedi card [M-2026-07-14-002](worldgen-biome-vocabularies-orphan.md) e [M-2026-07-14-003](worldgen-biome-class-key-overload.md).
+- **#3299 resta aperta**: 71 trait che nessuna regola bioma suggerisce mai. E' il debito **reale** smascherato -- non ripetere l'errore: **non backfillarlo**.
+- **56% del catalogo specie e' stub.** L'ADR cancella i 21 stub-only. Restano 38 stub dentro directory che hanno anche specie reali: quelli **non** sono coperti dall'ADR. Verificare separatamente.
+- **Domanda aperta**: perche' `7c62b510` cancello' i 38 keeper e perche' `9acadc69` li "ripristino'" vuoti? Nessun ADR copre quei due commit. Il movente resta ignoto.
+
+## Cross-links
+
+- [M-2026-07-14-002 -- Due vocabolari bioma orfani](worldgen-biome-vocabularies-orphan.md)
+- [M-2026-07-14-003 -- `biome_class`: una chiave, due significati](worldgen-biome-class-key-overload.md)
+- [M-2026-07-14-004 -- Node id MAIUSCOLI: convention leak](worldgen-network-node-id-uppercase-leak.md)
+- [M-2026-04-26-012 -- Worldgen Stack 4-livelli](worldgen-bioma-ecosistema-foodweb-network-stack.md) -- **aveva predetto questo fallimento**

--- a/docs/museum/cards/worldgen-bioma-ecosistema-foodweb-network-stack.md
+++ b/docs/museum/cards/worldgen-bioma-ecosistema-foodweb-network-stack.md
@@ -13,10 +13,12 @@ provenance:
 relevance_score: 5
 reuse_path: 'apps/backend/services/combat/biomeSpawnBias.js:1 — extend da affix-bias a full ecosystem loader; packs/evo_tactics_pack/data/ecosystems/ — dati già esistenti'
 related_pillars: [P1, P3, P6]
-status: curated
+status: revived
+revived_by: 'ADR biome/species data model (issue #3302) -- adotta lo stack 4-livelli come modello ENFORCED; promuove cryosteppe + deserto_caldo a biomi giocabili'
+revived_on: 2026-07-14
 excavated_by: repo-archaeologist
 excavated_on: 2026-04-26
-last_verified: 2026-04-26
+last_verified: 2026-07-14
 ---
 
 # Worldgen Stack 4-livelli: bioma → ecosistema → foodweb → network
@@ -84,3 +86,47 @@ Clima, aria, abiotico, struttura trofica (produttori → consumatori primari/sec
 - `bridge_species_map` cita `echo-wing`, `ferrocolonia-magnetotattica`, `archon-solare` — questi slug NON sono in `data/core/species.yaml` (solo 1 entry con `biome_affinity: savana` = dune_stalker). Conflict: bridge species vivono SOLO nel pack ecosystem, non nel core canonical. Serve ADR prima di wire runtime.
 - `biome_id` in `meta_network_alpha.yaml` usa slug come `canyons_risonanti`, `foresta_miceliale` — potrebbero non matchare slug in `data/core/biomes.yaml`. Verificare con `grep -n "canyons_risonanti" data/core/biomes.yaml` prima di wire.
 - "Non promuovere cross-event a meccanica player-visible senza UX research" — la foodweb è motore invisibile per design (SoT §4 esplicito: "impatto basso come meccanica esplicita").
+
+---
+
+## REVIVED -- 2026-07-14 (ADR biome/species data model, issue #3302)
+
+> **Questa card aveva predetto il fallimento, alla lettera, 2 mesi e mezzo prima che accadesse.**
+
+Riga scritta il 2026-04-26 nel Summary qui sopra:
+
+> _"Rischio: sessioni future di Claude descrivono il gioco come 'rotazione di mappe' ignorando 3 livelli profondi gia' documentati e validati."_
+
+**Cosa e' successo il 2026-07-14** (verificato in questa sessione):
+
+Una sessione ha contato **"5 ecosistemi"** leggendo `*.biome.yaml` (**5** file) invece di `*.ecosystem.yaml` (**21** file) -- cioe' ha letto il **livello 1** credendo di leggere il **livello 2**. Esattamente la confusione che questa card aveva nominato.
+
+Conseguenza sfiorata: `cryosteppe` e `deserto_caldo` stavano per essere **rimossi** come biomi vuoti. Sono invece, verificato su filesystem:
+
+| livello          | artefatto                      | `cryosteppe`                | `deserto_caldo`                                    |
+| ---------------- | ------------------------------ | --------------------------- | -------------------------------------------------- |
+| 2 -- ecosistema  | `*.ecosystem.yaml`             | si'                         | si'                                                |
+| 3 -- foodweb     | `data/foodwebs/*_foodweb.yaml` | si'                         | si'                                                |
+| 4 -- network     | `meta_network_alpha.yaml`      | nodo `CRYOSTEPPE`           | nodo `DESERTO_CALDO` -- **`start_node` del grafo** |
+| 4 -- cross-event | `cross_events.yaml`            | origine `evento-brinastorm` | origine `evento-ondata-termica`                    |
+| --               | specie reali                   | **5**                       | **5**                                              |
+
+`deserto_caldo` **e' il nodo di partenza dell'intero meta-network**. Stava per essere cancellato perche' non appariva tra i 5 `*.biome.yaml`.
+
+**Esito**: l'ADR (#3302) **ADOTTA lo stack 4-livelli come modello enforced** e **PROMUOVE** i due biomi a giocabili. La tesi centrale di questa card -- _il mondo e' una rete di ecosistemi a 4 livelli, non un elenco di mappe_ -- passa da documentata a **normativa**.
+
+**Perche' la predizione ha funzionato**: la card non diceva "questi dati sono utili". Diceva **"qualcuno li leggera' male, in questo modo specifico"**. Le card di museo che nominano il _modo del fallimento futuro_ valgono piu' di quelle che elencano il contenuto.
+
+### Cross-link alle card nate da questo evento
+
+- [M-2026-07-14-001 -- Coverage fabbricata: 5 strati impilati](lesson-coverage-fabrication-five-layers.md)
+- [M-2026-07-14-002 -- Due vocabolari bioma orfani](worldgen-biome-vocabularies-orphan.md)
+- [M-2026-07-14-003 -- `biome_class`: una chiave, due significati](worldgen-biome-class-key-overload.md)
+- [M-2026-07-14-004 -- Node id MAIUSCOLI: convention leak](worldgen-network-node-id-uppercase-leak.md)
+
+### Nota sui Risks qui sopra
+
+Due dei rischi elencati il 2026-04-26 sono stati **confermati** in questa sessione:
+
+- _"`biome_id` in `meta_network_alpha.yaml` usa slug come `canyons_risonanti`, `foresta_miceliale` -- potrebbero non matchare slug in `data/core/biomes.yaml`"_ -> **confermato e peggio**: i node id MAIUSCOLI sono colati dentro `echo-wing.yaml`, e la risoluzione `id -> biome_id` **contraddice** `biome_aliases.yaml` su 2 slug su 4. Vedi [M-2026-07-14-004](worldgen-network-node-id-uppercase-leak.md).
+- _"bridge species vivono SOLO nel pack ecosystem, non nel core canonical. Serve ADR prima di wire runtime"_ -> **l'ADR e' arrivato** (#3302).

--- a/docs/museum/cards/worldgen-biome-as-gameplay-fiction-package.md
+++ b/docs/museum/cards/worldgen-biome-as-gameplay-fiction-package.md
@@ -13,10 +13,12 @@ provenance:
 relevance_score: 5
 reuse_path: 'apps/backend/services/combat/biomeSpawnBias.js — estendi da affix-match a full bioma package consumer (StressWave + hazard + npc_archetypes + tono)'
 related_pillars: [P1, P3, P6]
-status: curated
+status: reviewed
+reviewed_by: 'ADR biome/species data model (issue #3302) -- 2 nuovi biomi (cryosteppe, deserto_caldo) promossi a giocabili richiedono il pacchetto completo che questa card descrive'
+reviewed_on: 2026-07-14
 excavated_by: repo-archaeologist
 excavated_on: 2026-04-26
-last_verified: 2026-04-26
+last_verified: 2026-07-14
 ---
 
 # Bioma come pacchetto gameplay+fiction: non è una mappa, è una mappa
@@ -107,3 +109,16 @@ const { applyBiomeBias } = require('./biomeSpawnBias');
 - `StressWave` naming in biomes.yaml vs `pressure` naming in session engine — sono la stessa cosa? Da chiarire prima di wire. Se mappano 1:1, è triviale. Se sono logiche separate, serve ADR.
 - `npc_archetypes.primary/support/threat` non ha slug verificati contro `data/core/` — verifica che `abyssal_forgers` sia uno slug valido per encounter generation prima di usarlo come constraint.
 - Anti-pattern: NON surfaciare `diff_base`/`mod_biome` al player come numeri naked — sono parametri interni di bilanciamento, non UI-facing.
+
+---
+
+## REVIEWED -- 2026-07-14 (ADR biome/species data model, issue #3302)
+
+Status `curated` -> `reviewed`. La sostanza della card **tiene** e diventa piu' urgente.
+
+- L'ADR **promuove `cryosteppe` e `deserto_caldo` a biomi giocabili**. Promuovere un bioma significa esattamente costruire il **pacchetto completo** che questa card descrive (`hazard` + `StressWave` + `npc_archetypes` + tono + hooks) -- non aggiungere una riga a una lista.
+- Questa card e' quindi la **specifica di cosa serve** per ogni nuova promozione a bioma giocabile. Usarla come checklist.
+- **Non risolto dall'ADR**: il claim centrale (5/7 campi di `biomes.yaml` caricati ma non consumati a runtime) resta **aperto**. L'ADR normalizza il _modello dati_, non il _consumo runtime_. Per questo `reviewed` e non `revived`.
+- Conteggio aggiornato: `data/core/biomes.yaml` ha oggi **20** biomi canonici (la card ne citava 30+; verificato 2026-07-14).
+
+Cross-link: [M-2026-07-14-002 -- Due vocabolari bioma orfani](worldgen-biome-vocabularies-orphan.md) (33 nomi bioma senza pacchetto) - [M-2026-04-26-012](worldgen-bioma-ecosistema-foodweb-network-stack.md) (**revived**).

--- a/docs/museum/cards/worldgen-biome-class-key-overload.md
+++ b/docs/museum/cards/worldgen-biome-class-key-overload.md
@@ -1,0 +1,146 @@
+---
+title: '`biome_class`: una chiave, due significati, due file'
+museum_id: M-2026-07-14-003
+type: architecture
+domain: [architecture]
+provenance:
+  found_at: 'packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml:2-30 + data/core/biomes.yaml (campo biome_class)'
+  git_sha_first: 'unknown'
+  git_sha_last: '2c5a8942'
+  last_modified: '2026-07-14'
+  last_author: 'MasterDD-L34D'
+  buried_reason: forgotten
+relevance_score: 3
+reuse_path: "docs/evo-tactics-pack/generator.js:3802 + tools/py/game_utils/trait_coverage.py:193 -- entrambi leggono `rule.when.biome_class`; quale dei due significati intendano non e' mai stato deciso"
+related_pillars: [P1, P3]
+status: curated
+excavated_by: repo-archaeologist
+excavated_on: 2026-07-14
+last_verified: 2026-07-14
+---
+
+# `biome_class`: una chiave, due significati, due file
+
+## Summary (30s)
+
+- `biome_class` significa **due cose diverse** in due file diversi, e nessuno dei due lo dichiara.
+- In `biome_classes.yaml` nomina **28 IDENTITA' bioma** (`badlands`, `rovine_planari`, `taiga`...). In `data/core/biomes.yaml` e' un **campo** che porta una **tassonomia ECOLOGICA grossolana a ~10 valori** (`arid`, `geothermal`, `canopy`, `littoral`, `wetland`, `subterranean`, `clastic`, `salt`, `upland`, `deltaic`).
+- Stessa chiave. Un file dice _"quale bioma"_, l'altro dice _"che tipo di bioma"_. Le regole in `env_traits.json` usano `when.biome_class` -- e **non e' mai stato deciso quale dei due intendano**.
+
+## What was buried
+
+### Significato 1 -- `biome_class` = identita' del bioma
+
+`packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml:2-30`:
+
+```yaml
+schema_version: '1.0'
+classes:
+  - foresta_temperata
+  - foresta_boreale
+  - taiga
+  - tundra
+  - cryosteppe
+# ... 28 totali
+```
+
+Qui una "biome class" **e'** un bioma. `taiga` e' una class. `rovine_planari` e' una class. Cardinalita': **28**.
+
+### Significato 2 -- `biome_class` = tipo ecologico del bioma
+
+`data/core/biomes.yaml`, campo dentro ogni bioma:
+
+```yaml
+biomes:
+  badlands:
+    biome_class: clastic # <-- non "badlands"
+    display_name_it: ...
+    hazard: ...
+    npc_archetypes: ...
+```
+
+Qui una "biome class" e' una **categoria ecologica**. Distribuzione reale sui 20 biomi canonici (verificata):
+
+| valore         | biomi |
+| -------------- | ----- |
+| `canopy`       | 4     |
+| `arid`         | 3     |
+| `upland`       | 3     |
+| `geothermal`   | 2     |
+| `littoral`     | 2     |
+| `clastic`      | 2     |
+| `subterranean` | 1     |
+| `wetland`      | 1     |
+| `salt`         | 1     |
+| `deltaic`      | 1     |
+
+Cardinalita': **10**. Nessuno di questi 10 valori compare nella lista `classes` di `biome_classes.yaml`. **I due insiemi sono disgiunti.**
+
+### Il punto di collisione
+
+Le regole in `packs/evo_tactics_pack/docs/catalog/env_traits.json` sono scritte come:
+
+```json
+{ "when": { "biome_class": "..." }, "suggest": { "traits": [...] } }
+```
+
+E vengono lette da **due consumatori indipendenti**:
+
+- **Runtime**: `docs/evo-tactics-pack/generator.js:3802` -- `const classId = rule.when?.biome_class;`
+- **Gate di copertura**: `tools/py/game_utils/trait_coverage.py:193` -- `biome = conditions.get("biome_class")`
+
+Nessuno dei due valida il valore contro un registro. Nessuno dei due dichiara quale dei due significati si aspetta. Una regola che scrive `biome_class: arid` e una che scrive `biome_class: badlands` sono **entrambe accettate** e trattate come chiavi opache.
+
+**Il matching e' string-match su una chiave che ha due domini di valori legittimi e disgiunti.**
+
+## Why it was buried
+
+Non e' stato sepolto: e' **collassato**. Due registri sono nati per scopi diversi (`biome_classes.yaml` = tassonomia ecologica koppen-based; `biomes.yaml` = biomi di gioco) e hanno finito per riusare lo stesso identificatore per concetti diversi -- probabilmente perche' nel design originale _le classi ecologiche erano i biomi_ (taiga, tundra, savanna **sono** insieme identita' e tipo ecologico nel mondo reale).
+
+Quando `biomes.yaml` ha virato su biomi esotici (`mezzanotte_orbitale`, `rovine_planari`, `steppe_algoritmiche`), il campo `biome_class` e' stato **rideclinato** come tassonomia astratta a 10 valori per continuare a raggruppare biomi che non condividevano piu' nomi reali. Il vecchio registro non e' stato ne' aggiornato ne' cancellato.
+
+Nessun ADR copre il pivot. Vedi [M-2026-07-14-002](worldgen-biome-vocabularies-orphan.md).
+
+## Why it might still matter
+
+**L'ADR (#3302) sta per cancellare `biome_classes.yaml`, il che risolve meta' del problema per sottrazione -- ma NON risolve l'ambiguita' della chiave.**
+
+Dopo la cancellazione resta comunque vero che:
+
+- `env_traits.json` continua a usare `when.biome_class`;
+- `generator.js` e `trait_coverage.py` continuano a leggerla come chiave opaca senza validazione;
+- il campo `biome_class` in `biomes.yaml` continua a portare i 10 valori ecologici.
+
+**Il rischio concreto**: qualcuno scrive una regola `when: {biome_class: "rovine_planari"}` (identita') aspettandosi che matchi, mentre il resto del sistema si sta muovendo verso i 10 valori ecologici -- o viceversa. La regola non fallisce: **non matcha e basta**, silenziosamente. E' esattamente la classe di silent-no-match che ha prodotto gli strati 1-3 della saga di fabbricazione ([M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md)).
+
+Questa card esiste perche' **il prossimo che tocca `biome_class` deve sapere che la chiave e' un campo minato**, anche dopo che il file sara' sparito.
+
+## Concrete reuse paths
+
+1. **Minimal** (P0, ~1h): **rinomina per disambiguare**. Nell'ADR, scegli un nome per ciascun concetto e rendilo esplicito: `biome_id` (identita') vs `biome_class` (tassonomia ecologica a 10 valori), oppure `biome_class` vs `eco_class`. Il costo e' un rename meccanico in `env_traits.json` + 2 consumatori. **Fallo nell'ADR, non dopo**: e' l'unico momento in cui il blast radius e' gia' accettato.
+2. **Moderate** (P1, ~2-3h): aggiungi **validazione al parser**. `trait_coverage.py` ha gia' il precedente giusto (`:197-210` rifiuta il `when` vuoto). Stesso pattern: rifiuta un `biome_class` che non appartiene all'enum atteso. Un valore fuori dominio deve **esplodere**, non fare silent-no-match. Blast radius x1.0 (validator).
+3. **Full** (P2, ~5h): promuovi i 10 valori ecologici a **enum canonico versionato** in `data/core/` con schema, e fai referenziare l'enum sia a `biomes.yaml` sia alle regole `env_traits`. Blast radius x2.0 (schema-changing, tocca `packages/contracts/`).
+
+**Raccomandazione**: opzione 1 + 2 dentro l'ADR. L'opzione 3 e' post-ADR.
+
+## Sources / provenance trail
+
+- Significato 1: [packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml:2-30](../../../packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml) -- 28 identita'
+- Significato 2: [data/core/biomes.yaml](../../../data/core/biomes.yaml) -- campo `biome_class`, 10 valori ecologici su 20 biomi
+- Consumatore runtime: [docs/evo-tactics-pack/generator.js:3802](../../evo-tactics-pack/generator.js)
+- Consumatore gate: [tools/py/game_utils/trait_coverage.py:193](../../../tools/py/game_utils/trait_coverage.py)
+- Precedente di validazione da imitare: [tools/py/game_utils/trait_coverage.py:197-210](../../../tools/py/game_utils/trait_coverage.py)
+
+Issue: [#3302](https://github.com/MasterDD-L34D/Game/issues/3302) OPEN -- il titolo nomina esplicitamente `biome_class key overload`.
+
+## Risks / open questions
+
+- **Schema drift severity: HIGH** (3+ fonti, conteggi diversi: 28 vs 10 vs 20). Per la policy dell'agente questo richiederebbe escalation a `sot-planner` per un ADR -- **l'ADR e' gia' in corso** (#3302), quindi l'escalation e' soddisfatta. Questa card e' l'input.
+- **Non verificato**: quale dei due significati intendano _davvero_ le 33 regole attuali di `env_traits.json`. Le 3 regole koppen non hanno `biome_class` del tutto; le altre 30 andrebbero controllate una per una contro entrambi i domini. **Non l'ho fatto** -- e' lavoro per l'ADR, non per una card.
+- `git_sha_first: unknown` -- non ho isolato il commit che ha introdotto la doppia semantica; e' una divergenza graduale, non un singolo commit.
+
+## Cross-links
+
+- [M-2026-07-14-001 -- Coverage fabbricata: 5 strati](lesson-coverage-fabrication-five-layers.md)
+- [M-2026-07-14-002 -- Due vocabolari bioma orfani](worldgen-biome-vocabularies-orphan.md)
+- [M-2026-07-14-004 -- Node id MAIUSCOLI: convention leak](worldgen-network-node-id-uppercase-leak.md) -- stessa famiglia: string-match che fallisce in silenzio

--- a/docs/museum/cards/worldgen-biome-vocabularies-orphan.md
+++ b/docs/museum/cards/worldgen-biome-vocabularies-orphan.md
@@ -1,0 +1,151 @@
+---
+title: 'Due vocabolari bioma orfani: 12 biomi reali mai cablati + 21 nomi fabbricati'
+museum_id: M-2026-07-14-002
+type: dataset
+domain: [architecture]
+provenance:
+  found_at: 'packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml:2-30 + packs/evo_tactics_pack/data/species/'
+  git_sha_first: '089b6aa0'
+  git_sha_last: '2c5a8942'
+  last_modified: '2026-07-14'
+  last_author: 'MasterDD-L34D'
+  buried_reason: unintegrated
+relevance_score: 4
+reuse_path: 'data/core/biomes.yaml -- i 2 vocabolari sono materiale grezzo per design bioma futuro; nessuno dei 33 nomi ha contenuto, tutti hanno intento'
+related_pillars: [P1, P3, P6]
+status: curated
+excavated_by: repo-archaeologist
+excavated_on: 2026-07-14
+last_verified: 2026-07-14
+---
+
+# Due vocabolari bioma orfani: 12 biomi reali mai cablati + 21 nomi fabbricati
+
+## Summary (30s)
+
+- L'ADR su issue #3302 sta per **cancellare** `biome_classes.yaml` (i suoi `koppen_examples` migrano in `data/core/biomes.yaml`) e le 21 directory bioma fabbricate. Dentro ci sono **due liste di nomi bioma** che nessuno ha mai progettato -- e che valgono piu' dei file che le contengono.
+- **Vocabolario A** (12 nomi): qualcuno ha costruito una **tassonomia bioma del mondo reale** (taiga, tundra, savanna, reef, macchia mediterranea...) e non l'ha **mai cablata**. Zero regole, zero specie, zero contenuto. Solo nomi in una lista.
+- **Vocabolario B** (21 nomi): nomi bioma **evocativi e originali** (`abisso_luminescente`, `cicloni_psionici`, `reti_micorriziche`, `paludi_gas_luminescenti`...) nati come stub `coverage_autogen` -- mai riempiti, ma **nomi buoni**.
+
+**Materiale grezzo per design bioma futuro. Cardato prima della cancellazione.**
+
+## What was buried
+
+### ATTENZIONE: il file NON e' morto -- e' load-bearing OGGI
+
+Prima di tutto, una correzione che deve precedere qualsiasi cancellazione.
+
+`packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml` **e' letto a runtime dal gate di copertura**: `tools/py/game_utils/trait_coverage.py:74-95` (`_load_koppen_biomes`) **inverte** i suoi `koppen_examples` in `{koppen_code: [biome_class, ...]}` per **espandere** le regole climatiche `koppen_in` / `koppen_any` sulle biome class che quei codici toccano davvero.
+
+> **Cancellare il file senza prima migrare `koppen_examples` rompe l'espansione koppen introdotta da #3300** -- cioe' esattamente il fix dello strato 3. L'ADR lo prevede (migrazione in `biomes.yaml`); questa card lo mette per iscritto perche' l'ordine delle operazioni e' load-bearing.
+
+> **Correzione di path**: il file **non** sta in `data/core/`. Sta in `packs/evo_tactics_pack/tools/config/registries/`.
+
+### La scomposizione dei 28
+
+`biome_classes.yaml:2-30` elenca **28** `classes`. Scomposte contro `data/core/biomes.yaml` (20 chiavi canoniche):
+
+| gruppo                      | N      | cosa sono                                          |
+| --------------------------- | ------ | -------------------------------------------------- |
+| duplicati di `biomes.yaml`  | **13** | ridondanza pura                                    |
+| **biomi reali mai cablati** | **12** | **Vocabolario A -- vedi sotto**                    |
+| risolvibili via alias       | **3**  | `cryosteppe`, `deserto_caldo`, `caverna_risonante` |
+
+I 13 duplicati: `foresta_temperata`, `palude`, `badlands`, `caldera_glaciale`, `foresta_acida`, `pianura_salina_iperarida`, `stratosfera_tempestosa`, `abisso_vulcanico`, `reef_luminescente`, `dorsale_termale_tropicale`, `canopia_ionica`, `steppe_algoritmiche`, `rovine_planari`.
+
+### Vocabolario A -- 12 biomi del mondo reale, mai cablati
+
+Qualcuno ha costruito una tassonomia bioma **realistica** e l'ha lasciata a meta'. Verificato: **zero** di questi 12 compare in `env_traits.json` (tranne 2, vedi nota), **zero** ha specie reali.
+
+| nome                   | in `biomes.yaml`? | `koppen_examples`? | alias?                 | dir specie? | specie reali   |
+| ---------------------- | ----------------- | ------------------ | ---------------------- | ----------- | -------------- |
+| `taiga`                | no                | no                 | no                     | no          | **0**          |
+| `tundra`               | no                | no                 | no                     | no          | **0**          |
+| `reef`                 | no                | no                 | no                     | no          | **0**          |
+| `costa_rocciosa`       | no                | no                 | no                     | no          | **0**          |
+| `foresta_boreale`      | no                | no                 | no                     | no          | **0**          |
+| `macchia_mediterranea` | no                | no                 | no                     | no          | **0**          |
+| `prateria_temperata`   | no                | no                 | no                     | no          | **0**          |
+| `deserto_freddo`       | no                | no                 | no                     | no          | **0**          |
+| `caverne`              | no                | no                 | no                     | no          | **0**          |
+| `savanna`              | no                | no                 | -> `savana`            | no          | **0**          |
+| `laguna_bioreattiva`   | no                | **si'** (Af, Am)   | -> `reef_luminescente` | si'         | **0** (1 stub) |
+| `mangrovieto_cinetico` | no                | **si'** (Am)       | -> `palude`            | si'         | **0** (1 stub) |
+
+**9 sono orfani totali** (nessun bioma canonico, nessun koppen, nessun alias, nessuna specie, nessuna directory): `taiga`, `tundra`, `reef`, `costa_rocciosa`, `foresta_boreale`, `macchia_mediterranea`, `prateria_temperata`, `deserto_freddo`, `caverne`.
+
+`savanna` e' solo una forma inglese aliasata su `savana`. `laguna_bioreattiva` e `mangrovieto_cinetico` sono gli unici due con _qualche_ aggancio (koppen + alias `expansion`) ma **zero specie reali**.
+
+**Questa e' una tassonomia bioma del mondo reale, progettata e mai collegata a nulla.** Nove nomi di biomi terrestri classici che Evo-Tactics non ha.
+
+### Vocabolario B -- 21 nomi fabbricati, mai riempiti
+
+Le 21 directory in `packs/evo_tactics_pack/data/species/` il cui unico file e' uno stub `*-trait-keeper.yaml` da 3 righe, **zero specie**. Nate `coverage_autogen` in `089b6aa0`, svuotate nel ciclo `7c62b510` -> `9acadc69` (vedi [M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md)).
+
+I nomi -- che sono la parte che vale:
+
+```
+abisso_luminescente          gole_ventose
+altipiani_solari             laghi_alcalini
+barriere_coralline_psioniche mangrovie_risonanti
+calotte_glaciali             paludi_gas_luminescenti
+canopie_sospese              permafrost_psionico
+cicloni_psionici             pianure_magnetiche
+delta_salmastri              picchi_cristallini
+dune_cristalline             reti_micorriziche
+foreste_nubose               sorgenti_geotermiche
+                             steppe_risonanti
+                             stratosfera_portante
+                             tundra_risonante
+```
+
+Sono nomi **coerenti col tono di Evo-Tactics** (psionico, risonante, cristallino, luminescente) e in buona parte **ecologicamente sensati** (`delta_salmastri`, `laghi_alcalini`, `sorgenti_geotermiche`, `reti_micorriziche`, `foreste_nubose` sono biomi reali con un twist). Nessuno e' mai stato progettato: hanno solo un nome e uno stub.
+
+**Un designer ha immaginato 21 biomi e li ha lasciati come cartelle vuote.**
+
+## Why it was buried
+
+Due sepolture diverse, stesso movente.
+
+- **Vocabolario A**: qualcuno ha impostato `biome_classes.yaml` come registro di _biome class_ (tassonomia ecologica del mondo reale) mentre `biomes.yaml` cresceva come registro di _biomi di gioco_ (fantasy/sci-fi). I due registri hanno divergito, il primo si e' fossilizzato. Nessun ADR copre la divergenza. Vedi card [M-2026-07-14-003](worldgen-biome-class-key-overload.md) per il danno semantico che ne e' seguito.
+- **Vocabolario B**: le 21 directory non sono state progettate -- sono state **generate** per far quadrare una metrica (`receipt.source: coverage_autogen`, `author: automation`). I nomi sono l'unico output umano/di design sopravvissuto al processo; il contenuto non e' mai esistito.
+
+## Why it might still matter
+
+**L'ADR li cancella. I nomi no.**
+
+- Evo-Tactics oggi ha **20 biomi canonici** in `biomes.yaml` e **6 nodi** nel meta-network. Il gioco e' _biome-poor_ rispetto alla sua stessa ambizione (lo stack 4-livelli di [M-2026-04-26-012](worldgen-bioma-ecosistema-foodweb-network-stack.md)).
+- Qui ci sono **33 nomi bioma gia' pensati** (12 + 21), zero dei quali richiede un ADR per essere riusato: sono vocabolario, non decisioni.
+- Il Vocabolario A copre un **buco reale**: Evo-Tactics non ha nessun bioma **temperato/boreale classico** (taiga, tundra, foresta boreale, prateria, macchia mediterranea). Tutti i 20 canonici sono estremi o esotici. Se serve un bioma "normale" come contrasto tonale, la lista e' gia' scritta.
+- Il Vocabolario B copre il buco opposto: nomi **gia' allineati al tono** per espansioni bioma senza dover inventare naming.
+
+## Concrete reuse paths
+
+1. **Minimal** (P0, ~0.5h): **preserva le due liste** (questa card lo fa). Nell'ADR, cita questa card come destinazione dei nomi prima del `git rm`. Costo zero, perdita evitata.
+2. **Moderate** (P1, ~4-6h): scegli **1** nome dal Vocabolario A come **bioma di contrasto tonale** (raccomandato: `foresta_boreale` o `prateria_temperata` -- i piu' "normali", massimo contrasto con l'attuale roster esotico) e progettalo davvero: entry in `data/core/biomes.yaml` (con `biome_class` corretto, vedi M-2026-07-14-003) + `koppen_examples` + 3-4 specie reali. Blast radius x1.0 (pure data YAML).
+3. **Full** (P2, ~20-30h): usa il Vocabolario B come **backlog di espansione bioma**. 21 nomi -> seleziona 5, progetta lo stack 4-livelli completo per ognuno (biome + ecosystem + foodweb + nodo network). Blast radius x1.2 (service layer: `biomeSpawnBias.js`, `catalog.js`). **Prerequisito**: l'ADR #3302 deve prima chiudere il modello dati, altrimenti si costruisce sopra la stessa ambiguita'.
+
+## Sources / provenance trail
+
+- Registro classi: [packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml:2-30](../../../packs/evo_tactics_pack/tools/config/registries/biome_classes.yaml) -- 28 `classes`, 16 `koppen_examples`
+- Consumatore load-bearing: [tools/py/game_utils/trait_coverage.py:74-95](../../../tools/py/game_utils/trait_coverage.py) -- `_load_koppen_biomes`
+- Biomi canonici: [data/core/biomes.yaml](../../../data/core/biomes.yaml) -- 20 chiavi
+- Directory fabbricate: `packs/evo_tactics_pack/data/species/<biome>/` -- 49 dir, 30 con solo keeper, **21 con keeper da 3 righe**
+- Nascita: `089b6aa0` (2025-10-29) `receipt: {source: coverage_autogen, author: automation}`
+- Svuotamento: `7c62b510` (2025-11-30, delete) -> `9acadc69` (2025-12-09, restore-as-stub)
+
+Issue / PR: [#3302](https://github.com/MasterDD-L34D/Game/issues/3302) OPEN -- _"21 fabricated biome dirs (coverage_autogen) + 4 contradictory aliases + biome_class key overload"_. Censimento: [#3304](https://github.com/MasterDD-L34D/Game/pull/3304) MERGED.
+
+## Risks / open questions
+
+- **ORDINE DI OPERAZIONI (P1)**: `koppen_examples` deve migrare in `biomes.yaml` **prima** che `biome_classes.yaml` venga cancellato, altrimenti `_load_koppen_biomes` restituisce `{}` e le 3 regole koppen ricollassano sulla combo insoddisfacibile `(None, None)` -- reintroducendo lo strato 3.
+- **Solo 16 dei 28** `classes` hanno `koppen_examples`. La migrazione copre 16 mapping; per i 12 senza koppen non c'e' nulla da migrare (sono i nomi nudi del Vocabolario A).
+- **Domanda aperta**: il Vocabolario A e' un residuo di un design _scientifico_ (koppen-based, mondo reale) poi abbandonato per un design _esotico_? Nessun ADR documenta il pivot. Se qualcuno lo ricorda, va scritto -- e' l'unica traccia rimasta di una direzione di design intera.
+- **Non confondere** i 21 stub-only con i **38 stub totali dentro directory che hanno anche specie reali**: quelli non sono coperti dall'ADR e restano debito aperto (59/105 = 56% del catalogo e' stub).
+
+## Cross-links
+
+- [M-2026-07-14-001 -- Coverage fabbricata: 5 strati](lesson-coverage-fabrication-five-layers.md)
+- [M-2026-07-14-003 -- `biome_class`: una chiave, due significati](worldgen-biome-class-key-overload.md)
+- [M-2026-04-26-018 -- Bioma come pacchetto gameplay+fiction](worldgen-biome-as-gameplay-fiction-package.md) -- cosa serve per rendere _reale_ un nome bioma
+- [M-2026-04-26-012 -- Worldgen Stack 4-livelli](worldgen-bioma-ecosistema-foodweb-network-stack.md)

--- a/docs/museum/cards/worldgen-cross-bioma-events-propagation.md
+++ b/docs/museum/cards/worldgen-cross-bioma-events-propagation.md
@@ -13,10 +13,12 @@ provenance:
 relevance_score: 4
 reuse_path: 'apps/backend/services/combat/reinforcementSpawner.js — aggiungi cross_event loader come pressure modifier pre-wave'
 related_pillars: [P1, P6]
-status: curated
+status: reviewed
+reviewed_by: "ADR biome/species data model (issue #3302) -- cross_events.yaml e' evidenza load-bearing; deserto_caldo + cryosteppe (origini di 2 dei 3 eventi) promossi a biomi giocabili"
+reviewed_on: 2026-07-14
 excavated_by: repo-archaeologist
 excavated_on: 2026-04-26
-last_verified: 2026-04-26
+last_verified: 2026-07-14
 ---
 
 # Cross-bioma event propagation: tempesta ferrosa pattern
@@ -101,3 +103,28 @@ La logica di propagation checking esiste nel validator — non esiste nel runtim
 - Gli effetti (`penalità visibilità/gear metallico`) non sono quantificati numericamente nel YAML — serve design decision prima di wire (es. -1 accuracy? +10% StressWave? capire come mappa su `data/core/biomes.yaml` hazard structure).
 - `species_id: evento-tempesta-ferrosa` usa campo `species_id` per naming di eventi — potenziale confusione con il campo omonimo per specie in altri schema. Pre-wire: verifica no collision con species catalog.
 - Anti-pattern: NON promuovere a meccanica narrativa player-visible (popup "tempesta ferrosa in arrivo!") senza UX research. Il player può non capire il trigger ecologico. Minimo: log Atlas + pressure modifier invisibile.
+
+---
+
+## REVIEWED -- 2026-07-14 (ADR biome/species data model, issue #3302)
+
+Status `curated` -> `reviewed`. **Questa card ha salvato due biomi.**
+
+`cross_events.yaml` e' stato **evidenza load-bearing** nell'indagine: `deserto_caldo` e `cryosteppe` sono le **origini** di 2 dei 3 eventi (`evento-ondata-termica` e `evento-brinastorm`), e questo -- insieme alla loro presenza come ecosistemi, foodweb e nodi di rete -- e' cio' che ha impedito di rimuoverli come "biomi vuoti". L'ADR ora li **promuove a giocabili**.
+
+Verificato 2026-07-14 su filesystem:
+
+| evento                    | `from_nodes`    | `to_nodes`                           |
+| ------------------------- | --------------- | ------------------------------------ |
+| `evento-tempesta-ferrosa` | `BADLANDS`      | `FORESTA_TEMPERATA`, `DESERTO_CALDO` |
+| `evento-ondata-termica`   | `DESERTO_CALDO` | `BADLANDS`                           |
+| `evento-brinastorm`       | `CRYOSTEPPE`    | `FORESTA_TEMPERATA`, `BADLANDS`      |
+
+**Aggiornamento sostanziale**: il file ha guadagnato `season` + `pressure_delta` + `hazard_modifier` (TKT-WORLDGEN-GAPB, 2026-05-29) -- il gap "effetti non quantificati" segnalato nei Risks qui sopra e' quindi **chiuso**. Gli eventi ora portano numeri (`pressure_delta: 2`) e un `hazard_modifier` nominato.
+
+**Due nuovi rischi trovati** (non presenti nella card originale):
+
+- I `from_nodes`/`to_nodes` sono **node id MAIUSCOLI**, non biome slug. Vedi [M-2026-07-14-004](worldgen-network-node-id-uppercase-leak.md) -- la convenzione e' **colata** dentro `echo-wing.yaml`, che e' proprio una bridge species.
+- Esiste un **duplicato** del file in `packs/evo_tactics_pack/data/ecosistemi/cross_events.yaml` (directory italiana). **Quale sia autoritativo non e' determinato.**
+
+Cross-link: [M-2026-04-26-012](worldgen-bioma-ecosistema-foodweb-network-stack.md) (**revived**) - [M-2026-07-14-004](worldgen-network-node-id-uppercase-leak.md).

--- a/docs/museum/cards/worldgen-forme-mbti-as-evolutionary-seed.md
+++ b/docs/museum/cards/worldgen-forme-mbti-as-evolutionary-seed.md
@@ -13,10 +13,12 @@ provenance:
 relevance_score: 4
 reuse_path: 'apps/backend/services/forms/formPackRecommender.js:101 — già operativo; gap: biome starter pack non wired in session /start'
 related_pillars: [P2, P4]
-status: curated
+status: reviewed
+reviewed_by: "ADR biome/species data model (issue #3302) -- il link bioma -> starter pack (`starter_bioma`) dipende da un modello bioma stabile, che l'ADR fornisce"
+reviewed_on: 2026-07-14
 excavated_by: repo-archaeologist
 excavated_on: 2026-04-26
-last_verified: 2026-04-26
+last_verified: 2026-07-14
 ---
 
 # 16 Forme MBTI come seed evolutivi: d12 bias + PI pacchetti vs telemetria VC
@@ -98,3 +100,17 @@ function recommendPacks({ form_id, job_id, d20_roll = null, d12_roll = null }) {
 - `starter_bioma` in pack universali è stringa, non tipo strutturato — design undefined. Serve decisione prima di wire: è un trait T1? Un item? Un affix bonus di sessione? Una sola risposta, user deve decidere.
 - `data/core/forms/mbti_forms.yaml` esiste ma non letto in questo flow — verificare se contiene info aggiuntive utili (es. biome affinity già mappata) prima di creare `biome_form_affinity.yaml` da zero.
 - NON confondere Forma (seed statico) con Forma evolved (output VC telemetria in-match). Forma iniziale ≠ Forma finale. Il biome influenza solo il punto di partenza.
+
+---
+
+## REVIEWED -- 2026-07-14 (ADR biome/species data model, issue #3302)
+
+Status `curated` -> `reviewed`. Nessun cambio di sostanza: il gap `starter_bioma` **resta aperto e non wired**.
+
+**Perche' la card viene toccata comunque**: il link _"bioma -> starter pack"_ che questa card chiede presuppone un **modello bioma stabile**. Fino a oggi non c'era: 4 fonti disallineate (`biomes.yaml` 20 chiavi / `biome_classes.yaml` 28 identita' / `biome_aliases.yaml` 18 alias di cui 4 contraddittori / 49 directory specie), con la chiave `biome_class` che significa **due cose diverse** in due file. Vedi [M-2026-07-14-003](worldgen-biome-class-key-overload.md).
+
+**Costruire `starter_bioma` prima dell'ADR sarebbe stato costruire su sabbia**: "quale bioma" non aveva una risposta unica. L'ADR fornisce il substrato; questa card diventa **eseguibile dopo**, non prima.
+
+**Precondizione aggiunta al reuse path**: attendere la chiusura di #3302 prima di progettare `biome_form_affinity.yaml`.
+
+Cross-link: [M-2026-07-14-003](worldgen-biome-class-key-overload.md) - [M-2026-04-26-012](worldgen-bioma-ecosistema-foodweb-network-stack.md) (**revived**).

--- a/docs/museum/cards/worldgen-network-node-id-uppercase-leak.md
+++ b/docs/museum/cards/worldgen-network-node-id-uppercase-leak.md
@@ -1,0 +1,146 @@
+---
+title: "Node id MAIUSCOLI: non e' un bug, e' una convenzione che cola"
+museum_id: M-2026-07-14-004
+type: architecture
+domain: [architecture]
+provenance:
+  found_at: 'packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml:19-56 + cross_events.yaml + packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml:5-9'
+  git_sha_first: '8ee399e8'
+  git_sha_last: '2c5a8942'
+  last_modified: '2026-07-14'
+  last_author: 'MasterDD-L34D'
+  buried_reason: forgotten
+relevance_score: 3
+reuse_path: 'packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml:7-9 -- 3 biomi MAIUSCOLI in un campo che vuole slug minuscoli; NON "correggere" abbassando il case'
+related_pillars: [P1, P3]
+status: curated
+excavated_by: repo-archaeologist
+excavated_on: 2026-07-14
+last_verified: 2026-07-14
+---
+
+# Node id MAIUSCOLI: non e' un bug, e' una convenzione che cola
+
+## Summary (30s)
+
+- Il **livello 4** dello stack worldgen (meta-network) usa **node id MAIUSCOLI**: `DESERTO_CALDO`, `CRYOSTEPPE`, `BADLANDS`. E' una convenzione **deliberata e coerente** dentro il suo livello.
+- Una specie l'ha **copiata nel posto sbagliato**: `badlands/echo-wing.yaml:5-9` dichiara `biomes: [badlands, FORESTA_TEMPERATA, DESERTO_CALDO, CRYOSTEPPE]` -- **1 slug minuscolo + 3 node id maiuscoli** nello stesso array.
+- Le regole ambientali fanno string-match su slug **minuscoli**. I 3 maiuscoli **non matchano mai**, in silenzio. **Sembra un bug. E' una convenzione che cola da un livello all'altro.**
+- **Il prossimo che lo vede non deve "correggerlo" abbassando il case** -- perche' il node id maiuscolo NON e' lo slug del bioma. C'e' un'indirezione.
+
+## What was buried
+
+### La convenzione (corretta, nel suo livello)
+
+`packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml:19-56`:
+
+```yaml
+network:
+  id: ET_NET_ALPHA
+  start_node: DESERTO_CALDO
+  nodes:
+    - id: BADLANDS
+      biome_id: canyons_risonanti # <-- INDIREZIONE
+      path: packs/.../badlands.ecosystem.yaml
+    - id: FORESTA_TEMPERATA
+      biome_id: foresta_miceliale
+    - id: DESERTO_CALDO
+      biome_id: savana
+    - id: CRYOSTEPPE
+      biome_id: mezzanotte_orbitale
+    - id: ROVINE_PLANARI
+      biome_id: rovine_planari
+      terminal: true
+    - id: ATOLLO_OBSIDIANA
+      biome_id: atollo_obsidiana
+```
+
+Il `MAIUSCOLO` e' un **node id di grafo** (`ET_NET_ALPHA`, `BADLANDS`), non uno slug di bioma. Il bioma vero e' in `biome_id`, minuscolo. Stessa convenzione in `cross_events.yaml` (`from_nodes: [BADLANDS]`, `to_nodes: [FORESTA_TEMPERATA, DESERTO_CALDO]`).
+
+**Dentro il livello 4 e' consistente e corretto.** Il MAIUSCOLO segnala "sono un nodo, non un bioma".
+
+### La colata (il problema)
+
+`packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml:5-9`:
+
+```yaml
+biomes:
+  - badlands # slug minuscolo -- matcha
+  - FORESTA_TEMPERATA # node id -- NON matcha
+  - DESERTO_CALDO # node id -- NON matcha
+  - CRYOSTEPPE # node id -- NON matcha
+```
+
+Il campo `biomes` di una specie vuole **slug di bioma minuscoli**. `echo-wing` e' una **bridge species** (`flags.bridge: true`, `role_trofico: dispersore_ponte`): il suo autore ha guardato il grafo di rete -- dove i ponti _vivono_ -- e ha copiato i node id da li'. Semanticamente ha ragione: echo-wing **e'** un ponte tra quei nodi. Sintatticamente sta scrivendo in un campo che parla un'altra lingua.
+
+Risultato: le regole ambientali che fanno string-match su `biomes` vedono **un solo bioma valido** (`badlands`) invece di quattro. Gli altri tre sono no-op silenziosi.
+
+### Perche' NON si corregge abbassando il case
+
+L'indirezione `id -> biome_id` **non e' l'identita'**:
+
+| node id             | `biome_id` reale      | lowercase ingenuo   | corretto? |
+| ------------------- | --------------------- | ------------------- | --------- |
+| `FORESTA_TEMPERATA` | `foresta_miceliale`   | `foresta_temperata` | **NO**    |
+| `DESERTO_CALDO`     | `savana`              | `deserto_caldo`     | **NO**    |
+| `CRYOSTEPPE`        | `mezzanotte_orbitale` | `cryosteppe`        | **NO**    |
+| `BADLANDS`          | `canyons_risonanti`   | `badlands`          | **NO**    |
+
+**Zero su quattro.** Un `.lower()` produrrebbe 4 slug che _esistono_ come directory specie ma che **non sono i biomi a cui il nodo punta**. Il fix "ovvio" e' sbagliato in tutti e quattro i casi -- e sbagliato **in silenzio**, perche' gli slug lowercase esistono davvero e matcherebbero qualcosa.
+
+**Il fix corretto e' risolvere via `biome_id`, non via case.**
+
+### Il terzo strato di confusione
+
+Gli stessi 4 slug lowercase (`foresta_temperata`, `badlands`, `deserto_caldo`, `cryosteppe`) sono **esattamente i 4 alias `status: migrated`** di `data/core/biome_aliases.yaml:12-27` -- e le mappature **non concordano** con il network:
+
+| slug                | `biome_aliases.yaml` dice      | `meta_network_alpha.yaml` dice | concordano? |
+| ------------------- | ------------------------------ | ------------------------------ | ----------- |
+| `foresta_temperata` | -> `foresta_miceliale`         | -> `foresta_miceliale`         | **si'**     |
+| `cryosteppe`        | -> `mezzanotte_orbitale`       | -> `mezzanotte_orbitale`       | **si'**     |
+| `badlands`          | -> `dorsale_termale_tropicale` | -> `canyons_risonanti`         | **NO**      |
+| `deserto_caldo`     | -> `abisso_vulcanico`          | -> `savana`                    | **NO**      |
+
+**Due fonti di verita' per la stessa risoluzione, in disaccordo su 2 casi su 4.** E tutti e 4 gli slug hanno comunque specie reali vive (vedi [M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md)).
+
+## Why it was buried
+
+Il MAIUSCOLO e' nato con il meta-network (`8ee399e8`, receipt `PTPF.v1.0`, 2025-10-25) come convenzione **interna al livello 4**, dove e' sensata: distingue nodi di grafo da biomi.
+
+Non e' mai stata scritta da nessuna parte come convenzione **di livello**. Non c'e' schema, non c'e' validator, non c'e' commento che dica "MAIUSCOLO = node id, minuscolo = biome slug". Quindi ha **colato** verso il basso appena un autore ha guardato il grafo per capire dove vive la sua bridge species.
+
+Un solo caso noto (`echo-wing`). Ma il meccanismo che l'ha prodotto e' ancora attivo.
+
+## Why it might still matter
+
+- **Trappola per il prossimo**: chiunque veda `FORESTA_TEMPERATA` in un campo `biomes` pensera' "typo, abbasso il case". Produrrebbe **4 mapping sbagliati su 4**, silenziosamente. Questa card esiste soprattutto per **impedire quel fix**.
+- **Famiglia di difetti nota**: e' lo stesso pattern degli strati 1-3 della saga coverage -- **string-match che fallisce in silenzio invece di esplodere** ([M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md)). La cura e' la stessa: **validare al parser**.
+- **L'ADR #3302 tocca proprio questo strato** (modello dati biome/species). E' il momento giusto per decidere la convenzione, non dopo.
+- `echo-wing` e' una bridge species: e' esattamente il tipo di entita' che il cross-bioma event propagation ([M-2026-04-26-014](worldgen-cross-bioma-events-propagation.md)) dovrebbe consumare. Finche' 3 dei suoi 4 biomi non matchano, e' un ponte **rotto**.
+
+## Concrete reuse paths
+
+1. **Minimal** (P0, ~0.5h): **valida al parser**. Il campo `biomes` di una specie rifiuta qualsiasi valore non-lowercase con un errore esplicito che dice _"i node id del meta-network non sono biome slug -- risolvi via `biome_id`"_. Stesso pattern di `trait_coverage.py:197-210`. Blast radius x1.0.
+2. **Moderate** (P1, ~1-2h): **ripara `echo-wing`** risolvendo i 3 node id via `biome_id` (-> `foresta_miceliale`, `savana`, `mezzanotte_orbitale`) **e non via lowercase**. Prima pero' va sciolto il disaccordo network-vs-aliases su `badlands`/`deserto_caldo` (vedi Risks). Blast radius x1.0 (data YAML), ma **gated** su una decisione di design.
+3. **Full** (P2, ~3-4h): **documenta la convenzione di livello** nello schema (`packs/evo_tactics_pack/docs/ecosystem.schema.v1.1.yaml`): MAIUSCOLO = node id livello 4, minuscolo = biome slug livelli 1-3. Aggiungi il validator. Blast radius x1.2.
+
+## Sources / provenance trail
+
+- Convenzione: [packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml:19-56](../../../packs/evo_tactics_pack/data/ecosystems/network/meta_network_alpha.yaml) -- `start_node: DESERTO_CALDO`, 6 nodi con indirezione `biome_id`
+- Convenzione (2): [packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml](../../../packs/evo_tactics_pack/data/ecosystems/network/cross_events.yaml) -- `from_nodes` / `to_nodes` MAIUSCOLI, 3 eventi
+- La colata: [packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml:5-9](../../../packs/evo_tactics_pack/data/species/badlands/echo-wing.yaml)
+- Il disaccordo: [data/core/biome_aliases.yaml:12-27](../../../data/core/biome_aliases.yaml)
+- Origine convenzione: `8ee399e8` -- receipt `source: PTPF.v1.0, author: designer, date: 2025-10-25`
+
+## Risks / open questions
+
+- **DUPLICATO NON RISOLTO**: esiste un **secondo** `cross_events.yaml` in `packs/evo_tactics_pack/data/ecosistemi/cross_events.yaml` (directory con nome **italiano** `ecosistemi/`, accanto a quella inglese `ecosystems/`). Anch'esso usa i node id MAIUSCOLI. **Non ho determinato quale sia autoritativo.** Va risolto nell'ADR -- due file con lo stesso nome e contenuto simile in due directory che differiscono solo per lingua sono un incidente in attesa.
+- **Disaccordo network-vs-aliases su 2/4 slug** (`badlands`, `deserto_caldo`): prima di riparare `echo-wing` bisogna decidere **quale fonte vince**. Non e' una domanda di implementazione, e' una domanda di design. **Non riparare `echo-wing` finche' non e' decisa.**
+- **Un solo caso noto** di colata (`echo-wing`). Non ho fatto uno sweep completo su tutti i 105 file specie per altri valori MAIUSCOLI nel campo `biomes` -- **da fare** prima di chiudere l'ADR.
+
+## Cross-links
+
+- [M-2026-07-14-001 -- Coverage fabbricata: 5 strati](lesson-coverage-fabrication-five-layers.md) -- stessa famiglia: silent-no-match
+- [M-2026-07-14-003 -- `biome_class`: una chiave, due significati](worldgen-biome-class-key-overload.md)
+- [M-2026-04-26-014 -- Cross-bioma event propagation](worldgen-cross-bioma-events-propagation.md) -- il consumatore che `echo-wing` dovrebbe servire
+- [M-2026-04-26-012 -- Worldgen Stack 4-livelli](worldgen-bioma-ecosistema-foodweb-network-stack.md) -- il livello 4 da cui cola la convenzione

--- a/docs/museum/cards/worldgen-species-emergence-from-ecosystem.md
+++ b/docs/museum/cards/worldgen-species-emergence-from-ecosystem.md
@@ -13,10 +13,12 @@ provenance:
 relevance_score: 4
 reuse_path: 'apps/backend/services/catalog.js:145 — role_templates già parsati, non esposti a spawn director'
 related_pillars: [P1, P3]
-status: curated
+status: reviewed
+reviewed_by: "ADR biome/species data model (issue #3302) -- lo stack 4-livelli diventa enforced; la catena bioma -> ruolo -> trait pool -> specie e' il livello che l'ADR normalizza"
+reviewed_on: 2026-07-14
 excavated_by: repo-archaeologist
 excavated_on: 2026-04-26
-last_verified: 2026-04-26
+last_verified: 2026-07-14
 ---
 
 # Emergenza specie da ecosistema: role_templates + biome_pools come PCG layer
@@ -106,3 +108,23 @@ const templates = Array.isArray(doc.role_templates) ? doc.role_templates : [];
 - `preferred_traits` in `biome_pools.json` non è cross-validato con `data/core/traits/active_effects.yaml` — slug potrebbero essere stale (es. `ghiaccio_piezoelettrico` existe? `criostasi_adattiva`?). Verificare con `grep -n "ghiaccio_piezoelettrico" data/core/traits/active_effects.yaml` prima di wire.
 - Pool copre 8 biomi ma `data/core/biomes.yaml` ha 30+ biomi — gap PCG se si wire solo i pool esistenti. Decision user: coverage completa (2-3h content fill) o solo biomi con pool.
 - NON usare come replacement di encounter YAML senza ADR + calibration harness N=10 (Pillar 6 rischio).
+
+---
+
+## REVIEWED -- 2026-07-14 (ADR biome/species data model, issue #3302)
+
+Status `curated` -> `reviewed`. La catena descritta da questa card (**bioma -> ruolo -> trait pool -> specie**) e' esattamente il livello che l'ADR normalizza.
+
+**Contesto nuovo e scomodo**: la card assumeva un catalogo specie sano. Non lo e'. Censimento verificato 2026-07-14:
+
+- **59 / 105** file specie sono **stub autogenerati** (**56%** del catalogo).
+- `rovine_planari`: **10 file, 10 stub, 0 specie reali**.
+- **21 directory bioma** contengono un solo stub keeper da 3 righe e **zero specie**.
+
+Il "PCG layer" ha quindi un substrato **molto piu' sottile** di quanto la card lasciasse intendere. `role_templates` + `biome_pools.json` restano validi come **infrastruttura**, ma la popolazione di specie reali su cui dovrebbero pescare e' meno della meta' del conteggio nominale.
+
+**Il gap `preferred_traits` non cross-validato** segnalato nei Risks qui sopra si e' rivelato **la punta di un problema piu' grosso**: il gate di copertura trait misurava zero perche' 5 strati di dati fabbricati lo tenevano su. Vedi [M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md).
+
+**Il rischio "pool copre 8 biomi ma biomes.yaml ne ha 30+"**: conteggio corretto -> `biomes.yaml` ha **20** biomi canonici (verificato 2026-07-14), non 30+.
+
+Cross-link: [M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md) - [M-2026-07-14-002](worldgen-biome-vocabularies-orphan.md) - [M-2026-04-26-012](worldgen-bioma-ecosistema-foodweb-network-stack.md) (**revived**).

--- a/docs/museum/cards/worldgen-trophic-roles-validator-not-runtime.md
+++ b/docs/museum/cards/worldgen-trophic-roles-validator-not-runtime.md
@@ -13,10 +13,12 @@ provenance:
 relevance_score: 4
 reuse_path: 'apps/backend/services/combat/reinforcementSpawner.js — leggere role_trofico da species + biome_pools per qualificare spawn pool'
 related_pillars: [P1, P3, P6]
-status: curated
+status: reviewed
+reviewed_by: 'ADR biome/species data model (issue #3302) -- il livello 3 (foodweb) entra nel modello enforced; 5 foodweb reali confermati su filesystem'
+reviewed_on: 2026-07-14
 excavated_by: repo-archaeologist
 excavated_on: 2026-04-26
-last_verified: 2026-04-26
+last_verified: 2026-07-14
 ---
 
 # Ruoli trofici: validator-time completo, runtime zero — gap M-future
@@ -109,3 +111,17 @@ Il biomeSpawnBias usa `AFFIX_TAG_AFFINITIES` hardcoded, NON `role_trofico` da YA
 - **Python bridge DEPRECATED**: portare `trophic_roles.py` a runtime Node richiede porting (~4-6h aggiuntive). La logica è pulita Python puro, porting fattibile. Ma NON usare il bridge esistente in `runtimeValidator` per gameplay hot path — troppo lento e segnato per rimozione.
 - `role_trofico` nei `*.ecosystem.yaml` usa slug italiani (`predatore_terziario_apex`) — `ROLE_ALIASES` in `trophic_roles.py` gestisce la traduzione ma serve implementazione Node. Candidato a `troicRoleResolver.js` standalone.
 - NON promuovere trophic role enforcement a player-visible UI senza design review. È un motore di coerenza ecologica, non un sistema di progressione esplicita.
+
+---
+
+## REVIEWED -- 2026-07-14 (ADR biome/species data model, issue #3302)
+
+Status `curated` -> `reviewed`. Il **livello 3** (foodweb) entra nel modello **enforced** adottato dall'ADR.
+
+Verificato 2026-07-14: i foodweb vivono in `packs/evo_tactics_pack/data/foodwebs/` -- **5 file reali**, tra cui `cryosteppe_foodweb.yaml` e `deserto_caldo_foodweb.yaml`. La loro esistenza e' parte della prova che quei due biomi **non erano vuoti** e non andavano rimossi. Vedi [M-2026-04-26-012](worldgen-bioma-ecosistema-foodweb-network-stack.md) (**revived**).
+
+**Il claim centrale della card resta vero**: `trophic_roles.py` + `foodweb.py` restano **validator-time, runtime zero**. L'ADR adotta il modello a 4 livelli come normativo, ma **non** wira il runtime. Per questo `reviewed` e non `revived`.
+
+**Nota di allineamento**: `role_trofico` e' popolato e usato nei file specie reali (es. `echo-wing.yaml` -> `dispersore_ponte`), quindi il campo **non e' morto** -- e' letto dal validator e ignorato dal gameplay. Esattamente il gap che la card nomina.
+
+Cross-link: [M-2026-04-26-012](worldgen-bioma-ecosistema-foodweb-network-stack.md) (**revived**) - [M-2026-07-14-002](worldgen-biome-vocabularies-orphan.md).

--- a/docs/planning/2026-07-14-content-substrate-census.md
+++ b/docs/planning/2026-07-14-content-substrate-census.md
@@ -123,7 +123,32 @@ specie: sono abbozzi, non ambienti.
 
 ---
 
-## 4. ECOSISTEMI -- **5** descrittori, **4** popolati
+## 4. ECOSISTEMI -- **21**, non 5
+
+> 🔴 **CORREZIONE (2026-07-14, stessa giornata)**: la prima stesura di questa sezione diceva
+> **"5 ecosistemi"**. **E' SBAGLIATO.** Contavo i file `*.biome.yaml` (5) credendo fossero i
+> descrittori di ecosistema. Gli ecosistemi sono `*.ecosystem.yaml` e sono **21** -- piu' 5
+> foodweb (livello 3) e 1 meta-network (livello 4), che questo censimento non aveva nemmeno
+> visto. L'errore e' stato scoperto solo consultando il Museum (carta `M-2026-04-26-012`), che
+> **aveva previsto testualmente** questo modo di sbagliare. Vedi ADR-2026-07-14.
+>
+> **Lo stack reale e' a 4 livelli** (SoT §3): `bioma (20) -> ecosistema (21) -> foodweb (5) ->
+network + cross-events (1)`. Le sezioni sopra restano valide; questa era sbagliata.
+
+| livello                             | reale  |
+| ----------------------------------- | ------ |
+| 1 — bioma (`biomes.yaml`)           | **20** |
+| 2 — ecosistema (`*.ecosystem.yaml`) | **21** |
+| 3 — foodweb (`*_foodweb.yaml`)      | **5**  |
+| 4 — network + cross-events          | **1**  |
+
+`cryosteppe` e `deserto_caldo` sono gli **unici 2 ecosistemi su 21** senza entry di livello 1 --
+eppure sono nodi della meta-rete (`DESERTO_CALDO` ne e' lo `start_node`) e origini canoniche di
+eventi cross-bioma. ADR-2026-07-14 li **promuove** a biomi giocabili (20 -> 22).
+
+### (sezione originale, conservata per onesta')
+
+**5** file `*.biome.yaml` -- una cosa DIVERSA dagli ecosistemi, e quasi tutta `null`:
 
 Solo 5 biomi hanno un `.biome.yaml` (descrittore PTPF v1.1 completo: koppen, NPP, morfologia,
 clima, rete trofica, servizi ecosistemici):

--- a/reports/docs/governance_drift_report.json
+++ b/reports/docs/governance_drift_report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T18:09:38+00:00",
+  "generated_at": "2026-07-14T19:05:37+00:00",
   "summary": {
     "total": 49,
     "errors": 0,


### PR DESCRIPTION
## ADR-2026-07-14 — closes #3302 **and** the scope question

**The model was never missing.** `00-SOURCE-OF-TRUTH.md` §3 already defines a canonical **4-level stack**: `bioma -> ecosistema -> foodweb -> network/eventi`.

What was missing is that **no file declared membership in it, and no guard enforced it.** In those gaps grew four biome vocabularies, three contradictory mappings, and a species catalog that is **56% placeholder**.

This ADR does not invent a model. It picks **which existing file is authoritative per level**, deletes the duplicates, adds the guards — and **names the target**.

## 10 decisions

**Model (1-6)** — the 4-level stack is the model · `biome_class` is a *field* of level 1, not a level · `biome_classes.yaml` **dissolves** (koppen migrates into `biomes.yaml`; **order is load-bearing** — `trait_coverage.py` inverts `koppen_examples` *today*, that **is** the layer-3 fix from #3300) · **`cryosteppe` + `deserto_caldo` are PROMOTED** (they are level-2 + level-3 + level-4 — `DESERTO_CALDO` is the meta-network's `start_node` — and lacked only the level-1 row) · the fabricated mappings are deleted · **a species = `biomes` + `role_trofico` + ≥1 trait** → honest catalog **46, not 105** · 4 guards, each with a negative control.

**The four open questions — all four CLOSED, none needed an opinion. Each was answered by measuring (7-10):**

- **D7 — what does `when.biome_class` mean?** Measured all 33 rules: **19 use a biome IDENTITY, 0 use the coarse family.** The overload was never a semantic ambiguity — just a **wrong name in two places**. Rename: `when.biome` / `ecological_family`. The **6 dangling rules** must be resolved *during* the migration.
- **D8 — which `cross_events.yaml`?** The network one (43 lines, 2026-05-30, the path the SoT names). The Italian copy is 31 lines and **9 months stale** — and **the pack publishes that one**. Delete it, repoint manifest + UI. But **do NOT delete `meta_ecosistema_alpha.yaml`**: it is not a duplicate (`ecosistema` ≠ `network`) and `update_evo_pack_catalog.js` reads it.
- **D9 — the narrative debt is ONE biome.** 19 of 20 have a name matching their summary. `savana` says *"Dune fotoniche"*, affix `sabbia`, family `arid`, affixes **copy-pasted verbatim** from `abisso_vulcanico`. It is a desert with the wrong name, sitting in the slot `deserto_caldo` actually fills. **Merge it in.** Playable: 20 +2 −1 = **21**.
- **D10 — the TARGET.** The core did not need inventing: **it was already written in the data, twice.** Foodwebs (level 3) exist for exactly **5** biomes. The meta-network (level 4) has **6 nodes** — those 5 + `atollo_obsidiana`. Whoever built this game had already chosen a core and authored the deep stack only for it.

## TARGET: nucleo-8

The core-5 covers only `arid`/`canopy`/`clastic` — **no water, no heat, no underground**. The 8 cover **6 of the 10 ecological families**:

| # | biome | family | why (data, not taste) |
|---|---|---|---|
| 1-5 | badlands · foresta_temperata · deserto_caldo · cryosteppe · **rovine_planari** | arid/canopy/clastic | the only 5 with a **foodweb** |
| 6 | `atollo_obsidiana` | **littoral** | **already a meta-network node** |
| 7 | `abisso_vulcanico` | **geothermal** | most species of any non-core |
| 8 | `caverna` | **subterranean** | absorbs `caverna_risonante` → **resolves 1 of the 6 dangling rules** + recovers **21 trait suggestions** pointing at a biome that does not exist |

### HOW MUCH IS MISSING — the number that did not exist
> **≈ 35 species + 3 foodwebs + 3 network nodes.**
> `rovine_planari` alone is worth **8** of them: modelled in full detail, **zero inhabitants**.

The **13 biomes outside the core are ARCHIVED** (museum card, not deleted). The catalog stops promising a world that does not exist.

## Museum
**4 cards written, 6 updated** (repo-archaeologist, curate mode). **M-2026-04-26-012 REVIVED** — it predicted this exact failure in April: *"future Claude sessions describe the game as a rotation of maps, ignoring 3 documented and validated deep levels."* That is precisely what I did (counted `*.biome.yaml` = 5 instead of `*.ecosystem.yaml` = **21**) and nearly merged away two level-4 nodes. **Consult the museum BEFORE the dig.**

Also **corrects** the census (#3304), which shipped that same wrong count.

## Still open
Only one, and it is not a model question — it is a plan: **who authors the ~35 species.** Species-Curator-gated, per biome, never all at once.

Refs #3302, #3299, #3304. merge = master-dd.