### PR TITLE
fix(species): recover rovine_planari -- it was a scar, not a hole (+ ADR addendum: 4 gaps)

### DIFF
--- a/data/derived/analysis/README.md
+++ b/data/derived/analysis/README.md
@@ -23,8 +23,8 @@ Report derivati rigenerabili dal core e dal pack Evo Tactics.
 
 | File | sha256 |
 | --- | --- |
-| `data/derived/analysis/trait_coverage_report.json` | `1e2f8c1a95326964e968d69f51ba239a4b7ac64fe284b54197ebe8ba8dfb6ce4` |
-| `data/derived/analysis/trait_coverage_matrix.csv` | `a8773a82ded968d2649fc430204400d8f87b6d6abc4683aa4f5f99c8070f8cf6` |
+| `data/derived/analysis/trait_coverage_report.json` | `c659366c69b9acf81342865d740c8ffd2d106c575afd12dcc70ab66fb01e3d12` |
+| `data/derived/analysis/trait_coverage_matrix.csv` | `ac2a66f39e09c981698e087033211b6b47f83386a1da32aacaca1ef587637a63` |
 | `data/derived/analysis/trait_gap_report.json` | `a0ef558023bba99f39cdd6c8c173c7e77d60a8ede00b16cf4225a7ad693227c2` |
 | `data/derived/analysis/trait_baseline.yaml` | `029076d96a7ee93dcab610d77a64be4ff9ab0e0b317af72b5666f23b808c78f5` |
 | `data/derived/analysis/trait_env_mapping.json` | `8b0c0e07c8fca118707efe948092992d2dece80996ad9c270a6a56b3ba851ddc` |

--- a/data/derived/analysis/manifest.json
+++ b/data/derived/analysis/manifest.json
@@ -4,8 +4,8 @@
   "command": "python scripts/generate_derived_analysis.py --core-root data/core --pack-root packs/evo_tactics_pack --update-readme",
   "log_tag": null,
   "artifacts": {
-    "data/derived/analysis/trait_coverage_report.json": "1e2f8c1a95326964e968d69f51ba239a4b7ac64fe284b54197ebe8ba8dfb6ce4",
-    "data/derived/analysis/trait_coverage_matrix.csv": "a8773a82ded968d2649fc430204400d8f87b6d6abc4683aa4f5f99c8070f8cf6",
+    "data/derived/analysis/trait_coverage_report.json": "c659366c69b9acf81342865d740c8ffd2d106c575afd12dcc70ab66fb01e3d12",
+    "data/derived/analysis/trait_coverage_matrix.csv": "ac2a66f39e09c981698e087033211b6b47f83386a1da32aacaca1ef587637a63",
     "data/derived/analysis/trait_gap_report.json": "a0ef558023bba99f39cdd6c8c173c7e77d60a8ede00b16cf4225a7ad693227c2",
     "data/derived/analysis/trait_baseline.yaml": "029076d96a7ee93dcab610d77a64be4ff9ab0e0b317af72b5666f23b808c78f5",
     "data/derived/analysis/trait_env_mapping.json": "8b0c0e07c8fca118707efe948092992d2dece80996ad9c270a6a56b3ba851ddc",

--- a/data/derived/analysis/trait_coverage_matrix.csv
+++ b/data/derived/analysis/trait_coverage_matrix.csv
@@ -8,6 +8,7 @@ ali_fulminee,Ali Fulminee,Ali Fulminee,stratosfera_tempestosa,,1,1
 ali_ioniche,Ali Ioniche,Ionic Wings,canopia_ionica,,1,1
 ali_membrana_sonica,Ali a Membrana Sonica,Sonic Membrane Wings,caverna_risonante,,1,1
 ali_solari_fotoni,Ali Solari Fotoniche,Solar Photon Wings,canopia_ionica,serpentiforme_alato,0,1
+ali_solari_fotoni,Ali Solari Fotoniche,Solar Photon Wings,rovine_planari,volatore_planatore,0,2
 ali_solari_fotoni,Ali Solari Fotoniche,Solar Photon Wings,savana,alato_veliero,0,1
 antenne_dustsense,Antenne Dustsense,Dustsense Antennae,pianura_salina_iperarida,,1,1
 antenne_eco_turbina,Antenne Eco Turbina,Antenne Eco Turbina,dorsale_termale_tropicale,,1,1
@@ -23,9 +24,12 @@ appendici_thermotattiche,Appendici Thermotattiche,Appendici Thermotattiche,abiss
 armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,,,0,1
 armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,badlands,scavatore_corazzato,0,1
 armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,caverna,costrutto_corazzato,0,1
+armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,rovine_planari,cursoriale_quadrupede,0,1
+armatura_pietra_planare,Armatura di Pietra Planare,Planar Stone Plating,rovine_planari,scavenger_corazzato,0,1
 artigli_acidofagi,Artigli Acidofagi,Artigli Acidofagi,foresta_acida,,1,1
 artigli_induzione,Artigli Induzione,Artigli Induzione,canopia_ionica,,1,1
 artigli_psionici,Artigli Psionici,Artigli Psionici,foresta_temperata,felino_psionico,0,1
+artigli_psionici,Artigli Psionici,Artigli Psionici,rovine_planari,cursoriale_quadrupede,0,1
 artigli_radice,Artigli Radice,Artigli Radice,mangrovieto_cinetico,,1,1
 artigli_scivolo_silente,Artigli Scivolo Silente,Artigli Scivolo Silente,caverna_risonante,,1,1
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,badlands,cursoriale_quadrupede,0,1
@@ -36,9 +40,11 @@ artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,dorsale_termale_tropicale
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,mezzanotte_orbitale,,0,1
 artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,mezzanotte_orbitale,cursoriale_quadrupede,1,0
+artigli_sette_vie,Artigli a Sette Vie,Seven-Way Talons,rovine_planari,cursoriale_quadrupede,0,2
 artigli_sghiaccio_glaciale,Artigli Sghiaccio Glaciale,Artigli Sghiaccio Glaciale,,,0,1
 artigli_vetrificati,Artigli Vetrificati,Artigli Vetrificati,caldera_glaciale,,1,1
 aura_scudo_radianza,Aura Scudo di Radianza,Radiant Shield Aura,,,0,1
+aura_scudo_radianza,Aura Scudo di Radianza,Radiant Shield Aura,rovine_planari,volatore_planatore,0,1
 aura_scudo_radianza,Aura Scudo di Radianza,Radiant Shield Aura,savana,alato_veliero,0,1
 baffi_mareomotori,Baffi Mareomotori,Baffi Mareomotori,mangrovieto_cinetico,,1,1
 barbigli_sensori_plasma,Barbigli Sensori Plasma,Barbigli Sensori Plasma,stratosfera_tempestosa,,1,1
@@ -69,6 +75,8 @@ carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,cr
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,mezzanotte_orbitale,,0,1
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,mezzanotte_orbitale,cursoriale_quadrupede,1,0
 carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,palude,bipede_filtratore,0,1
+carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,rovine_planari,cursoriale_quadrupede,0,1
+carapace_fase_variabile,Carapace a Variazione di Fase,Phase-Shifting Carapace,rovine_planari,scavenger_corazzato,0,1
 carapace_luminiscente_abissale,Carapace Luminiscente Abissale,Carapace Luminiscente Abissale,,,0,1
 carapace_segmenti_logici,Carapace Segmenti Logici,Carapace Segmenti Logici,steppe_algoritmiche,,1,1
 carapaci_ferruginosi,Carapaci Ferruginosi,Carapaci Ferruginosi,abisso_vulcanico,,1,1
@@ -95,12 +103,14 @@ coda_coppia_retroattiva,Coda Coppia Retroattiva,Coda Coppia Retroattiva,steppe_a
 coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,badlands,scavatore_corazzato,0,1
 coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,dorsale_termale_tropicale,,0,1
 coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,dorsale_termale_tropicale,cursoriale_quadrupede,1,0
+coda_frusta_cinetica,Coda a Frusta Cinetica,Kinetic Lash Tail,rovine_planari,cursoriale_quadrupede,0,2
 coda_stabilizzatrice_filo,Coda Stabilizzatrice Filo,Coda Stabilizzatrice Filo,canopia_ionica,,1,1
 coda_stabilizzatrice_geiser,Coda Stabilizzatrice Geiser,Coda Stabilizzatrice Geiser,dorsale_termale_tropicale,,1,1
 coda_stabilizzatrice_vortex,Coda Stabilizzatrice Vortex,Coda Stabilizzatrice Vortex,stratosfera_tempestosa,,1,1
 colonne_vibromagnetiche,Colonne Vibromagnetiche,Colonne Vibromagnetiche,caverna_risonante,,1,1
 coralli_partner,Coralli Partner,Coralli Partner,reef_luminescente,,1,1
 corteccia_memetica,Corteccia Memetica,Corteccia Memetica,foresta_miceliale,flora_radicata,0,1
+corteccia_memetica,Corteccia Memetica,Corteccia Memetica,rovine_planari,ingegnere_radicante,0,1
 criostasi_adattiva,Criostasi,Adaptive Cryostasis,cryosteppe,volatore_planatore,0,1
 criostasi_adattiva,Criostasi,Adaptive Cryostasis,mezzanotte_orbitale,,0,1
 criostasi_adattiva,Criostasi,Adaptive Cryostasis,mezzanotte_orbitale,volatore_planatore,1,0
@@ -132,10 +142,13 @@ eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,dorsale_term
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,dorsale_termale_tropicale,volatore_planatore,1,0
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_orbitale,,0,1
 eco_interno_riflesso,Riflesso dell'Eco Interno,Internal Echo Reflex,mezzanotte_orbitale,volatore_planatore,1,0
+eco_sismico,Eco Sismico,Eco Sismico,rovine_planari,volatore_planatore,0,1
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,canopia_ionica,serpentiforme_alato,0,1
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_miceliale,,1,1
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_temperata,,0,1
 empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,foresta_temperata,felino_psionico,0,1
+empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,rovine_planari,cursoriale_quadrupede,0,1
+empatia_coordinativa,Empatia Coordinativa,Coordinated Empathy,rovine_planari,volatore_planatore,0,2
 enzimi_antifase_termica,Enzimi Antifase Termica,Enzimi Antifase Termica,caldera_glaciale,,1,1
 enzimi_antipredatori_algali,Enzimi Antipredatori Algali,Enzimi Antipredatori Algali,reef_luminescente,,1,1
 enzimi_chelanti,Enzimi Chelanti,Enzimi Chelanti,,,1,1
@@ -157,6 +170,7 @@ filamenti_magnetotrofi,Filamenti Magnetotrofi,Filamenti Magnetotrofi,abisso_vulc
 filamenti_superconduttivi,Filamenti Superconduttivi,Filamenti Superconduttivi,caldera_glaciale,,1,1
 filamenti_termoconduzione,Filamenti Termoconduzione,Filamenti Termoconduzione,dorsale_termale_tropicale,,1,1
 filtri_bioattivi,Filtri Bioattivi,Filtri Bioattivi,palude,bipede_filtratore,0,1
+filtri_bioattivi,Filtri Bioattivi,Filtri Bioattivi,rovine_planari,anfibio_filtratore,0,1
 filtri_planctonici,Filtri Planctonici,Filtri Planctonici,laguna_bioreattiva,,1,1
 flagelli_ancoranti,Flagelli Ancoranti,Flagelli Ancoranti,laguna_bioreattiva,,1,1
 focus_frazionato,Focus Frazionato,Fractional Focus,canopia_psionica_leggera,,1,1
@@ -168,6 +182,7 @@ foliaggio_spugna,Foliaggio Spugna,Foliaggio Spugna,mangrovieto_cinetico,,1,1
 frusta_fiammeggiante,Frusta Fiammeggiante,Flame Lash,,,0,1
 frusta_fiammeggiante,Frusta Fiammeggiante,Flame Lash,abisso_vulcanico,alato_corazzato,0,1
 frusta_fiammeggiante,Frusta Fiammeggiante,Flame Lash,abisso_vulcanico,multi_arto_rotante,0,1
+frusta_fiammeggiante,Frusta Fiammeggiante,Flame Lash,rovine_planari,cursoriale_quadrupede,0,1
 ghiaccio_piezoelettrico,Ghiaccio Piezoelettrico,Ghiaccio Piezoelettrico,caldera_glaciale,,1,1
 ghiandola_caustica,Ghiandola Caustica,Caustic Gland,foresta_miceliale,,1,1
 ghiandola_caustica,Ghiandola Caustica,Caustic Gland,foresta_temperata,,0,1
@@ -200,6 +215,7 @@ gusci_magnesio,Gusci Magnesio,Gusci Magnesio,dorsale_termale_tropicale,,1,1
 lamelle_shear,Lamelle Shear,Lamelle Shear,stratosfera_tempestosa,,1,1
 lamelle_sincroniche,Lamelle Sincroniche,Lamelle Sincroniche,steppe_algoritmiche,,1,1
 lamelle_termoforetiche,Lamelle Termoforetiche,Thermophoretic Lamellae,,,0,1
+lamelle_termoforetiche,Lamelle Termoforetiche,Thermophoretic Lamellae,rovine_planari,cursoriale_quadrupede,0,1
 lamine_filtranti_aeree,Lamine Filtranti Aeree,Lamine Filtranti Aeree,mangrovieto_cinetico,,1,1
 lamine_scudo_silice,Lamine Scudo Silice,Lamine Scudo Silice,dorsale_termale_tropicale,,1,1
 linfa_tampone,Linfa Tampone,Linfa Tampone,foresta_acida,,1,1
@@ -212,10 +228,13 @@ mantelli_geotermici,Mantelli Geotermici,Mantelli Geotermici,caldera_glaciale,,1,
 mantello_meteoritico,Mantello Meteoritico,Meteoric Mantle,,,0,1
 mantello_meteoritico,Mantello Meteoritico,Meteoric Mantle,abisso_vulcanico,alato_corazzato,0,1
 mantello_meteoritico,Mantello Meteoritico,Meteoric Mantle,abisso_vulcanico,multi_arto_rotante,0,1
+mantello_meteoritico,Mantello Meteoritico,Meteoric Mantle,rovine_planari,cursoriale_quadrupede,0,1
 matrice_antimagia,Matrice Antimagia,Matrice Antimagia,caverna,costrutto_corazzato,0,1
+matrice_antimagia,Matrice Antimagia,Matrice Antimagia,rovine_planari,scavenger_corazzato,0,1
 membrane_captura_rugiada,Membrane Captura Rugiada,Membrane Captura Rugiada,pianura_salina_iperarida,,1,1
 membrane_eliofiltranti,Membrane Eliofiltranti,Membrane Eliofiltranti,,,0,1
 membrane_osmotiche,Membrane Osmotiche,Membrane Osmotiche,palude,bipede_filtratore,0,1
+membrane_osmotiche,Membrane Osmotiche,Membrane Osmotiche,rovine_planari,anfibio_filtratore,0,1
 membrane_planata_vectored,Membrane Planata Vectored,Membrane Planata Vectored,canopia_ionica,,1,1
 membrane_pneumatofori,Membrane Pneumatofori,Membrane Pneumatofori,mangrovieto_cinetico,,1,1
 midollo_antivibrazione,Midollo Antivibrazione,Midollo Antivibrazione,caverna_risonante,,1,1
@@ -230,6 +249,7 @@ mucillagine_simbionte_mangrovie,Mucillagine Simbionte delle Mangrovie,Mucillagin
 mucose_aderenza_sonica,Mucose Aderenza Sonica,Mucose Aderenza Sonica,caverna_risonante,,1,1
 mucose_barofile,Mucose Barofile,Mucose Barofile,abisso_vulcanico,,1,1
 nodi_micorrizici_oracolari,Nodi Micorrizici Oracolari,Nodi Micorrizici Oracolari,,,0,1
+nuclei_di_controllo,Nuclei Di Controllo,Nuclei Di Controllo,rovine_planari,scavenger_corazzato,0,1
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,abisso_vulcanico,multi_arto_rotante,0,1
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,badlands,cursoriale_quadrupede,0,1
 nucleo_ovomotore_rotante,"Uovo rotaia, uovo grande e uova piccole dentro...",Rotating Ovomotor Core,dorsale_termale_tropicale,,0,1
@@ -283,10 +303,12 @@ pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,deserto_caldo,ingegnere_rad
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,deserto_caldo,scavenger_corazzato,0,1
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,deserto_caldo,volatore_planatore,0,2
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,foresta_miceliale,flora_radicata,0,1
+pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,rovine_planari,ingegnere_radicante,0,1
 pigmenti_aurorali,pigmenti_aurorali,Auroral Pigments,steppe_algoritmiche,,1,0
 piume_solari_fotovoltaiche,Piume Solari Fotovoltaiche,Piume Solari Fotovoltaiche,,,0,1
 polmoni_cristallini_alta_quota,Polmoni Cristallini d'Alta Quota,Polmoni Cristallini d'Alta Quota,,,0,1
 radici_ancora_planare,Radici Ancora Planare,Radici Ancora Planare,foresta_miceliale,flora_radicata,0,1
+radici_ancora_planare,Radici Ancora Planare,Radici Ancora Planare,rovine_planari,ingegnere_radicante,0,1
 random,Trait Random,Trait Random,,,0,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,badlands,scavenger_corazzato,0,1
 respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,cryosteppe,cursoriale_quadrupede,0,1
@@ -297,6 +319,7 @@ respiro_a_scoppio,Respiro a scoppio,Burst Breath Propulsion,mezzanotte_orbitale,
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,canyons_risonanti,alato_spettrale,0,1
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_miceliale,,1,1
 risonanza_di_branco,Risonanza di Branco,Pack Resonance,foresta_temperata,,0,1
+risonanza_di_branco,Risonanza di Branco,Pack Resonance,rovine_planari,volatore_planatore,0,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,badlands,cursoriale_quadrupede,0,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_ionica,aliante_mimetico,0,1
 sacche_galleggianti_ascensoriali,Sacche galleggianti ascensoriali,Elevating Buoyancy Sacs,canopia_psionica_leggera,,1,1
@@ -321,10 +344,13 @@ scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dors
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,dorsale_termale_tropicale,scavenger_corazzato,1,0
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,mezzanotte_orbitale,,0,1
 scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,mezzanotte_orbitale,cursoriale_quadrupede,1,0
+scheletro_idro_regolante,Scheletro Idro-Regolante,Hydro-Regulating Skeleton,rovine_planari,cursoriale_quadrupede,0,1
 secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,badlands,ingegnere_radicante,0,1
 secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,dorsale_termale_tropicale,,0,1
 secrezione_rallentante_palmi,Mani secernano liquido rallentante,Retarding Palm Secretions,dorsale_termale_tropicale,ingegnere_radicante,1,0
 sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,,,0,1
+sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,rovine_planari,cursoriale_quadrupede,0,2
+sensori_geomagnetici,Sensori a Risonanza Geomagnetica,Geomagnetic Resonance Sensors,rovine_planari,volatore_planatore,0,1
 sensori_sismici,Sensori Sismici,Seismic Sensors,caverna_risonante,bipede_agile,0,1
 sinapsi_coraline_polifoniche,Sinapsi Coraline Polifoniche,Sinapsi Coraline Polifoniche,,,0,1
 sonno_emisferico_alternato,Dormire con solo metà cervello alla volta,Unihemispheric Sleep,CRYOSTEPPE,volatore_planatore,0,1
@@ -356,6 +382,7 @@ struttura_elastica_amorfa,"Struttura elastica, allungabile, amorfa, retrattile",
 tattiche_di_branco,Tattiche di Branco,Pack Tactics,foresta_miceliale,,1,1
 tattiche_di_branco,Tattiche di Branco,Pack Tactics,foresta_temperata,,0,1
 tessuti_adattivi,Tessuti Adattivi,Tessuti Adattivi,foresta_temperata,felino_psionico,0,1
+tessuti_adattivi,Tessuti Adattivi,Tessuti Adattivi,rovine_planari,cursoriale_quadrupede,0,1
 vello_condensatore_nebbie,Vello Condensatore di Nebbie,Vello Condensatore di Nebbie,,,0,1
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,badlands,scavenger_corazzato,0,1
 ventriglio_gastroliti,"Denti sonci (ciottoli/sassi), ti nutri di tutto",Gastrolith Grinding Gizzard,cryosteppe,cursoriale_quadrupede,0,1

--- a/data/derived/analysis/trait_coverage_report.json
+++ b/data/derived/analysis/trait_coverage_report.json
@@ -10,13 +10,13 @@
   "summary": {
     "traits_total": 308,
     "traits_with_rules": 151,
-    "traits_with_species": 189,
-    "traits_with_affinity": 200,
+    "traits_with_species": 191,
+    "traits_with_affinity": 201,
     "rule_combos_total": 189,
-    "species_combos_total": 328,
+    "species_combos_total": 355,
     "rules_missing_species_total": 5,
-    "affinity_missing_species_total": 4,
-    "affinity_missing_matrix_total": 89,
+    "affinity_missing_species_total": 0,
+    "affinity_missing_matrix_total": 125,
     "traits_missing_species": [
       "cuticole_cerose",
       "grassi_termici",
@@ -47,6 +47,7 @@
       "criostasi_adattiva",
       "cuticole_cerose",
       "eco_interno_riflesso",
+      "eco_sismico",
       "empatia_coordinativa",
       "enzimi_chelanti",
       "filamenti_digestivi_compattanti",
@@ -64,6 +65,7 @@
       "mimetismo_cromatico_passivo",
       "mucillagine_simbionte_mangrovie",
       "nodi_micorrizici_oracolari",
+      "nuclei_di_controllo",
       "nucleo_ovomotore_rotante",
       "occhi_cristallo_modulare",
       "occhi_infrarosso_composti",
@@ -196,19 +198,33 @@
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "archon-solare",
+          "aurora-gull",
+          "balor-fission",
+          "banshee-risonante",
+          "couatl-aurora",
+          "echo-wing",
+          "noctule-termico"
+        ]
       },
       "affinity": {
-        "total_species": 4,
+        "total_species": 11,
         "roles_breakdown": {
-          "core": 4,
+          "core": 11,
           "optional": 4
         },
         "top_species": [
           "auroserpens_photonicus",
           "heliopteryx_radians",
           "pyroflagellum_meteoriticum",
-          "sonovespera_lamentans"
+          "sonovespera_lamentans",
+          "archon-solare",
+          "aurora-gull",
+          "balor-fission",
+          "banshee-risonante",
+          "couatl-aurora",
+          "echo-wing"
         ]
       }
     },
@@ -401,7 +417,7 @@
         "coverage": []
       },
       "species": {
-        "total": 2,
+        "total": 4,
         "coverage": [
           {
             "biome": "canopia_ionica",
@@ -409,6 +425,15 @@
             "count": 1,
             "examples": [
               "auroserpens_photonicus"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "archon-solare",
+              "couatl-aurora"
             ]
           },
           {
@@ -429,6 +454,10 @@
             "morphotype": "serpentiforme_alato"
           },
           {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          },
+          {
             "biome": "savana",
             "morphotype": "alato_veliero"
           }
@@ -437,14 +466,16 @@
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 2,
+        "total_species": 4,
         "roles_breakdown": {
           "core": 2,
-          "optional": 2
+          "optional": 4
         },
         "top_species": [
           "auroserpens_photonicus",
-          "heliopteryx_radians"
+          "heliopteryx_radians",
+          "archon-solare",
+          "couatl-aurora"
         ]
       }
     },
@@ -964,7 +995,7 @@
         "coverage": []
       },
       "species": {
-        "total": 3,
+        "total": 5,
         "coverage": [
           {
             "biome": null,
@@ -989,6 +1020,22 @@
             "examples": [
               "lithoconstructus_inhibens"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "golem-runico"
+            ]
           }
         ]
       },
@@ -1006,26 +1053,40 @@
           {
             "biome": "caverna",
             "morphotype": "costrutto_corazzato"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": [
+          "bulette-fase",
           "pyroflagellum_meteoriticum",
-          "radiciforma_ancorans"
+          "radiciforma_ancorans",
+          "treant-portale"
         ]
       },
       "affinity": {
-        "total_species": 5,
+        "total_species": 9,
         "roles_breakdown": {
-          "core": 4,
-          "optional": 3
+          "core": 5,
+          "optional": 7
         },
         "top_species": [
+          "golem-runico",
           "lithoconstructus_inhibens",
           "tellurmordax_phasicus",
           "pyroflagellum_meteoriticum",
           "radiciforma_ancorans",
-          "global-trait-keeper"
+          "balor-fission",
+          "bulette-fase",
+          "global-trait-keeper",
+          "treant-portale"
         ]
       }
     },
@@ -1198,7 +1259,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "foresta_temperata",
@@ -1206,6 +1267,14 @@
             "count": 1,
             "examples": [
               "illusiopardus_psionicus"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "rakshasa-corte"
             ]
           }
         ]
@@ -1216,19 +1285,24 @@
           {
             "biome": "foresta_temperata",
             "morphotype": "felino_psionico"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 2,
         "roles_breakdown": {
           "core": 1,
-          "optional": 1
+          "optional": 2
         },
         "top_species": [
-          "illusiopardus_psionicus"
+          "illusiopardus_psionicus",
+          "rakshasa-corte"
         ]
       }
     },
@@ -1346,7 +1420,7 @@
         ]
       },
       "species": {
-        "total": 7,
+        "total": 9,
         "coverage": [
           {
             "biome": "badlands",
@@ -1396,6 +1470,15 @@
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "balor-fission",
+              "marilith-vault"
+            ]
           }
         ]
       },
@@ -1409,21 +1492,27 @@
           {
             "biome": "cryosteppe",
             "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": [
+          "couatl-aurora",
           "ferrimordax-rutilus",
+          "otyugh-sentinella",
           "pyroflagellum_meteoriticum",
           "rotabrachium_ferox",
           "rubrospina-velox"
         ]
       },
       "affinity": {
-        "total_species": 10,
+        "total_species": 14,
         "roles_breakdown": {
           "core": 5,
-          "optional": 7
+          "optional": 11
         },
         "top_species": [
           "dune-stalker",
@@ -1431,11 +1520,11 @@
           "pyroflagellum_meteoriticum",
           "rotabrachium_ferox",
           "rubrospina-velox",
+          "balor-fission",
           "caverna-risonante-trait-keeper",
+          "couatl-aurora",
           "cryo-lynx",
-          "dorsale-termale-tropicale-trait-keeper",
-          "ferrimordax-rutilus",
-          "mezzanotte-orbitale-trait-keeper"
+          "dorsale-termale-tropicale-trait-keeper"
         ]
       }
     },
@@ -1616,7 +1705,7 @@
         "coverage": []
       },
       "species": {
-        "total": 2,
+        "total": 3,
         "coverage": [
           {
             "biome": null,
@@ -1624,6 +1713,14 @@
             "count": 1,
             "examples": [
               "global-trait-keeper"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "archon-solare"
             ]
           },
           {
@@ -1644,6 +1741,10 @@
             "morphotype": null
           },
           {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          },
+          {
             "biome": "savana",
             "morphotype": "alato_veliero"
           }
@@ -1652,12 +1753,13 @@
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 2,
+        "total_species": 3,
         "roles_breakdown": {
-          "core": 1,
-          "optional": 2
+          "core": 2,
+          "optional": 3
         },
         "top_species": [
+          "archon-solare",
           "heliopteryx_radians",
           "global-trait-keeper"
         ]
@@ -2852,7 +2954,7 @@
         ]
       },
       "species": {
-        "total": 5,
+        "total": 7,
         "coverage": [
           {
             "biome": "badlands",
@@ -2893,6 +2995,22 @@
             "examples": [
               "filtrophagus_custos"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "golem-runico"
+            ]
           }
         ]
       },
@@ -2914,32 +3032,43 @@
           {
             "biome": "palude",
             "morphotype": "bipede_filtratore"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": [
+          "bulette-fase",
           "nano-rust-bloom",
+          "otyugh-sentinella",
           "pyroflagellum_meteoriticum",
           "sand-burrower",
           "steppe-bison-mini"
         ]
       },
       "affinity": {
-        "total_species": 9,
+        "total_species": 13,
         "roles_breakdown": {
           "core": 4,
-          "optional": 8
+          "optional": 12
         },
         "top_species": [
           "filtrophagus_custos",
           "lithoconstructus_inhibens",
           "tellurmordax_phasicus",
           "pyroflagellum_meteoriticum",
+          "balor-fission",
+          "bulette-fase",
           "cryo-lynx",
+          "golem-runico",
           "mezzanotte-orbitale-trait-keeper",
-          "nano-rust-bloom",
-          "sand-burrower",
-          "steppe-bison-mini"
+          "nano-rust-bloom"
         ]
       }
     },
@@ -4050,7 +4179,7 @@
         ]
       },
       "species": {
-        "total": 2,
+        "total": 4,
         "coverage": [
           {
             "biome": "badlands",
@@ -4067,6 +4196,15 @@
             "examples": [
               "dorsale-termale-tropicale-trait-keeper"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "bulette-fase",
+              "marilith-vault"
+            ]
           }
         ]
       },
@@ -4076,6 +4214,10 @@
           {
             "biome": "badlands",
             "morphotype": "scavatore_corazzato"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
           }
         ],
         "missing_in_affinity": [],
@@ -4085,16 +4227,18 @@
         ]
       },
       "affinity": {
-        "total_species": 4,
+        "total_species": 6,
         "roles_breakdown": {
           "core": 2,
-          "optional": 3
+          "optional": 5
         },
         "top_species": [
           "tellurmordax_phasicus",
           "rotabrachium_ferox",
+          "bulette-fase",
           "dorsale-termale-tropicale-trait-keeper",
-          "dune-stalker"
+          "dune-stalker",
+          "marilith-vault"
         ]
       }
     },
@@ -4448,7 +4592,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -4456,6 +4600,14 @@
             "count": 1,
             "examples": [
               "radiciforma_ancorans"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "treant-portale"
             ]
           }
         ]
@@ -4466,19 +4618,24 @@
           {
             "biome": "foresta_miceliale",
             "morphotype": "flora_radicata"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "ingegnere_radicante"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 2,
         "roles_breakdown": {
           "core": 1,
-          "optional": 1
+          "optional": 2
         },
         "top_species": [
-          "radiciforma_ancorans"
+          "radiciforma_ancorans",
+          "treant-portale"
         ]
       }
     },
@@ -4549,20 +4706,22 @@
         "missing_in_affinity": [],
         "missing_in_matrix": [
           "aerostatocyon_altivolans",
+          "balor-fission",
           "cryo-lynx",
           "dune-stalker",
           "rubrospina-velox"
         ]
       },
       "affinity": {
-        "total_species": 6,
+        "total_species": 7,
         "roles_breakdown": {
           "core": 1,
-          "optional": 5
+          "optional": 6
         },
         "top_species": [
           "aerostatocyon_altivolans",
           "aurora-gull",
+          "balor-fission",
           "cryo-lynx",
           "dune-stalker",
           "mezzanotte-orbitale-trait-keeper",
@@ -5360,14 +5519,37 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "banshee-risonante"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
+      },
+      "affinity": {
+        "total_species": 1,
+        "roles_breakdown": {
+          "optional": 1
+        },
+        "top_species": [
+          "banshee-risonante"
+        ]
       }
     },
     "ectotermia_dinamica": {
@@ -5466,7 +5648,7 @@
         ]
       },
       "species": {
-        "total": 4,
+        "total": 7,
         "coverage": [
           {
             "biome": "canopia_ionica",
@@ -5499,6 +5681,23 @@
             "examples": [
               "illusiopardus_psionicus"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "rakshasa-corte"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 2,
+            "examples": [
+              "archon-solare",
+              "couatl-aurora"
+            ]
           }
         ]
       },
@@ -5516,21 +5715,31 @@
           {
             "biome": "foresta_temperata",
             "morphotype": "felino_psionico"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": [
+          "balor-fission",
           "heliopteryx_radians",
+          "marilith-vault",
           "nebulocornis-mollis",
           "rotabrachium_ferox",
           "sentinella-radice"
         ]
       },
       "affinity": {
-        "total_species": 8,
+        "total_species": 13,
         "roles_breakdown": {
           "core": 4,
-          "optional": 5,
+          "optional": 10,
           "synergy": 1
         },
         "top_species": [
@@ -5539,9 +5748,11 @@
           "heliopteryx_radians",
           "rotabrachium_ferox",
           "nebulocornis-mollis",
+          "archon-solare",
+          "balor-fission",
+          "couatl-aurora",
           "foresta-miceliale-trait-keeper",
-          "lupus-temperatus",
-          "sentinella-radice"
+          "lupus-temperatus"
         ]
       }
     },
@@ -6319,7 +6530,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "palude",
@@ -6327,6 +6538,14 @@
             "count": 1,
             "examples": [
               "filtrophagus_custos"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "anfibio_filtratore",
+            "count": 1,
+            "examples": [
+              "otyugh-sentinella"
             ]
           }
         ]
@@ -6337,19 +6556,24 @@
           {
             "biome": "palude",
             "morphotype": "bipede_filtratore"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "anfibio_filtratore"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 2,
         "roles_breakdown": {
           "core": 1,
-          "optional": 1
+          "optional": 2
         },
         "top_species": [
-          "filtrophagus_custos"
+          "filtrophagus_custos",
+          "otyugh-sentinella"
         ]
       }
     },
@@ -6555,32 +6779,38 @@
         "missing_in_matrix": [
           "aerostatocyon_altivolans",
           "arboryxis-lenis",
+          "archon-solare",
+          "balor-fission",
+          "banshee-risonante",
+          "couatl-aurora",
           "cryptopennatus_psionicus",
           "dune-stalker",
           "lupus-temperatus",
+          "marilith-vault",
           "nebulocornis-mollis",
+          "rakshasa-corte",
           "rotabrachium_ferox",
           "rubrospina-velox"
         ]
       },
       "affinity": {
-        "total_species": 12,
+        "total_species": 18,
         "roles_breakdown": {
-          "core": 3,
-          "optional": 5,
-          "synergy": 4
+          "core": 4,
+          "optional": 9,
+          "synergy": 8
         },
         "top_species": [
           "aerostatocyon_altivolans",
+          "archon-solare",
+          "banshee-risonante",
+          "couatl-aurora",
           "cryptopennatus_psionicus",
+          "marilith-vault",
           "rotabrachium_ferox",
           "arboryxis-lenis",
-          "dune-stalker",
-          "nebulocornis-mollis",
-          "rubrospina-velox",
-          "canopia-psionica-leggera-trait-keeper",
-          "foresta-miceliale-trait-keeper",
-          "lupus-temperatus"
+          "balor-fission",
+          "dune-stalker"
         ]
       }
     },
@@ -6702,7 +6932,7 @@
         "coverage": []
       },
       "species": {
-        "total": 3,
+        "total": 4,
         "coverage": [
           {
             "biome": null,
@@ -6727,6 +6957,14 @@
             "examples": [
               "rotabrachium_ferox"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
           }
         ]
       },
@@ -6744,20 +6982,28 @@
           {
             "biome": "abisso_vulcanico",
             "morphotype": "multi_arto_rotante"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "marilith-vault"
+        ]
       },
       "affinity": {
-        "total_species": 3,
+        "total_species": 5,
         "roles_breakdown": {
-          "core": 2,
-          "optional": 3
+          "core": 4,
+          "optional": 4
         },
         "top_species": [
+          "balor-fission",
           "pyroflagellum_meteoriticum",
           "rotabrachium_ferox",
+          "marilith-vault",
           "global-trait-keeper"
         ]
       }
@@ -7632,17 +7878,17 @@
             "morphotype": "volatore_planatore"
           }
         ],
-        "missing_in_affinity": [
-          "sand-burrower"
-        ],
+        "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 7,
+        "total_species": 8,
         "roles_breakdown": {
-          "optional": 7
+          "core": 1,
+          "optional": 8
         },
         "top_species": [
+          "sand-burrower",
           "cactus-weaver",
           "evento-brinastorm",
           "evento-ondata-termica",
@@ -7919,7 +8165,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": null,
@@ -7927,6 +8173,14 @@
             "count": 1,
             "examples": [
               "global-trait-keeper"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "bulette-fase"
             ]
           }
         ]
@@ -7937,22 +8191,33 @@
           {
             "biome": null,
             "morphotype": null
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": [
-          "amorphovenator_magneticus"
+          "amorphovenator_magneticus",
+          "archon-solare",
+          "couatl-aurora",
+          "otyugh-sentinella"
         ]
       },
       "affinity": {
-        "total_species": 2,
+        "total_species": 6,
         "roles_breakdown": {
           "core": 1,
-          "optional": 1
+          "optional": 5
         },
         "top_species": [
           "amorphovenator_magneticus",
-          "global-trait-keeper"
+          "archon-solare",
+          "bulette-fase",
+          "couatl-aurora",
+          "global-trait-keeper",
+          "otyugh-sentinella"
         ]
       }
     },
@@ -8408,7 +8673,7 @@
         "coverage": []
       },
       "species": {
-        "total": 3,
+        "total": 4,
         "coverage": [
           {
             "biome": null,
@@ -8433,6 +8698,14 @@
             "examples": [
               "rotabrachium_ferox"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "balor-fission"
+            ]
           }
         ]
       },
@@ -8450,20 +8723,28 @@
           {
             "biome": "abisso_vulcanico",
             "morphotype": "multi_arto_rotante"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "marilith-vault"
+        ]
       },
       "affinity": {
-        "total_species": 3,
+        "total_species": 5,
         "roles_breakdown": {
-          "core": 2,
-          "optional": 3
+          "core": 4,
+          "optional": 4
         },
         "top_species": [
+          "balor-fission",
           "pyroflagellum_meteoriticum",
           "rotabrachium_ferox",
+          "marilith-vault",
           "global-trait-keeper"
         ]
       }
@@ -8543,7 +8824,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "caverna",
@@ -8551,6 +8832,14 @@
             "count": 1,
             "examples": [
               "lithoconstructus_inhibens"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "golem-runico"
             ]
           }
         ]
@@ -8561,19 +8850,24 @@
           {
             "biome": "caverna",
             "morphotype": "costrutto_corazzato"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 2,
         "roles_breakdown": {
           "core": 1,
-          "optional": 1
+          "optional": 2
         },
         "top_species": [
-          "lithoconstructus_inhibens"
+          "lithoconstructus_inhibens",
+          "golem-runico"
         ]
       }
     },
@@ -8714,7 +9008,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "palude",
@@ -8722,6 +9016,14 @@
             "count": 1,
             "examples": [
               "filtrophagus_custos"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "anfibio_filtratore",
+            "count": 1,
+            "examples": [
+              "otyugh-sentinella"
             ]
           }
         ]
@@ -8732,19 +9034,24 @@
           {
             "biome": "palude",
             "morphotype": "bipede_filtratore"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "anfibio_filtratore"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 2,
         "roles_breakdown": {
           "core": 1,
-          "optional": 1
+          "optional": 2
         },
         "top_species": [
-          "filtrophagus_custos"
+          "filtrophagus_custos",
+          "otyugh-sentinella"
         ]
       }
     },
@@ -9331,24 +9638,40 @@
         "coverage": []
       },
       "species": {
-        "total": 0,
-        "coverage": []
+        "total": 1,
+        "coverage": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato",
+            "count": 1,
+            "examples": [
+              "golem-runico"
+            ]
+          }
+        ]
       },
       "diff": {
         "missing_in_species": [],
-        "missing_in_rules": [],
+        "missing_in_rules": [
+          {
+            "biome": "rovine_planari",
+            "morphotype": "scavenger_corazzato"
+          }
+        ],
         "missing_in_affinity": [],
         "missing_in_matrix": [
           "lithoconstructus_inhibens"
         ]
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 2,
         "roles_breakdown": {
-          "core": 1
+          "core": 1,
+          "optional": 1
         },
         "top_species": [
-          "lithoconstructus_inhibens"
+          "lithoconstructus_inhibens",
+          "golem-runico"
         ]
       }
     },
@@ -9627,18 +9950,20 @@
         "missing_in_affinity": [],
         "missing_in_matrix": [
           "aurora-gull",
+          "couatl-aurora",
           "lupus-temperatus"
         ]
       },
       "affinity": {
-        "total_species": 4,
+        "total_species": 5,
         "roles_breakdown": {
           "core": 1,
-          "optional": 4
+          "optional": 5
         },
         "top_species": [
           "echo-wing",
           "aurora-gull",
+          "couatl-aurora",
           "dorsale-termale-tropicale-trait-keeper",
           "lupus-temperatus"
         ]
@@ -10172,17 +10497,17 @@
             "morphotype": "volatore_planatore"
           }
         ],
-        "missing_in_affinity": [
-          "echo-wing"
-        ],
+        "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 6,
+        "total_species": 7,
         "roles_breakdown": {
-          "optional": 6
+          "core": 1,
+          "optional": 7
         },
         "top_species": [
+          "echo-wing",
           "cactus-weaver",
           "evento-brinastorm",
           "evento-ondata-termica",
@@ -10254,17 +10579,17 @@
           }
         ],
         "missing_in_rules": [],
-        "missing_in_affinity": [
-          "cryptopennatus_psionicus"
-        ],
+        "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 2,
         "roles_breakdown": {
-          "optional": 1
+          "core": 1,
+          "optional": 2
         },
         "top_species": [
+          "cryptopennatus_psionicus",
           "evento-seme-uragano"
         ]
       }
@@ -10353,7 +10678,7 @@
         ]
       },
       "species": {
-        "total": 10,
+        "total": 11,
         "coverage": [
           {
             "biome": "badlands",
@@ -10427,6 +10752,14 @@
             "examples": [
               "radiciforma_ancorans"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "treant-portale"
+            ]
           }
         ]
       },
@@ -10457,27 +10790,31 @@
           {
             "biome": "foresta_miceliale",
             "morphotype": "flora_radicata"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "ingegnere_radicante"
           }
         ],
-        "missing_in_affinity": [
-          "ferrocolonia-magnetotattica"
-        ],
+        "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 7,
+        "total_species": 9,
         "roles_breakdown": {
-          "core": 1,
-          "optional": 7
+          "core": 2,
+          "optional": 9
         },
         "top_species": [
+          "ferrocolonia-magnetotattica",
           "radiciforma_ancorans",
           "cactus-weaver",
           "evento-brinastorm",
           "evento-ondata-termica",
           "noctule-termico",
           "silica-bloom",
-          "thermo-raptor"
+          "thermo-raptor",
+          "treant-portale"
         ]
       }
     },
@@ -10657,7 +10994,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "foresta_miceliale",
@@ -10665,6 +11002,14 @@
             "count": 1,
             "examples": [
               "radiciforma_ancorans"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "ingegnere_radicante",
+            "count": 1,
+            "examples": [
+              "treant-portale"
             ]
           }
         ]
@@ -10675,19 +11020,27 @@
           {
             "biome": "foresta_miceliale",
             "morphotype": "flora_radicata"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "ingegnere_radicante"
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "cactus-weaver"
+        ]
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 3,
         "roles_breakdown": {
-          "core": 1,
-          "optional": 1
+          "core": 2,
+          "optional": 2
         },
         "top_species": [
-          "radiciforma_ancorans"
+          "radiciforma_ancorans",
+          "cactus-weaver",
+          "treant-portale"
         ]
       }
     },
@@ -10864,7 +11217,7 @@
         ]
       },
       "species": {
-        "total": 3,
+        "total": 4,
         "coverage": [
           {
             "biome": "canyons_risonanti",
@@ -10889,6 +11242,14 @@
             "examples": [
               "lupus-temperatus"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "archon-solare"
+            ]
           }
         ]
       },
@@ -10902,29 +11263,41 @@
           {
             "biome": "foresta_temperata",
             "morphotype": null
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": [
           "auroserpens_photonicus",
+          "banshee-risonante",
+          "couatl-aurora",
           "dune-stalker",
-          "heliopteryx_radians"
+          "heliopteryx_radians",
+          "rakshasa-corte",
+          "treant-portale"
         ]
       },
       "affinity": {
-        "total_species": 6,
+        "total_species": 11,
         "roles_breakdown": {
-          "core": 3,
-          "optional": 3,
-          "synergy": 1
+          "core": 4,
+          "optional": 5,
+          "synergy": 5
         },
         "top_species": [
+          "banshee-risonante",
           "sonovespera_lamentans",
+          "archon-solare",
           "auroserpens_photonicus",
           "heliopteryx_radians",
+          "couatl-aurora",
           "dune-stalker",
-          "foresta-miceliale-trait-keeper",
-          "lupus-temperatus"
+          "rakshasa-corte",
+          "treant-portale",
+          "foresta-miceliale-trait-keeper"
         ]
       }
     },
@@ -11139,16 +11512,17 @@
         "missing_in_matrix": [
           "arboryxis-lenis",
           "aurora-gull",
+          "bulette-fase",
           "dune-stalker",
           "echo-wing",
           "steppe-bison-mini"
         ]
       },
       "affinity": {
-        "total_species": 12,
+        "total_species": 13,
         "roles_breakdown": {
           "core": 3,
-          "optional": 12
+          "optional": 13
         },
         "top_species": [
           "aerostatocyon_altivolans",
@@ -11156,11 +11530,11 @@
           "sand-burrower",
           "arboryxis-lenis",
           "aurora-gull",
+          "bulette-fase",
           "canopia-psionica-leggera-trait-keeper",
           "dorsale-termale-tropicale-trait-keeper",
           "dune-stalker",
-          "echo-wing",
-          "mezzanotte-orbitale-trait-keeper"
+          "echo-wing"
         ]
       }
     },
@@ -11382,7 +11756,7 @@
         ]
       },
       "species": {
-        "total": 6,
+        "total": 7,
         "coverage": [
           {
             "biome": "badlands",
@@ -11424,6 +11798,14 @@
             "examples": [
               "mezzanotte-orbitale-trait-keeper"
             ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "bulette-fase"
+            ]
           }
         ]
       },
@@ -11441,6 +11823,10 @@
           {
             "biome": "cryosteppe",
             "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
           }
         ],
         "missing_in_affinity": [],
@@ -11451,10 +11837,10 @@
         ]
       },
       "affinity": {
-        "total_species": 9,
+        "total_species": 10,
         "roles_breakdown": {
           "core": 5,
-          "optional": 7
+          "optional": 8
         },
         "top_species": [
           "dune-stalker",
@@ -11462,6 +11848,7 @@
           "sand-burrower",
           "amorphovenator_magneticus",
           "tellurmordax_phasicus",
+          "bulette-fase",
           "dorsale-termale-tropicale-trait-keeper",
           "mezzanotte-orbitale-trait-keeper",
           "rust-scavenger",
@@ -11692,7 +12079,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 4,
         "coverage": [
           {
             "biome": null,
@@ -11700,6 +12087,23 @@
             "count": 1,
             "examples": [
               "global-trait-keeper"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 2,
+            "examples": [
+              "bulette-fase",
+              "marilith-vault"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore",
+            "count": 1,
+            "examples": [
+              "couatl-aurora"
             ]
           }
         ]
@@ -11710,18 +12114,29 @@
           {
             "biome": null,
             "morphotype": null
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "volatore_planatore"
           }
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": []
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 4,
         "roles_breakdown": {
-          "optional": 1
+          "optional": 4
         },
         "top_species": [
-          "global-trait-keeper"
+          "bulette-fase",
+          "couatl-aurora",
+          "global-trait-keeper",
+          "marilith-vault"
         ]
       }
     },
@@ -12488,17 +12903,19 @@
         ],
         "missing_in_affinity": [],
         "missing_in_matrix": [
+          "balor-fission",
           "dune-stalker"
         ]
       },
       "affinity": {
-        "total_species": 3,
+        "total_species": 4,
         "roles_breakdown": {
-          "optional": 2,
+          "optional": 3,
           "synergy": 1
         },
         "top_species": [
           "dune-stalker",
+          "balor-fission",
           "foresta-miceliale-trait-keeper",
           "lupus-temperatus"
         ]
@@ -12594,7 +13011,7 @@
         "coverage": []
       },
       "species": {
-        "total": 1,
+        "total": 2,
         "coverage": [
           {
             "biome": "foresta_temperata",
@@ -12602,6 +13019,14 @@
             "count": 1,
             "examples": [
               "illusiopardus_psionicus"
+            ]
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede",
+            "count": 1,
+            "examples": [
+              "rakshasa-corte"
             ]
           }
         ]
@@ -12612,19 +13037,27 @@
           {
             "biome": "foresta_temperata",
             "morphotype": "felino_psionico"
+          },
+          {
+            "biome": "rovine_planari",
+            "morphotype": "cursoriale_quadrupede"
           }
         ],
         "missing_in_affinity": [],
-        "missing_in_matrix": []
+        "missing_in_matrix": [
+          "marilith-vault"
+        ]
       },
       "affinity": {
-        "total_species": 1,
+        "total_species": 3,
         "roles_breakdown": {
           "core": 1,
-          "optional": 1
+          "optional": 3
         },
         "top_species": [
-          "illusiopardus_psionicus"
+          "illusiopardus_psionicus",
+          "marilith-vault",
+          "rakshasa-corte"
         ]
       }
     },
@@ -13099,7 +13532,7 @@
         ]
       },
       "dispersore_ponte": {
-        "total_species": 6,
+        "total_species": 8,
         "biomes": {
           "CRYOSTEPPE": {
             "count": 1,
@@ -13202,6 +13635,33 @@
                 "source": "packs/evo_tactics_pack/data/species/deserto_caldo/noctule-termico.yaml"
               }
             ]
+          },
+          "rovine_planari": {
+            "count": 2,
+            "playable_count": 2,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "archon-solare",
+                "playable_unit": true,
+                "core_traits": [
+                  "ali_solari_fotoni",
+                  "empatia_coordinativa",
+                  "risonanza_di_branco"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml"
+              },
+              {
+                "id": "couatl-aurora",
+                "playable_unit": true,
+                "core_traits": [
+                  "empatia_coordinativa",
+                  "sensori_geomagnetici",
+                  "ali_solari_fotoni"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
@@ -13214,7 +13674,7 @@
         ]
       },
       "erbivoro_primario": {
-        "total_species": 1,
+        "total_species": 2,
         "biomes": {
           "badlands": {
             "count": 1,
@@ -13232,10 +13692,28 @@
                 "source": "packs/evo_tactics_pack/data/species/badlands/sand-burrower.yaml"
               }
             ]
+          },
+          "rovine_planari": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "bulette-fase",
+                "playable_unit": false,
+                "core_traits": [
+                  "scheletro_idro_regolante",
+                  "sensori_geomagnetici",
+                  "coda_frusta_cinetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
-          "badlands"
+          "badlands",
+          "rovine_planari"
         ]
       },
       "esploratore": {
@@ -13264,7 +13742,7 @@
         ]
       },
       "evento_ecologico": {
-        "total_species": 11,
+        "total_species": 12,
         "biomes": {
           "badlands": {
             "count": 4,
@@ -13375,10 +13853,26 @@
                 "source": "packs/evo_tactics_pack/data/species/foresta_temperata/myco-spire-warden.yaml"
               }
             ]
+          },
+          "rovine_planari": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "banshee-risonante",
+                "playable_unit": false,
+                "core_traits": [
+                  "eco_sismico"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
-          "deserto_caldo"
+          "deserto_caldo",
+          "rovine_planari"
         ]
       },
       "filtratore_aereo": {
@@ -13457,7 +13951,7 @@
         ]
       },
       "ingegneri_ecosistema": {
-        "total_species": 4,
+        "total_species": 7,
         "biomes": {
           "badlands": {
             "count": 1,
@@ -13526,6 +14020,42 @@
                 "source": "packs/evo_tactics_pack/data/species/foresta_temperata/sentinella-radice.yaml"
               }
             ]
+          },
+          "rovine_planari": {
+            "count": 3,
+            "playable_count": 0,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "golem-runico",
+                "playable_unit": false,
+                "core_traits": [
+                  "carapace_fase_variabile",
+                  "armatura_pietra_planare",
+                  "nuclei_di_controllo"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml"
+              },
+              {
+                "id": "otyugh-sentinella",
+                "playable_unit": false,
+                "core_traits": [
+                  "filtri_bioattivi",
+                  "membrane_osmotiche"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml"
+              },
+              {
+                "id": "treant-portale",
+                "playable_unit": false,
+                "core_traits": [
+                  "radici_ancora_planare",
+                  "pigmenti_aurorali",
+                  "corteccia_memetica"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
@@ -13536,7 +14066,7 @@
         ]
       },
       "minaccia_microbica": {
-        "total_species": 4,
+        "total_species": 5,
         "biomes": {
           "badlands": {
             "count": 1,
@@ -13605,13 +14135,31 @@
                 "source": "packs/evo_tactics_pack/data/species/foresta_temperata/blight-micotico.yaml"
               }
             ]
+          },
+          "rovine_planari": {
+            "count": 1,
+            "playable_count": 0,
+            "meets_threshold": false,
+            "species": [
+              {
+                "id": "rakshasa-corte",
+                "playable_unit": false,
+                "core_traits": [
+                  "empatia_coordinativa",
+                  "artigli_psionici",
+                  "tessuti_adattivi"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml"
+              }
+            ]
           }
         },
         "biomes_missing_threshold": [
           "badlands",
           "cryosteppe",
           "deserto_caldo",
-          "foresta_temperata"
+          "foresta_temperata",
+          "rovine_planari"
         ]
       },
       "predatore_acquatico_agile": {
@@ -13883,7 +14431,7 @@
         ]
       },
       "predatore_terziario_apex": {
-        "total_species": 4,
+        "total_species": 6,
         "biomes": {
           "badlands": {
             "count": 1,
@@ -13950,6 +14498,33 @@
                   "risonanza_di_branco"
                 ],
                 "source": "packs/evo_tactics_pack/data/species/foresta_temperata/lupus-temperatus.yaml"
+              }
+            ]
+          },
+          "rovine_planari": {
+            "count": 2,
+            "playable_count": 0,
+            "meets_threshold": true,
+            "species": [
+              {
+                "id": "balor-fission",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie",
+                  "frusta_fiammeggiante",
+                  "armatura_pietra_planare"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml"
+              },
+              {
+                "id": "marilith-vault",
+                "playable_unit": false,
+                "core_traits": [
+                  "artigli_sette_vie",
+                  "coda_frusta_cinetica",
+                  "sensori_geomagnetici"
+                ],
+                "source": "packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml"
               }
             ]
           }

--- a/data/traits/index.json
+++ b/data/traits/index.json
@@ -510,6 +510,20 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "archon-solare",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "completion_flags": {
@@ -1859,6 +1873,14 @@
       "data_origin": "pathfinder_dataset",
       "species_affinity": [
         {
+          "species_id": "golem-runico",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
           "species_id": "lithoconstructus_inhibens",
           "roles": [
             "core",
@@ -1889,7 +1911,28 @@
           "weight": 3
         },
         {
+          "species_id": "balor-fission",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "bulette-fase",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "treant-portale",
           "roles": [
             "optional"
           ],
@@ -1957,6 +2000,14 @@
       "data_origin": "pathfinder_dataset",
       "species_affinity": [
         {
+          "species_id": "balor-fission",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
           "species_id": "pyroflagellum_meteoriticum",
           "roles": [
             "core",
@@ -1971,6 +2022,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "marilith-vault",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
         },
         {
           "species_id": "global-trait-keeper",
@@ -3825,6 +3883,13 @@
           "weight": 1
         },
         {
+          "species_id": "bulette-fase",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "canopia-psionica-leggera-trait-keeper",
           "roles": [
             "optional"
@@ -4873,7 +4938,21 @@
           "weight": 3
         },
         {
+          "species_id": "balor-fission",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "caverna-risonante-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "couatl-aurora",
           "roles": [
             "optional"
           ],
@@ -4901,7 +4980,21 @@
           "weight": 1
         },
         {
+          "species_id": "marilith-vault",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "mezzanotte-orbitale-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "otyugh-sentinella",
           "roles": [
             "optional"
           ],
@@ -5483,6 +5576,13 @@
           "weight": 3
         },
         {
+          "species_id": "bulette-fase",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "dorsale-termale-tropicale-trait-keeper",
           "roles": [
             "optional"
@@ -5491,6 +5591,13 @@
         },
         {
           "species_id": "dune-stalker",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "marilith-vault",
           "roles": [
             "optional"
           ],
@@ -6761,6 +6868,13 @@
           "weight": 1
         },
         {
+          "species_id": "balor-fission",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "cryo-lynx",
           "roles": [
             "optional"
@@ -7161,6 +7275,14 @@
       ],
       "data_origin": "controllo_psionico",
       "species_affinity": [
+        {
+          "species_id": "sand-burrower",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
         {
           "species_id": "cactus-weaver",
           "roles": [
@@ -8472,6 +8594,14 @@
       "data_origin": "pathfinder_dataset",
       "species_affinity": [
         {
+          "species_id": "balor-fission",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
           "species_id": "pyroflagellum_meteoriticum",
           "roles": [
             "core",
@@ -8486,6 +8616,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "marilith-vault",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
         },
         {
           "species_id": "global-trait-keeper",
@@ -9199,7 +9336,35 @@
           "weight": 3
         },
         {
+          "species_id": "archon-solare",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "bulette-fase",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "otyugh-sentinella",
           "roles": [
             "optional"
           ],
@@ -11282,6 +11447,13 @@
           "weight": 1
         },
         {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "dorsale-termale-tropicale-trait-keeper",
           "roles": [
             "optional"
@@ -11557,7 +11729,28 @@
       "data_origin": "controllo_psionico",
       "species_affinity": [
         {
+          "species_id": "bulette-fase",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "global-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "marilith-vault",
           "roles": [
             "optional"
           ],
@@ -13629,7 +13822,38 @@
           "weight": 3
         },
         {
+          "species_id": "archon-solare",
+          "roles": [
+            "optional",
+            "synergy"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "banshee-risonante",
+          "roles": [
+            "optional",
+            "synergy"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "optional",
+            "synergy"
+          ],
+          "weight": 3
+        },
+        {
           "species_id": "cryptopennatus_psionicus",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "marilith-vault",
           "roles": [
             "core"
           ],
@@ -13644,6 +13868,13 @@
         },
         {
           "species_id": "arboryxis-lenis",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "balor-fission",
           "roles": [
             "synergy"
           ],
@@ -13693,6 +13924,13 @@
         },
         {
           "species_id": "orbita-psionica-inversa-trait-keeper",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "rakshasa-corte",
           "roles": [
             "optional"
           ],
@@ -14328,6 +14566,13 @@
           "weight": 2
         },
         {
+          "species_id": "balor-fission",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "foresta-miceliale-trait-keeper",
           "roles": [
             "optional"
@@ -14722,7 +14967,28 @@
           "weight": 3
         },
         {
+          "species_id": "balor-fission",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "bulette-fase",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "cryo-lynx",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "golem-runico",
           "roles": [
             "optional"
           ],
@@ -14737,6 +15003,13 @@
         },
         {
           "species_id": "nano-rust-bloom",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "otyugh-sentinella",
           "roles": [
             "optional"
           ],
@@ -15518,6 +15791,13 @@
           "weight": 3
         },
         {
+          "species_id": "bulette-fase",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "dorsale-termale-tropicale-trait-keeper",
           "roles": [
             "optional"
@@ -15876,6 +16156,14 @@
       ],
       "data_origin": "pathfinder_dataset",
       "species_affinity": [
+        {
+          "species_id": "archon-solare",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
         {
           "species_id": "heliopteryx_radians",
           "roles": [
@@ -16390,6 +16678,27 @@
           "weight": 2
         },
         {
+          "species_id": "archon-solare",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "balor-fission",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
           "species_id": "foresta-miceliale-trait-keeper",
           "roles": [
             "optional"
@@ -16398,6 +16707,20 @@
         },
         {
           "species_id": "lupus-temperatus",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "marilith-vault",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "rakshasa-corte",
           "roles": [
             "optional"
           ],
@@ -16810,12 +17133,28 @@
       "data_origin": "controllo_psionico",
       "species_affinity": [
         {
+          "species_id": "banshee-risonante",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
           "species_id": "sonovespera_lamentans",
           "roles": [
             "core",
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "archon-solare",
+          "roles": [
+            "optional",
+            "synergy"
+          ],
+          "weight": 3
         },
         {
           "species_id": "auroserpens_photonicus",
@@ -16832,7 +17171,28 @@
           "weight": 3
         },
         {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
           "species_id": "dune-stalker",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "rakshasa-corte",
+          "roles": [
+            "synergy"
+          ],
+          "weight": 2
+        },
+        {
+          "species_id": "treant-portale",
           "roles": [
             "synergy"
           ],
@@ -17571,6 +17931,14 @@
       },
       "species_affinity": [
         {
+          "species_id": "cryptopennatus_psionicus",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
           "species_id": "evento-seme-uragano",
           "roles": [
             "optional"
@@ -18151,6 +18519,14 @@
       },
       "species_affinity": [
         {
+          "species_id": "echo-wing",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
+        {
           "species_id": "cactus-weaver",
           "roles": [
             "optional"
@@ -18381,6 +18757,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "golem-runico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "debolezza": "i18n:traits.matrice_antimagia.debolezza"
@@ -18416,6 +18799,13 @@
             "core"
           ],
           "weight": 3
+        },
+        {
+          "species_id": "golem-runico",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "debolezza": "i18n:traits.nuclei_di_controllo.debolezza"
@@ -18453,6 +18843,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "treant-portale",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "debolezza": "i18n:traits.corteccia_memetica.debolezza"
@@ -18489,6 +18886,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "rakshasa-corte",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "debolezza": "i18n:traits.artigli_psionici.debolezza"
@@ -18525,6 +18929,20 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "marilith-vault",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "rakshasa-corte",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "debolezza": "i18n:traits.tessuti_adattivi.debolezza"
@@ -18561,6 +18979,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "otyugh-sentinella",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "debolezza": "i18n:traits.filtri_bioattivi.debolezza"
@@ -18597,6 +19022,13 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "otyugh-sentinella",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "debolezza": "i18n:traits.membrane_osmotiche.debolezza"
@@ -18625,6 +19057,14 @@
         "design_stub": false
       },
       "species_affinity": [
+        {
+          "species_id": "ferrocolonia-magnetotattica",
+          "roles": [
+            "core",
+            "optional"
+          ],
+          "weight": 4
+        },
         {
           "species_id": "radiciforma_ancorans",
           "roles": [
@@ -18670,6 +19110,13 @@
         },
         {
           "species_id": "thermo-raptor",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        },
+        {
+          "species_id": "treant-portale",
           "roles": [
             "optional"
           ],
@@ -18734,6 +19181,55 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "archon-solare",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "aurora-gull",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "balor-fission",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "banshee-risonante",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "couatl-aurora",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "echo-wing",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "noctule-termico",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
         }
       ],
       "debolezza": "i18n:traits.adattamento_volo.debolezza"
@@ -18770,6 +19266,20 @@
             "optional"
           ],
           "weight": 4
+        },
+        {
+          "species_id": "cactus-weaver",
+          "roles": [
+            "core"
+          ],
+          "weight": 3
+        },
+        {
+          "species_id": "treant-portale",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
         }
       ],
       "debolezza": "i18n:traits.radici_ancora_planare.debolezza"
@@ -18798,7 +19308,16 @@
       "completion_flags": {
         "design_stub": false
       },
-      "debolezza": "i18n:traits.eco_sismico.debolezza"
+      "debolezza": "i18n:traits.eco_sismico.debolezza",
+      "species_affinity": [
+        {
+          "species_id": "banshee-risonante",
+          "roles": [
+            "optional"
+          ],
+          "weight": 1
+        }
+      ]
     },
     "artigli_sette_vie_2": {
       "schema_version": "2.0",

--- a/data/traits/species_affinity.json
+++ b/data/traits/species_affinity.json
@@ -41,6 +41,55 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "archon-solare",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "aurora-gull",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "balor-fission",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "banshee-risonante",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "couatl-aurora",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "echo-wing",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "noctule-termico",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
     }
   ],
   "ali_fono_risonanti": [
@@ -103,6 +152,20 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "archon-solare",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "couatl-aurora",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "antenne_dustsense": [
@@ -213,6 +276,14 @@
   ],
   "armatura_pietra_planare": [
     {
+      "species_id": "golem-runico",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
       "species_id": "lithoconstructus_inhibens",
       "roles": [
         "core",
@@ -243,7 +314,28 @@
       "weight": 3
     },
     {
+      "species_id": "balor-fission",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "bulette-fase",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "treant-portale",
       "roles": [
         "optional"
       ],
@@ -285,6 +377,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "rakshasa-corte",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "artigli_radice": [
@@ -344,7 +443,21 @@
       "weight": 3
     },
     {
+      "species_id": "balor-fission",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "caverna-risonante-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "couatl-aurora",
       "roles": [
         "optional"
       ],
@@ -372,7 +485,21 @@
       "weight": 1
     },
     {
+      "species_id": "marilith-vault",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "mezzanotte-orbitale-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "otyugh-sentinella",
       "roles": [
         "optional"
       ],
@@ -398,6 +525,14 @@
     }
   ],
   "aura_scudo_radianza": [
+    {
+      "species_id": "archon-solare",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
     {
       "species_id": "heliopteryx_radians",
       "roles": [
@@ -661,7 +796,28 @@
       "weight": 3
     },
     {
+      "species_id": "balor-fission",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "bulette-fase",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "cryo-lynx",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "golem-runico",
       "roles": [
         "optional"
       ],
@@ -676,6 +832,13 @@
     },
     {
       "species_id": "nano-rust-bloom",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "otyugh-sentinella",
       "roles": [
         "optional"
       ],
@@ -927,6 +1090,13 @@
       "weight": 3
     },
     {
+      "species_id": "bulette-fase",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "dorsale-termale-tropicale-trait-keeper",
       "roles": [
         "optional"
@@ -935,6 +1105,13 @@
     },
     {
       "species_id": "dune-stalker",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "marilith-vault",
       "roles": [
         "optional"
       ],
@@ -994,6 +1171,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "treant-portale",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "criostasi_adattiva": [
@@ -1006,6 +1190,13 @@
     },
     {
       "species_id": "aurora-gull",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "balor-fission",
       "roles": [
         "optional"
       ],
@@ -1255,6 +1446,15 @@
       "weight": 1
     }
   ],
+  "eco_sismico": [
+    {
+      "species_id": "banshee-risonante",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    }
+  ],
   "empatia_coordinativa": [
     {
       "species_id": "auroserpens_photonicus",
@@ -1294,6 +1494,27 @@
       "weight": 2
     },
     {
+      "species_id": "archon-solare",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "balor-fission",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "couatl-aurora",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "foresta-miceliale-trait-keeper",
       "roles": [
         "optional"
@@ -1302,6 +1523,20 @@
     },
     {
       "species_id": "lupus-temperatus",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "marilith-vault",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "rakshasa-corte",
       "roles": [
         "optional"
       ],
@@ -1513,6 +1748,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "otyugh-sentinella",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "filtri_planctonici": [
@@ -1542,7 +1784,38 @@
       "weight": 3
     },
     {
+      "species_id": "archon-solare",
+      "roles": [
+        "optional",
+        "synergy"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "banshee-risonante",
+      "roles": [
+        "optional",
+        "synergy"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "couatl-aurora",
+      "roles": [
+        "optional",
+        "synergy"
+      ],
+      "weight": 3
+    },
+    {
       "species_id": "cryptopennatus_psionicus",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "marilith-vault",
       "roles": [
         "core"
       ],
@@ -1557,6 +1830,13 @@
     },
     {
       "species_id": "arboryxis-lenis",
+      "roles": [
+        "synergy"
+      ],
+      "weight": 2
+    },
+    {
+      "species_id": "balor-fission",
       "roles": [
         "synergy"
       ],
@@ -1612,6 +1892,13 @@
       "weight": 1
     },
     {
+      "species_id": "rakshasa-corte",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "sentinella-radice",
       "roles": [
         "optional"
@@ -1639,6 +1926,14 @@
   ],
   "frusta_fiammeggiante": [
     {
+      "species_id": "balor-fission",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
       "species_id": "pyroflagellum_meteoriticum",
       "roles": [
         "core",
@@ -1653,6 +1948,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "marilith-vault",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
     },
     {
       "species_id": "global-trait-keeper",
@@ -1815,6 +2117,14 @@
   ],
   "grassi_termici": [
     {
+      "species_id": "sand-burrower",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
       "species_id": "cactus-weaver",
       "roles": [
         "optional"
@@ -1909,7 +2219,35 @@
       "weight": 3
     },
     {
+      "species_id": "archon-solare",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "bulette-fase",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "couatl-aurora",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "otyugh-sentinella",
       "roles": [
         "optional"
       ],
@@ -2020,6 +2358,14 @@
   ],
   "mantello_meteoritico": [
     {
+      "species_id": "balor-fission",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
       "species_id": "pyroflagellum_meteoriticum",
       "roles": [
         "core",
@@ -2034,6 +2380,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "marilith-vault",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
     },
     {
       "species_id": "global-trait-keeper",
@@ -2076,6 +2429,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "golem-runico",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "membrane_captura_rugiada": [
@@ -2104,6 +2464,13 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "otyugh-sentinella",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "membrane_planata_vectored": [
@@ -2229,6 +2596,13 @@
         "core"
       ],
       "weight": 3
+    },
+    {
+      "species_id": "golem-runico",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "nucleo_ovomotore_rotante": [
@@ -2312,6 +2686,13 @@
     },
     {
       "species_id": "aurora-gull",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "couatl-aurora",
       "roles": [
         "optional"
       ],
@@ -2459,6 +2840,14 @@
   ],
   "pelli_cave": [
     {
+      "species_id": "echo-wing",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
       "species_id": "cactus-weaver",
       "roles": [
         "optional"
@@ -2503,6 +2892,14 @@
   ],
   "pelli_fitte": [
     {
+      "species_id": "cryptopennatus_psionicus",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
+    {
       "species_id": "evento-seme-uragano",
       "roles": [
         "optional"
@@ -2527,6 +2924,14 @@
     }
   ],
   "pigmenti_aurorali": [
+    {
+      "species_id": "ferrocolonia-magnetotattica",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
     {
       "species_id": "radiciforma_ancorans",
       "roles": [
@@ -2572,6 +2977,13 @@
     },
     {
       "species_id": "thermo-raptor",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "treant-portale",
       "roles": [
         "optional"
       ],
@@ -2658,6 +3070,20 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "cactus-weaver",
+      "roles": [
+        "core"
+      ],
+      "weight": 3
+    },
+    {
+      "species_id": "treant-portale",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "random": [
@@ -2770,9 +3196,24 @@
         "optional"
       ],
       "weight": 1
+    },
+    {
+      "species_id": "treant-portale",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "risonanza_di_branco": [
+    {
+      "species_id": "banshee-risonante",
+      "roles": [
+        "core",
+        "optional"
+      ],
+      "weight": 4
+    },
     {
       "species_id": "sonovespera_lamentans",
       "roles": [
@@ -2780,6 +3221,14 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "archon-solare",
+      "roles": [
+        "optional",
+        "synergy"
+      ],
+      "weight": 3
     },
     {
       "species_id": "auroserpens_photonicus",
@@ -2796,7 +3245,28 @@
       "weight": 3
     },
     {
+      "species_id": "couatl-aurora",
+      "roles": [
+        "synergy"
+      ],
+      "weight": 2
+    },
+    {
       "species_id": "dune-stalker",
+      "roles": [
+        "synergy"
+      ],
+      "weight": 2
+    },
+    {
+      "species_id": "rakshasa-corte",
+      "roles": [
+        "synergy"
+      ],
+      "weight": 2
+    },
+    {
+      "species_id": "treant-portale",
       "roles": [
         "synergy"
       ],
@@ -2851,6 +3321,13 @@
     },
     {
       "species_id": "aurora-gull",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "bulette-fase",
       "roles": [
         "optional"
       ],
@@ -2993,6 +3470,13 @@
       "weight": 3
     },
     {
+      "species_id": "bulette-fase",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "dorsale-termale-tropicale-trait-keeper",
       "roles": [
         "optional"
@@ -3056,7 +3540,28 @@
   ],
   "sensori_geomagnetici": [
     {
+      "species_id": "bulette-fase",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "couatl-aurora",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "global-trait-keeper",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "marilith-vault",
       "roles": [
         "optional"
       ],
@@ -3244,6 +3749,13 @@
       "weight": 2
     },
     {
+      "species_id": "balor-fission",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
       "species_id": "foresta-miceliale-trait-keeper",
       "roles": [
         "optional"
@@ -3266,6 +3778,20 @@
         "optional"
       ],
       "weight": 4
+    },
+    {
+      "species_id": "marilith-vault",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
+    },
+    {
+      "species_id": "rakshasa-corte",
+      "roles": [
+        "optional"
+      ],
+      "weight": 1
     }
   ],
   "vello_condensatore_nebbie": [

--- a/docs/adr/ADR-2026-07-14-worldgen-data-model.md
+++ b/docs/adr/ADR-2026-07-14-worldgen-data-model.md
@@ -397,7 +397,41 @@ che questo repo ha appena passato un giorno a smontare.
 
 **Risoluzione adottata in `aa92afed`**: i 23 riferimenti orfani sono **preservati, non consumati**,
 sotto un campo `pending_trait_definitions:` in ogni specie (con commento). Non cancellati in
-silenzio, non fabbricati in silenzio. **Vanno autorati (Species-Curator-gated).**
+silenzio, non fabbricati in silenzio. **Vanno autorati (Trait-Curator-gated -- issue #3307).**
+
+> #### ⚠️ Aggiornamento — il numero onesto e' **13**, non 23 (verdetto Trait-Curator, verificato)
+>
+> Il Trait-Curator ha **falsificato la premessa** di questo Gap. **8 dei 23 non sono tratti**:
+> sono **marker di import** dal dataset esterno `data/external/pathfinder_bestiary_1e.json`
+> (1211 creature), che deriva meccanicamente un `genetic_traits` da un blocco `biology` di
+> booleani (`breathes: true` -> `respirazione_biologica`).
+>
+> Sulle 10 specie formano una **partizione complementare perfetta** (misurata):
+>
+> | marker                                                                                             | portato da                                                                | frequenza nel bestiario |
+> | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------- |
+> | `respirazione_biologica` · `metabolismo_attivo` · `ciclo_vitale_completo`                          | **8/8 le viventi**, 0 le altre                                            | 1052 / 1077 / 1077      |
+> | `assenza_respirazione` · `metabolismo_sostentato` · `ciclo_vitale_anomalo` · `origine_artificiale` | **2/2 le non-biologiche** (banshee `undead`, golem construct), 0 le altre | 159 / 134 / 134 / 134   |
+>
+> **Un tratto posseduto dal 100% di una classe e dallo 0% dell'altra non e' un tratto: e'
+> l'etichetta della classe.** Definirli avrebbe mosso il contatore di 8 e cambiato **nulla** --
+> la forma esatta di `M-2026-07-14-001`, stavolta **con una definizione vera come alibi**.
+>
+> L'ottavo, `fisiologia_predatoria`, e' contraddetto **tre volte** sulla `bulette-fase`:
+> `role_trofico: erbivoro_primario`, `functional_tags: [prede, detritivoro]`, e nel foodweb
+> **e' la preda** (`treant -> bulette` _herbivory_, `balor -> bulette` _predation_). Nel
+> Pathfinder la bulette e' carnivora; Evo l'ha ri-fusa come unico consumatore primario del bioma
+> e il marker d'import le e' rimasto attaccato.
+>
+> Altri **2 sono duplicati** di tratti gia' nel glossario: `sensori_chimici` ->
+> `acuita_chemorecettiva`, `voce_spettrale` -> `voce_imperiosa` (entrambi verificati esistenti).
+>
+> **Verdetto: 13 da creare · 2 duplicati · 8 riferimenti da togliere.**
+> Proposta (non applicata): `docs/planning/traits_rovine_planari_proposal.md`.
+>
+> Nota: gli stessi `adattamento_volo` / `adattamento_acquatico` vengono da quel vocabolario
+> d'import, e sono **gli unici due mai promossi a tratto vero**. La promozione e' possibile --
+> ma e' una decisione, non un automatismo.
 
 I 23: `assenza_respirazione`, `campo_di_fase`, `ciclo_vitale_anomalo`, `ciclo_vitale_completo`,
 `fisiologia_predatoria`, `fotosintesi_bifase`, `ghiandole_nettare_memetico`,

--- a/docs/adr/ADR-2026-07-14-worldgen-data-model.md
+++ b/docs/adr/ADR-2026-07-14-worldgen-data-model.md
@@ -121,15 +121,24 @@ riga L1 mancante (hazard/npc/difficolta'/narrativa). Zero contenuto perso, zero 
 > **Una specie e' un'entita' con `biomes`, `role_trofico` e almeno un tratto.**
 > Tutto il resto non e' una specie e non puo' vivere nel catalogo specie.
 
-Oggi **59 file su 105 (56%)** non lo sono: sono stub autogen da 3 righe, nati per far quadrare
-una matrice di coverage (`receipt: {source: coverage_autogen, author: automation}`).
+Oggi **63 file su 105** non lo sono. _(L'Addendum 2026-07-15 corregge i conteggi di questa
+sezione: erano 59, e la descrizione del receipt era sbagliata.)_
 
-- **I 52 stub puri sono cancellati** (con le 34 cartelle-bioma vuote). Non codificano nulla che
-  il registro dei biomi non abbia gia'. **Sono la trappola**: sono l'unico "abitante" di quei
+> 🛑 **ATTENZIONE -- questa decisione, eseguita alla lettera, distrugge contenuto autorato.**
+> **10 dei "52 stub puri" sono le specie di `rovine_planari`**, che NON sono stub: erano specie
+> complete, cancellate per errore, e la loro cicatrice dice cosi' testualmente
+> (`notes: 'stub auto-generato per **ripristinare inventario**'`). Sono state **recuperate**
+> (`aa92afed`). Vedi Addendum. **Il numero di stub cancellabili scende da 52 a 42.**
+
+- **I 42 stub puri restanti sono cancellati** (con le cartelle-bioma vuote). Non codificano nulla
+  che il registro dei biomi non abbia gia'. **Sono la trappola**: sono l'unico "abitante" di quei
   biomi, quindi chiunque insegua un contatore puo' appiccicargli tratti e azzerarlo.
-- **I 7 con `role_trofico: evento_ecologico`** NON sono rumore: `event` e' un **ruolo minimo
-  canonico del livello 2**. Vanno ricondotti al modello degli eventi (L4), non cancellati.
-- Catalogo onesto: **46 specie**, non 105.
+  **Prima di cancellare, passare ogni file al test di provenienza** (vedi Addendum): un file il
+  cui `receipt` dice `author: designer` non e' uno stub, e' una cicatrice.
+- **I `role_trofico: evento_ecologico`** NON sono rumore: `event` e' un **ruolo minimo canonico
+  del livello 2**. Vanno ricondotti al modello degli eventi (L4), non cancellati.
+  _(Sono 11 sul main misurato, non 7.)_
+- Catalogo onesto: **42 specie** sul main _(non 46)_; **52 dopo il recupero di `rovine_planari`**.
 
 ## Decisione 6 — I guard (perche' non ricresca)
 
@@ -149,10 +158,18 @@ Ogni guard con **negative control** (un guard non testato e' un guard vacuo -- L
    re-introduce il layer 3).
 2. Promuovi `cryosteppe` + `deserto_caldo` -> riga L1.
 3. Cancella i 4 alias `migrated` + il campo `biome_id` dei nodi.
-4. Cancella i 52 stub + le 34 cartelle vuote; riconduci i 7 eventi al modello L4.
+   **3b. (NUOVO, load-bearing)** I 4 alias vivono anche in `environment_affinity.biome_class` di
+   **21 specie** -- e sono le specie dei 4 biomi profondi del nucleo. Vanno ripuntati sul bioma
+   reale **nello stesso passo**, o il guard #3 le fa fallire tutte. Vedi Addendum, Gap A.
+4. ~~Cancella i 52 stub~~ -> **RECUPERA i 10 di `rovine_planari`** (fatto: `aa92afed`), poi
+   cancella i **42** restanti + le cartelle vuote; riconduci gli eventi al modello L4.
+   **Passa ogni file al test di provenienza prima di cancellarlo** (Addendum, Gap C).
 5. Elimina `biome_classes.yaml`.
 6. Accendi i 4 guard (con negative control).
-7. **Ratchet del gate coverage** (oggi `max_missing=5`, `min_traits=189`).
+   **6b. (NUOVO)** Aggiungi il **guard di provenienza**: un file specie non puo' essere cancellato
+   da automazione se il suo `receipt.author` e' `designer`. Vedi Addendum, Gap C.
+7. **Ratchet del gate coverage**. Il recupero l'ha gia' alzato: `min_traits` **189 -> 191**
+   (`max_missing` resta 5).
 
 ## Decisione 7 — `when.biome_class` significa IDENTITA' DI BIOMA. Il campo va rinominato
 
@@ -221,24 +238,43 @@ solo per quello.
 
 **TARGET = 8 biomi, ~8 specie ciascuno, con ecosistema + foodweb completi.**
 
-| #   | bioma               | famiglia         | perche' (dato, non gusto)                                                                                                        | specie        | mancano |
-| --- | ------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------- |
-| 1   | `badlands`          | arid             | foodweb + nodo                                                                                                                   | 11            | ✅      |
-| 2   | `foresta_temperata` | canopy           | foodweb + nodo                                                                                                                   | 7             | +1      |
-| 3   | `deserto_caldo`     | arid             | foodweb + **`start_node`** della meta-rete                                                                                       | 5 +1 (savana) | +2      |
-| 4   | `cryosteppe`        | arid             | foodweb + nodo                                                                                                                   | 5             | +3      |
-| 5   | `rovine_planari`    | clastic          | foodweb + eco completi, **0 abitanti**                                                                                           | **0**         | **+8**  |
-| 6   | `atollo_obsidiana`  | **littoral**     | **gia' nodo della meta-rete**; unica famiglia acquatica                                                                          | 0             | +8      |
-| 7   | `abisso_vulcanico`  | **geothermal**   | piu' specie di ogni non-core; il nucleo non ha **nessun** bioma caldo                                                            | 2             | +6      |
-| 8   | `caverna`           | **subterranean** | assorbe `caverna_risonante` -> **risolve 1 delle 6 regole orfane** e recupera **21 tratti suggeriti** che oggi puntano nel vuoto | 1 +1          | +7      |
+> ⚠️ **La tabella qui sotto e' CORRETTA dall'Addendum 2026-07-15** (in fondo al documento):
+> `rovine_planari` non era un buco, era un **recupero**, ed e' stato recuperato. Il gap totale
+> scende da ~35 a **~27**. Le righe corrette sono marcate.
+
+| #   | bioma               | famiglia         | perche' (dato, non gusto)                                                                                                        | specie               | mancano |
+| --- | ------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ------- |
+| 1   | `badlands`          | arid             | foodweb + nodo                                                                                                                   | 12 _(misurato)_      | ✅      |
+| 2   | `foresta_temperata` | canopy           | foodweb + nodo                                                                                                                   | 7                    | +1      |
+| 3   | `deserto_caldo`     | arid             | foodweb + **`start_node`** della meta-rete                                                                                       | 5 +1 (savana)        | +2      |
+| 4   | `cryosteppe`        | arid             | foodweb + nodo                                                                                                                   | 5                    | +3      |
+| 5   | `rovine_planari`    | clastic          | foodweb + eco completi; **le 10 specie erano state cancellate, sono state RECUPERATE** (Addendum)                                | **10** _(#aa92afed)_ | **✅**  |
+| 6   | `atollo_obsidiana`  | **littoral**     | **gia' nodo della meta-rete**; unica famiglia acquatica. Buco VERO (verificato: mai autorate)                                    | 0                    | +8      |
+| 7   | `abisso_vulcanico`  | **geothermal**   | piu' specie di ogni non-core; il nucleo non ha **nessun** bioma caldo                                                            | 2                    | +6      |
+| 8   | `caverna`           | **subterranean** | assorbe `caverna_risonante` -> **risolve 1 delle 6 regole orfane** e recupera **21 tratti suggeriti** che oggi puntano nel vuoto | 1 +1                 | +7      |
 
 > Il nucleo-5 copriva solo `arid`/`canopy`/`clastic`: **niente acqua, niente calore, niente
 > sottosuolo**. Il nucleo-8 copre **6 famiglie ecologiche su 10**.
 
 ### QUANTO MANCA (il numero che finora non esisteva)
 
-> **≈ 35 specie da autorare + 3 foodweb + 3 nodi di rete.**
-> `rovine_planari` da solo ne vale 8: modellato in ogni dettaglio, **senza un solo abitante**.
+> **≈ 27 specie da autorare + 3 foodweb + 2 nodi di rete.** _(era ~35 + 3 + 3; corretto
+> dall'Addendum 2026-07-15)_
+> `rovine_planari` **non e' piu' nel conto**: le sue 10 specie non erano da autorare, erano da
+> **recuperare** -- erano state autorate il 2025-10-29 e distrutte due giorni dopo. Il nodo di
+> rete ce l'ha gia'.
+
+**Il gap non e' "27 specie generiche". E' quali RUOLI mancano in quale bioma** (i ruoli minimi
+del livello 2 -- `apex`/`keystone`/`bridge`/`threat`/`event`):
+
+| bioma              | specie vere | eco | foodweb | nodo | **ruoli mancanti**                        |
+| ------------------ | ----------- | --- | ------- | ---- | ----------------------------------------- |
+| `atollo_obsidiana` | 0           | ✅  | ❌      | ✅   | **apex, keystone, bridge, threat, event** |
+| `abisso_vulcanico` | 2           | ✅  | ❌      | ❌   | **keystone, bridge, event**               |
+| `caverna`          | 1           | ✅  | ❌      | ❌   | **apex, keystone, bridge, event**         |
+
+`foresta_temperata` (+1), `deserto_caldo` (+2) e `cryosteppe` (+3) hanno gia' **tutti e cinque**
+i ruoli minimi coperti: il loro gap e' **profondita'**, non copertura. Vanno dopo, non prima.
 
 **I 13 biomi fuori dal nucleo vengono ARCHIVIATI** (museum card, **non** cancellati): escono dal
 gioco e dalle metriche, restano nel Museum come idee. Il catalogo smette di promettere un mondo
@@ -277,3 +313,167 @@ codice, non l'opinione.
 - Censimento `docs/planning/2026-07-14-content-substrate-census.md` (#3304)
   — ⚠️ **da correggere**: dice "5 ecosistemi", sono **21** (contava `.biome.yaml`)
 - Issue #3302, #3299
+
+---
+
+## Addendum 2026-07-15 — `rovine_planari` era un RECUPERO. E i conteggi non riproducevano
+
+> Sessione di indagine (nessuna specie autorata). Ogni numero qui sotto e' **misurato** contro
+> file e git. Le correzioni ai numeri sono gia' applicate inline sopra; qui c'e' il perche' e i
+> gap che l'ADR non vedeva.
+
+### Il fatto principale: `rovine_planari` non era un buco
+
+L'ADR lo dava a **`0` abitanti, `+8`, il singolo buco piu' grande del gioco**. Era falso.
+
+| quando         | commit     | cosa                                                                                             |
+| -------------- | ---------- | ------------------------------------------------------------------------------------------------ |
+| **2025-10-29** | `e83c810c` | crea `rovine_planari` **completo**: 10 specie autorate (83-103 righe, `author: designer`)        |
+| **2025-10-31** | `5a06b64b` | _"docs(tri_sorgente): introduce variant docs"_ -- cancella **302.220 righe su 932 file**         |
+| **2025-12-09** | `9acadc69` | _"Restore ... species inventory"_ -- recupera `badlands`, ma di `rovine_planari` solo i **nomi** |
+| **2026-07-15** | `aa92afed` | **RECUPERO**: le 10 specie tornano, gate verdi                                                   |
+
+Le specie erano **danno collaterale** di una cancellazione di massa travestita da commit di
+documentazione. Il "restore" del 2025-12-09 e' riuscito a meta': ha recuperato l'inventario dei
+nomi, non i corpi -- e lo ha **detto**, nella nota che ha lasciato nei file:
+`notes: 'stub auto-generato per **ripristinare inventario**: sostituire con specifica completa.'`
+
+**Ecosistema e foodweb sono sopravvissuti e nominano ancora tutte e 10 le specie per `id` esatto**
+(`.ecosystem.yaml` -> produttori/consumatori/decompositori; `_foodweb.yaml` -> 10 nodi
+`kind: species` + 24 archi). Il bioma non aveva zero abitanti: aveva **l'impronta di dieci
+abitanti in ogni livello dello stack, e i corpi vuoti**.
+
+Le 10 recuperate soddisfano **da sole tutte e cinque** le `rules.at_least` del proprio ecosistema
+(apex 1, keystone 2, bridge 2, threat 3, event 1) e **tutte e 10 passano la Decisione 5**.
+
+**Controllo negativo** (e' cio' che rende il finding affidabile): lo stesso metodo **falsifica** il
+recupero per `atollo_obsidiana`. Il suo ecosystem nomina 3 specie (`anguis-magnetica`,
+`vitricyba-punctata`, `magnetocola-pastoris`) e **nessuna e' mai esistita come file in git**.
+`atollo_obsidiana` e' un **buco vero**. Il metodo discrimina: non dice "recupero" a tutto.
+
+---
+
+### Gap A (P1, load-bearing) — `biome_class` ha un TERZO posto, e l'ADR ne vede due
+
+La Decisione 7 misura l'overload su `env_traits.json` (le regole) e su `biomes.yaml` (il campo).
+Ne manca uno: **`environment_affinity.biome_class` dentro i file specie**.
+
+Misurato: **0 su 16** valori distinti usano la famiglia ecologica. Sono **tutti** identita' di
+bioma -- la stessa identica patologia, in un posto che l'ADR non nomina.
+
+Peggio: **21 specie ci portano dentro i 4 alias fabbricati** che la Decisione 4 vuole cancellare.
+E non sono specie qualsiasi: sono **tutte e sole quelle dei 4 biomi profondi del nucleo**.
+
+| alias fabbricato            | usato da                           | specie |
+| --------------------------- | ---------------------------------- | ------ |
+| `dorsale_termale_tropicale` | le 7 specie di `badlands`          | 7      |
+| `mezzanotte_orbitale`       | le 5 specie di `cryosteppe`        | 5      |
+| `abisso_vulcanico` (!)      | le 5 specie di `deserto_caldo`     | 5      |
+| `foresta_miceliale`         | le 4 specie di `foresta_temperata` | 4      |
+
+**Conseguenza**: cancellare i 4 alias (Decisione 4) **senza** ripuntare queste 21 specie fa
+fallire il **guard #3** (bioma referenziato inesistente) su tutto il nucleo del gioco.
+-> Aggiunto come **passo 3b** dell'ordine di migrazione.
+
+---
+
+### Gap B (P1) — le specie di `rovine_planari` referenziano 23 tratti MAI definiti
+
+Le 10 specie recuperate referenziano **53 tratti**, di cui **23 non hanno voce in
+`data/core/traits/glossary.json`** -- e non l'hanno mai avuta (verificato: **0 su 24** sono mai
+esistiti come file `data/traits/*/*.json`). **Le specie erano state autorate in anticipo sul
+catalogo tratti.** Il recupero e' quindi **meta' recupero**: la meta' specie e' sopravvissuta, la
+meta' tratti non e' mai stata scritta.
+
+Questo e' un **vettore di fabbricazione**, non un dettaglio: `build_species_trait_bridge.py:145`
+fa `trait_index.setdefault(trait_id, {})`. Rigenerare il bridge con quei 23 riferimenti avrebbe
+creato **23 voci di tratto nude, senza definizione** -- esattamente la forma della copertura finta
+che questo repo ha appena passato un giorno a smontare.
+
+> **L'invariante vero del repo e' il glossario**, non il per-trait DB: **203 su 203** tratti del
+> bridge hanno una voce nel glossario (zero eccezioni); solo 3 non hanno un file per-trait, e
+> quello **e' tollerato**. Chi tocca il bridge deve difendere il glossario, non il DB.
+
+**Risoluzione adottata in `aa92afed`**: i 23 riferimenti orfani sono **preservati, non consumati**,
+sotto un campo `pending_trait_definitions:` in ogni specie (con commento). Non cancellati in
+silenzio, non fabbricati in silenzio. **Vanno autorati (Species-Curator-gated).**
+
+I 23: `assenza_respirazione`, `campo_di_fase`, `ciclo_vitale_anomalo`, `ciclo_vitale_completo`,
+`fisiologia_predatoria`, `fotosintesi_bifase`, `ghiandole_nettare_memetico`,
+`intangibilita_parziale`, `lamenti_diradanti`, `maschera_illusoria`, `metabolismo_attivo`,
+`metabolismo_sostentato`, `nodi_micotici`, `origine_artificiale`, `proboscide_polifaga`,
+`respirazione_biologica`, `riflessi_preternaturali`, `rinforzi_modulari`, `secrezioni_antisepsi`,
+`sensori_chimici`, `sinapsi_riflettenti`, `visione_spettrale`, `voce_spettrale`.
+
+---
+
+### Gap C (P1) — la Decisione 5, eseguita alla lettera, ricancella il contenuto recuperato
+
+Il passo 4 diceva _"cancella i 52 stub puri"_. **10 di quei 52 erano `rovine_planari`.**
+L'automazione avrebbe distrutto lo stesso contenuto **una seconda volta**, e stavolta
+definitivamente rispetto al modello.
+
+**Il discriminante non e' la dimensione del file. E' `receipt.source`.**
+
+| `receipt`                                         | cos'e'         | esempio                         |
+| ------------------------------------------------- | -------------- | ------------------------------- |
+| `author: designer` + fonte reale                  | **autorato**   | `PF1E.Bestiary.v1`, `PTPF.v1.0` |
+| `author: automation` + `source: coverage_autogen` | **fabbricato** | i `*-trait-keeper.yaml`         |
+| _(nessun receipt)_                                | **stub**       | i 42 stub puri restanti         |
+
+Un grep ingenuo _"recupera ogni stub che un tempo aveva contenuto"_ restituisce **34 file**. **21**
+di questi sono `*-trait-keeper.yaml` con **59 righe** di contenuto -- sembrano ricchi. Ma il loro
+`receipt` dice `coverage_autogen`: recuperarli **reintroduce la malattia**. Solo **13** sono
+contenuto vero (i 10 di `rovine_planari` + 3 fuori dal nucleo: `psionic-canopy-scout`,
+`magnet-fathom-surveyor`, `orbital-ascendant`, `PTPF.v1.0`, ~84 righe -- preservati in git, i loro
+biomi sono archiviati dall'ADR).
+
+-> **Guard di provenienza** aggiunto come passo **6b**: nessuna automazione cancella un file specie
+il cui `receipt.author` e' `designer`.
+
+---
+
+### Gap D — i conteggi della Decisione 5 non riproducono
+
+Misurato sul `main` pre-recupero, applicando la Decisione 5 **come e' scritta**
+(`biomes` + `role_trofico` + >=1 tratto):
+
+| l'ADR dice                                         | misurato                     |
+| -------------------------------------------------- | ---------------------------- |
+| catalogo onesto: **46 specie**                     | **42**                       |
+| **59** file non-specie                             | **63**                       |
+| **7** con `role_trofico: evento_ecologico`         | **11**                       |
+| i 52 stub hanno `receipt.source: coverage_autogen` | **falso: non hanno receipt** |
+
+La causa del delta: **11 file portano un receipt** (quindi l'ADR li conta fra i "veri") ma hanno
+**zero tratti** -- falliscono la Decisione 5. Sei di questi stanno **nei biomi del nucleo**:
+
+- `receipt: runtime-generator`, 0 tratti -> `magneto-ridge-hunter`, `slag-veil-ambusher`
+  (badlands) · `aurora-bridge-runner`, `zephyr-spore-courier` (cryosteppe) ·
+  `glowcap-weaver`, `myco-spire-warden` (foresta_temperata)
+- `receipt: M5-#3.stub` / `M13-P6.stub`, 0 tratti -> 5 specie del bioma `tutorial`
+
+**Post-recupero il catalogo onesto e' 52.** Non e' un miglioramento cosmetico: sono 10 specie vere
+in piu' e 4 numeri che ora si possono verificare.
+
+---
+
+### Evidenza dei gate (misurata prima/dopo, non asserita)
+
+| gate                                   | prima (main) | dopo (`aa92afed`)   | soglia    |
+| -------------------------------------- | ------------ | ------------------- | --------- |
+| `traits_with_species`                  | 189          | **191**             | min 189   |
+| `rules_missing_species_total`          | 5            | 5                   | max 5     |
+| `check_derived_reproducible.py --deep` | 3/3 OK       | **3/3 OK**          | enforcing |
+| `validate_datasets.py`                 | valid        | valid               | —         |
+| `trait_audit.py --check`               | no regress.  | no regress.         | —         |
+| trait-bridge: trait-id                 | 203          | 204 (+1, 0 rimossi) | —         |
+
+Il `+1` e' `eco_sismico`, **definito nel glossario**. Nessuna voce fabbricata.
+
+> Il valore del recupero **non e' il contatore** (+2 tratti coperti). Sono le **10 specie**.
+
+### Riferimenti aggiunti
+
+- Carte museum `M-2026-07-15-*` (recupero + la lezione della provenienza)
+- Commit del recupero: `aa92afed`

--- a/docs/adr/ADR-2026-07-14-worldgen-data-model.md
+++ b/docs/adr/ADR-2026-07-14-worldgen-data-model.md
@@ -339,12 +339,13 @@ nomi, non i corpi -- e lo ha **detto**, nella nota che ha lasciato nei file:
 `notes: 'stub auto-generato per **ripristinare inventario**: sostituire con specifica completa.'`
 
 **Ecosistema e foodweb sono sopravvissuti e nominano ancora tutte e 10 le specie per `id` esatto**
-(`.ecosystem.yaml` -> produttori/consumatori/decompositori; `_foodweb.yaml` -> 10 nodi
-`kind: species` + 24 archi). Il bioma non aveva zero abitanti: aveva **l'impronta di dieci
-abitanti in ogni livello dello stack, e i corpi vuoti**.
+(`.ecosystem.yaml` -> produttori/consumatori/decompositori; `_foodweb.yaml` -> 14 nodi, di cui
+**10 `kind: species`**, e **23 archi**). Il bioma non aveva zero abitanti: aveva **l'impronta di
+dieci abitanti in ogni livello dello stack, e i corpi vuoti**.
 
-Le 10 recuperate soddisfano **da sole tutte e cinque** le `rules.at_least` del proprio ecosistema
-(apex 1, keystone 2, bridge 2, threat 3, event 1) e **tutte e 10 passano la Decisione 5**.
+Le 10 recuperate soddisfano **da sole tutte e cinque** le `rules.at_least` del proprio ecosistema.
+Il requisito e' **`>= 1` per ciascuno** dei cinque ruoli; il set recuperato **consegna** apex 1,
+keystone 2, bridge 2, threat 3, event 1. E **tutte e 10 passano la Decisione 5**.
 
 **Controllo negativo** (e' cio' che rende il finding affidabile): lo stesso metodo **falsifica** il
 recupero per `atollo_obsidiana`. Il suo ecosystem nomina 3 specie (`anguis-magnetica`,

--- a/docs/museum/MUSEUM.md
+++ b/docs/museum/MUSEUM.md
@@ -24,6 +24,9 @@
 - [Enneagramma Mechanics Registry — 16 hook stub](cards/enneagramma-mechanics-registry.md) — **5/5** · plug-in `enneaEffects.js` 3h · unintegrated
 - [Enneagramma Dataset — 9 tipi canonical](cards/enneagramma-dataset-9-types.md) — **5/5** · Skiv voice palette type 5/7 · unintegrated
 - [Coverage fabbricata: 5 strati impilati](cards/lesson-coverage-fabrication-five-layers.md) — **5/5** · 🆕 2026-07-14 · LESSON: gate a zero per 7 mesi, numero onesto 9; metodo REMOVE-THEN-REMEASURE · superseded
+- [`receipt.source` e' il discriminante, non le righe](cards/lesson-receipt-provenance-scar-vs-lie.md) — **5/5** · 🆕 2026-07-15 · LESSON: la meta' opposta di M-001 — filtra per PROVENIENZA, mai per dimensione; 21 keeper da 59 righe stavano per essere "recuperati" · curated
+- [rovine_planari: cicatrice, non buco](cards/worldgen-rovine-planari-recovery.md) — **5/5** · 🆕 2026-07-15 · ✅ RECOVERED (aa92afed): 10 specie autorate 2025-10-29, distrutte da un commit "docs" da -302k righe; TARGET 35 → 27 · revived
+- [Specie autorate prima del catalogo tratti](cards/lesson-species-authored-ahead-of-trait-catalog.md) — **4/5** · 🆕 2026-07-15 · 23 tratti orfani; `setdefault` a build_species_trait_bridge.py:145 li fabbricherebbe · unintegrated
 - [Worldgen Stack 4-livelli](cards/worldgen-bioma-ecosistema-foodweb-network-stack.md) — **5/5** · ✅ REVIVED 2026-07-14 (ADR #3302 adotta lo stack come modello enforced) · **aveva predetto il fallimento** · revived
 - [Bioma come pacchetto gameplay+fiction](cards/worldgen-biome-as-gameplay-fiction-package.md) — **5/5** · 5/7 campi biomes.yaml non consumati; spec per ogni nuova promozione a bioma giocabile · reviewed
 - [Due vocabolari bioma orfani](cards/worldgen-biome-vocabularies-orphan.md) — **4/5** · 🆕 2026-07-14 · 12 biomi reali mai cablati + 21 nomi fabbricati, cancellati dall'ADR · unintegrated
@@ -114,6 +117,8 @@ _Pool secco. 10/10 species in `incoming/species/*.json` già canonical via commi
 ### Pipeline failure modes
 
 - [Coverage fabbricata: 5 strati impilati](cards/lesson-coverage-fabrication-five-layers.md) — score 5/5 · 🆕 **LESSON** · gate copertura trait a zero per 7 mesi (2025-12-03 → 2026-07-14); numero onesto = 9. 5 artefatti fabbricati impilati, tutti runtime-inerti. **Metodo: REMOVE-THEN-REMEASURE** — un `max_missing = 73` fantasma stava per essere baselineato in CI · superseded
+- [`receipt.source` e' il discriminante, non il numero di righe](cards/lesson-receipt-provenance-scar-vs-lie.md) — score 5/5 · 🆕 **LESSON** · la **meta' opposta** di M-2026-07-14-001: quella rimuove il falso (_remove-then-remeasure_), questa evita di cancellare il vero ferito (_filter-by-provenance_). Un grep "recupera ogni stub da 3 righe" restituiva 34 file: 21 erano keeper `coverage_autogen` da **59 righe** — recuperarli avrebbe re-introdotto la malattia. **Il numero di righe non e' un segnale; `receipt` si'** · curated
+- [Specie autorate prima del catalogo tratti](cards/lesson-species-authored-ahead-of-trait-catalog.md) — score 4/5 · 🆕 23 tratti riferiti dalle specie e **mai definiti**; `build_species_trait_bridge.py:145` (`setdefault`) li avrebbe **fabbricati** come voci nude. Terzo modo di fabbricare copertura: **automatico, senza che nessuno decida** · unintegrated
 - [evo-swarm run #5 discarded claims](cards/evo-swarm-run-5-discarded-claims.md) — score 4/5 · 8 hallucinated + 2 redundant, OD-022 gate reference + LLM prompt training · curated (⚠️ user-requested autonomous deviation Museum-first protocol — repo-archaeologist agent review pending)
 
 _Restanti: 22 artifact in inventory (1 ADR formally Superseded + 4 partial supersedes + DEPRECATED.md cleanup + concept-explorations vertical-slice). Vedi [excavations/2026-04-25-architecture-inventory.md](excavations/2026-04-25-architecture-inventory.md)._
@@ -129,6 +134,7 @@ _Restanti: 22 artifact in inventory (1 ADR formally Superseded + 4 partial super
 - [16 Forme MBTI come seed evolutivi](cards/worldgen-forme-mbti-as-evolutionary-seed.md) — score 4/5 · starter_bioma undefined; eseguibile solo post-ADR (serviva un modello bioma stabile) · reviewed
 - [Emergenza specie da ecosistema](cards/worldgen-species-emergence-from-ecosystem.md) — score 4/5 · biome_pools.json role_templates non esposti a spawn; substrato reale = 46/105 specie (56% stub) · reviewed
 - [Cross-bioma event propagation](cards/worldgen-cross-bioma-events-propagation.md) — score 4/5 · **ha salvato 2 biomi**: deserto_caldo + cryosteppe sono origini cross-event, stavano per essere rimossi · reviewed
+- [rovine_planari: una cicatrice, non un buco](cards/worldgen-rovine-planari-recovery.md) — score 5/5 · 🆕 ✅ **RECOVERED 2026-07-14** (`aa92afed`) — le 10 specie erano autorate (`e83c810c`, 2025-10-29) e distrutte per **danno collaterale** da `5a06b64b`, un commit "docs" da **-302.220 righe**. Ecosistema e foodweb (impronta) le nominavano tutte per id. **TARGET nucleo-8: ~35 → ~27**. Controllo negativo: `atollo_obsidiana` **e'** un buco vero · revived
 - [Bridge species network glue](cards/worldgen-bridge-species-network-glue.md) — score 3/5 · 3 bridge species nel pack ecosystem, non in data/core · unintegrated
 
 📎 **Gallery**: [galleries/worldgen.md](galleries/worldgen.md) — 7 card worldgen, gap analysis completo, reuse path consolidato tier 1/2/3. _(NB: gallery non aggiornata con le 3 card 2026-07-14 — pending.)_
@@ -163,12 +169,12 @@ _Restanti: 22 artifact in inventory (1 ADR formally Superseded + 4 partial super
 
 ## 📊 Stats
 
-- **Excavations run**: 14 totali (4 session-1 + 4 session-2 + 1 session-3: worldgen + 1 session-5: ancestors reentry + 1 session-6 cross-validation 2026-05-13 + 1 session-7 Phase 3 Path D methodology 2026-05-15 + 1 session-8 coop WS test infra 2026-05-20 + **1 session-9 curate pre-ADR biome/species 2026-07-14**)
-- **Artifact identificati**: ~112 totali (107 precedenti + 5 artefatti pre-cancellazione ADR #3302)
-- **Cards total**: 39 curate (10 score 5/5 · 14 score 4/5 · 13 score 3/5 · 2 score 2/5) — +4 session-9
-- **Lifecycle**: 2 `revived` (mating engine, worldgen stack 4-livelli) · 5 `reviewed` (worldgen cluster, 2026-07-14)
-- **Galleries**: 3 (enneagramma + ancestors + worldgen) — worldgen gallery **pending** update per le 3 card 2026-07-14
-- **Last excavate**: **2026-07-14** (session 9 curate-mode pre-ADR: saga coverage-fabrication 5 strati + 2 vocabolari bioma orfani + key overload + convention leak; M-2026-07-14-001..004)
+- **Excavations run**: 15 totali (4 session-1 + 4 session-2 + 1 session-3: worldgen + 1 session-5: ancestors reentry + 1 session-6 cross-validation 2026-05-13 + 1 session-7 Phase 3 Path D methodology 2026-05-15 + 1 session-8 coop WS test infra 2026-05-20 + 1 session-9 curate pre-ADR biome/species 2026-07-14 + **1 session-10 recovery rovine_planari 2026-07-15**)
+- **Artifact identificati**: ~115 totali (112 precedenti + 3 session-10)
+- **Cards total**: 42 curate (12 score 5/5 · 15 score 4/5 · 13 score 3/5 · 2 score 2/5) — +3 session-10
+- **Lifecycle**: 3 `revived` (mating engine, worldgen stack 4-livelli, **rovine_planari recovery**) · 5 `reviewed` (worldgen cluster, 2026-07-14)
+- **Galleries**: 3 (enneagramma + ancestors + worldgen) — worldgen gallery **pending** update per le card 2026-07-14/15
+- **Last excavate**: **2026-07-15** (session 10: recovery `rovine_planari` + lezione `receipt`-as-discriminator + 23 tratti orfani; M-2026-07-15-001..003)
 - **Coverage**: **100%+** (9/9 domain + indie research cluster nuovi)
 - **Skiv unblock**: 8/11 card hanno reuse path Skiv-aware (Sprint A: 2, Sprint B: 1, Sprint C: 4, biome-mover differentiation: 1)
 - **Cross-agent validation**: ✅ PASS 2026-04-25 (creature-aspect-illuminator consulted MUSEUM.md spontaneously, 6 GAP found, 10-15min saved)
@@ -227,7 +233,10 @@ docs/museum/
 │   ├── lesson-coverage-fabrication-five-layers.md           # M-2026-07-14-001 score 5/5 (NEW — LESSON)
 │   ├── worldgen-biome-vocabularies-orphan.md                # M-2026-07-14-002 score 4/5 (NEW)
 │   ├── worldgen-biome-class-key-overload.md                 # M-2026-07-14-003 score 3/5 (NEW)
-│   └── worldgen-network-node-id-uppercase-leak.md           # M-2026-07-14-004 score 3/5 (NEW)
+│   ├── worldgen-network-node-id-uppercase-leak.md           # M-2026-07-14-004 score 3/5
+│   ├── worldgen-rovine-planari-recovery.md                  # M-2026-07-15-001 score 5/5 (NEW — RECOVERED)
+│   ├── lesson-receipt-provenance-scar-vs-lie.md             # M-2026-07-15-002 score 5/5 (NEW — LESSON)
+│   └── lesson-species-authored-ahead-of-trait-catalog.md    # M-2026-07-15-003 score 4/5 (NEW)
 └── galleries/
     ├── ancestors.md                                         # 1 card aggregato
     ├── enneagramma.md                                       # 3 cards aggregato
@@ -249,6 +258,16 @@ docs/museum/
 ---
 
 ## 📅 Last verified
+
+**2026-07-15** — Session 10, **recovery-mode**. La sessione precedente aveva rimosso 5 strati di copertura **fabbricata**. Questa ha trovato il fallimento **inverso**: contenuto **reale**, ferito, scambiato per fabbricazione.
+
+**3 card nuove** (M-2026-07-15-001..003), branch `fix/rovine-planari-recovery` (`aa92afed`), ogni SHA verificato con `git show --stat`:
+
+- **M-001 5/5 RECOVERED** — `worldgen-rovine-planari-recovery.md`. ADR-2026-07-14 Decision 10 contava `rovine_planari` come **il buco piu' grande: +8 specie**. Non era un buco, era una **cicatrice**: le 10 specie erano autorate per intero in `e83c810c` (2025-10-29, `receipt.author: designer`, 88-108 righe l'una) e distrutte due giorni dopo per **danno collaterale** da `5a06b64b` — un commit intitolato **"docs(tri_sorgente)"** che ha cancellato **932 file e 302.220 righe**, workflow CI inclusi. `9acadc69` ("Restore") ne ha recuperato **solo i nomi**: 10 stub da 3 righe. **Ecosistema e foodweb sono sopravvissuti** e nominavano tutte e 10 le specie per id esatto (10 nodi `kind: species`, 23 edge): il bioma aveva l'impronta di dieci abitanti a ogni livello dello stack, e i corpi vuoti. **Recuperate.** TARGET nucleo-8: **~35 → ~27 specie**. **Controllo negativo**: lo stesso metodo **falsifica** il recupero di `atollo_obsidiana` — le sue 3 specie non sono **mai** esistite come file. Quello e' un buco vero.
+- **M-002 5/5 LESSON** — `lesson-receipt-provenance-scar-vs-lie.md`. **La meta' opposta di M-2026-07-14-001.** Un grep ingenuo — _"recupera ogni stub da 3 righe che una volta aveva contenuto"_ — restituiva **34 file**. **21** erano `*-trait-keeper.yaml` che in git pesano **59 righe**: sembrano ricchi. La loro ricevuta dice `source: coverage_autogen` / `author: automation` — sono **esattamente lo strato fabbricato rimosso il giorno prima**. Recuperarli avrebbe **re-introdotto la malattia**. **Il numero di righe non e' un segnale. La provenienza si'.** `receipt` e' il marcatore onesto sopravvissuto a ogni strato di fabbricazione — proprio perche' **nessuna metrica lo consuma**.
+- **M-003 4/5** — `lesson-species-authored-ahead-of-trait-catalog.md`. Le 10 specie riferiscono **34 tratti unici**; **23 non hanno voce nel glossario e non l'hanno mai avuta**. `build_species_trait_bridge.py:145` fa `trait_index.setdefault(trait_id, {})` — rigenerare il bridge **fabbricherebbe 23 voci nude**. E' il **terzo modo** di fabbricare copertura, ed e' il piu' insidioso: **avviene da solo**. Risoluzione: preservati, non consumati, sotto `pending_trait_definitions:`.
+
+> **La coppia di lezioni**: M-2026-07-14-001 = _remove-then-remeasure_ (non trattare il fabbricato come reale). M-2026-07-15-002 = _filter-by-provenance_ (non trattare il reale ferito come fabbricato). Applicare solo la prima porta a **cancellare cicatrici**. Applicare solo la seconda porta a **resuscitare bugie**. Il repo ha corso **entrambi i rischi nella stessa settimana**.
 
 **2026-07-14** — Session 9, **curate-mode pre-ADR** (issue #3302, modello dati biome/species). L'ADR sta per **cancellare** artefatti che contengono informazione riusabile: curati **prima** della cancellazione (il museo e' additive-only, l'ADR no).
 

--- a/docs/museum/cards/lesson-coverage-fabrication-five-layers.md
+++ b/docs/museum/cards/lesson-coverage-fabrication-five-layers.md
@@ -117,6 +117,8 @@ Tutti e quattro gli slug "migrati" sono **ancora vivi con specie reali**. E' una
 - **59 / 105** file specie sono stub autogenerati (**56%**).
 - `rovine_planari`: **10 file, 10 stub, 0 specie reali**. Un bioma intero fatto di niente.
 
+> **CORREZIONE 2026-07-15** (`aa92afed`): la riga qui sopra e' **sbagliata**, e questa card ha contribuito a farla credere. I 10 stub di `rovine_planari` **non** erano fabbricazione: erano le **lapidi** di 10 specie autorate per intero (`author: designer`, `source: PF1E.Bestiary.v1`) e distrutte per danno collaterale da `5a06b64b`. **Sono state recuperate.** Il censimento corretto e' **49/105** stub. Vedi [M-2026-07-15-001](worldgen-rovine-planari-recovery.md) e la lezione [M-2026-07-15-002](lesson-receipt-provenance-scar-vs-lie.md).
+
 ## Why it was buried
 
 Non e' stato sepolto: e' stato **costruito**, strato su strato, ognuno in buona fede per far tornare verde un gate.
@@ -205,6 +207,18 @@ Censimento: [docs/planning/2026-07-14-content-substrate-census.md](../../plannin
 
 ## Cross-links
 
+### ⚠️ La meta' opposta di questa lezione (leggere INSIEME)
+
+- [M-2026-07-15-002 -- `receipt.source` e' il discriminante, non il numero di righe](lesson-receipt-provenance-scar-vs-lie.md)
+
+> Questa card insegna a **rimuovere il falso** (_remove-then-remeasure_). M-2026-07-15-002 insegna il fallimento **inverso**: **uno stub onesto sopravvissuto a un restauro parziale NON e' uno stub fabbricato**, e trattarlo come tale **distrugge contenuto reale**. Il giorno dopo la rimozione dei 5 strati, un grep "recupera ogni stub da 3 righe che una volta aveva contenuto" restituiva **34 file**: **10 erano specie vere** (`author: designer`), **21 erano i keeper `coverage_autogen`** di questa card -- e in git pesano **59 righe**, piu' di alcune specie reali. **Filtrare per dimensione avrebbe recuperato la malattia e lasciato la cicatrice.** Il filtro giusto e' `receipt`.
+>
+> Applicare solo M-001 porta a **cancellare cicatrici**. Applicare solo M-2026-07-15-002 porta a **resuscitare bugie**. Sono due meta' della stessa lezione.
+
+### Altre
+
+- [M-2026-07-15-001 -- rovine_planari: una cicatrice, non un buco](worldgen-rovine-planari-recovery.md) -- 10 specie recuperate; **il "56% stub" di questa card e' ora 10 file piu' onesto**
+- [M-2026-07-15-003 -- Specie autorate prima del catalogo tratti](lesson-species-authored-ahead-of-trait-catalog.md) -- il **terzo** modo di fabbricare copertura: `setdefault` in un generatore
 - [M-2026-07-14-002 -- Due vocabolari bioma orfani](worldgen-biome-vocabularies-orphan.md)
 - [M-2026-07-14-003 -- `biome_class`: una chiave, due significati](worldgen-biome-class-key-overload.md)
 - [M-2026-07-14-004 -- Node id MAIUSCOLI: convention leak](worldgen-network-node-id-uppercase-leak.md)

--- a/docs/museum/cards/lesson-receipt-provenance-scar-vs-lie.md
+++ b/docs/museum/cards/lesson-receipt-provenance-scar-vs-lie.md
@@ -1,0 +1,146 @@
+---
+title: "`receipt.source` e' il discriminante, non il numero di righe: distinguere una cicatrice da una bugia"
+museum_id: M-2026-07-15-002
+type: decision
+domain: [architecture]
+provenance:
+  found_at: 'packs/evo_tactics_pack/data/species/**/*.yaml -- campo `receipt` (source + author)'
+  git_sha_first: '089b6aa0'
+  git_sha_last: 'aa92afed'
+  last_modified: '2026-07-14'
+  last_author: 'Eduardo Scarpelli'
+  buried_reason: forgotten
+relevance_score: 5
+reuse_path: "packs/evo_tactics_pack/data/species/**/*.yaml:2-6 -- il campo `receipt` e' l'unico filtro affidabile prima di QUALSIASI recupero di massa da git"
+related_pillars: [P1, P3, P6]
+status: curated
+excavated_by: repo-archaeologist
+excavated_on: 2026-07-15
+last_verified: 2026-07-15
+---
+
+# `receipt.source` e' il discriminante, non il numero di righe
+
+## Summary (30s)
+
+- Questa card e' **la meta' opposta** di [M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md). Quella insegnava _remove-then-remeasure_: **rimuovi il falso**. Questa insegna il fallimento inverso: **uno stub onesto sopravvissuto a un restauro parziale NON e' uno stub fabbricato**, e trattarlo come tale **distrugge contenuto reale**.
+- Un grep ingenuo -- _"recupera ogni stub da 3 righe che una volta aveva contenuto"_ -- restituiva **34 file**. **21** di quelli sono `*-trait-keeper.yaml` che in git pesano **59 righe**: sembrano ricchi. La loro ricevuta dice `source: coverage_autogen` / `author: automation`. Sono **esattamente lo strato fabbricato** che il repo aveva appena passato un giorno a rimuovere. Recuperarli avrebbe **re-introdotto la malattia**.
+- **Il numero di righe non e' un segnale. La provenienza si'.** `receipt` e' il marcatore onesto che e' sopravvissuto a ogni strato di fabbricazione, ed e' l'unica cosa che permette di distinguere una **cicatrice** da una **bugia**.
+
+## What was buried
+
+Il campo `receipt`, in testa a ogni file specie del pack. Non e' consumato dal runtime, non e' letto da nessun gate, non compare in nessun report. E' l'unica cosa nel catalogo che dica **chi ha scritto questo file e da dove viene**.
+
+### Le due ricevute
+
+**Contenuto reale** (`e83c810c`, 2025-10-29 -- una delle 10 specie `rovine_planari`):
+
+```yaml
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: f47f771787d8d19cc44ceb22efef67e01b481d088b7e74815416c4462deca4cd
+```
+
+**Copertura fabbricata** (`089b6aa0`, 2025-10-29 -- stesso giorno, stesso repo, stessa dimensione d'ordine):
+
+```yaml
+schema_version: 1.7
+receipt:
+  source: coverage_autogen
+  author: automation
+  date: '2025-10-29'
+  trace_hash: to-fill
+```
+
+`trace_hash: to-fill`. La ricevuta **lo dice a voce alta**.
+
+### Il grep che stava per sbagliare
+
+Il candidato ovvio dopo il recupero di `rovine_planari` (vedi [M-2026-07-15-001](worldgen-rovine-planari-recovery.md)) e': _"quanti altri stub da 3 righe una volta avevano contenuto?"_. Risposta pre-recupero: **34 file**. Composizione reale, verificata:
+
+| gruppo                     | n   | righe in git | `receipt.source`   | `receipt.author` | verdetto             |
+| -------------------------- | --- | ------------ | ------------------ | ---------------- | -------------------- |
+| specie `rovine_planari`    | 10  | 88-108       | `PF1E.Bestiary.v1` | `designer`       | **RECUPERA** (fatto) |
+| `*-trait-keeper.yaml`      | 21  | **59**       | `coverage_autogen` | `automation`     | **NON TOCCARE**      |
+| 3 specie psioniche (sotto) | 3   | 80-81        | `PTPF.v1.0`        | `designer`       | reale, ma archiviato |
+
+I 21 keeper sono i **piu' grossi** del gruppo dopo le specie vere. Se il criterio fosse stato "quanto contenuto c'era", sarebbero **passati**. E riportarli in tree avrebbe rimesso in piedi lo **strato 4** dei 5 strati di copertura fabbricata che [M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md) documenta -- dentro la stessa settimana in cui erano stati rimossi.
+
+### I 3 recuperabili reali fuori da `rovine_planari`
+
+Contenuto autentico, `author: designer`, `source: PTPF.v1.0`, ~80 righe, vivo in git a `5a06b64b^`:
+
+- `psionic-canopy-scout` -- `canopia_psionica_leggera`
+- `magnet-fathom-surveyor` -- `falde_magnetiche_psioniche`
+- `orbital-ascendant` -- `orbita_psionica_inversa`
+
+Vivono in biomi che l'ADR-2026-07-14 **archivia**: **non riducono il TARGET**. Ma sono contenuto autorato da un designer, e vanno registrati come **preservati in git** (`git show 5a06b64b^:<path>`), non come "stub da cancellare".
+
+## Why it was buried
+
+`receipt` non e' sepolto: e' **ignorato**. Nessun gate lo legge. Per sette mesi l'unica domanda posta al catalogo specie e' stata _"quante ce ne sono"_, mai _"chi le ha scritte"_.
+
+Ed e' precisamente il motivo per cui e' sopravvissuto intatto attraverso cinque strati di fabbricazione: **un campo che nessuna metrica consuma e' un campo che nessuno ha interesse a falsificare.** L'automazione ha scritto onestamente `author: automation` perche' nessuno stava guardando.
+
+## Why it might still matter
+
+**E' la lezione, non l'artefatto.**
+
+### La regola
+
+> **Prima di qualsiasi recupero di massa da git, filtra per `receipt`, mai per dimensione.**
+>
+> - `author: designer` + `source` reale (`PF1E.Bestiary.v1`, `PTPF.v1.0`) -> **cicatrice**. Contenuto vero, ferito da un incidente. Recuperabile.
+> - `author: automation` + `source: coverage_autogen` -> **bugia**. Copertura fabbricata. Recuperarla = re-introdurre il debito.
+>
+> **Un file grosso puo' essere una bugia. Un file da 3 righe puo' essere la lapide di qualcosa di vero.**
+
+### La coppia di lezioni
+
+| card                                                           | fallimento                                   | metodo                  |
+| -------------------------------------------------------------- | -------------------------------------------- | ----------------------- |
+| [M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md) | trattare il **fabbricato** come reale        | _remove-then-remeasure_ |
+| **M-2026-07-15-002** (questa)                                  | trattare il **reale ferito** come fabbricato | _filter-by-provenance_  |
+
+Sono **due meta' della stessa lezione**. Applicare solo la prima porta a cancellare cicatrici. Applicare solo la seconda porta a resuscitare bugie. Il repo ha corso entrambi i rischi **nella stessa settimana**.
+
+### Perche' funziona
+
+La provenienza e' l'unico attributo che **non degrada** con le trasformazioni successive. Righe, nomi, directory, conteggi: tutti riscrivibili da uno script. `receipt.author` racconta **l'atto di creazione**, e nessun restore-as-hollow-shell lo ha mai riscritto.
+
+## Concrete reuse paths
+
+1. **Minimal** (P0, ~0h -- gia' applicato): il recupero `aa92afed` ha usato questo filtro. Le 10 recuperate hanno tutte `author: designer`; i 21 keeper sono stati **lasciati stare**.
+2. **Moderate** (P1, ~2h): rendi il filtro **eseguibile**. Uno script `tools/py/audit_receipts.py` che classifichi ogni file specie in `designer` / `automation` / `senza receipt` e stampi i conteggi. Il terzo gruppo -- **nessuna ricevuta** -- e' quello da guardare per primo: e' l'unico dove il metodo e' cieco.
+3. **Full** (P2, ~4h): promuovi `receipt` da campo decorativo a **campo validato**: schema che richiede `source` + `author` non vuoti, e un gate che **rifiuta** `trace_hash: to-fill`. Un artefatto che dichiara di essere autogenerato e incompleto non dovrebbe poter entrare in `main`. Blast radius x2.0 (schema-changing) -> ~8h reali.
+
+## Sources / provenance trail
+
+Verificato in questa sessione:
+
+- Ricevuta reale: `git show e83c810c:packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml` -> `source: PF1E.Bestiary.v1`, `author: designer`
+- Ricevuta fabbricata: `git show 7c62b510^:packs/evo_tactics_pack/data/species/abisso_luminescente/abisso-luminescente-trait-keeper.yaml` -> **59 righe**, `source: coverage_autogen`, `author: automation`, `trace_hash: to-fill`
+- Ricevuta reale archiviata: `git show 5a06b64b^:packs/evo_tactics_pack/data/species/canopia_psionica_leggera/psionic-canopy-scout.yaml` -> **80 righe**, `source: PTPF.v1.0`, `author: designer`
+- Stub oggi in tree (<=4 righe): **24** file = **21** `*-trait-keeper.yaml` + **3** specie psioniche. (Erano **34** prima di `aa92afed`.)
+
+| SHA        | data       | messaggio                                                 | ruolo                                 |
+| ---------- | ---------- | --------------------------------------------------------- | ------------------------------------- |
+| `089b6aa0` | 2025-10-29 | Add coverage trait keepers for Evo Tactics biomes         | nascita 38 keeper `coverage_autogen`  |
+| `e83c810c` | 2025-10-29 | Add Pathfinder planar ruins biome with translated species | nascita 10 specie `designer`          |
+| `7c62b510` | 2025-11-30 | Enhance Evo pack pipeline and derived outputs             | cancella i 38 keeper (59 righe l'uno) |
+| `aa92afed` | 2026-07-14 | feat(species): recover 10 rovine_planari species          | recupero **filtrato per provenienza** |
+
+## Risks / open questions
+
+- **File senza `receipt`**: il metodo e' **cieco** dove la ricevuta manca. Non censito in questa sessione -- e' il primo buco da chiudere (reuse path Moderate).
+- **`receipt` e' auto-dichiarato**: non e' firmato ne' verificato. Un'automazione futura _potrebbe_ scrivere `author: designer`. Oggi non e' successo (i 5 strati fabbricati hanno tutti dichiarato la verita' su se stessi), ma il campo regge **per convenzione**, non per costruzione.
+- **I 21 keeper restano in tree** come stub da 3 righe. L'ADR-2026-07-14 li cancella. **Corretto: vanno cancellati, non recuperati.** Questa card esiste per garantire che qualcuno, tra sei mesi, non li veda in git a 59 righe e pensi di aver trovato un tesoro.
+
+## Cross-links
+
+- [M-2026-07-14-001 -- Coverage fabbricata: 5 strati impilati](lesson-coverage-fabrication-five-layers.md) -- **la meta' opposta di questa lezione**
+- [M-2026-07-15-001 -- rovine_planari: una cicatrice, non un buco](worldgen-rovine-planari-recovery.md) -- il recupero che ha usato questo filtro
+- [M-2026-07-15-003 -- Specie autorate prima del catalogo tratti](lesson-species-authored-ahead-of-trait-catalog.md)

--- a/docs/museum/cards/lesson-species-authored-ahead-of-trait-catalog.md
+++ b/docs/museum/cards/lesson-species-authored-ahead-of-trait-catalog.md
@@ -1,0 +1,128 @@
+---
+title: 'Specie autorate prima del catalogo tratti: 23 riferimenti orfani e il terzo modo di mentire'
+museum_id: M-2026-07-15-003
+type: artifact
+domain: [architecture]
+provenance:
+  found_at: 'packs/evo_tactics_pack/data/species/rovine_planari/*.yaml -- campo `pending_trait_definitions` + tools/py/build_species_trait_bridge.py:145'
+  git_sha_first: 'e83c810c'
+  git_sha_last: 'aa92afed'
+  last_modified: '2026-07-14'
+  last_author: 'Eduardo Scarpelli'
+  buried_reason: unintegrated
+relevance_score: 4
+reuse_path: 'data/core/traits/glossary.json -- i 23 tratti vanno autorati (Species-Curator-gated); poi rientrano in `genetic_traits` dei rispettivi file specie'
+related_pillars: [P1, P3]
+status: curated
+excavated_by: repo-archaeologist
+excavated_on: 2026-07-15
+last_verified: 2026-07-15
+---
+
+# Specie autorate prima del catalogo tratti: 23 riferimenti orfani
+
+## Summary (30s)
+
+- Le 10 specie `rovine_planari` recuperate ([M-2026-07-15-001](worldgen-rovine-planari-recovery.md)) riferiscono **34 tratti unici**. **23** non hanno voce nel glossario -- e **non l'hanno mai avuta**. Il design pass del 2025-10-29 ha scritto le specie **contro un catalogo tratti che non esisteva ancora**.
+- Non e' un dettaglio cosmetico: `build_species_trait_bridge.py:145` fa `trait_index.setdefault(trait_id, {})`. Rigenerare il bridge con quei riferimenti **fabbricherebbe 23 voci tratto nude, senza definizione** -- **esattamente la forma** della coverage fabbricata che il repo ha appena rimosso ([M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md)).
+- Risoluzione adottata in `aa92afed`: i 23 sono **preservati, non consumati**, sotto un campo nuovo `pending_trait_definitions:`. Ne' scartati in silenzio, ne' fabbricati in silenzio.
+
+## What was buried
+
+Il pass di autoring di `e83c810c` (2025-10-29) ha scritto 10 specie complete usando un vocabolario di tratti **piu' ricco del catalogo**. I 23 orfani:
+
+```
+assenza_respirazione, campo_di_fase, ciclo_vitale_anomalo, ciclo_vitale_completo,
+fisiologia_predatoria, fotosintesi_bifase, ghiandole_nettare_memetico,
+intangibilita_parziale, lamenti_diradanti, maschera_illusoria, metabolismo_attivo,
+metabolismo_sostentato, nodi_micotici, origine_artificiale, proboscide_polifaga,
+respirazione_biologica, riflessi_preternaturali, rinforzi_modulari,
+secrezioni_antisepsi, sensori_chimici, sinapsi_riflettenti, visione_spettrale,
+voce_spettrale
+```
+
+Verificato: **0/23** hanno una voce in `data/core/traits/glossary.json` (501 tratti). Verificato via pickaxe: **nessuno** e' mai esistito come file `data/traits/<categoria>/<id>.json`.
+
+Non sono tratti **persi**. Sono tratti **mai scritti**: il designer li ha _nominati_ in una specie, dando per scontato che sarebbero stati definiti dopo. Non e' mai successo.
+
+## Why it was buried
+
+Ordine di lavoro invertito: **prima le creature, poi il vocabolario**. E' un ordine legittimo in fase creativa -- si scrive "questo golem non respira" prima di aver deciso come si chiama e cosa fa il tratto `assenza_respirazione`. Diventa debito nel momento in cui il vocabolario non arriva mai, e nessun gate se ne accorge perche' le specie sono state **cancellate due giorni dopo** (`5a06b64b`) e con esse i riferimenti.
+
+Il recupero le ha riportate. E con loro il debito, intatto, dopo 8 mesi e mezzo.
+
+## Why it might still matter
+
+### Il terzo modo di fabbricare copertura
+
+Il repo ha gia' catalogato due modi di mentire sui numeri:
+
+1. **Fabbricare il falso** -- una regola `when: {}` che dichiara coperto cio' che non lo e' ([M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md)).
+2. **Cancellare il vero** -- trattare una cicatrice come uno stub ([M-2026-07-15-002](lesson-receipt-provenance-scar-vs-lie.md)).
+
+Questo e' il **terzo**, ed e' il piu' insidioso perche' **avviene da solo**, senza che nessuno decida niente:
+
+> **Un riferimento a un'entita' inesistente, dato in pasto a un generatore che usa `setdefault`, diventa un'entita' esistente e vuota.**
+
+`tools/py/build_species_trait_bridge.py:145`:
+
+```python
+trait_entry = trait_index.setdefault(trait_id, {})
+```
+
+Nessuna validazione. Se un file specie nomina `campo_di_fase`, il bridge **crea** `campo_di_fase` -- un tratto senza definizione, senza effetto, senza glossario, ma **presente nell'indice**. E un tratto presente nell'indice **conta**. Bastava un `npm run build:trait-bridge` per aggiungere 23 fantasmi al catalogo, senza che nessun essere umano scrivesse una riga di dati falsi.
+
+### L'invariante reale del repo
+
+Verificato su `origin/main` **e** su questo branch:
+
+> **Ogni tratto nel bridge (`data/traits/index.json`, 308 voci) ha una voce nel glossario. 308/308. Zero mancanti.**
+
+E' la vera invariante, ed e' intatta. (Un tratto **puo'** invece non avere un file DB per-tratto: quella tolleranza esiste ed e' documentata.) I 23 orfani, se consumati, l'avrebbero **rotta per la prima volta**.
+
+### La risoluzione adottata
+
+`aa92afed` non li scarta e non li fabbrica. Li **parcheggia**, con il perche' scritto accanto, in ognuno dei 10 file specie:
+
+```yaml
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - assenza_respirazione
+  - campo_di_fase
+  - ...
+```
+
+Il campo **non e' letto da nulla**. E' un'informazione conservata fuori dal circuito delle metriche -- lo stesso posto in cui `receipt` e' sopravvissuto sette mesi di fabbricazione.
+
+## Concrete reuse paths
+
+1. **Minimal** (P0, ~0h -- gia' fatto): i 23 sono preservati e inerti in `aa92afed`. Nessuna azione. **Non** rigenerare il bridge aspettandosi che li ignori: li ignora **perche'** sono fuori da `genetic_traits`, non per virtu' dello script.
+2. **Moderate** (P1, ~6h): autora i 23 tratti nel glossario (Species-Curator-gated) e rimettili in `genetic_traits` delle rispettive specie. Alcuni sono ovvi e a costo quasi zero (`respirazione_biologica`, `metabolismo_attivo`, `sensori_chimici`); altri sono **design vero** (`campo_di_fase`, `intangibilita_parziale`, `ghiandole_nettare_memetico`). Blast radius x1.0 (data YAML) -> ~6h.
+3. **Full** (P2, ~3h): chiudi il buco alla sorgente. Sostituisci il `setdefault` a `build_species_trait_bridge.py:145` con un **fail esplicito**: un tratto riferito da una specie e assente dal glossario deve **rompere la build con l'id e il file**, non essere creato. E' lo stesso guard-alla-sorgente di `trait_coverage.py:197-210` ([M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md), reuse path 1), applicato al secondo generatore. **Rifiuta nel parser, non nella code review.**
+
+## Sources / provenance trail
+
+- Riferimenti orfani: [packs/evo_tactics_pack/data/species/rovine_planari/\*.yaml](../../../packs/evo_tactics_pack/data/species/rovine_planari/) -- campo `pending_trait_definitions`
+- Il `setdefault` che fabbricherebbe: [tools/py/build_species_trait_bridge.py:145](../../../tools/py/build_species_trait_bridge.py)
+- Glossario canonico: [data/core/traits/glossary.json](../../../data/core/traits/glossary.json) -- 501 tratti; **0/23** presenti
+- Bridge: [data/traits/index.json](../../../data/traits/index.json) -- 308 voci, **308/308** con voce nel glossario (verificato su `origin/main` e su `HEAD`)
+- Guard gemello gia' in tree: [tools/py/game_utils/trait_coverage.py:197-210](../../../tools/py/game_utils/trait_coverage.py)
+
+| SHA        | data       | messaggio                                                 | ruolo                                        |
+| ---------- | ---------- | --------------------------------------------------------- | -------------------------------------------- |
+| `e83c810c` | 2025-10-29 | Add Pathfinder planar ruins biome with translated species | autora le specie contro tratti mai definiti  |
+| `aa92afed` | 2026-07-14 | feat(species): recover 10 rovine_planari species          | preserva i 23 in `pending_trait_definitions` |
+
+## Risks / open questions
+
+- **Il `setdefault` e' ancora li'.** Finche' non diventa un fail, qualunque futura specie che nomini un tratto inesistente lo **creera'** in silenzio. I 23 di oggi sono disinnescati; il meccanismo no.
+- **Chi autora i 23?** Il gate e' Species-Curator. Finche' non lo fanno, le 10 specie recuperate sono **complete come creature ma incomplete come dati**: `genetic_traits` porta 11 tratti su 34 riferiti dal design originale.
+- **Quanti altri?** Questa sessione ha controllato **solo** le 10 specie di `rovine_planari`. Nessuno ha verificato se altre specie del catalogo riferiscano tratti fuori dal glossario. Il bridge dice **308/308 puliti** oggi -- ma dice solo cio' che e' **consumato**, non cio' che e' **scritto**.
+
+## Cross-links
+
+- [M-2026-07-15-001 -- rovine_planari: una cicatrice, non un buco](worldgen-rovine-planari-recovery.md) -- le specie che portano questi 23 tratti
+- [M-2026-07-15-002 -- `receipt.source` e' il discriminante](lesson-receipt-provenance-scar-vs-lie.md)
+- [M-2026-07-14-001 -- Coverage fabbricata: 5 strati impilati](lesson-coverage-fabrication-five-layers.md) -- il guard-alla-sorgente da replicare

--- a/docs/museum/cards/worldgen-rovine-planari-recovery.md
+++ b/docs/museum/cards/worldgen-rovine-planari-recovery.md
@@ -1,0 +1,141 @@
+---
+title: 'rovine_planari: una cicatrice, non un buco -- 10 specie recuperate da un commit docs'
+museum_id: M-2026-07-15-001
+type: dataset
+domain: [architecture]
+provenance:
+  found_at: 'packs/evo_tactics_pack/data/species/rovine_planari/ (10 file) + rovine_planari.ecosystem.yaml + rovine_planari_foodweb.yaml'
+  git_sha_first: 'e83c810c'
+  git_sha_last: 'aa92afed'
+  last_modified: '2026-07-14'
+  last_author: 'Eduardo Scarpelli'
+  buried_reason: forgotten
+relevance_score: 5
+reuse_path: "packs/evo_tactics_pack/data/species/rovine_planari/*.yaml -- gia' recuperate in aa92afed; il METODO (ecosistema+foodweb come impronta -> git pickaxe -> recover) e' riusabile su ogni bioma con specie mancanti"
+related_pillars: [P1, P3, P6]
+status: revived
+revived_by: 'aa92afed (branch fix/rovine-planari-recovery) -- 10 specie riportate dal loro commit di nascita e83c810c'
+revived_on: 2026-07-14
+excavated_by: repo-archaeologist
+excavated_on: 2026-07-15
+last_verified: 2026-07-15
+---
+
+# rovine_planari: una cicatrice, non un buco -- 10 specie recuperate da un commit docs
+
+## Summary (30s)
+
+- L'ADR-2026-07-14 (Decision 10) contava `rovine_planari` come **il buco piu' grande del gioco: +8 specie da inventare**. Non era un buco. Era una **cicatrice**: le 10 specie erano state **autorate per intero** il 2025-10-29 e **distrutte per danno collaterale** due giorni dopo, da un commit intitolato "docs".
+- L'ecosistema e la foodweb sono **sopravvissuti** e nominavano tutte e 10 le specie **per id esatto**. Il bioma aveva l'impronta di dieci abitanti a ogni livello dello stack, e i corpi vuoti.
+- **Recuperate** in `aa92afed`. Il TARGET nucleo-8 passa da ~35 a **~27 specie mancanti**. E il metodo ha un **controllo negativo**: applicato ad `atollo_obsidiana` **falsifica** il recupero -- quello e' un buco vero.
+
+## What was buried
+
+### La nascita -- `e83c810c` (2025-10-29)
+
+Commit "Add Pathfinder planar ruins biome with translated species" (24 file, +2114). Autora `rovine_planari` **completo su tutti e quattro i livelli** dello stack worldgen (vedi [M-2026-04-26-012](worldgen-bioma-ecosistema-foodweb-network-stack.md)):
+
+- bioma + ecosistema + foodweb + **10 specie autorate per intero** (88-108 righe ciascuna).
+- Ogni specie con `schema_version: 1.7` e ricevuta onesta:
+
+```yaml
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: f47f771787d8d19cc44ceb22efef67e01b481d088b7e74815416c4462deca4cd
+```
+
+`author: designer`, non `automation`. `source: PF1E.Bestiary.v1`, non `coverage_autogen`. Questa e' la differenza che conta -- vedi [M-2026-07-15-002](lesson-receipt-provenance-scar-vs-lie.md).
+
+Le 10: `archon-solare`, `balor-fission`, `banshee-risonante`, `bulette-fase`, `couatl-aurora`, `golem-runico`, `marilith-vault`, `otyugh-sentinella`, `rakshasa-corte`, `treant-portale`.
+
+### La distruzione -- `5a06b64b` (2025-10-31)
+
+Commit "docs(tri_sorgente): introduce variant docs (README, SPEC, PRIMER, CHANGELOG)".
+
+```
+932 files changed, 114 insertions(+), 302220 deletions(-)
+```
+
+**Trecentoduemiladuecentoventi righe cancellate da un commit intitolato "docs"**, workflow CI inclusi. Le 10 specie non erano il bersaglio: erano **danno collaterale**. Nessun ADR copre quel commit.
+
+### Il restauro parziale -- `9acadc69` (2025-12-09)
+
+"Restore Evo Tactics species inventory resources". Ha ripristinato `badlands` **con contenuto reale**, ma per `rovine_planari` e' riuscito a recuperare **solo i nomi**: 10 file da 3 righe, la cui nota lo dichiara da sola:
+
+```yaml
+notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+```
+
+Da qui il conteggio "0 specie reali" che ha attraversato 7 mesi e l'ADR.
+
+### Cio' che e' sopravvissuto -- l'impronta
+
+L'ecosistema e la foodweb **non** sono stati toccati, e nominano tutte e 10 le specie **per id esatto**:
+
+- `rovine_planari.ecosystem.yaml` -- le elenca su produttori / consumatori (primari, secondari, terziari) / decompositori; `links.species_dir` punta alla directory.
+- `rovine_planari_foodweb.yaml` -- **14 nodi (10 `kind: species` + 4 `kind: resource`), 23 edge**.
+
+Un bioma con la rete trofica intera e nessuno dentro.
+
+## Why it was buried
+
+Non e' stato sepolto per decisione. E' stato **raso al suolo per errore** e poi **mal ricostruito**: il "restore" ha ripristinato l'inventario (i nomi), non il contenuto. E lo stub era **onesto** -- diceva di essere uno stub -- ma nessuno ha piu' riletto la nota, e il conteggio automatico ha registrato "0 specie".
+
+Il risultato: per 7 mesi il gioco ha creduto di **dover inventare** 8 creature che erano gia' state disegnate e vivevano nella storia di git.
+
+## Why it might still matter
+
+**E' gia' successo il recupero** -- `aa92afed`. Cio' che resta e' il **metodo**, ed e' quello a valere.
+
+### Il metodo -- l'impronta prima dello scavo
+
+1. **L'ecosistema e la foodweb sono l'impronta.** Se nominano specie per id, quelle specie **sono state pensate**. Non e' una prova che esistessero come file -- e' la domanda giusta da porre a git.
+2. **Git pickaxe sull'id**: `git log --all --diff-filter=A -- '*<id>*'`. Se il file e' mai esistito, esce il commit di nascita. Se non esce nulla, non e' mai esistito.
+3. **Recupera dal commit di nascita**, non dal successivo restauro (che potrebbe essere lo stub).
+
+### Il controllo negativo (e' questo che lo rende affidabile)
+
+Lo stesso metodo, applicato ad `atollo_obsidiana`, **falsifica** il recupero. Il suo ecosistema nomina 3 specie -- `anguis-magnetica`, `vitricyba-punctata`, `magnetocola-pastoris` -- e il pickaxe su tutti e tre **non restituisce nulla**: nessuna di esse e' **mai** esistita come file in git.
+
+> `atollo_obsidiana` **e'** un buco vero. `rovine_planari` **era** una cicatrice. Un metodo che dice si' a tutto non serve a niente; questo dice no.
+
+### Verifica di conformita' delle 10 recuperate
+
+`rovine_planari.ecosystem.yaml` -> `rules.at_least` chiede **>=1** per ognuno di apex / keystone / bridge / threat / event. Il set recuperato consegna, dai `flags` delle specie: **apex 1, keystone 2, bridge 2, threat 3, event 1**. Tutte e cinque le regole soddisfatte. Tutte e 10 passano la Decision 5 di ADR-2026-07-14.
+
+## Concrete reuse paths
+
+1. **Minimal** (P0, ~0h -- gia' fatto): le 10 specie sono in tree su `fix/rovine-planari-recovery` (`aa92afed`). Nessuna azione.
+2. **Moderate** (P1, ~2h): applica il metodo **impronta -> pickaxe -> recover** a **ogni altro bioma** con specie nominate dall'ecosistema e mancanti dal filesystem. Costo per bioma: ~15 min (il pickaxe risponde si'/no in un comando). Aspettativa realistica: **quasi tutti saranno buchi veri** -- come `atollo_obsidiana`. Il valore e' che il no costa 15 minuti e il si' vale 8 specie.
+3. **Full** (P2, ~4h): promuovi il controllo a **gate**: uno script che, per ogni id specie nominato in un `*.ecosystem.yaml` o `*_foodweb.yaml` e assente da `data/species/`, cerca il commit di nascita e **fallisce con il SHA** se ne trova uno. Un file cancellato per sbaglio non dovrebbe poter diventare un requisito di design.
+
+## Sources / provenance trail
+
+Git history verificata in questa sessione (`git show <sha> --stat`):
+
+| SHA        | data       | messaggio                                                         | ruolo                                            |
+| ---------- | ---------- | ----------------------------------------------------------------- | ------------------------------------------------ |
+| `e83c810c` | 2025-10-29 | Add Pathfinder planar ruins biome with translated species         | nascita: bioma + eco + foodweb + **10 specie**   |
+| `5a06b64b` | 2025-10-31 | docs(tri_sorgente): introduce variant docs                        | **932 file, -302220 righe** -- danno collaterale |
+| `9acadc69` | 2025-12-09 | Restore Evo Tactics species inventory resources                   | ripristina i **nomi**: 10 stub da 3 righe        |
+| `aa92afed` | 2026-07-14 | feat(species): recover 10 rovine_planari species lost in 5a06b64b | **recupero** (16 file, +2743)                    |
+
+- Impronta ecosistema: [packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml](../../../packs/evo_tactics_pack/data/ecosystems/rovine_planari.ecosystem.yaml)
+- Impronta foodweb: [packs/evo_tactics_pack/data/foodwebs/rovine_planari_foodweb.yaml](../../../packs/evo_tactics_pack/data/foodwebs/rovine_planari_foodweb.yaml) -- 10 nodi specie, 23 edge
+- Specie recuperate: [packs/evo_tactics_pack/data/species/rovine_planari/](../../../packs/evo_tactics_pack/data/species/rovine_planari/)
+- Controllo negativo: [packs/evo_tactics_pack/data/ecosystems/atollo_obsidiana.ecosystem.yaml](../../../packs/evo_tactics_pack/data/ecosystems/atollo_obsidiana.ecosystem.yaml) -- 3 specie mai esistite
+
+## Risks / open questions
+
+- **L'ADR va corretto**: Decision 10 di ADR-2026-07-14 dice `rovine_planari +8`. E' **coperto**. Il gap TARGET nucleo-8 scende da ~35 a **~27**. Finche' l'ADR non e' emendato, resta un documento che chiede di inventare cio' che esiste.
+- **23 tratti orfani** viaggiano con le 10 specie recuperate. Non sono stati ne' scartati ne' fabbricati: sono preservati sotto `pending_trait_definitions:`. Vedi [M-2026-07-15-003](lesson-species-authored-ahead-of-trait-catalog.md). **Non regenerare il trait-bridge da quei riferimenti** senza averli prima autorati.
+- **Movente ignoto**: perche' un commit di documentazione ha cancellato 302k righe e i workflow CI? Nessun ADR, nessuna issue. Stessa domanda aperta di [M-2026-07-14-001](lesson-coverage-fabrication-five-layers.md) su `7c62b510`/`9acadc69`. Il pattern e' ricorrente: **i commit di "docs" e "restore" di questo repo hanno una storia di distruzione di dati**.
+
+## Cross-links
+
+- [M-2026-07-15-002 -- `receipt.source` e' il discriminante, non il numero di righe](lesson-receipt-provenance-scar-vs-lie.md) -- **la lezione di questo recupero**
+- [M-2026-07-15-003 -- Specie autorate prima del catalogo tratti](lesson-species-authored-ahead-of-trait-catalog.md)
+- [M-2026-07-14-001 -- Coverage fabbricata: 5 strati impilati](lesson-coverage-fabrication-five-layers.md) -- **la meta' opposta**: li' si rimuove il falso, qui si recupera il vero
+- [M-2026-04-26-012 -- Worldgen Stack 4-livelli](worldgen-bioma-ecosistema-foodweb-network-stack.md) -- lo stack che ha reso possibile leggere l'impronta

--- a/docs/planning/2026-07-14-content-substrate-census.md
+++ b/docs/planning/2026-07-14-content-substrate-census.md
@@ -83,7 +83,24 @@ Nessuno ha meccanica e nessuno ha prosa autorata. Sono **nomi**.
 
 ---
 
-## 2. SPECIE -- 105 file, **46 reali**
+## 2. SPECIE -- 105 file, **46 reali** ⚠️ CORRETTO 2026-07-15
+
+> 🛑 **CORREZIONE (2026-07-15)**: i numeri di questa sezione **non riproducono**, e la frase
+> "non sono specie incomplete: sono segnaposto" e' **falsa per 10 file su 59**.
+> Vedi ADR-2026-07-14 §Addendum 2026-07-15 (Gap C + Gap D).
+>
+> | questa sezione dice | misurato (main, Decisione 5 come scritta) |
+> | ------------------- | ----------------------------------------- |
+> | specie vere: **46** | **42** (e **52** dopo il recupero)        |
+> | stub: **59**        | **63**                                    |
+>
+> **10 dei 59 "stub" NON erano segnaposto**: erano le specie di `rovine_planari`, autorate per
+> intero il 2025-10-29 (`e83c810c`, 83-103 righe, `author: designer`) e distrutte due giorni dopo
+> come danno collaterale di `5a06b64b`, un commit che ha cancellato 302.220 righe. Sono state
+> **recuperate** (`aa92afed`). Il loro `notes` lo diceva: _"stub auto-generato per **ripristinare
+> inventario**"_ -- e' la cicatrice di un restore parziale, non un segnaposto.
+>
+> **Il discriminante e' `receipt.source`, non la lunghezza del file.**
 
 |                                                           | n            |
 | --------------------------------------------------------- | ------------ |
@@ -155,9 +172,15 @@ clima, rete trofica, servizi ecosistemici):
 
 `badlands` · `cryosteppe` · `deserto_caldo` · `foresta_temperata` · **`rovine_planari`**
 
-> ⚠️ **`rovine_planari` ha l'ecosistema descritto e ZERO specie vere** (10 file, 10 stub).
+> ~~⚠️ **`rovine_planari` ha l'ecosistema descritto e ZERO specie vere** (10 file, 10 stub).
 > E' una classe canonica di prima categoria -- koppen Cfa/Cfb, `.biome.yaml` completo -- con
-> una cartella che _sembra_ popolata e non lo e'.
+> una cartella che _sembra_ popolata e non lo e'.~~
+>
+> ✅ **SMENTITO 2026-07-15.** La cartella _era_ popolata: 10 specie autorate per intero il
+> 2025-10-29 (`e83c810c`), distrutte due giorni dopo da `5a06b64b`. **Recuperate** (`aa92afed`).
+> L'ecosistema e il foodweb erano sopravvissuti e **nominavano ancora tutte e 10 le specie per
+> `id` esatto** -- non era un buco, era l'impronta di dieci abitanti coi corpi vuoti.
+> Vedi ADR-2026-07-14 §Addendum 2026-07-15.
 
 Quindi: **28 classi canoniche, 5 descritte, 4 vive.**
 

--- a/docs/planning/traits_rovine_planari_proposal.md
+++ b/docs/planning/traits_rovine_planari_proposal.md
@@ -1,0 +1,824 @@
+# Proposta: i 23 tratti orfani di `rovine_planari`
+
+- **Autore**: `trait-curator` (agent) -- carta: `agents/trait-curator.md`, `.ai/trait-curator/PROFILE.md`
+- **Data**: 2026-07-14
+- **Issue**: #3307 -- PR di riferimento: #3306 (`fix/rovine-planari-recovery`)
+- **Stato**: PROPOSTA. **Nulla di quanto segue e' stato applicato.** Nessun file sotto `data/` e' stato toccato.
+- **Ratifica**: master-dd. Numeri/tier -> **Balancer**. Framing narrativo -> **Lore Designer**.
+
+---
+
+## 0. TL;DR
+
+| Verdetto               | Numero | Tratti                                                                                                                                                                                                                                                                                               |
+| ---------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **create**             | **13** | `campo_di_fase`, `fotosintesi_bifase`, `ghiandole_nettare_memetico`, `intangibilita_parziale`, `lamenti_diradanti`, `maschera_illusoria`, `nodi_micotici`, `proboscide_polifaga`, `riflessi_preternaturali`, `rinforzi_modulari`, `secrezioni_antisepsi`, `sinapsi_riflettenti`, `visione_spettrale` |
+| **duplicate-of**       | **2**  | `sensori_chimici` -> `acuita_chemorecettiva` -- `voce_spettrale` -> `voce_imperiosa`                                                                                                                                                                                                                 |
+| **drop-the-reference** | **8**  | `respirazione_biologica`, `metabolismo_attivo`, `ciclo_vitale_completo`, `assenza_respirazione`, `metabolismo_sostentato`, `ciclo_vitale_anomalo`, `origine_artificiale`, `fisiologia_predatoria`                                                                                                    |
+
+**Il risultato principale di questa analisi e' negativo.** 8 dei 23 non sono tratti: sono **marcatori di fisiologia auto-derivati dall'import Pathfinder**, copiati per inerzia nel file specie. Definirli nel glossario avrebbe aggiunto 8 voci che **non discriminano niente** -- esattamente la forma della copertura fabbricata di `M-2026-07-14-001`, ma stavolta con l'alibi di una "definizione vera".
+
+Il numero onesto di tratti da autorare non e' 23. E' **13**.
+
+---
+
+## 1. La prova: gli 8 non sono tratti, sono l'`import`
+
+### 1.1 Il segnale
+
+`git grep` dei 23 id, escludendo `packs/.../rovine_planari/`:
+
+- **8 su 23** compaiono in **`data/external/pathfinder_bestiary_1e.json`**.
+- **15 su 23** non compaiono **da nessuna parte** nel repo. (Verificato: 0/23 nel glossario, 0/23 come file `data/traits/*/*.json`.)
+
+Gli 8 sono esattamente: `respirazione_biologica`, `metabolismo_attivo`, `ciclo_vitale_completo`, `assenza_respirazione`, `metabolismo_sostentato`, `ciclo_vitale_anomalo`, `origine_artificiale`, `fisiologia_predatoria`.
+
+### 1.2 Cosa sono in quel file
+
+`data/external/pathfinder_bestiary_1e.json` (`meta.record_count: 1211`) da' a **ogni** creatura un blocco `biology` di booleani e un array `genetic_traits` **derivato meccanicamente da quei booleani**:
+
+```json
+"biology": { "needs_food": true, "needs_water": true, "breathes": true, "has_growth_cycle": true },
+"genetic_traits": ["ciclo_vitale_completo", "metabolismo_attivo", "respirazione_biologica"]
+```
+
+Il vocabolario **completo** di `genetic_traits` nell'import e' di **10 id**, con queste frequenze su 1211 creature (misurate, non stimate):
+
+| id                       | occorrenze | mappa da                    |
+| ------------------------ | ---------- | --------------------------- |
+| `ciclo_vitale_completo`  | 1077       | `has_growth_cycle: true`    |
+| `metabolismo_attivo`     | 1077       | `needs_food: true`          |
+| `respirazione_biologica` | 1052       | `breathes: true`            |
+| `fisiologia_predatoria`  | 376        | carnivoria (tipo/dieta)     |
+| `assenza_respirazione`   | 159        | `breathes: false`           |
+| `ciclo_vitale_anomalo`   | 134        | `has_growth_cycle: false`   |
+| `metabolismo_sostentato` | 134        | `needs_food: false`         |
+| `origine_artificiale`    | 134        | non-nato (undead/costrutto) |
+| `adattamento_volo`       | 417        | movimento `fly`             |
+| `adattamento_acquatico`  | 95         | movimento `swim`            |
+
+Gli ultimi due sono gli unici del gruppo che il repo ha **promosso a tratto reale**: `adattamento_volo` **e'** nel glossario ed **e' consumato** dalle specie. Gli altri 8 no. Non per svista: perche' **non sono tratti**.
+
+### 1.3 La partizione che lo dimostra
+
+Sulle 10 specie recuperate i marcatori formano una **partizione perfetta e complementare**:
+
+- 8 specie "vive" (archon, balor, bulette, couatl, marilith, otyugh, rakshasa, treant) portano **tutte e tre** `ciclo_vitale_completo` + `metabolismo_attivo` + `respirazione_biologica`. Nessuna eccezione.
+- 2 specie non-biologiche (banshee = `undead`, golem = costrutto) portano **tutte e quattro** `assenza_respirazione` + `metabolismo_sostentato` + `ciclo_vitale_anomalo` + `origine_artificiale`. Nessuna eccezione.
+
+Un tratto portato dal **100%** dei membri di una classe e dallo **0%** dell'altra non e' un tratto: e' **l'etichetta della classe**. Non differenzia nessuna build, non entra in nessuna sinergia, non ha nessun conflitto. Se lo si definisce nel glossario, il contatore sale di 8 e **il gioco non cambia di una virgola**.
+
+> E' il modo di fabbricare copertura che `M-2026-07-14-001` descrive, travestito da lavoro onesto: la definizione **esisterebbe davvero**, ma non **direbbe** niente.
+
+### 1.4 Il caso a parte: `fisiologia_predatoria` su `bulette-fase`
+
+`fisiologia_predatoria` e' riferito da **una sola specie**, `bulette-fase` -- e la contraddice in **tre punti indipendenti**:
+
+| fonte                                                            | dice                                                                                                                                                  |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bulette-fase.yaml` -> `role_trofico`                            | `erbivoro_primario`                                                                                                                                   |
+| `bulette-fase.yaml` -> `functional_tags`                         | `prede`, `detritivoro`                                                                                                                                |
+| `rovine_planari.ecosystem.yaml` -> `trofico.consumatori.primari` | `[bulette-fase]` (unico)                                                                                                                              |
+| `rovine_planari_foodweb.yaml`                                    | `treant-portale -> bulette-fase` type **`herbivory`** (0.5); `balor-fission -> bulette-fase` type **`predation`** (0.5) -- la bulette e' **la preda** |
+
+L'origine e' evidente: nel bestiario Pathfinder la bulette **e'** un carnivoro (`type: magical beast`, `genetic_traits` include `fisiologia_predatoria`). Il design pass Evo l'ha **ri-castata come erbivoro primario**, perche' l'ecosistema aveva bisogno di un consumatore primario e non ne aveva altri. Il marcatore dell'import e' rimasto attaccato.
+
+**Verdetto**: `drop-the-reference`. Il modello trofico -- due file, quattro asserzioni concordi -- vince su un token ereditato dall'import. L'alternativa (ri-assegnare il `role_trofico` della bulette a carnivoro) **spezzerebbe l'unico link erbivoro dell'ecosistema** e lascerebbe il treant senza consumatore: e' una decisione da **Species Curator + Biome/Ecosystem Curator**, non da qui, e la sconsiglio.
+
+### 1.5 Cosa fare degli 8, concretamente
+
+**Non** definirli. Due opzioni, entrambe fuori dal mio ambito di scrittura:
+
+- **Opzione A (raccomandata)**: promuoverli a **campo di specie**, non a tratto -- p.es. un `physiology:` con `breathes: bool`, `growth_cycle: natural|anomalous`, `origin: natural|artificial`, `diet: ...`. E' informazione **vera e utile** (serve gia' a `rules.at_least` e ai ruoli trofici), ma appartiene alla **tassonomia della specie**, non al catalogo tratti. Richiede una modifica a `schema_version 1.7` delle specie -> **Species Curator + schema owner**.
+- **Opzione B (minima)**: rimuovere le 8 voci da `pending_trait_definitions` e chiudere il punto, annotando nel file specie che derivano dall'import. Costo zero, perdita di informazione zero (il dato originale resta in `data/external/pathfinder_bestiary_1e.json`, indicizzato per `id` di creatura).
+
+In entrambi i casi: **nessuna voce di glossario**, **nessun file `data/traits/`**, **nessuna entry nel bridge**.
+
+---
+
+## 2. Verdict table completa
+
+`sp.` = specie che lo riferiscono (da `pending_trait_definitions`).
+
+| #   | trait id                     | verdetto                                 | sp.              | motivo                                                                                                                                        |
+| --- | ---------------------------- | ---------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `assenza_respirazione`       | **drop**                                 | banshee, golem   | marcatore `biology.breathes:false` dell'import PF (159/1211). Etichetta di classe, non tratto.                                                |
+| 2   | `campo_di_fase`              | **create**                               | golem            | Campo di stabilizzazione emesso. Ancora agli edge `fortification` del golem verso archon/couatl e a `deploy_barrier`.                         |
+| 3   | `ciclo_vitale_anomalo`       | **drop**                                 | banshee, golem   | marcatore `biology.has_growth_cycle:false` (134/1211).                                                                                        |
+| 4   | `ciclo_vitale_completo`      | **drop**                                 | 8 specie vive    | marcatore `biology.has_growth_cycle:true` (1077/1211). Portato dal 100% dei vivi: zero potere discriminante.                                  |
+| 5   | `fisiologia_predatoria`      | **drop**                                 | bulette          | Contraddetto da `role_trofico: erbivoro_primario`, da `functional_tags: [prede]` e da **due** edge del foodweb. Vedi sez. 1.4.                |
+| 6   | `fotosintesi_bifase`         | **create**                               | treant           | Il treant e' l'**unico** `produttore` dell'ecosistema. Zero tratti fotosintetici in 501 voci di glossario.                                    |
+| 7   | `ghiandole_nettare_memetico` | **create**                               | couatl           | Edge `couatl-aurora -> treant-portale` type `pollination` (0.5) + risorsa `spore_memetiche` + meteo `vento_memetico`.                         |
+| 8   | `intangibilita_parziale`     | **create**                               | banshee          | `required_capabilities: phase_shift`. Nessun tratto di incorporeita' nel catalogo.                                                            |
+| 9   | `lamenti_diradanti`          | **create**                               | banshee          | Gli **unici due** edge `disruption` del foodweb partono dalla banshee (-> balor 0.5, -> rakshasa 0.4). Questo tratto **e'** quegli edge.      |
+| 10  | `maschera_illusoria`         | **create**                               | rakshasa         | `required_capabilities: infiltrate` + `services_links: minaccia:corruzione_iconica` + `parasitism` verso archon e treant.                     |
+| 11  | `metabolismo_attivo`         | **drop**                                 | 8 specie vive    | marcatore `biology.needs_food:true` (1077/1211).                                                                                              |
+| 12  | `metabolismo_sostentato`     | **drop**                                 | banshee, golem   | marcatore `biology.needs_food:false` (134/1211).                                                                                              |
+| 13  | `nodi_micotici`              | **create**                               | otyugh, treant   | Edge `otyugh-sentinella -> treant-portale` type `nutrient_cycle` (0.4). **Collisione da arbitrare**: vedi sez. 4.1.                           |
+| 14  | `origine_artificiale`        | **drop**                                 | banshee, golem   | marcatore non-nato dell'import (134/1211).                                                                                                    |
+| 15  | `proboscide_polifaga`        | **create**                               | otyugh           | Tre edge in entrata: `spore_memetiche` (detritus 0.6), `detrito` (0.5), `bulette-fase` (waste 0.3).                                           |
+| 16  | `respirazione_biologica`     | **drop**                                 | 8 specie vive    | marcatore `biology.breathes:true` (1052/1211).                                                                                                |
+| 17  | `riflessi_preternaturali`    | **create**                               | marilith         | `required_capabilities: multi_attack` + `encounter_role: elite` + edge `contest` verso il balor.                                              |
+| 18  | `rinforzi_modulari`          | **create**                               | golem            | `morphotype: scavenger_corazzato` + `resistance_archetype: corazzato` + hazard `cedimenti_portale`.                                           |
+| 19  | `secrezioni_antisepsi`       | **create**                               | otyugh           | `required_capabilities: purge_toxins` + `services_links: regolazione:depurazione_residui`. Distinto da `secrezioni_antistatiche` (elettrico). |
+| 20  | `sensori_chimici`            | **duplicate-of `acuita_chemorecettiva`** | otyugh           | Il catalogo ha gia' **6** tratti di chemocezione. Vedi sez. 3.1.                                                                              |
+| 21  | `sinapsi_riflettenti`        | **create**                               | rakshasa         | `resistance_archetype: psionico` + `required_capabilities: disrupt_psionics`. Distinto da `neurone_specchio` (vedi sez. 4.2).                 |
+| 22  | `visione_spettrale`          | **create**                               | archon, marilith | Le due specie con `functional_tags: sentinella` e `sentient: true`, nel bioma che ospita una banshee incorporea.                              |
+| 23  | `voce_spettrale`             | **duplicate-of `voce_imperiosa`**        | banshee          | Collide meccanicamente con un tratto esistente **e** con `lamenti_diradanti` sulla stessa creatura. Vedi sez. 3.2.                            |
+
+---
+
+## 3. I due duplicati
+
+### 3.1 `sensori_chimici` -> `acuita_chemorecettiva`
+
+`sensori_chimici` e' il nome piu' generico possibile per una funzione che il catalogo copre **sei volte**:
+
+| id esistente               | `description_it`                                                 |
+| -------------------------- | ---------------------------------------------------------------- |
+| `acuita_chemorecettiva`    | "The range for detection of the source of an odor is increased." |
+| `chemotopia_odoranti`      | identificazione automatica odori non minacciosi                  |
+| `chemotopia_delle_minacce` | identificazione automatica odori minacciosi                      |
+| `chemiorecettori_bromuro`  | (boilerplate, bioma-specifico: pianura salina)                   |
+| `olfatto`                  | range di rilevamento odore                                       |
+| `sistemi_chimio_sonici`    | "Mappare spazio e correnti d'aria senza vista."                  |
+
+Il bisogno dell'otyugh -- fiutare cibo e tossine nel liquame delle fogne astrali -- e' **interamente coperto** da `acuita_chemorecettiva`. Aggiungere un settimo tratto di chemocezione con il nome piu' vago dei sette e' bloat di catalogo.
+
+**Raccomandazione**: **Species Curator** sostituisce il riferimento in `otyugh-sentinella.yaml` con `acuita_chemorecettiva`, che ha gia' voce nel glossario. **Zero nuove definizioni.**
+
+> Nota separata, fuori scope: `acuita_chemorecettiva`, `olfatto`, `chemotopia_*`, `riflesso_di_ritiro`, `azione_evasiva_predator` e `neurone_specchio` hanno tutti come `description_it` **testo inglese non tradotto importato dal dump Ancestors** ("MOVE (button) to choose direction", "ask clan members to mimic..."). E' un problema di qualita' del glossario **preesistente e non mio**, ma va segnalato: sono voci che il censimento non conta tra le 116 boilerplate e che sono comunque rotte.
+
+### 3.2 `voce_spettrale` -> `voce_imperiosa` (**escalation Lore Designer**)
+
+`voce_imperiosa` gia' esiste: _"Voce risonante che paralizza la volonta' dei deboli applicando 2 turni di panic in melee."_ E', meccanicamente, il wail della banshee.
+
+Il problema aggiuntivo e' **interno**: la banshee riferisce **due** tratti vocali, `voce_spettrale` **e** `lamenti_diradanti`. Definirli entrambi le da' tre effetti sonori (contando `risonanza_di_branco`, gia' consumato) su una creatura `event` che compare a `densita: event`. `lamenti_diradanti` e' il tratto che **il foodweb modella davvero** (i due edge `disruption`). `voce_spettrale` no: non ha nessun aggancio strutturale al di la' del nome.
+
+**Verdetto**: `duplicate-of voce_imperiosa`. Il riferimento va sostituito, non definito.
+
+**Ribalta a `create` solo se** il **Lore Designer** stabilisce che il _wail_ della banshee deve essere un tratto nominato proprio (e' iconico in PF1E, e "voce imperiosa" ha una connotazione di **comando**, non di **lutto**). **Non decido io.** Se il verdetto e' `create`, serve comunque una separazione meccanica netta da `lamenti_diradanti` -- e quella e' una decisione **Balancer**.
+
+---
+
+## 4. Collisioni segnalate (non risolte da me)
+
+### 4.1 `nodi_micotici` vs `nodi_micorrizici_oracolari` (esistente)
+
+Esiste gia': `nodi_micorrizici_oracolari` -- _"Nodi micorrizici che anticipano minacce tramite segnali fungini."_ E' un tratto **sensoriale** (preveggenza via rete fungina).
+
+`nodi_micotici` come lo ancoro io e' un tratto **trofico**: il tubo di trasferimento nutrienti fra decompositore (otyugh) e produttore (treant), cioe' l'edge `nutrient_cycle` 0.4. Semanticamente distinti; nominalmente vicinissimi.
+
+Propongo `create`, ma segnalo l'alternativa: **collassare** i due in `nodi_micorrizici_oracolari` estendendone lo scope e fare `drop-the-reference`. E' una decisione sulla **forma del catalogo** (quanti tratti fungini vogliamo) -> **master-dd**, con parere **Lore Designer** sul naming. Se resta `create`, valutare un rename a qualcosa di meno confondibile (p.es. `rete_micotica_detritica`) -- ma il rename tocca i file specie, quindi **Species Curator**.
+
+### 4.2 `visione_spettrale` vs `visione_multi_spettrale_amplificata` (esistente)
+
+`visione_multi_spettrale_amplificata` significa, nella sua descrizione, _"Vedere in luminanza estremamente bassa"_ -- e' **visione notturna**, malgrado il nome. `visione_spettrale` che propongo significa **vedere l'incorporeo**. Sono cose diverse, ma i due nomi si leggono come sinonimi. **Non e' un duplicato**; e' una **trappola di naming**, e la segnalo perche' qualcuno la calpestera'. Rename dell'uno o dell'altro -> **Lore Designer**.
+
+### 4.3 `sinapsi_riflettenti` vs `neurone_specchio` (esistente)
+
+Non e' un duplicato: `neurone_specchio` e' imitazione motoria (e la sua descrizione e' testo Ancestors non tradotto, vedi sez. 3.1). `sinapsi_riflettenti` e' **riflessione psionica** (rimanda al mittente). Ancorato a `resistance_archetype: psionico` + `disrupt_psionics` del rakshasa. `create` senza riserve.
+
+---
+
+## 5. Patch proposta -- glossario (13 voci)
+
+> **NON APPLICATA.** Patch testuale per `data/core/traits/glossary.json`, chiave `traits` (dict alfabetico, 501 voci -> 514).
+> Prosa autorata. `label_en` **tradotta** (nessuna voce lascia `label_en` uguale a `label_it`, e nessuna usa il pattern "X permette alle squadre di..." -- misurato: **116 su 501** voci esistenti hanno quel pattern, non ne aggiungo una).
+> Le descrizioni sono **draft del Curator**: richiedono **co-firma Lore Designer** (sez. 2.3 della carta).
+
+```diff
+--- a/data/core/traits/glossary.json
++++ b/data/core/traits/glossary.json
+@@ traits @@
++    "campo_di_fase": {
++      "label_it": "Campo di Fase",
++      "label_en": "Phase Field",
++      "description_it": "Emettitore runico che intreccia una sottile membrana fuori-fase attorno al portatore e agli alleati adiacenti: cio' che l'attraversa perde un istante di sincronia con questo piano, e arriva smorzato.",
++      "description_en": "Runic emitter weaving a thin out-of-phase membrane around the bearer and adjacent allies: whatever crosses it loses a moment of sync with this plane, and lands blunted."
++    },
++    "fotosintesi_bifase": {
++      "label_it": "Fotosintesi Bifase",
++      "label_en": "Two-Phase Photosynthesis",
++      "description_it": "Doppio apparato fotosintetico: clorofilla ordinaria nella quiete planare, tessuto radianzo-attivo quando i flussi di radianza montano. Accumula nella calma e converte nella tempesta -- ed e' l'unica bocca da cui l'energia entra nelle rovine.",
++      "description_en": "A twin photosynthetic apparatus: ordinary chlorophyll during planar calm, radiance-reactive tissue when the radiance flows surge. It stores in the lull and converts in the storm -- and it is the only mouth through which energy enters the ruins."
++    },
++    "ghiandole_nettare_memetico": {
++      "label_it": "Ghiandole di Nettare Memetico",
++      "label_en": "Memetic Nectar Glands",
++      "description_it": "Ghiandole che distillano un nettare carico di frammenti di memoria altrui. Chi lo raccoglie riceve nutrimento e, insieme, un ricordo che non e' suo: e' la moneta con cui il couatl paga il treant per l'impollinazione.",
++      "description_en": "Glands distilling a nectar laced with fragments of other minds. Whoever gathers it takes food and, with it, a memory that is not their own: the coin the couatl pays the treant for pollination."
++    },
++    "intangibilita_parziale": {
++      "label_it": "Intangibilita' Parziale",
++      "label_en": "Partial Intangibility",
++      "description_it": "Il corpo non e' mai del tutto qui. Attraversa muri e corpi come se fossero un disegno mal ricalcato, ma paga la traversata: ogni passaggio lo sfuoca, e cio' che e' sfuocato non puo' afferrare nulla.",
++      "description_en": "The body is never entirely here. It passes through walls and bodies as through a badly traced drawing, but the crossing costs: each passage blurs it, and what is blurred can grip nothing."
++    },
++    "lamenti_diradanti": {
++      "label_it": "Lamenti Diradanti",
++      "label_en": "Thinning Laments",
++      "description_it": "Un lamento a bassa frequenza che non ferisce: separa. I gruppi che lo ascoltano perdono la coesione e si sparpagliano, e nelle rovine e' l'unica forza capace di rompere una muta di balor a fissione.",
++      "description_en": "A low-frequency wail that does not wound: it separates. Groups that hear it lose cohesion and scatter, and in the ruins it is the only force able to break a pack of fission balors."
++    },
++    "maschera_illusoria": {
++      "label_it": "Maschera Illusoria",
++      "label_en": "Illusory Mask",
++      "description_it": "Non un camuffamento della pelle, ma dello sguardo altrui: il rakshasa indossa il volto che l'osservatore si aspettava di vedere. Regge finche' nessuno lo guarda con un senso che non sia la vista.",
++      "description_en": "Not a disguise of the skin but of the onlooker's gaze: the rakshasa wears the face the observer expected to see. It holds until someone looks with a sense that is not sight."
++    },
++    "nodi_micotici": {
++      "label_it": "Nodi Micotici",
++      "label_en": "Mycotic Nodes",
++      "description_it": "Noduli fungini che saldano radice e intestino: il decompositore restituisce al produttore l'azoto strappato al detrito senza che nessuno dei due si muova. E' il condotto lungo cui la materia risale la rete trofica.",
++      "description_en": "Fungal nodules welding root to gut: the decomposer returns to the producer the nitrogen torn from detritus, without either of them moving. It is the duct along which matter climbs back up the food web."
++    },
++    "proboscide_polifaga": {
++      "label_it": "Proboscide Polifaga",
++      "label_en": "Polyphagous Proboscis",
++      "description_it": "Proboscide muscolare priva di specializzazione: ingoia carcasse, spore, scorie minerali e reliquie corrose con la stessa indifferenza. Cio' che le rovine non digeriscono, lo digerisce lei.",
++      "description_en": "A muscular, unspecialised proboscis: it swallows carcasses, spores, mineral slag and corroded relics with equal indifference. Whatever the ruins cannot digest, it digests."
++    },
++    "riflessi_preternaturali": {
++      "label_it": "Riflessi Preternaturali",
++      "label_en": "Preternatural Reflexes",
++      "description_it": "Sei braccia governate da un tronco nervoso che non aspetta il proprio turno: la marilith risponde mentre il colpo e' ancora in volo, e non le resta un lato cieco da cui aggirarla.",
++      "description_en": "Six arms governed by a nerve trunk that does not wait its turn: the marilith answers while the blow is still in the air, and she is left with no blind side to be flanked from."
++    },
++    "rinforzi_modulari": {
++      "label_it": "Rinforzi Modulari",
++      "label_en": "Modular Reinforcements",
++      "description_it": "La corazza non guarisce: si sostituisce. Il golem stacca le piastre incrinate e le rimpiazza con detriti di pietra planare raccolti sul posto, restando in piedi mentre si ricostruisce.",
++      "description_en": "The plating does not heal: it is replaced. The golem sheds cracked plates and swaps in planar stone rubble gathered on the spot, staying upright while it rebuilds itself."
++    },
++    "secrezioni_antisepsi": {
++      "label_it": "Secrezioni di Antisepsi",
++      "label_en": "Antiseptic Secretions",
++      "description_it": "Muco battericida che riveste bocca e canali digestivi. E' cio' che consente di vivere immersi nei residui delle fogne astrali senza esserne infettati -- e, colato nell'acqua ferma, la rende potabile per gli altri.",
++      "description_en": "Bactericidal mucus lining mouth and gut. It is what allows life immersed in the sludge of the astral sewers without infection -- and, spilled into standing water, it makes that water drinkable for others."
++    },
++    "sinapsi_riflettenti": {
++      "label_it": "Sinapsi Riflettenti",
++      "label_en": "Reflecting Synapses",
++      "description_it": "Sinapsi rivestite di uno strato che rimanda indietro cio' che riceve: l'intrusione psionica torna al mittente, portandosi dietro un frammento di cio' che era venuta a leggere.",
++      "description_en": "Synapses sheathed in a layer that sends back what it receives: the psionic intrusion returns to its sender, carrying with it a fragment of what it had come to read."
++    },
++    "visione_spettrale": {
++      "label_it": "Visione Spettrale",
++      "label_en": "Spectral Sight",
++      "description_it": "Occhi tarati sulla banda in cui le rovine tengono i propri morti: vedono cio' che e' presente solo a meta'. E' il senso che separa una sentinella da una preda, in un bioma dove meta' delle minacce non proietta ombra.",
++      "description_en": "Eyes tuned to the band in which the ruins keep their dead: they see what is only half present. It is the sense that separates a sentinel from prey, in a biome where half the threats cast no shadow."
++    },
+```
+
+---
+
+## 6. Patch proposta -- file per-tratto (13 file)
+
+> **NON APPLICATI.** Conformi a `config/schemas/trait.schema.json` (`schema_version: "2.0"`, `additionalProperties: false`).
+> Modelli usati (file reali, ben autorati, stessa lineage `pathfinder_dataset`): **`data/traits/difensivo/armatura_pietra_planare.json`** e **`data/traits/sensoriale/antenne_waveguide.json`**.
+> `data_origin: pathfinder_dataset` / `fonte: pathfinder_import` -- **mai** `coverage_autogen` (e' il marcatore dello strato fabbricato rimosso il 2026-07-14).
+
+### 6.1 Campi che NON decido io
+
+Ogni file sotto riporta `"tier": "<<BALANCER>>"`. **Lo schema richiede `tier` con pattern `^T[1-6]$`: i file NON sono validi cosi' come sono, ed e' voluto.** Non posso applicarli neanche volendo. Il Balancer sostituisce il placeholder e allora diventano validi.
+
+Ownership:
+
+| campo                                                                                      | owner                          |
+| ------------------------------------------------------------------------------------------ | ------------------------------ |
+| `tier`, `slot`, `slot_profile`                                                             | **Balancer**                   |
+| `data/core/traits/active_effects.yaml` (meccanica + numeri runtime)                        | **Balancer** (+ runtime owner) |
+| `conflitti` (sono vincoli di gameplay)                                                     | **Balancer**                   |
+| `label`/`mutazione_indotta`/`uso_funzione`/`spinta_selettiva`/`debolezza` (stringhe i18n)  | **Lore Designer**              |
+| `sinergie`, `famiglia_tipologia`, `requisiti_ambientali`, `biome_tags`, categoria/cartella | **Trait Curator** (io)         |
+| spostamento da `pending_trait_definitions` a `genetic_traits`                              | **Species Curator**            |
+
+Le `sinergie` che propongo puntano **solo** a tratti gia' esistenti nel glossario (verificato uno per uno).
+
+### 6.2 I file
+
+**`data/traits/difensivo/campo_di_fase.json`** -- golem-runico
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "campo_di_fase",
+  "label": "i18n:traits.campo_di_fase.label",
+  "famiglia_tipologia": "Difesa/Campo",
+  "fattore_mantenimento_energetico": "Alto (emissione continua)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": [
+    "armatura_pietra_planare",
+    "nuclei_di_controllo",
+    "matrice_antimagia",
+    "aura_scudo_radianza"
+  ],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": ["deploy_barrier"],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "Ancora agli edge `fortification` golem -> archon / couatl / treant del foodweb."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.campo_di_fase.mutazione_indotta",
+  "uso_funzione": "i18n:traits.campo_di_fase.uso_funzione",
+  "spinta_selettiva": "i18n:traits.campo_di_fase.spinta_selettiva",
+  "debolezza": "i18n:traits.campo_di_fase.debolezza",
+  "usage_tags": ["support", "tank"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/metabolico/fotosintesi_bifase.json`** -- treant-portale
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "fotosintesi_bifase",
+  "label": "i18n:traits.fotosintesi_bifase.label",
+  "famiglia_tipologia": "Metabolismo/Autotrofia",
+  "fattore_mantenimento_energetico": "Basso (autotrofo)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": [
+    "pigmenti_aurorali",
+    "reti_capillari_radici",
+    "radici_ancora_planare",
+    "nodi_micotici"
+  ],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "Il treant e' l'unico `produttore` in rovine_planari.ecosystem.yaml; risorsa `flussi_radianza`, meteo `quiete_planare` vs hazard `tempesta_radianza`."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.fotosintesi_bifase.mutazione_indotta",
+  "uso_funzione": "i18n:traits.fotosintesi_bifase.uso_funzione",
+  "spinta_selettiva": "i18n:traits.fotosintesi_bifase.spinta_selettiva",
+  "debolezza": "i18n:traits.fotosintesi_bifase.debolezza",
+  "usage_tags": ["support"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/simbiotico/ghiandole_nettare_memetico.json`** -- couatl-aurora
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "ghiandole_nettare_memetico",
+  "label": "i18n:traits.ghiandole_nettare_memetico.label",
+  "famiglia_tipologia": "Simbiosi/Impollinazione",
+  "fattore_mantenimento_energetico": "Medio (secrezione ciclica)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": [
+    "ghiandole_mnemoniche",
+    "ali_solari_fotoni",
+    "empatia_coordinativa",
+    "fotosintesi_bifase"
+  ],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "Edge `couatl-aurora -> treant-portale` type `pollination` (0.5); risorsa `spore_memetiche`; meteo `vento_memetico`."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.ghiandole_nettare_memetico.mutazione_indotta",
+  "uso_funzione": "i18n:traits.ghiandole_nettare_memetico.uso_funzione",
+  "spinta_selettiva": "i18n:traits.ghiandole_nettare_memetico.spinta_selettiva",
+  "debolezza": "i18n:traits.ghiandole_nettare_memetico.debolezza",
+  "usage_tags": ["support"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/difensivo/intangibilita_parziale.json`** -- banshee-risonante
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "intangibilita_parziale",
+  "label": "i18n:traits.intangibilita_parziale.label",
+  "famiglia_tipologia": "Difesa/Fase",
+  "fattore_mantenimento_energetico": "Medio (perdita di coerenza)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": ["carapace_fase_variabile", "eco_sismico", "adattamento_volo"],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": ["phase_shift"],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "`required_capabilities: phase_shift` della banshee; hazard `fratture_planari`."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.intangibilita_parziale.mutazione_indotta",
+  "uso_funzione": "i18n:traits.intangibilita_parziale.uso_funzione",
+  "spinta_selettiva": "i18n:traits.intangibilita_parziale.spinta_selettiva",
+  "debolezza": "i18n:traits.intangibilita_parziale.debolezza",
+  "usage_tags": ["skirmisher"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/offensivo/lamenti_diradanti.json`** -- banshee-risonante
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "lamenti_diradanti",
+  "label": "i18n:traits.lamenti_diradanti.label",
+  "famiglia_tipologia": "Offesa/Sonico",
+  "fattore_mantenimento_energetico": "Alto (scarica emozionale)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": ["eco_sismico", "risonanza_di_branco", "intangibilita_parziale"],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": ["sonic_control"],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "Gli unici due edge `disruption` del foodweb: banshee -> balor (0.5), banshee -> rakshasa (0.4). Il tratto E' quegli edge."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.lamenti_diradanti.mutazione_indotta",
+  "uso_funzione": "i18n:traits.lamenti_diradanti.uso_funzione",
+  "spinta_selettiva": "i18n:traits.lamenti_diradanti.spinta_selettiva",
+  "debolezza": "i18n:traits.lamenti_diradanti.debolezza",
+  "usage_tags": ["breaker"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/cognitivo/maschera_illusoria.json`** -- rakshasa-corte
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "maschera_illusoria",
+  "label": "i18n:traits.maschera_illusoria.label",
+  "famiglia_tipologia": "Cognitivo/Illusione",
+  "fattore_mantenimento_energetico": "Medio (proiezione sostenuta)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": [
+    "artigli_psionici",
+    "tessuti_adattivi",
+    "sinapsi_riflettenti",
+    "mimetismo_cromatico_passivo"
+  ],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": ["infiltrate"],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "Edge `parasitism` rakshasa -> archon (0.3) e -> treant (0.3); `services_links: minaccia:corruzione_iconica`. La maschera e' il vettore del parassitismo."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.maschera_illusoria.mutazione_indotta",
+  "uso_funzione": "i18n:traits.maschera_illusoria.uso_funzione",
+  "spinta_selettiva": "i18n:traits.maschera_illusoria.spinta_selettiva",
+  "debolezza": "i18n:traits.maschera_illusoria.debolezza",
+  "usage_tags": ["scout", "skirmisher"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/simbiotico/nodi_micotici.json`** -- otyugh-sentinella, treant-portale -- **vedi sez. 4.1**
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "nodi_micotici",
+  "label": "i18n:traits.nodi_micotici.label",
+  "famiglia_tipologia": "Simbiosi/Micorrizica",
+  "fattore_mantenimento_energetico": "Basso (passivo)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": [
+    "reti_capillari_radici",
+    "fotosintesi_bifase",
+    "filtri_bioattivi",
+    "nodi_micorrizici_oracolari"
+  ],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "Edge `otyugh-sentinella -> treant-portale` type `nutrient_cycle` (0.4): l'unico ritorno di nutrienti al produttore. Collisione di naming con nodi_micorrizici_oracolari: arbitrato pendente (master-dd)."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.nodi_micotici.mutazione_indotta",
+  "uso_funzione": "i18n:traits.nodi_micotici.uso_funzione",
+  "spinta_selettiva": "i18n:traits.nodi_micotici.spinta_selettiva",
+  "debolezza": "i18n:traits.nodi_micotici.debolezza",
+  "usage_tags": ["support"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/alimentazione/proboscide_polifaga.json`** -- otyugh-sentinella
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "proboscide_polifaga",
+  "label": "i18n:traits.proboscide_polifaga.label",
+  "famiglia_tipologia": "Alimentazione/Detritivoria",
+  "fattore_mantenimento_energetico": "Medio (masticazione continua)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": ["filtri_bioattivi", "membrane_osmotiche", "secrezioni_antisepsi", "nodi_micotici"],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": ["anchor_waste"],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "Tre edge in entrata sull'otyugh: `spore_memetiche` (detritus 0.6), `detrito` (0.5), `bulette-fase` (waste 0.3). Tre fonti diverse, una sola bocca."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.proboscide_polifaga.mutazione_indotta",
+  "uso_funzione": "i18n:traits.proboscide_polifaga.uso_funzione",
+  "spinta_selettiva": "i18n:traits.proboscide_polifaga.spinta_selettiva",
+  "debolezza": "i18n:traits.proboscide_polifaga.debolezza",
+  "usage_tags": ["support"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/nervoso/riflessi_preternaturali.json`** -- marilith-vault
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "riflessi_preternaturali",
+  "label": "i18n:traits.riflessi_preternaturali.label",
+  "famiglia_tipologia": "Nervoso/Reattivita",
+  "fattore_mantenimento_energetico": "Alto (vigilanza continua)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": [
+    "focus_frazionato",
+    "artigli_sette_vie",
+    "articolazioni_multiassiali",
+    "visione_spettrale"
+  ],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": ["multi_attack"],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "`required_capabilities: multi_attack` + `encounter_role: elite`; edge `contest` marilith -> balor (0.4): contende l'apex senza esserlo."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.riflessi_preternaturali.mutazione_indotta",
+  "uso_funzione": "i18n:traits.riflessi_preternaturali.uso_funzione",
+  "spinta_selettiva": "i18n:traits.riflessi_preternaturali.spinta_selettiva",
+  "debolezza": "i18n:traits.riflessi_preternaturali.debolezza",
+  "usage_tags": ["skirmisher"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/strutturale/rinforzi_modulari.json`** -- golem-runico
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "rinforzi_modulari",
+  "label": "i18n:traits.rinforzi_modulari.label",
+  "famiglia_tipologia": "Struttura/Modularita",
+  "fattore_mantenimento_energetico": "Medio (ricambio piastre)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": ["armatura_pietra_planare", "campo_di_fase", "nuclei_di_controllo"],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "`morphotype: scavenger_corazzato` + `resistance_archetype: corazzato`; hazard `cedimenti_portale` fornisce la pietra di ricambio."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.rinforzi_modulari.mutazione_indotta",
+  "uso_funzione": "i18n:traits.rinforzi_modulari.uso_funzione",
+  "spinta_selettiva": "i18n:traits.rinforzi_modulari.spinta_selettiva",
+  "debolezza": "i18n:traits.rinforzi_modulari.debolezza",
+  "usage_tags": ["tank"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/escretorio/secrezioni_antisepsi.json`** -- otyugh-sentinella
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "secrezioni_antisepsi",
+  "label": "i18n:traits.secrezioni_antisepsi.label",
+  "famiglia_tipologia": "Escrezione/Antisepsi",
+  "fattore_mantenimento_energetico": "Medio (produzione mucosa)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": ["filtri_bioattivi", "membrane_osmotiche", "proboscide_polifaga"],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": ["purge_toxins"],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "`services_links: regolazione:depurazione_residui` + `supporto:riciclo_nutrienti`; hazard `invasione_vite_dimensionali`. Distinto da `secrezioni_antistatiche` (dispersione elettrica)."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.secrezioni_antisepsi.mutazione_indotta",
+  "uso_funzione": "i18n:traits.secrezioni_antisepsi.uso_funzione",
+  "spinta_selettiva": "i18n:traits.secrezioni_antisepsi.spinta_selettiva",
+  "debolezza": "i18n:traits.secrezioni_antisepsi.debolezza",
+  "usage_tags": ["support"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/nervoso/sinapsi_riflettenti.json`** -- rakshasa-corte
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "sinapsi_riflettenti",
+  "label": "i18n:traits.sinapsi_riflettenti.label",
+  "famiglia_tipologia": "Nervoso/Psionico",
+  "fattore_mantenimento_energetico": "Alto (schermatura attiva)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": ["artigli_psionici", "maschera_illusoria", "tessuti_adattivi", "focus_frazionato"],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": ["disrupt_psionics"],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "`resistance_archetype: psionico`; hazard `eco_mnemonico`. Il rakshasa e' l'unico bersaglio dell'edge `suppression` della marilith (0.4): la riflessione e' la sua risposta."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.sinapsi_riflettenti.mutazione_indotta",
+  "uso_funzione": "i18n:traits.sinapsi_riflettenti.uso_funzione",
+  "spinta_selettiva": "i18n:traits.sinapsi_riflettenti.spinta_selettiva",
+  "debolezza": "i18n:traits.sinapsi_riflettenti.debolezza",
+  "usage_tags": ["skirmisher", "support"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+**`data/traits/sensoriale/visione_spettrale.json`** -- archon-solare, marilith-vault -- **vedi sez. 4.2**
+
+```json
+{
+  "schema_version": "2.0",
+  "id": "visione_spettrale",
+  "label": "i18n:traits.visione_spettrale.label",
+  "famiglia_tipologia": "Sensoriale/Spettrale",
+  "fattore_mantenimento_energetico": "Basso (passivo)",
+  "tier": "<<BALANCER>>",
+  "slot": [],
+  "sinergie": [
+    "occhi_infrarosso_composti",
+    "sensori_geomagnetici",
+    "focus_frazionato",
+    "riflessi_preternaturali"
+  ],
+  "conflitti": [],
+  "biome_tags": ["rovine_planari"],
+  "requisiti_ambientali": [
+    {
+      "capacita_richieste": [],
+      "condizioni": { "biome_class": "rovine_planari" },
+      "fonte": "pathfinder_import",
+      "meta": {
+        "expansion": "pathfinder_dataset",
+        "notes": "Riferito dalle due specie con `functional_tags: sentinella` e `sentient: true` (archon, marilith), in un bioma che ospita una banshee `phase_shift`. Naming da disambiguare vs `visione_multi_spettrale_amplificata` (che e' visione notturna)."
+      }
+    }
+  ],
+  "mutazione_indotta": "i18n:traits.visione_spettrale.mutazione_indotta",
+  "uso_funzione": "i18n:traits.visione_spettrale.uso_funzione",
+  "spinta_selettiva": "i18n:traits.visione_spettrale.spinta_selettiva",
+  "debolezza": "i18n:traits.visione_spettrale.debolezza",
+  "usage_tags": ["scout"],
+  "data_origin": "pathfinder_dataset"
+}
+```
+
+---
+
+## 7. Sequenza di applicazione (per chi ratifica)
+
+**Non eseguirla ora.** Ordine vincolante -- il passo 5 e' l'unico che tocca il bridge, ed e' l'ultimo.
+
+1. **master-dd** ratifica la verdict table (13 create / 2 duplicate / 8 drop) e arbitra sez. 4.1.
+2. **Lore Designer** co-firma le 13 descrizioni di glossario (sez. 5) e riempie le stringhe i18n; verdetto su `voce_spettrale` (sez. 3.2) e sui rename di sez. 4.1/sez. 4.2.
+3. **Balancer** sostituisce i 13 `<<BALANCER>>`, decide `slot`/`slot_profile`/`conflitti` e -- se e quando servono effetti runtime -- le entry in `data/core/traits/active_effects.yaml`. Finche' i placeholder ci sono, **i file non validano**: e' il guard.
+4. **Species Curator** modifica i 10 YAML: rimuove gli 8 marcatori (sez. 1.5), sostituisce i 2 duplicati (`sensori_chimici` -> `acuita_chemorecettiva`, `voce_spettrale` -> `voce_imperiosa`), sposta i 13 da `pending_trait_definitions` a `genetic_traits`/`derived_from_environment`. `pending_trait_definitions` sparisce da tutti e 10.
+5. **Solo allora** rigenerare il bridge + `check_derived_reproducible.py --deep` + verifica invariante glossario.
+
+### 7.1 Il `setdefault` resta un buco
+
+`tools/py/build_species_trait_bridge.py:145` fa ancora `trait_index.setdefault(trait_id, {})`. Se qualcuno esegue il passo 5 **prima** dei passi 1-4, il bridge **fabbrica 23 voci nude** e nessun gate se ne accorge. La proposta **non lo risolve** (non e' nel mio ambito di scrittura): resta il reuse path 3 di `M-2026-07-15-003` -- sostituire `setdefault` con un **fail esplicito**. Raccomando di farlo **prima** del passo 5, non dopo.
+
+### 7.2 L'invariante da difendere
+
+Misurato ora, su questo branch:
+
+- `data/traits/species_affinity.json`: **204 trait id, 204 con voce di glossario. Zero mancanti.**
+  (L'issue #3307 dice "203/203": il numero misurato oggi e' **204**. Discrepanza minima, segnalata per onesta'; il rapporto -- 100% -- e' identico.)
+- Trait id privi di file per-tratto: **3** (`pigmenti_termici`, `proteine_shock_termico`, `reti_capillari_radici`) -- tolleranza confermata.
+- File per-tratto totali: **309**. Voci di glossario: **501**.
+
+Applicando questa proposta nell'ordine dato, l'invariante **resta a 100%**: le 13 voci di glossario **precedono** il consumo dei 13 id.
+
+---
+
+## 8. Domande aperte per master-dd
+
+1. **Gli 8 marcatori**: opzione A (campo `physiology:` nello schema specie 1.7) o opzione B (rimozione secca)? A conserva informazione ed e' gia' implicitamente usata dai ruoli trofici; B costa zero. **Non ho preferenza forte, ma A e' piu' onesta.**
+2. **`fisiologia_predatoria` / bulette**: confermi che il modello trofico (erbivoro primario) vince sull'origine Pathfinder (carnivoro)? Se **no**, l'ecosistema resta senza consumatori primari e il foodweb ha un edge `herbivory` da riscrivere -- e la questione diventa Species + Biome Curator, non trait.
+3. **sez. 4.1 `nodi_micotici`**: due tratti fungini (uno trofico, uno oracolare) o uno solo esteso? Decide la forma del catalogo.
+4. **sez. 3.2 `voce_spettrale`**: il wail della banshee e' un tratto proprio (lore) o e' `voce_imperiosa` (riuso)? Serve il **Lore Designer**.
+5. **Le 15 sinergie che propongo puntano a tratti esistenti, ma non ho verificato la reciprocita'** (sez. 7.2 della carta: "non rimuovere sinergie/conflitti senza verifica di reciprocita'"). Aggiungere `nodi_micotici` alle `sinergie` di `reti_capillari_radici` ecc. sarebbe una modifica a file **esistenti**, e non l'ho proposta. Va fatta? Da chi?
+6. **Quante altre specie riferiscono tratti fuori dal glossario?** `M-2026-07-15-003` lo dichiara non verificato. Le 10 di `rovine_planari` sono le uniche controllate. Vale un audit sull'intero catalogo specie **prima** di toccare il bridge.
+
+---
+
+## 9. Cosa NON ho fatto (dichiarato)
+
+- **Non ho scritto nulla fuori da questo file.** `data/traits/**`, `data/core/traits/*.json`, `data/traits/species_affinity.json`, i file specie, gli `*-trait-keeper.yaml` e le regole env: **intatti**. (`git status` lo conferma.)
+- **Non ho deciso nessun `tier`, `slot`, numero o effetto runtime** -- Balancer.
+- **Non ho scritto le stringhe i18n** (`mutazione_indotta` / `uso_funzione` / `spinta_selettiva` / `debolezza`): sono lore, e sono del **Lore Designer**. Le descrizioni di glossario in sez. 5 sono **draft che richiedono la sua co-firma**, non testo finale.
+- **Non ho rigenerato il bridge, non ho eseguito i gate, non ho committato, non ho aperto PR.**
+- **Non ho verificato** che il resto del catalogo specie (le ~95 specie fuori da `rovine_planari`) sia pulito rispetto al glossario. Domanda aperta #6.

--- a/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/archon-solare.yaml
@@ -1,3 +1,108 @@
-resistance_archetype: adattivo
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: 24d857d1a1ff25ab704156f02b4b61f5df2b2ecdd9d1f760a143421739ff784c
 id: archon-solare
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Archon Solare Custode
+biomes:
+  - rovine_planari
+role_trofico: dispersore_ponte
+functional_tags:
+  - impollinatore
+  - dispersore
+  - specie_chiave
+  - sentinella
+morphotype: volatore_planatore
+resistance_archetype: adattivo
+flags:
+  apex: false
+  keystone: true
+  sentient: true
+  bridge: true
+  threat: false
+  event: false
+playable_unit: true
+pi_loadout:
+  weight_budget: 13
+  default_parts:
+    locomotion: glide_wings
+    senses:
+      - echolocate
+    offense:
+      - claw_finesse
+    defense:
+      - elastomer_skin
+vc:
+  aggro: 0.5
+  risk: 0.4
+  cohesion: 0.8
+  setup: 0.6
+  explore: 0.7
+  tilt: 0.2
+services_links:
+  - supporto:luci_sacre
+  - regolazione:scudi_radiani
+spawn_rules:
+  orario:
+    - crepuscolo
+    - notte
+  meteo:
+    - nebbia_risonante
+    - quiete_planare
+  densita: low
+balance:
+  rarity: R3
+  threat_tier: T2
+  encounter_role: support
+telemetry:
+  expected_pick_rate: 0.24
+  spawn_weight: 0.18
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - tempesta_radianza
+    - fratture_planari
+derived_from_environment:
+  suggested_traits:
+    - ali_solari_fotoni
+    - empatia_coordinativa
+    - risonanza_di_branco
+    - aura_scudo_radianza
+  optional_traits:
+    - focus_frazionato
+    - lamelle_termoforetiche
+  required_capabilities:
+    - flight
+    - radiant_resist
+  services_links:
+    - supporto:rinforzo_barriere
+    - culturale:guida_spirituale
+  jobs_bias:
+    - invoker
+    - skirmisher
+genetic_traits:
+  core:
+    - adattamento_volo
+    - aura_scudo_radianza
+  optional:
+    - empatia_coordinativa
+  synergy:
+    - focus_frazionato
+    - risonanza_di_branco
+mate_synergy:
+  - empatia_coordinativa
+jobs_synergy: []
+description: i18n:species.archon-solare.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - ciclo_vitale_completo
+  - metabolismo_attivo
+  - respirazione_biologica
+  - visione_spettrale

--- a/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/balor-fission.yaml
@@ -1,3 +1,91 @@
-resistance_archetype: termico
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: e300bb3c457a32a1d02f2d1d24e4f8e7e93919d3ac6c57847caee3f789945be5
 id: balor-fission
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Balor a Fissione
+biomes:
+  - rovine_planari
+role_trofico: predatore_terziario_apex
+functional_tags:
+  - predatore
+  - minaccia
+morphotype: cursoriale_quadrupede
+resistance_archetype: termico
+flags:
+  apex: true
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: true
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.9
+  risk: 0.8
+  cohesion: 0.3
+  setup: 0.5
+  explore: 0.4
+  tilt: 0.6
+spawn_rules:
+  orario:
+    - notte
+  meteo:
+    - tempesta_radianza
+    - pioggia_cenere
+  densita: very_low
+balance:
+  rarity: R4
+  threat_tier: T4
+  encounter_role: boss
+services_links:
+  - minaccia:collasso_portali
+telemetry:
+  expected_pick_rate: 0.08
+  spawn_weight: 0.05
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - vortici_abiurazione
+    - piogge_cenere_planare
+derived_from_environment:
+  suggested_traits:
+    - artigli_sette_vie
+    - frusta_fiammeggiante
+    - armatura_pietra_planare
+    - carapace_fase_variabile
+    - mantello_meteoritico
+  optional_traits:
+    - criostasi_adattiva
+    - tattiche_di_branco
+  required_capabilities:
+    - fire_resist
+    - void_stride
+  jobs_bias:
+    - vanguard
+    - warden
+genetic_traits:
+  core:
+    - adattamento_volo
+    - mantello_meteoritico
+    - frusta_fiammeggiante
+  optional:
+    - empatia_coordinativa
+    - carapace_fase_variabile
+  synergy:
+    - focus_frazionato
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.balor-fission.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - ciclo_vitale_completo
+  - metabolismo_attivo
+  - respirazione_biologica

--- a/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/banshee-risonante.yaml
@@ -1,3 +1,90 @@
-resistance_archetype: psionico
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: 6ad1db6176039b9b95b058d71cd389ea8cf008b5b5f1bea28ed9d1be10d2e0ef
 id: banshee-risonante
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Banshee Risonante
+biomes:
+  - rovine_planari
+role_trofico: evento_ecologico
+functional_tags:
+  - pulse_climatico
+  - minaccia
+morphotype: volatore_planatore
+resistance_archetype: psionico
+flags:
+  apex: false
+  keystone: false
+  sentient: true
+  bridge: false
+  threat: true
+  event: true
+playable_unit: false
+vc:
+  aggro: 0.6
+  risk: 0.7
+  cohesion: 0.2
+  setup: 0.6
+  explore: 0.5
+  tilt: 0.8
+services_links:
+  - culturale:avvisi_spettrali
+spawn_rules:
+  orario:
+    - notte
+  meteo:
+    - nebbia_risonante
+    - pioggia_cenere
+  densita: event
+balance:
+  rarity: R5
+  threat_tier: T4
+  encounter_role: event
+telemetry:
+  expected_pick_rate: null
+  spawn_weight: null
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfb
+  hazards_expected:
+    - tempesta_radianza
+    - eco_mnemonico
+derived_from_environment:
+  suggested_traits:
+    - eco_sismico
+  optional_traits:
+    - focus_frazionato
+    - risonanza_di_branco
+  required_capabilities:
+    - phase_shift
+    - sonic_control
+  services_links:
+    - culturale:memorie_orali
+    - regolazione:scarico_emozionale
+  jobs_bias:
+    - invoker
+    - support
+genetic_traits:
+  core:
+    - adattamento_volo
+    - risonanza_di_branco
+  optional: []
+  synergy:
+    - focus_frazionato
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.banshee-risonante.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - assenza_respirazione
+  - ciclo_vitale_anomalo
+  - intangibilita_parziale
+  - lamenti_diradanti
+  - metabolismo_sostentato
+  - origine_artificiale
+  - voce_spettrale

--- a/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/bulette-fase.yaml
@@ -1,3 +1,88 @@
-resistance_archetype: corazzato
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: 82f0fd302ed964e9cc1e8b9725d11129e09b8b1c711b39b2c6dbb8aa3eeb7ce7
 id: bulette-fase
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Bulette di Fase
+biomes:
+  - rovine_planari
+role_trofico: erbivoro_primario
+functional_tags:
+  - prede
+  - detritivoro
+morphotype: cursoriale_quadrupede
+resistance_archetype: corazzato
+flags:
+  apex: false
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.35
+  risk: 0.5
+  cohesion: 0.6
+  setup: 0.4
+  explore: 0.7
+  tilt: 0.3
+services_links:
+  - approvvigionamento:minerali_planari
+spawn_rules:
+  orario:
+    - diurno
+  meteo:
+    - pioggia_cenere
+    - quiete_planare
+  densita: high
+balance:
+  rarity: R1
+  threat_tier: T2
+  encounter_role: minion
+telemetry:
+  expected_pick_rate: 0.28
+  spawn_weight: 0.32
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+  hazards_expected:
+    - cedimenti_portale
+    - tempesta_radianza
+derived_from_environment:
+  suggested_traits:
+    - scheletro_idro_regolante
+    - sensori_geomagnetici
+    - coda_frusta_cinetica
+    - lamelle_termoforetiche
+  optional_traits:
+    - carapace_fase_variabile
+    - sacche_galleggianti_ascensoriali
+  required_capabilities:
+    - burrow
+    - planar_tremor_sense
+  services_links:
+    - approvvigionamento:estrazione_fragili
+  jobs_bias:
+    - vanguard
+    - warden
+genetic_traits:
+  core:
+  optional:
+    - carapace_fase_variabile
+    - armatura_pietra_planare
+  synergy: []
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.bulette-fase.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - ciclo_vitale_completo
+  - fisiologia_predatoria
+  - metabolismo_attivo
+  - respirazione_biologica

--- a/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/couatl-aurora.yaml
@@ -1,3 +1,104 @@
-resistance_archetype: adattivo
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: 04573cf0da854192d12f2cd4f015e3c569684169af5dd08f662693c42da30f24
 id: couatl-aurora
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Couatl Aurora Custode
+biomes:
+  - rovine_planari
+role_trofico: dispersore_ponte
+functional_tags:
+  - impollinatore
+  - dispersore
+  - simbionte
+morphotype: volatore_planatore
+resistance_archetype: adattivo
+flags:
+  apex: false
+  keystone: false
+  sentient: true
+  bridge: true
+  threat: false
+  event: false
+playable_unit: true
+pi_loadout:
+  weight_budget: 11
+  default_parts:
+    locomotion: glide_wings
+    senses:
+      - echolocate
+    offense:
+      - acid_gland
+vc:
+  aggro: 0.4
+  risk: 0.3
+  cohesion: 0.7
+  setup: 0.6
+  explore: 0.8
+  tilt: 0.3
+services_links:
+  - supporto:cartografia_planare
+  - culturale:oracolo_di_corrente
+spawn_rules:
+  orario:
+    - diurno
+    - crepuscolo
+  meteo:
+    - quiete_planare
+    - vento_memetico
+  densita: mid
+balance:
+  rarity: R2
+  threat_tier: T1
+  encounter_role: support
+telemetry:
+  expected_pick_rate: 0.26
+  spawn_weight: 0.25
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - tempesta_radianza
+    - pioggia_cenere
+derived_from_environment:
+  suggested_traits:
+    - empatia_coordinativa
+    - sensori_geomagnetici
+    - ali_solari_fotoni
+  optional_traits:
+    - occhi_infrarosso_composti
+    - focus_frazionato
+  required_capabilities:
+    - flight
+    - planar_map
+  services_links:
+    - supporto:rituale_migrazione
+    - culturale:memoria_delle_porte
+  jobs_bias:
+    - invoker
+    - skirmisher
+genetic_traits:
+  core:
+    - adattamento_volo
+  optional:
+    - empatia_coordinativa
+    - lamelle_termoforetiche
+    - artigli_sette_vie
+  synergy:
+    - focus_frazionato
+    - risonanza_di_branco
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.couatl-aurora.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - ciclo_vitale_completo
+  - ghiandole_nettare_memetico
+  - metabolismo_attivo
+  - respirazione_biologica

--- a/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/golem-runico.yaml
@@ -1,3 +1,89 @@
-resistance_archetype: corazzato
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: f47f771787d8d19cc44ceb22efef67e01b481d088b7e74815416c4462deca4cd
 id: golem-runico
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Golem Runico Custodiale
+biomes:
+  - rovine_planari
+role_trofico: ingegneri_ecosistema
+functional_tags:
+  - ingegneri_ecosistema
+  - sentinella
+morphotype: scavenger_corazzato
+resistance_archetype: corazzato
+flags:
+  apex: false
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.4
+  risk: 0.3
+  cohesion: 0.6
+  setup: 0.7
+  explore: 0.3
+  tilt: 0.2
+services_links:
+  - supporto:mantenimento_sigilli
+  - regolazione:scarico_energia
+spawn_rules:
+  orario:
+    - diurno
+  meteo:
+    - quiete_planare
+  densita: mid
+balance:
+  rarity: R2
+  threat_tier: T2
+  encounter_role: support
+telemetry:
+  expected_pick_rate: 0.18
+  spawn_weight: 0.2
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - scariche_arcane
+    - cedimenti_portale
+derived_from_environment:
+  suggested_traits:
+    - carapace_fase_variabile
+    - armatura_pietra_planare
+    - nuclei_di_controllo
+    - matrice_antimagia
+  optional_traits:
+  required_capabilities:
+    - deploy_barrier
+    - purge_magic
+  services_links:
+    - supporto:manutenzione_sigilli
+    - regolazione:smaltimento_residui
+  jobs_bias:
+    - warden
+    - artificer
+genetic_traits:
+  core:
+    - armatura_pietra_planare
+  optional: []
+  synergy: []
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.golem-runico.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - assenza_respirazione
+  - campo_di_fase
+  - ciclo_vitale_anomalo
+  - metabolismo_sostentato
+  - origine_artificiale
+  - rinforzi_modulari

--- a/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/marilith-vault.yaml
@@ -1,3 +1,92 @@
-resistance_archetype: adattivo
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: 1b60da12e4d894b757b0ff51e430d0b5dba967196240e374f260c1a19c92175a
 id: marilith-vault
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Marilith delle Volte
+biomes:
+  - rovine_planari
+role_trofico: predatore_terziario_apex
+functional_tags:
+  - predatore
+  - sentinella
+morphotype: cursoriale_quadrupede
+resistance_archetype: adattivo
+flags:
+  apex: false
+  keystone: false
+  sentient: true
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.85
+  risk: 0.7
+  cohesion: 0.4
+  setup: 0.6
+  explore: 0.5
+  tilt: 0.5
+services_links:
+  - sicurezza:duello_portale
+spawn_rules:
+  orario:
+    - notte
+    - crepuscolo
+  meteo:
+    - quiete_planare
+    - vento_memetico
+  densita: low
+balance:
+  rarity: R3
+  threat_tier: T3
+  encounter_role: elite
+telemetry:
+  expected_pick_rate: 0.14
+  spawn_weight: 0.12
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfb
+    - Cfc
+  hazards_expected:
+    - vortici_abiurazione
+    - lame_risonanti
+derived_from_environment:
+  suggested_traits:
+    - artigli_sette_vie
+    - coda_frusta_cinetica
+    - sensori_geomagnetici
+  optional_traits:
+    - tessuti_adattivi
+  required_capabilities:
+    - multi_attack
+    - planar_anchor
+  services_links:
+    - sicurezza:controllo_passaggi
+  jobs_bias:
+    - vanguard
+    - skirmisher
+genetic_traits:
+  core:
+    - mantello_meteoritico
+    - frusta_fiammeggiante
+    - focus_frazionato
+  optional:
+    - empatia_coordinativa
+    - artigli_sette_vie
+  synergy: []
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.marilith-vault.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - ciclo_vitale_completo
+  - metabolismo_attivo
+  - respirazione_biologica
+  - riflessi_preternaturali
+  - visione_spettrale

--- a/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/otyugh-sentinella.yaml
@@ -1,3 +1,92 @@
-resistance_archetype: adattivo
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: 748b10c3e764dbd85f75fccc91284d83b7c6788d2609806719f62f431416b4e4
 id: otyugh-sentinella
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Otyugh Sentinella delle Fogne Astrali
+biomes:
+  - rovine_planari
+role_trofico: ingegneri_ecosistema
+functional_tags:
+  - filtratore
+  - detritivoro
+  - ingegneri_ecosistema
+morphotype: anfibio_filtratore
+resistance_archetype: adattivo
+flags:
+  apex: false
+  keystone: false
+  sentient: false
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.3
+  risk: 0.4
+  cohesion: 0.5
+  setup: 0.6
+  explore: 0.5
+  tilt: 0.2
+services_links:
+  - regolazione:depurazione_residui
+  - supporto:riciclo_nutrienti
+spawn_rules:
+  orario:
+    - diurno
+    - notte
+  meteo:
+    - pioggia_cenere
+    - nebbia_risonante
+  densita: mid
+balance:
+  rarity: R2
+  threat_tier: T2
+  encounter_role: ambient
+telemetry:
+  expected_pick_rate: 0.22
+  spawn_weight: 0.24
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - invasione_vite_dimensionali
+    - eco_mnemonico
+derived_from_environment:
+  suggested_traits:
+    - filtri_bioattivi
+    - membrane_osmotiche
+  optional_traits:
+  required_capabilities:
+    - purge_toxins
+    - anchor_waste
+  services_links:
+    - regolazione:purificazione_canali
+  jobs_bias:
+    - artificer
+    - warden
+genetic_traits:
+  core:
+  optional:
+    - carapace_fase_variabile
+    - lamelle_termoforetiche
+    - artigli_sette_vie
+  synergy: []
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.otyugh-sentinella.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - ciclo_vitale_completo
+  - metabolismo_attivo
+  - nodi_micotici
+  - proboscide_polifaga
+  - respirazione_biologica
+  - secrezioni_antisepsi
+  - sensori_chimici

--- a/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/rakshasa-corte.yaml
@@ -1,3 +1,88 @@
-resistance_archetype: psionico
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: 936482cdbee7f7bff06c8230d70140e05a26f9c36883d27a5864ead7ba8317c5
 id: rakshasa-corte
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Rakshasa della Corte Spezzata
+biomes:
+  - rovine_planari
+role_trofico: minaccia_microbica
+functional_tags:
+  - parassita
+  - predatore
+morphotype: cursoriale_quadrupede
+resistance_archetype: psionico
+flags:
+  apex: false
+  keystone: false
+  sentient: true
+  bridge: false
+  threat: true
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.55
+  risk: 0.6
+  cohesion: 0.4
+  setup: 0.7
+  explore: 0.6
+  tilt: 0.5
+services_links:
+  - minaccia:corruzione_iconica
+spawn_rules:
+  orario:
+    - notte
+    - crepuscolo
+  meteo:
+    - nebbia_risonante
+    - vento_memetico
+  densita: low
+balance:
+  rarity: R3
+  threat_tier: T3
+  encounter_role: elite
+telemetry:
+  expected_pick_rate: 0.16
+  spawn_weight: 0.14
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+  hazards_expected:
+    - eco_mnemonico
+    - invasioni_iconiche
+derived_from_environment:
+  suggested_traits:
+    - empatia_coordinativa
+    - artigli_psionici
+    - tessuti_adattivi
+  optional_traits:
+    - focus_frazionato
+  required_capabilities:
+    - infiltrate
+    - disrupt_psionics
+  services_links:
+    - minaccia:propagazione_iconica
+  jobs_bias:
+    - invoker
+    - skirmisher
+genetic_traits:
+  core:
+  optional:
+    - empatia_coordinativa
+  synergy:
+    - risonanza_di_branco
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.rakshasa-corte.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - ciclo_vitale_completo
+  - maschera_illusoria
+  - metabolismo_attivo
+  - respirazione_biologica
+  - sinapsi_riflettenti

--- a/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
+++ b/packs/evo_tactics_pack/data/species/rovine_planari/treant-portale.yaml
@@ -1,3 +1,91 @@
-resistance_archetype: adattivo
+schema_version: 1.7
+receipt:
+  source: PF1E.Bestiary.v1
+  author: designer
+  date: '2025-10-30'
+  trace_hash: 71a56b1b50e317511cff76bbd497bb2aabf153e55e38b0acd3c622f3f12f62e1
 id: treant-portale
-notes: 'stub auto-generato per ripristinare inventario: sostituire con specifica completa.'
+display_name: Treant dei Portali Antichi
+biomes:
+  - rovine_planari
+role_trofico: ingegneri_ecosistema
+functional_tags:
+  - ingegneri_ecosistema
+  - specie_chiave
+  - simbionte
+morphotype: ingegnere_radicante
+resistance_archetype: adattivo
+flags:
+  apex: false
+  keystone: true
+  sentient: true
+  bridge: false
+  threat: false
+  event: false
+playable_unit: false
+vc:
+  aggro: 0.3
+  risk: 0.2
+  cohesion: 0.9
+  setup: 0.7
+  explore: 0.5
+  tilt: 0.2
+services_links:
+  - supporto:stabilizzazione_portali
+  - regolazione:assorbimento_energia
+spawn_rules:
+  orario:
+    - diurno
+  meteo:
+    - pioggia_cenere
+    - quiete_planare
+  densita: mid
+balance:
+  rarity: R2
+  threat_tier: T2
+  encounter_role: ambient
+telemetry:
+  expected_pick_rate: 0.2
+  spawn_weight: 0.22
+environment_affinity:
+  biome_class: rovine_planari
+  koppen:
+    - Cfa
+    - Cfb
+  hazards_expected:
+    - fratture_planari
+    - invasione_vite_dimensionali
+derived_from_environment:
+  suggested_traits:
+    - radici_ancora_planare
+    - reti_capillari_radici
+    - pigmenti_aurorali
+    - corteccia_memetica
+  optional_traits:
+  required_capabilities:
+    - stabilize_gate
+    - cleanse_corruption
+  services_links:
+    - supporto:rinforzo_strutturale
+    - regolazione:depurazione_flussi
+  jobs_bias:
+    - artificer
+    - warden
+genetic_traits:
+  core:
+  optional:
+    - armatura_pietra_planare
+  synergy:
+    - risonanza_di_branco
+mate_synergy: []
+jobs_synergy: []
+description: i18n:species.treant-portale.description
+# Tratti autorati nel design originale (e83c810c, 2025-10-29) ma MAI definiti nel
+# glossario. Preservati qui, fuori dalle liste consumate, per non fabbricare voci nel
+# trait-bridge. Vanno autorati (Species-Curator-gated) e poi rimessi in genetic_traits.
+pending_trait_definitions:
+  - ciclo_vitale_completo
+  - fotosintesi_bifase
+  - metabolismo_attivo
+  - nodi_micotici
+  - respirazione_biologica


### PR DESCRIPTION
## TL;DR

ADR-2026-07-14 called `rovine_planari` **"0 abitanti, +8, the single largest gap in the game"**. That was false. The 10 species were **authored in full on 2025-10-29** and destroyed two days later as collateral damage of a commit titled *"docs"*. They are **recovered** here.

**The TARGET gap drops from ~35 to ~27 species.** No species were authored in this PR.

Worse: **Decision 5, executed literally, would have destroyed them a second time** -- it ordered "delete the 52 pure stubs", and 10 of those 52 were `rovine_planari`.

## What happened

| when | commit | what |
| --- | --- | --- |
| 2025-10-29 | `e83c810c` | creates `rovine_planari` complete: 10 authored species (83-103 lines, `receipt.source: PF1E.Bestiary.v1`, `author: designer`) |
| 2025-10-31 | `5a06b64b` | *"docs(tri_sorgente): introduce variant docs"* -- deletes **302,220 lines across 932 files**, CI workflows included |
| 2025-12-09 | `9acadc69` | *"Restore ... species inventory"* -- recovers `badlands`, but for `rovine_planari` recovers only the **names**, re-adding 3-line stubs |
| **this PR** | `aa92afed` | **recovery** |

The stubs' own note said so: `notes: 'stub auto-generato per **ripristinare inventario**: sostituire con specifica completa.'` It is the **scar of a partial restore**, honestly labelled at the time and then forgotten.

**The ecosystem and foodweb survived** and still name all 10 species by exact id: `.ecosystem.yaml` lists them across produttori/consumatori/decompositori, `_foodweb.yaml` wires them as 10 `kind: species` nodes with 23 edges. The biome did not have zero inhabitants -- it had **the imprint of ten inhabitants at every level of the stack, and the bodies empty**.

The recovered set satisfies all five `rules.at_least` of its own ecosystem (requirement is >=1 each; it delivers apex 1, keystone 2, bridge 2, threat 3, event 1) and all 10 pass Decision 5.

### Negative control (this is what makes it trustworthy)

The same method **falsifies** a recovery for `atollo_obsidiana`: its ecosystem names 3 species (`anguis-magnetica`, `vitricyba-punctata`, `magnetocola-pastoris`) and **none ever existed as a file in git**. It is a genuine hole. The method discriminates -- it does not say "recovery" to everything.

## Two traps avoided during the recovery

1. **A bare `git checkout` drops `resistance_archetype`** (added post-deletion by #1640 / #3173). Preserved: zero fields lost.
2. **The species reference 23 traits that were NEVER defined** in `glossary.json` (0 of 24 ever existed as a `data/traits/*.json` file) -- they were authored *ahead of the trait catalog*. `build_species_trait_bridge.py:145` does `trait_index.setdefault()`, so regenerating the bridge with them would have **fabricated 23 bare trait entries with no definition** -- the exact shape of the coverage fabrication this repo just spent a day removing. They are preserved **unconsumed** under `pending_trait_definitions`, and must be authored (Species-Curator-gated).

## Gates (measured before/after, not asserted)

| gate | before (main) | after | threshold |
| --- | --- | --- | --- |
| `traits_with_species` | 189 | **191** | min 189 |
| `rules_missing_species_total` | 5 | 5 | max 5 |
| `check_derived_reproducible.py --deep` | 3/3 OK | **3/3 OK** | enforcing |
| `validate_datasets.py` | valid | valid | -- |
| `trait_audit.py --check` | no regression | no regression | -- |
| trait-bridge trait-ids | 203 | 204 (+1 `eco_sismico`, glossary-defined; **0 removed**) | -- |

The value of the recovery is **not the counter** (+2 covered traits). It is the **10 species**.

## The 4 gaps the ADR missed (Addendum 2026-07-15)

- **Gap A (P1)** -- `biome_class` has a **third** overload site the ADR does not name: `environment_affinity.biome_class` inside species files. 0 of 16 distinct values use the ecological family; all are biome identities. **21 species carry the 4 fabricated aliases** Decision 4 deletes -- and they are exactly the species of the 4 deep core biomes. Deleting the aliases without repointing them fails **guard #3 across the entire core**. Added as migration step **3b**.
- **Gap B (P1)** -- the 23 undefined traits (above). The repo's real invariant is the **glossary** (203/203 in `species_affinity.json`), not the per-trait DB (3 gaps tolerated).
- **Gap C (P1)** -- Decision 5 would have re-deleted the recovered content. **The discriminator is `receipt.source`, not file size**: a naive "recover every stub that once had content" grep returns 34 files, **21 of which are `*-trait-keeper.yaml` carrying 59 lines of `coverage_autogen` fabrication** -- more lines than some real species. Added a **provenance guard** as migration step **6b**.
- **Gap D** -- the Decision 5 counts do not reproduce. Measured on main: **42** real species (not 46), **63** non-species (not 59), **11** event species (not 7), and the 52 stubs carry **no receipt at all** (not `coverage_autogen`). The delta is 11 receipted files with **zero traits**, 6 of them `runtime-generator` species sitting in the core biomes.

Decision 10 corrected, and the gap re-expressed as **which ROLES are missing in which biome** rather than a species count:

| biome | real species | eco | foodweb | node | **missing roles** |
| --- | --- | --- | --- | --- | --- |
| `atollo_obsidiana` | 0 | yes | no | yes | **apex, keystone, bridge, threat, event** |
| `abisso_vulcanico` | 2 | yes | no | no | **keystone, bridge, event** |
| `caverna` | 1 | yes | no | no | **apex, keystone, bridge, event** |

`foresta_temperata` (+1), `deserto_caldo` (+2) and `cryosteppe` (+3) already have all five minimum roles: their gap is **depth**, not coverage.

## Museum

- **M-2026-07-15-001** (5/5, `revived`) -- the recovery + the negative control.
- **M-2026-07-15-002** (5/5) -- **the lesson, and the exact inverse of M-2026-07-14-001.** That card taught *remove-then-remeasure*. This one teaches the opposite failure: **an honest stub that survived a partial restore is not a fabricated stub, and treating it as one destroys real content.** Apply only one and you delete scars; apply only the other and you resurrect lies. They now cross-link.
- **M-2026-07-15-003** (4/5) -- species authored ahead of the trait catalog: a third way to fabricate coverage.

`M-2026-07-14-001` corrected inline: its line *"rovine_planari: 10 file, 10 stub, 0 specie reali -- un bioma intero fatto di niente"* was wrong, and the card helped make it believed.

## Review notes

The `repo-archaeologist` adversarially re-checked every claim and falsified five. **Two were real errors and are fixed**: the foodweb has **23** edges (not 24), and `rules.at_least` requires **>=1 per role** (the higher figures are what the set *delivers*, not what the ecosystem *demands*). The other three did not survive re-measurement and the original numbers stand.

**Not done, deliberately**: no species authored, `species_affinity.json` / `*-trait-keeper.yaml` / env rules not hand-edited (the derived artifacts were **regenerated by the pipeline** from the changed source, which is a different thing -- the diff is +1 trait-id, 0 removed).